### PR TITLE
ci(release): manual dev release pipeline (macOS + Linux + Docker/GHCR)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,181 @@
+name: Release (dev)
+
+# Manual dev builds. Dispatch selecting the `dev` branch:
+#   Actions → "Release (dev)" → Run workflow → Branch: dev
+#   (or: gh workflow run release.yml --ref dev)
+#
+# IMPORTANT: workflow_dispatch is only OFFERED when this file exists on the
+# repository's DEFAULT branch (master). Selecting `dev` at dispatch time then
+# runs this workflow + the Makefile FROM `dev` and checks out `dev`'s tree — so
+# the file must live on both `master` (to expose the trigger) and `dev` (what
+# actually builds). See .claude/plans/2026-07-19-dev-release-pipeline-design.md.
+#
+# Wails cannot cross-compile (CGO + OS-native webview), so each desktop platform
+# builds on its own native runner: macOS (arm64) and Linux (amd64). All four
+# tarballs/zip plus a GHCR Docker image land in a single ROLLING pre-release
+# tagged `dev`, replaced on every run.
+
+on:
+  workflow_dispatch:
+
+# Only one dev release build at a time; a newer dispatch supersedes an older one
+# so they never race on the shared `dev` release/tag.
+concurrency:
+  group: release-dev
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  macos:
+    name: Build macOS (arm64)
+    runs-on: macos-latest # Apple Silicon
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Fetch native libs (ONNX Runtime, graphqlite, libtokenizers.a)
+        run: make setup
+      - name: Package server tarball + desktop .app zip
+        run: make release
+      - uses: actions/upload-artifact@v4
+        with:
+          name: darwin-arm64
+          path: dist/release/*
+          if-no-files-found: error
+          retention-days: 7
+
+  linux:
+    name: Build Linux (amd64)
+    runs-on: ubuntu-latest # x86_64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # GTK4 + WebKitGTK 6.0 + libsoup3 dev stack the Wails desktop build links.
+      - name: Install desktop build deps
+        run: make desktop-deps
+      - name: Fetch native libs
+        run: make setup
+      - name: Package server tarball + desktop tarball
+        run: make release
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-amd64
+          path: dist/release/*
+          if-no-files-found: error
+          retention-days: 7
+
+  docker:
+    name: Build + push Docker image (GHCR)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push to ghcr.io/<owner>/<repo>
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve version
+        id: ver
+        run: echo "full=$(make -s print-version)" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # The Dockerfile is self-contained: it fetches native libs and bakes the
+      # embedding model at build time (knomit warm-models), so the pushed image
+      # needs no startup downloads. amd64 only for now (matches the Linux tarballs).
+      - name: Build + push
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          FULL: ${{ steps.ver.outputs.full }}
+        run: |
+          docker build -t "$IMAGE:dev" -t "$IMAGE:$FULL" .
+          docker push "$IMAGE:dev"
+          docker push "$IMAGE:$FULL"
+
+  publish:
+    name: Publish rolling dev pre-release
+    runs-on: ubuntu-latest
+    needs: [macos, linux, docker]
+    permissions:
+      contents: write # create the GitHub release + move the `dev` tag
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts # → artifacts/<job-name>/<file>
+      - name: Resolve version
+        id: ver
+        run: echo "full=$(make -s print-version)" >> "$GITHUB_OUTPUT"
+      - name: Write release notes
+        env:
+          FULL: ${{ steps.ver.outputs.full }}
+          IMAGE: ghcr.io/${{ github.repository }}
+        run: |
+          cat > notes.md <<EOF
+          Rolling development build from \`dev\` — **$FULL** (\`$GITHUB_SHA\`).
+
+          This pre-release is replaced on every run; the download URLs are stable.
+
+          ## Downloads
+
+          | Platform | Server | Desktop |
+          |----------|--------|---------|
+          | macOS (Apple Silicon) | \`knomit-$FULL-darwin-arm64.tar.gz\` | \`Knomit-$FULL-darwin-arm64.app.zip\` |
+          | Linux (x86_64) | \`knomit-$FULL-linux-amd64.tar.gz\` | \`knomit-desktop-$FULL-linux-amd64.tar.gz\` |
+
+          ## Install
+
+          **macOS desktop (unsigned):** the app is not notarized, so Gatekeeper
+          blocks it on first launch. After unzipping, clear the quarantine flag:
+          \`\`\`sh
+          xattr -dr com.apple.quarantine Knomit.app
+          open Knomit.app
+          \`\`\`
+          (or right-click the app → Open the first time).
+
+          **Server (macOS/Linux):** extract and run — native libs resolve from the
+          bundled \`lib/\` automatically. The embedding model (~600 MB) downloads on
+          first run.
+          \`\`\`sh
+          tar xzf knomit-$FULL-<platform>.tar.gz && cd knomit-$FULL-<platform>
+          ./knomit serve
+          \`\`\`
+
+          **Linux desktop:** requires GTK 4 + WebKitGTK 6.0 runtime libraries.
+          Extract, then run \`./install.sh\` to register the app-menu launcher (keep
+          the extracted folder in place), or run \`./knomit-desktop\` directly.
+
+          **Docker:**
+          \`\`\`sh
+          docker run -p 19278:19278 -v knomit-data:/data $IMAGE:dev
+          \`\`\`
+          Use a named volume (not a host bind-mount) for \`/data\` so the baked model is preserved.
+          EOF
+      - name: Recreate the rolling `dev` pre-release
+        env:
+          FULL: ${{ steps.ver.outputs.full }}
+        run: |
+          # Remove the previous release AND its tag so the new one points at this
+          # commit. Delete a stray tag too (belt-and-suspenders: gh release create
+          # on a pre-existing tag would ignore --target and keep the old commit).
+          gh release delete dev --yes --cleanup-tag 2>/dev/null || true
+          git push origin --delete dev 2>/dev/null || true
+          gh release create dev \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "dev ($FULL)" \
+            --notes-file notes.md \
+            artifacts/*/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build web test clean run dev setup dist docker docker-amd64 desktop desktop-deps desktop-app-macos desktop-icons desktop-install desktop-run download-ort download-graphqlite tokenizers-lib e2e e2e-ui e2e-setup e2e-report
+.PHONY: build web test clean run dev setup dist docker docker-amd64 desktop desktop-deps desktop-app-macos desktop-icons desktop-install desktop-run download-ort download-graphqlite tokenizers-lib e2e e2e-ui e2e-setup e2e-report release release-server release-desktop print-version
 
 # All build artifacts are written under a per-platform directory,
 # dist/<goos>-<goarch> (e.g. dist/darwin-arm64, dist/linux-arm64), so builds for
@@ -246,4 +246,69 @@ ifeq ($(GOOS),darwin)
 	open $(APP)
 else
 	$(DIST)/knomit-desktop
+endif
+
+# ---- release packaging ------------------------------------------------------
+# Assemble downloadable release artifacts under dist/release/. Wails cannot
+# cross-compile, so each runner packages ONLY its own platform's artifacts;
+# the GitHub release job collects the per-platform outputs. Filenames carry
+# FULL_VERSION (semver.sha) + PLATFORM so a single rolling release holds builds
+# from several runners without collision. Every target builds its prerequisite
+# (`build` / `desktop`) first, so `make release` on a clean checkout produces
+# that platform's downloads end to end.
+RELEASE_DIR       := dist/release
+SERVER_PKG        := knomit-$(FULL_VERSION)-$(PLATFORM)
+DESKTOP_MAC_ZIP   := Knomit-$(FULL_VERSION)-$(PLATFORM).app.zip
+DESKTOP_LINUX_PKG := knomit-desktop-$(FULL_VERSION)-$(PLATFORM)
+
+release: release-server release-desktop
+	@echo "Release artifacts for $(PLATFORM):"
+	@ls -1 $(RELEASE_DIR)
+
+# Print the full build version (semver.sha) — the single source of truth the
+# release workflow uses to tag the Docker image and name the GitHub release.
+print-version:
+	@echo $(FULL_VERSION)
+
+# Server tarball. The per-platform dist dir already IS the runtime layout —
+# knomit + knomit-bridge resolve their ONNX/graphqlite libs from <exe>/lib
+# (internal/embeddings/embedder.go, internal/store/vec.go) — so we just stage
+# those three things under a versioned top-level dir and tar it. libtokenizers.a
+# is a build-time STATIC lib (never dlopen'd at runtime), so it is dropped.
+release-server: build
+	mkdir -p $(RELEASE_DIR)
+	rm -rf $(DIST)/$(SERVER_PKG)
+	mkdir -p $(DIST)/$(SERVER_PKG)/lib
+	cp $(DIST)/knomit $(DIST)/knomit-bridge $(DIST)/$(SERVER_PKG)/
+	cp -R $(LIBDIR)/. $(DIST)/$(SERVER_PKG)/lib/
+	rm -f $(DIST)/$(SERVER_PKG)/lib/*.a
+	tar -C $(DIST) -czf $(RELEASE_DIR)/$(SERVER_PKG).tar.gz $(SERVER_PKG)
+	rm -rf $(DIST)/$(SERVER_PKG)
+	@echo "Packaged $(RELEASE_DIR)/$(SERVER_PKG).tar.gz"
+
+# Desktop bundle/tarball.
+#   - macOS: ditto-zip the .app (preserves the bundle's symlinks + attrs; a
+#            plain `zip` corrupts it). Unsigned — install notes cover Gatekeeper.
+#   - Linux: stage knomit-desktop + knomit-bridge + lib/ (runtime libs resolved
+#            from <exe>/lib, so they must ship beside the binary) + the app icon,
+#            the .desktop launcher template, and install.sh (registers the
+#            launcher pointing at wherever the user extracted the tarball).
+release-desktop: desktop
+	mkdir -p $(RELEASE_DIR)
+ifeq ($(GOOS),darwin)
+	rm -f $(RELEASE_DIR)/$(DESKTOP_MAC_ZIP)
+	ditto -c -k --sequesterRsrc --keepParent $(APP) $(RELEASE_DIR)/$(DESKTOP_MAC_ZIP)
+	@echo "Packaged $(RELEASE_DIR)/$(DESKTOP_MAC_ZIP)"
+else
+	rm -rf $(DIST)/$(DESKTOP_LINUX_PKG)
+	mkdir -p $(DIST)/$(DESKTOP_LINUX_PKG)/lib
+	cp $(DIST)/knomit-desktop $(DIST)/knomit-bridge $(DIST)/$(DESKTOP_LINUX_PKG)/
+	cp -R $(LIBDIR)/. $(DIST)/$(DESKTOP_LINUX_PKG)/lib/
+	rm -f $(DIST)/$(DESKTOP_LINUX_PKG)/lib/*.a
+	cp tools/desktop/appicon.png $(DIST)/$(DESKTOP_LINUX_PKG)/
+	cp tools/desktop/linux/knomit-desktop.desktop $(DIST)/$(DESKTOP_LINUX_PKG)/
+	install -m 0755 tools/desktop/linux/install.sh $(DIST)/$(DESKTOP_LINUX_PKG)/install.sh
+	tar -C $(DIST) -czf $(RELEASE_DIR)/$(DESKTOP_LINUX_PKG).tar.gz $(DESKTOP_LINUX_PKG)
+	rm -rf $(DIST)/$(DESKTOP_LINUX_PKG)
+	@echo "Packaged $(RELEASE_DIR)/$(DESKTOP_LINUX_PKG).tar.gz"
 endif

--- a/tools/desktop/linux/install.sh
+++ b/tools/desktop/linux/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+# Install the Knomit desktop launcher from an extracted release tarball.
+#
+# The knomit-desktop binary resolves its ONNX/graphqlite libs from <exe>/lib,
+# so it must keep running from THIS extracted directory — this script does not
+# copy the binary anywhere. It only registers a .desktop launcher (with Exec
+# pointing at the binary's absolute path here) and installs the app icon into
+# the user's XDG dirs, so Knomit shows up in the GNOME/KDE app grid.
+#
+# Runtime prerequisites (install with your distro's package manager first):
+#   GTK 4 + WebKitGTK 6.0 + libsoup 3 runtime libraries.
+#
+# Re-run this script if you move the extracted directory.
+set -eu
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+XDG_DATA="${XDG_DATA_HOME:-$HOME/.local/share}"
+APPS="$XDG_DATA/applications"
+ICONS="$XDG_DATA/icons/hicolor/256x256/apps"
+
+if [ ! -x "$DIR/knomit-desktop" ]; then
+	echo "error: knomit-desktop not found in $DIR — run this from the extracted tarball." >&2
+	exit 1
+fi
+
+mkdir -p "$APPS" "$ICONS"
+install -m 0644 "$DIR/appicon.png" "$ICONS/knomit-desktop.png"
+# {{EXEC}} is the placeholder in the committed .desktop template.
+sed "s#{{EXEC}}#$DIR/knomit-desktop#" "$DIR/knomit-desktop.desktop" > "$APPS/knomit-desktop.desktop"
+
+update-desktop-database "$APPS" 2>/dev/null || true
+gtk-update-icon-cache -f -t "$XDG_DATA/icons/hicolor" 2>/dev/null || true
+
+echo "Installed Knomit launcher. Launch it from your app menu, or run directly:"
+echo "  $DIR/knomit-desktop"


### PR DESCRIPTION
## What

Adds a `workflow_dispatch`-triggered release pipeline that delivers downloadable builds from `dev` as a single **rolling `dev` pre-release**, plus a Docker image on GHCR.

### Artifacts (Essentials matrix)
| Platform | Server | Desktop |
|----------|--------|---------|
| macOS Apple Silicon (arm64) | `knomit-<ver>-darwin-arm64.tar.gz` | `Knomit-<ver>-darwin-arm64.app.zip` |
| Linux x86_64 (amd64) | `knomit-<ver>-linux-amd64.tar.gz` | `knomit-desktop-<ver>-linux-amd64.tar.gz` |
| Docker (linux/amd64) | `ghcr.io/knomit/knomit:dev` + `:<ver>` | — |

## How

- **Wails can't cross-compile** → macOS builds on `macos-latest` (arm64), Linux on `ubuntu-latest` (amd64).
- Binaries resolve ONNX/graphqlite libs from `<exe>/lib`, so `make build` output already **is** the server tarball layout.
- New Makefile targets (`release-server`, `release-desktop`, `release`, `print-version`) are locally runnable and reproduce exactly what CI does — verified end-to-end on macOS arm64 (server tarball runs; `.app` bundle valid).
- `tools/desktop/linux/install.sh` registers the XDG launcher from an extracted Linux desktop tarball.
- 4 jobs: `macos`, `linux`, `docker` (GHCR via `GITHUB_TOKEN`, `packages: write`), `publish` (recreates the rolling `dev` release, `contents: write`).

## Decisions
Manual dispatch only · rolling `dev` tag · unsigned macOS (notes document the Gatekeeper `xattr` step) · GHCR only (no Docker Hub) · model **not** baked into the server tarball (downloads on first run).

## ⚠️ Required after merge (two manual steps)
1. **Land `release.yml` on `master` too.** `workflow_dispatch` is only offered when the workflow exists on the **default branch**. Merging this into `dev` alone will **not** show the "Run workflow" button — merge `dev`→`master` or add the file to `master` separately.
2. **Make the GHCR package public** once after the first Docker push (repo/org → Packages settings). No secrets needed.

Then dispatch: **Actions → "Release (dev)" → Run workflow → Branch: `dev`** (or `gh workflow run release.yml --ref dev`).

Design notes: `.claude/plans/2026-07-19-dev-release-pipeline-design.md` (local).