### PR TITLE
Lens browsing UI + union stats/tree, connect panel, graph & breadcrumb fixes

### DIFF
--- a/internal/federate/federate.go
+++ b/internal/federate/federate.go
@@ -1,9 +1,9 @@
-package mcp
-
-// Federation helpers for lens read fan-out (lenses RFC §7): reciprocal rank
-// fusion for relevance, k-way timestamp merge for recency, the kb:// wire
-// path form, and ontology-aware fan-out target selection. Everything here is
-// pure — no store access — so it is exhaustively unit-testable.
+// Package federate holds the lens union-read machinery shared by every reader
+// front-end (MCP handlers, REST endpoints): reciprocal rank fusion for
+// relevance, k-way timestamp merge for recency, the kb:// wire path form, and
+// ontology-aware fan-out target selection. Everything here is pure — no store
+// access — so it is exhaustively unit-testable (lenses RFC §7).
+package federate
 
 import (
 	"fmt"
@@ -21,26 +21,27 @@ const rrfK = 60
 // kb://<id>/ wire form (RFC §6.1).
 const repoIDWireLen = 12
 
-const kbScheme = "kb://"
+// KBScheme is the kb:// wire-path scheme prefix (RFC §6.1).
+const KBScheme = "kb://"
 
-// mountRef addresses one row of a per-mount result list: lists[Mount][Rank].
-type mountRef struct {
+// MountRef addresses one row of a per-mount result list: lists[Mount][Rank].
+type MountRef struct {
 	Mount int
 	Rank  int
 }
 
-// fuseRRF orders the union of per-mount ranked lists by reciprocal rank
+// FuseRRF orders the union of per-mount ranked lists by reciprocal rank
 // fusion (RFC §7.1). Replica mounts are rejected at lens create, so every
 // fact appears in exactly one list and the fused score collapses to the
 // single term 1/(rrfK+rank). Equal fused scores (same rank, different
 // mounts) tie-break by mount order so fusion is deterministic; with one
 // list the output order is the input order (the N=1 no-behavior-change
 // invariant).
-func fuseRRF(listLens []int) []mountRef {
-	var out []mountRef
+func FuseRRF(listLens []int) []MountRef {
+	var out []MountRef
 	for m, n := range listLens {
 		for r := range n {
-			out = append(out, mountRef{Mount: m, Rank: r})
+			out = append(out, MountRef{Mount: m, Rank: r})
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool {
@@ -54,20 +55,20 @@ func fuseRRF(listLens []int) []mountRef {
 	return out
 }
 
-// mergeRecent orders the union of per-mount recency lists by committed_at
+// MergeRecent orders the union of per-mount recency lists by committed_at
 // DESC, capped at max. Commit timestamps are directly comparable across
 // mounts, so this is a plain k-way timestamp merge — RRF would be wrong
 // here (rank fusion exists for INcomparable relevance scores; RFC §7.1).
 // Ties break by mount order then per-mount position, deterministically.
 // Each input list must already be committed_at-DESC — the order RecentFacts
 // returns for a text-LESS recency query. WITH a text query RecentFacts returns
-// relevance order instead, which federates by fuseRRF, not this merge (see
+// relevance order instead, which federates by FuseRRF, not this merge (see
 // queryRecent).
-func mergeRecent(stamps [][]int64, max int) []mountRef {
-	var out []mountRef
+func MergeRecent(stamps [][]int64, max int) []MountRef {
+	var out []MountRef
 	for m, list := range stamps {
 		for r := range list {
-			out = append(out, mountRef{Mount: m, Rank: r})
+			out = append(out, MountRef{Mount: m, Rank: r})
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool {
@@ -86,7 +87,7 @@ func mergeRecent(stamps [][]int64, max int) []mountRef {
 	return out
 }
 
-// readSetFingerprint is the canonical identity of a binding's READ SET: every
+// ReadSetFingerprint is the canonical identity of a binding's READ SET: every
 // mount rendered as id12@len:branch, sorted lexicographically and comma-joined
 // (lenses RFC §7.3). A cursor pins this fingerprint at mint; resume recomputes
 // it from the current binding and rejects any mismatch. So re-pinning a mount to
@@ -101,34 +102,34 @@ func mergeRecent(stamps [][]int64, max int) []mountRef {
 // serialize identically to two mounts "<id1>@a" + "<id2>@b", colliding two
 // distinct read sets and wrongly accepting a stale cursor after a lens
 // redefinition (lenses RFC §7.3).
-func readSetFingerprint(b *repos.Binding) string {
+func ReadSetFingerprint(b *repos.Binding) string {
 	reads := b.Reads()
 	parts := make([]string, len(reads))
 	for i, rt := range reads {
-		parts[i] = id12(rt.RI.ID()) + "@" + strconv.Itoa(len(rt.Branch)) + ":" + rt.Branch
+		parts[i] = ID12(rt.RI.ID()) + "@" + strconv.Itoa(len(rt.Branch)) + ":" + rt.Branch
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, ",")
 }
 
-// id12 shortens a full root-commit hash to the wire form.
-func id12(fullID string) string {
+// ID12 shortens a full root-commit hash to the wire form.
+func ID12(fullID string) string {
 	if len(fullID) <= repoIDWireLen {
 		return fullID
 	}
 	return fullID[:repoIDWireLen]
 }
 
-// qualifyPath renders the canonical qualified wire form (RFC §6.2).
-func qualifyPath(id12, rel string) string {
-	return kbScheme + id12 + "/" + rel
+// QualifyPath renders the canonical qualified wire form (RFC §6.2).
+func QualifyPath(id12, rel string) string {
+	return KBScheme + id12 + "/" + rel
 }
 
-// parseQualifiedPath splits a wire path. A bare path returns qualified=false
+// ParseQualifiedPath splits a wire path. A bare path returns qualified=false
 // with rel=p. A kb:// path must carry exactly repoIDWireLen lowercase-hex id
 // chars and a non-empty repo-relative remainder; anything else is malformed.
-func parseQualifiedPath(p string) (id, rel string, qualified bool, err error) {
-	rest, ok := strings.CutPrefix(p, kbScheme)
+func ParseQualifiedPath(p string) (id, rel string, qualified bool, err error) {
+	rest, ok := strings.CutPrefix(p, KBScheme)
 	if !ok {
 		return "", p, false, nil
 	}
@@ -148,14 +149,14 @@ func isLowerHex(s string) bool {
 	return true
 }
 
-// writeRepoPath resolves a write-tool file argument to the repo-relative path
+// WriteRepoPath resolves a write-tool file argument to the repo-relative path
 // on the binding's write repo (RFC §6.2). Unqualified paths are the write
 // repo's own ("current directory"); kb://<write-id>/… is accepted and exactly
 // equivalent to bare; a qualified path to any OTHER mount is a read-only-mount
 // error (writes have exactly one target), and an unmounted ID is the
 // not-mounted error. The error naming the repo is prose, not addressing.
-func writeRepoPath(b *repos.Binding, file string) (string, error) {
-	id, rel, qualified, err := parseQualifiedPath(file)
+func WriteRepoPath(b *repos.Binding, file string) (string, error) {
+	id, rel, qualified, err := ParseQualifiedPath(file)
 	if err != nil {
 		return "", err
 	}
@@ -190,22 +191,22 @@ func topicOfPathFilter(pathFilter string) string {
 	return topic
 }
 
-// fanTarget is one mount a query fans out to, with its per-mount
+// Target is one mount a query fans out to, with its per-mount
 // (repo-relative) path filter.
-type fanTarget struct {
+type Target struct {
 	RT   repos.ReadTarget
 	Path string
 }
 
-// readTargetsFor selects a query's fan-out targets (RFC §6.2 addressing +
+// ReadTargetsFor selects a query's fan-out targets (RFC §6.2 addressing +
 // §7.2 ontology-aware fan-out). A kb://-qualified path filter restricts the
 // query to that single mount with the filter made repo-relative; an
 // unqualified filter applies per-mount as-is, skipping mounts whose ontology
 // lacks a fully-delimited topic constraint. The skip is a pure internal
 // optimization: a skipped mount is indistinguishable from one that matched
 // nothing (decision 17 — no coverage metadata, ever).
-func readTargetsFor(b *repos.Binding, pathFilter string) ([]fanTarget, error) {
-	id, rel, qualified, err := parseQualifiedPath(pathFilter)
+func ReadTargetsFor(b *repos.Binding, pathFilter string) ([]Target, error) {
+	id, rel, qualified, err := ParseQualifiedPath(pathFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -214,17 +215,17 @@ func readTargetsFor(b *repos.Binding, pathFilter string) ([]fanTarget, error) {
 		if !ok {
 			return nil, fmt.Errorf("repo %s is not mounted in this binding", id)
 		}
-		return []fanTarget{{RT: rt, Path: rel}}, nil
+		return []Target{{RT: rt, Path: rel}}, nil
 	}
 	topic := topicOfPathFilter(rel)
-	var out []fanTarget
+	var out []Target
 	for _, rt := range b.Reads() {
 		if topic != "" {
 			if o := rt.RI.Ontology(); o != nil && !containsString(o.TopicNames(), topic) {
 				continue
 			}
 		}
-		out = append(out, fanTarget{RT: rt, Path: rel})
+		out = append(out, Target{RT: rt, Path: rel})
 	}
 	return out, nil
 }

--- a/internal/federate/federate_test.go
+++ b/internal/federate/federate_test.go
@@ -1,0 +1,93 @@
+package federate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFuseRRF(t *testing.T) {
+	// N=1: identity order (the RFC's N=1 no-behavior-change invariant).
+	got := FuseRRF([]int{3})
+	require.Equal(t, []MountRef{{0, 0}, {0, 1}, {0, 2}}, got)
+
+	// Two lists [3,2]: rank layers, mount order within a layer.
+	got = FuseRRF([]int{3, 2})
+	require.Equal(t, []MountRef{
+		{0, 0}, {1, 0}, // rank 0 layer
+		{0, 1}, {1, 1}, // rank 1 layer
+		{0, 2}, // rank 2 layer
+	}, got)
+
+	// Empty lists mixed with non-empty.
+	got = FuseRRF([]int{0, 2, 0})
+	require.Equal(t, []MountRef{{1, 0}, {1, 1}}, got)
+
+	// All-empty → empty.
+	require.Empty(t, FuseRRF([]int{0, 0}))
+	require.Empty(t, FuseRRF(nil))
+}
+
+func TestMergeRecent(t *testing.T) {
+	// [[100,50],[70]] → committed_at DESC: 100(0,0), 70(1,0), 50(0,1).
+	got := MergeRecent([][]int64{{100, 50}, {70}}, 10)
+	require.Equal(t, []MountRef{{0, 0}, {1, 0}, {0, 1}}, got)
+
+	// cap max=2 truncates.
+	got = MergeRecent([][]int64{{100, 50}, {70}}, 2)
+	require.Equal(t, []MountRef{{0, 0}, {1, 0}}, got)
+
+	// Equal stamps across mounts → mount order, then per-mount order.
+	got = MergeRecent([][]int64{{100, 100}, {100}}, 10)
+	require.Equal(t, []MountRef{{0, 0}, {0, 1}, {1, 0}}, got)
+}
+
+func TestID12(t *testing.T) {
+	require.Equal(t, "3f9a2c1e8b7d", ID12("3f9a2c1e8b7d0000000000000000000000000000"))
+	// Short input returned as-is.
+	require.Equal(t, "abc", ID12("abc"))
+	require.Equal(t, "3f9a2c1e8b7d", ID12("3f9a2c1e8b7d"))
+}
+
+func TestQualifyPath(t *testing.T) {
+	require.Equal(t, "kb://3f9a2c1e8b7d/kb/a/b.md", QualifyPath("3f9a2c1e8b7d", "kb/a/b.md"))
+}
+
+func TestParseQualifiedPath(t *testing.T) {
+	// Bare path → not qualified.
+	id, rel, qualified, err := ParseQualifiedPath("kb/a/b.md")
+	require.NoError(t, err)
+	require.False(t, qualified)
+	require.Equal(t, "", id)
+	require.Equal(t, "kb/a/b.md", rel)
+
+	// Well-formed qualified path.
+	id, rel, qualified, err = ParseQualifiedPath("kb://3f9a2c1e8b7d/kb/a/b.md")
+	require.NoError(t, err)
+	require.True(t, qualified)
+	require.Equal(t, "3f9a2c1e8b7d", id)
+	require.Equal(t, "kb/a/b.md", rel)
+
+	// Malformed variants.
+	for _, p := range []string{
+		"kb://short/x.md",
+		"kb://GGGGGGGGGGGG/x.md",
+		"kb://3f9a2c1e8b7d",  // no rel
+		"kb://3f9a2c1e8b7d/", // empty rel
+	} {
+		_, _, qualified, err := ParseQualifiedPath(p)
+		require.True(t, qualified, "%q is a kb:// path", p)
+		require.Error(t, err, "%q must be rejected", p)
+	}
+}
+
+func TestTopicOfPathFilter(t *testing.T) {
+	require.Equal(t, "decisions", topicOfPathFilter("kb/decisions/lens/"))
+	require.Equal(t, "decisions", topicOfPathFilter("kb/decisions/x.md"))
+	// Prefix filter, topic segment NOT delimited → no constraint.
+	require.Equal(t, "", topicOfPathFilter("kb/decisions"))
+	require.Equal(t, "", topicOfPathFilter("kb/"))
+	require.Equal(t, "", topicOfPathFilter("kb"))
+	require.Equal(t, "", topicOfPathFilter(""))
+	require.Equal(t, "", topicOfPathFilter("other/x"))
+}

--- a/internal/mcp/explain.go
+++ b/internal/mcp/explain.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 	"knomit/internal/store"
 
@@ -97,7 +98,7 @@ func classifyRefs(refs []string) *classifiedRefs {
 	for _, ref := range refs {
 		// A kb:// ref points into another repo — a cross-repo pointer, not a
 		// local fact edge — so it is External despite ending in .md.
-		if !strings.HasPrefix(ref, kbScheme) && strings.HasSuffix(ref, ".md") {
+		if !strings.HasPrefix(ref, federate.KBScheme) && strings.HasSuffix(ref, ".md") {
 			cr.Local = append(cr.Local, ref)
 		} else {
 			cr.External = append(cr.External, ref)
@@ -291,7 +292,7 @@ func explainFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, fi
 	// Route the input fact to its mount: a kb://-qualified file names a specific
 	// mount; a bare file is the write repo. explain never fans out — the whole
 	// provenance walk lives inside this single mount (RFC §6.2).
-	id, rel, qualified, err := parseQualifiedPath(file)
+	id, rel, qualified, err := federate.ParseQualifiedPath(file)
 	if err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
@@ -312,7 +313,7 @@ func explainFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, fi
 	qualify := rt.RI != b.Write()
 	prefix := ""
 	if qualify {
-		prefix = kbScheme + id12(rt.RI.ID()) + "/"
+		prefix = federate.KBScheme + federate.ID12(rt.RI.ID()) + "/"
 	}
 	wire := func(p string) string {
 		if qualify {
@@ -391,7 +392,7 @@ func explainFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, fi
 		queueItems = append(queueItems, store.QueueItem{Path: wire(e.Path), CommitHash: e.Commit, SortKey: 1})
 	}
 
-	session, err := sWrite.toolSession.CreateToolSession(ctx, "explain", b.WriteMountBranch(), rel, b.Name(), readSetFingerprint(b))
+	session, err := sWrite.toolSession.CreateToolSession(ctx, "explain", b.WriteMountBranch(), rel, b.Name(), federate.ReadSetFingerprint(b))
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("create session error: %v", err)), nil
 	}
@@ -448,7 +449,7 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 	// flags and truncate the walk. The error is indistinguishable from expiry BY
 	// DESIGN (lenses RFC §7.3): a caller must not be able to tell a re-pinned read
 	// set — or a branch change — from an expired cursor.
-	if session.ReadSet != readSetFingerprint(b) {
+	if session.ReadSet != federate.ReadSetFingerprint(b) {
 		return mcpgo.NewToolResultError("session expired or not found — omit cursor to start a new session"), nil
 	}
 
@@ -478,7 +479,7 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 		}
 
 		for _, item := range items {
-			id, rel, qualified, perr := parseQualifiedPath(item.Path)
+			id, rel, qualified, perr := federate.ParseQualifiedPath(item.Path)
 			if perr != nil {
 				return mcpgo.NewToolResultError(fmt.Sprintf("page decode error: %v", perr)), nil
 			}
@@ -500,7 +501,7 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 			// mount), so child edges stay qualified iff the item was.
 			wire := func(p string) string {
 				if qualified {
-					return kbScheme + id + "/" + p
+					return federate.KBScheme + id + "/" + p
 				}
 				return p
 			}

--- a/internal/mcp/explain_federation_test.go
+++ b/internal/mcp/explain_federation_test.go
@@ -9,6 +9,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 )
 
@@ -55,7 +56,7 @@ func explainAllVia(t *testing.T, b *repos.Binding, file, commit string) ([]expFa
 // TestExplainFederation_QualifiedFileRoutesToMount: a lens over write repo A +
 // read repo B, explaining a kb://-qualified path, returns B's fact and every
 // entry path in the response (root and, across cursor pages, every summary
-// node) carries the kb://<id12(B)>/ prefix. Refs in the root body/frontmatter
+// node) carries the kb://<federate.ID12(B)>/ prefix. Refs in the root body/frontmatter
 // are returned exactly as stored (unqualified).
 func TestExplainFederation_QualifiedFileRoutesToMount(t *testing.T) {
 	repoA, _ := fedRepo(t)
@@ -71,8 +72,8 @@ func TestExplainFederation_QualifiedFileRoutesToMount(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
 	)
-	prefix := qualifyPath(id12(repoB.ID()), "")
-	file := qualifyPath(id12(repoB.ID()), "kb/root.md")
+	prefix := federate.QualifyPath(federate.ID12(repoB.ID()), "")
+	file := federate.QualifyPath(federate.ID12(repoB.ID()), "kb/root.md")
 
 	facts, _ := explainAllVia(t, b, file, "")
 	require.NotEmpty(t, facts)
@@ -80,7 +81,7 @@ func TestExplainFederation_QualifiedFileRoutesToMount(t *testing.T) {
 	// Every entry (root + summaries across pages) is qualified to B.
 	for _, f := range facts {
 		require.Truef(t, strings.HasPrefix(f.Path, prefix),
-			"every explain entry must carry the kb://<id12(B)>/ prefix: %s", f.Path)
+			"every explain entry must carry the kb://<federate.ID12(B)>/ prefix: %s", f.Path)
 	}
 
 	root := findExpFact(facts, file)
@@ -89,8 +90,8 @@ func TestExplainFederation_QualifiedFileRoutesToMount(t *testing.T) {
 	require.Equal(t, 0, root.Depth)
 
 	// Both children surface, qualified.
-	require.NotNil(t, findExpFact(facts, qualifyPath(id12(repoB.ID()), "kb/child1.md")))
-	require.NotNil(t, findExpFact(facts, qualifyPath(id12(repoB.ID()), "kb/child2.md")))
+	require.NotNil(t, findExpFact(facts, federate.QualifyPath(federate.ID12(repoB.ID()), "kb/child1.md")))
+	require.NotNil(t, findExpFact(facts, federate.QualifyPath(federate.ID12(repoB.ID()), "kb/child2.md")))
 
 	// Refs in the root are returned exactly as stored — never rewritten to
 	// qualified form.
@@ -114,14 +115,14 @@ func TestExplainFederation_UnqualifiedFileIsWriteRepo(t *testing.T) {
 	)
 
 	facts, first := explainAllVia(t, b, "kb/root.md", "")
-	require.NotContains(t, first, kbScheme, "unqualified explain output must never be kb://-qualified")
+	require.NotContains(t, first, federate.KBScheme, "unqualified explain output must never be kb://-qualified")
 
 	root := findExpFact(facts, "kb/root.md")
 	require.NotNil(t, root, "root must appear under its bare path")
 	require.Equal(t, "RootA", root.Title)
 	require.NotNil(t, findExpFact(facts, "kb/child.md"), "child must appear bare")
 	for _, f := range facts {
-		require.NotContainsf(t, f.Path, kbScheme, "write-repo entry must be bare: %s", f.Path)
+		require.NotContainsf(t, f.Path, federate.KBScheme, "write-repo entry must be bare: %s", f.Path)
 	}
 }
 
@@ -155,9 +156,9 @@ func TestExplainFederation_LensOfOneUnchanged(t *testing.T) {
 	b := repos.NewBindingForTest(repoA, repos.ReadTarget{RI: repoA, Branch: "agent/test"})
 
 	facts, first := explainAllVia(t, b, "kb/root.md", "")
-	require.NotContains(t, first, kbScheme, "lens-of-one output must never be kb://-qualified")
+	require.NotContains(t, first, federate.KBScheme, "lens-of-one output must never be kb://-qualified")
 	for _, f := range facts {
-		require.NotContainsf(t, f.Path, kbScheme, "lens-of-one entry must be bare: %s", f.Path)
+		require.NotContainsf(t, f.Path, federate.KBScheme, "lens-of-one entry must be bare: %s", f.Path)
 	}
 	require.NotNil(t, findExpFact(facts, "kb/root.md"))
 	require.NotNil(t, findExpFact(facts, "kb/child.md"))

--- a/internal/mcp/federate_test.go
+++ b/internal/mcp/federate_test.go
@@ -8,55 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 )
-
-func TestFuseRRF(t *testing.T) {
-	// N=1: identity order (the RFC's N=1 no-behavior-change invariant).
-	got := fuseRRF([]int{3})
-	require.Equal(t, []mountRef{{0, 0}, {0, 1}, {0, 2}}, got)
-
-	// Two lists [3,2]: rank layers, mount order within a layer.
-	got = fuseRRF([]int{3, 2})
-	require.Equal(t, []mountRef{
-		{0, 0}, {1, 0}, // rank 0 layer
-		{0, 1}, {1, 1}, // rank 1 layer
-		{0, 2}, // rank 2 layer
-	}, got)
-
-	// Empty lists mixed with non-empty.
-	got = fuseRRF([]int{0, 2, 0})
-	require.Equal(t, []mountRef{{1, 0}, {1, 1}}, got)
-
-	// All-empty → empty.
-	require.Empty(t, fuseRRF([]int{0, 0}))
-	require.Empty(t, fuseRRF(nil))
-}
-
-func TestMergeRecent(t *testing.T) {
-	// [[100,50],[70]] → committed_at DESC: 100(0,0), 70(1,0), 50(0,1).
-	got := mergeRecent([][]int64{{100, 50}, {70}}, 10)
-	require.Equal(t, []mountRef{{0, 0}, {1, 0}, {0, 1}}, got)
-
-	// cap max=2 truncates.
-	got = mergeRecent([][]int64{{100, 50}, {70}}, 2)
-	require.Equal(t, []mountRef{{0, 0}, {1, 0}}, got)
-
-	// Equal stamps across mounts → mount order, then per-mount order.
-	got = mergeRecent([][]int64{{100, 100}, {100}}, 10)
-	require.Equal(t, []mountRef{{0, 0}, {0, 1}, {1, 0}}, got)
-}
-
-func TestID12(t *testing.T) {
-	require.Equal(t, "3f9a2c1e8b7d", id12("3f9a2c1e8b7d0000000000000000000000000000"))
-	// Short input returned as-is.
-	require.Equal(t, "abc", id12("abc"))
-	require.Equal(t, "3f9a2c1e8b7d", id12("3f9a2c1e8b7d"))
-}
-
-func TestQualifyPath(t *testing.T) {
-	require.Equal(t, "kb://3f9a2c1e8b7d/kb/a/b.md", qualifyPath("3f9a2c1e8b7d", "kb/a/b.md"))
-}
 
 // TestReadSetFingerprint_InjectiveAcrossBranchSeparators pins the fix for the
 // collision the old "id12@branch, comma-joined" scheme allowed: because '@' and
@@ -70,12 +24,12 @@ func TestReadSetFingerprint_InjectiveAcrossBranchSeparators(t *testing.T) {
 	// Order so the single-mount repo (small id) sorts before the embedded one,
 	// making the old-scheme sorted join of the two-mount set collide exactly.
 	small, large := r1, r2
-	if id12(large.ID()) < id12(small.ID()) {
+	if federate.ID12(large.ID()) < federate.ID12(small.ID()) {
 		small, large = large, small
 	}
 
 	// Set A: ONE mount whose branch smuggles the separators — "a,<large-id>@b".
-	craftedBranch := "a," + id12(large.ID()) + "@b"
+	craftedBranch := "a," + federate.ID12(large.ID()) + "@b"
 	bA := repos.NewBindingForTest(small, repos.ReadTarget{RI: small, Branch: craftedBranch})
 	// Set B: TWO genuinely-distinct mounts, small@a + large@b.
 	bB := repos.NewBindingForTest(small,
@@ -88,7 +42,7 @@ func TestReadSetFingerprint_InjectiveAcrossBranchSeparators(t *testing.T) {
 		reads := b.Reads()
 		parts := make([]string, len(reads))
 		for i, rt := range reads {
-			parts[i] = id12(rt.RI.ID()) + "@" + rt.Branch
+			parts[i] = federate.ID12(rt.RI.ID()) + "@" + rt.Branch
 		}
 		sort.Strings(parts)
 		return strings.Join(parts, ",")
@@ -96,36 +50,8 @@ func TestReadSetFingerprint_InjectiveAcrossBranchSeparators(t *testing.T) {
 	require.Equal(t, oldFP(bA), oldFP(bB),
 		"sanity: the two distinct read sets DID collide under the old scheme")
 
-	require.NotEqual(t, readSetFingerprint(bA), readSetFingerprint(bB),
+	require.NotEqual(t, federate.ReadSetFingerprint(bA), federate.ReadSetFingerprint(bB),
 		"length-prefixed fingerprint must distinguish the two read sets (lenses RFC §7.3)")
-}
-
-func TestParseQualifiedPath(t *testing.T) {
-	// Bare path → not qualified.
-	id, rel, qualified, err := parseQualifiedPath("kb/a/b.md")
-	require.NoError(t, err)
-	require.False(t, qualified)
-	require.Equal(t, "", id)
-	require.Equal(t, "kb/a/b.md", rel)
-
-	// Well-formed qualified path.
-	id, rel, qualified, err = parseQualifiedPath("kb://3f9a2c1e8b7d/kb/a/b.md")
-	require.NoError(t, err)
-	require.True(t, qualified)
-	require.Equal(t, "3f9a2c1e8b7d", id)
-	require.Equal(t, "kb/a/b.md", rel)
-
-	// Malformed variants.
-	for _, p := range []string{
-		"kb://short/x.md",
-		"kb://GGGGGGGGGGGG/x.md",
-		"kb://3f9a2c1e8b7d",  // no rel
-		"kb://3f9a2c1e8b7d/", // empty rel
-	} {
-		_, _, qualified, err := parseQualifiedPath(p)
-		require.True(t, qualified, "%q is a kb:// path", p)
-		require.Error(t, err, "%q must be rejected", p)
-	}
 }
 
 func TestWriteRepoPath(t *testing.T) {
@@ -135,44 +61,33 @@ func TestWriteRepoPath(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
 	)
-	writeID := id12(repoA.ID())
-	readID := id12(repoB.ID())
+	writeID := federate.ID12(repoA.ID())
+	readID := federate.ID12(repoB.ID())
 
 	// Bare path → repo-relative, untouched.
-	rel, err := writeRepoPath(b, "kb/a/b.md")
+	rel, err := federate.WriteRepoPath(b, "kb/a/b.md")
 	require.NoError(t, err)
 	require.Equal(t, "kb/a/b.md", rel)
 
 	// Qualified to the write repo ≡ bare (RFC §6.2).
-	rel, err = writeRepoPath(b, qualifyPath(writeID, "kb/a/b.md"))
+	rel, err = federate.WriteRepoPath(b, federate.QualifyPath(writeID, "kb/a/b.md"))
 	require.NoError(t, err)
 	require.Equal(t, "kb/a/b.md", rel)
 
 	// Qualified to a read mount → read-only-mount error naming the 12-hex id.
-	_, err = writeRepoPath(b, qualifyPath(readID, "kb/a/b.md"))
+	_, err = federate.WriteRepoPath(b, federate.QualifyPath(readID, "kb/a/b.md"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "read-only mount")
 	require.Contains(t, err.Error(), readID)
 
 	// Qualified to an unmounted ID → the shared not-mounted wording.
-	_, err = writeRepoPath(b, "kb://ffffffffffff/kb/a/b.md")
+	_, err = federate.WriteRepoPath(b, "kb://ffffffffffff/kb/a/b.md")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not mounted in this binding")
 
-	// Malformed kb:// path → parseQualifiedPath's error propagates.
-	_, err = writeRepoPath(b, "kb://short/x.md")
+	// Malformed kb:// path → ParseQualifiedPath's error propagates.
+	_, err = federate.WriteRepoPath(b, "kb://short/x.md")
 	require.Error(t, err)
-}
-
-func TestTopicOfPathFilter(t *testing.T) {
-	require.Equal(t, "decisions", topicOfPathFilter("kb/decisions/lens/"))
-	require.Equal(t, "decisions", topicOfPathFilter("kb/decisions/x.md"))
-	// Prefix filter, topic segment NOT delimited → no constraint.
-	require.Equal(t, "", topicOfPathFilter("kb/decisions"))
-	require.Equal(t, "", topicOfPathFilter("kb/"))
-	require.Equal(t, "", topicOfPathFilter("kb"))
-	require.Equal(t, "", topicOfPathFilter(""))
-	require.Equal(t, "", topicOfPathFilter("other/x"))
 }
 
 // ontologyWithTopic parses a minimal one-topic ontology.
@@ -192,7 +107,7 @@ func TestReadTargetsFor(t *testing.T) {
 	)
 
 	// Unqualified filter with no topic → all read mounts, Path passed through.
-	got, err := readTargetsFor(b, "kb/")
+	got, err := federate.ReadTargetsFor(b, "kb/")
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 	require.Same(t, repoA, got[0].RT.RI)
@@ -201,25 +116,25 @@ func TestReadTargetsFor(t *testing.T) {
 	require.Equal(t, "kb/", got[1].Path)
 
 	// Qualified filter → single mount, Path rewritten repo-relative.
-	qual := qualifyPath(id12(repoB.ID()), "kb/x.md")
-	got, err = readTargetsFor(b, qual)
+	qual := federate.QualifyPath(federate.ID12(repoB.ID()), "kb/x.md")
+	got, err = federate.ReadTargetsFor(b, qual)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Same(t, repoB, got[0].RT.RI)
 	require.Equal(t, "kb/x.md", got[0].Path)
 
 	// Qualified to an unmounted ID → error containing "not mounted".
-	_, err = readTargetsFor(b, qualifyPath("aaaaaaaaaaaa", "kb/x.md"))
+	_, err = federate.ReadTargetsFor(b, federate.QualifyPath("aaaaaaaaaaaa", "kb/x.md"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not mounted")
 
 	// Topic-constrained filter skips a mount whose Ontology lacks the topic.
-	got, err = readTargetsFor(b, "kb/decisions/")
+	got, err = federate.ReadTargetsFor(b, "kb/decisions/")
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Same(t, repoA, got[0].RT.RI)
 
 	// Malformed qualified filter → error.
-	_, err = readTargetsFor(b, "kb://short/x.md")
+	_, err = federate.ReadTargetsFor(b, "kb://short/x.md")
 	require.Error(t, err)
 }

--- a/internal/mcp/instructions.go
+++ b/internal/mcp/instructions.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 )
 
@@ -43,7 +44,7 @@ func lensInstructions(b *repos.Binding) string {
 			src = "—"
 		}
 		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %s |\n",
-			rt.RI.Name(), id12(rt.RI.ID()), rt.Branch, role, src))
+			rt.RI.Name(), federate.ID12(rt.RI.ID()), rt.Branch, role, src))
 	}
 
 	// The branch column is the READ branch of each mount. Writes never go there:
@@ -64,7 +65,7 @@ func lensInstructions(b *repos.Binding) string {
 	for _, rt := range b.Reads() {
 		if rt.RI != b.Write() {
 			sb.WriteString(fmt.Sprintf("Example: a fact in %q reads as `kb://%s/%s/…`.\n\n",
-				rt.RI.Name(), id12(rt.RI.ID()), rt.RI.OntologyRoot()))
+				rt.RI.Name(), federate.ID12(rt.RI.ID()), rt.RI.OntologyRoot()))
 			break
 		}
 	}
@@ -84,7 +85,7 @@ func lensInstructions(b *repos.Binding) string {
 				topics = strings.Join(names, ", ")
 			}
 		}
-		sb.WriteString(fmt.Sprintf("- **%s** (`%s`): %s\n", rt.RI.Name(), id12(rt.RI.ID()), topics))
+		sb.WriteString(fmt.Sprintf("- **%s** (`%s`): %s\n", rt.RI.Name(), federate.ID12(rt.RI.ID()), topics))
 	}
 
 	return sb.String()

--- a/internal/mcp/instructions_test.go
+++ b/internal/mcp/instructions_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 )
 
@@ -80,7 +81,7 @@ func TestBindingInstructions_LensAppendsMountTable(t *testing.T) {
 	base := ProfileInstructions("code", writeRepo.OntologyRoot(), writeRepo.Ontology())
 
 	require.True(t, strings.HasPrefix(got, base), "lens instructions must begin with the write-repo base")
-	require.Contains(t, got, id12(readRepo.ID()), "lens instructions must carry the mount table")
+	require.Contains(t, got, federate.ID12(readRepo.ID()), "lens instructions must carry the mount table")
 	require.Contains(t, got, "Federated knowledge base (lens)", "lens addendum header must be present")
 }
 
@@ -96,8 +97,8 @@ func TestLensInstructions_BuildsMountTableAndConventions(t *testing.T) {
 		repos.ReadTarget{RI: writeRepo, Branch: "agent/test"},
 		repos.ReadTarget{RI: readRepo, Branch: "agent/test", Source: "core-src"},
 	)
-	writeID := id12(writeRepo.ID())
-	readID := id12(readRepo.ID())
+	writeID := federate.ID12(writeRepo.ID())
+	readID := federate.ID12(readRepo.ID())
 
 	out := lensInstructions(lens)
 	require.NotEmpty(t, out)
@@ -113,7 +114,7 @@ func TestLensInstructions_BuildsMountTableAndConventions(t *testing.T) {
 	// kb:// qualified-path convention text (load-bearing, verbatim).
 	require.Contains(t, out, "kb://<repo-id>/…")
 	require.Contains(t, out, "Use the qualified path verbatim as the `file` argument to `knomit_explain`")
-	// Concrete example uses a real read-mount id12.
+	// Concrete example uses a real read-mount federate.ID12.
 	require.Contains(t, out, "kb://"+readID+"/")
 
 	// Read-mount read-only rule (workflow sentence, load-bearing).

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 	"knomit/internal/store"
 	"knomit/internal/synthesize"
@@ -30,7 +31,7 @@ func localEvidenceRefs(f fact.Fact) []string {
 		if r == f.Path() {
 			continue
 		}
-		if !strings.HasPrefix(r, kbScheme) && strings.HasSuffix(r, ".md") {
+		if !strings.HasPrefix(r, federate.KBScheme) && strings.HasSuffix(r, ".md") {
 			localRefs = append(localRefs, r)
 		}
 	}

--- a/internal/mcp/lens_endtoend_test.go
+++ b/internal/mcp/lens_endtoend_test.go
@@ -16,6 +16,7 @@ import (
 
 	"knomit/internal/config"
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 	"knomit/internal/store"
 )
@@ -170,8 +171,8 @@ func TestLensE2E_InitializeEmitsMountTable(t *testing.T) {
 	require.Equalf(t, http.StatusOK, rec.Code, "middleware rejected the lens: %s", rec.Body.String())
 
 	// Mount table with BOTH repos' 12-hex ids.
-	require.Contains(t, instr, id12(repoA.ID()), "write mount id in the table")
-	require.Contains(t, instr, id12(repoB.ID()), "read mount id in the table")
+	require.Contains(t, instr, federate.ID12(repoA.ID()), "write mount id in the table")
+	require.Contains(t, instr, federate.ID12(repoB.ID()), "read mount id in the table")
 	// Read-mount workflow sentence (load-bearing).
 	require.Contains(t, instr, "Facts from read mounts are READ-ONLY through this lens")
 	// Write repo's profile addendum (default "code").
@@ -197,7 +198,7 @@ func TestLensE2E_InitializeLensOfOneHasNoMountTable(t *testing.T) {
 
 // TestLensE2E_QueryFederatesAndPages: knomit_query through the lens endpoint
 // returns rows from BOTH repos — the write repo (alpha) bare, the foreign read
-// mount (beta) kb://<id12(beta)>/-qualified — and pages to exhaustion via the
+// mount (beta) kb://<federate.ID12(beta)>/-qualified — and pages to exhaustion via the
 // cursor, every row appearing exactly once with its mount-correct qualification.
 func TestLensE2E_QueryFederatesAndPages(t *testing.T) {
 	m, _, repoB, ctxA, ctxB, lens := newLensE2E(t)
@@ -206,7 +207,7 @@ func TestLensE2E_QueryFederatesAndPages(t *testing.T) {
 	seedFedMany(t, ctxA, perMount, "Alpha", "alpha body ", "store")
 	seedFedMany(t, ctxB, perMount, "Bravo", "bravo body ", "ui")
 
-	qualPrefix := qualifyPath(id12(repoB.ID()), "")
+	qualPrefix := federate.QualifyPath(federate.ID12(repoB.ID()), "")
 
 	seen := map[string]bool{}
 	qualified, bare := 0, 0
@@ -214,7 +215,7 @@ func TestLensE2E_QueryFederatesAndPages(t *testing.T) {
 		for _, f := range facts {
 			require.Falsef(t, seen[f.File], "row %s returned twice across pages", f.File)
 			seen[f.File] = true
-			if strings.HasPrefix(f.File, kbScheme) {
+			if strings.HasPrefix(f.File, federate.KBScheme) {
 				require.Truef(t, strings.HasPrefix(f.File, qualPrefix), "beta row must be qualified to beta: %s", f.File)
 				require.Truef(t, strings.HasPrefix(f.Title, "Bravo"), "qualified row must carry beta's title: %s", f.Title)
 				qualified++
@@ -268,7 +269,7 @@ func TestLensE2E_ExplainCopyPastePath(t *testing.T) {
 	var resp queryResponse
 	require.NoError(t, json.Unmarshal([]byte(text), &resp))
 	rowB := factByTitle(t, resp, "Bravo")
-	require.Truef(t, strings.HasPrefix(rowB.File, qualifyPath(id12(repoB.ID()), "")),
+	require.Truef(t, strings.HasPrefix(rowB.File, federate.QualifyPath(federate.ID12(repoB.ID()), "")),
 		"query row for beta must be kb://-qualified: %s", rowB.File)
 
 	// Copy the path VERBATIM — no rewriting — into explain through the lens.
@@ -320,7 +321,7 @@ func TestLensE2E_LearnLandsOnWriteRepo(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(text), &learned))
 	require.Len(t, learned.Commits, 1, "learn must commit exactly one fact: %s", text)
 	writtenPath := learned.Commits[0].File
-	require.NotContains(t, writtenPath, kbScheme, "write path must be returned bare (unqualified): %s", writtenPath)
+	require.NotContains(t, writtenPath, federate.KBScheme, "write path must be returned bare (unqualified): %s", writtenPath)
 	require.True(t, strings.HasPrefix(writtenPath, "kb/principles/mission/store/"),
 		"write must land under the requested category: %s", writtenPath)
 
@@ -330,7 +331,7 @@ func TestLensE2E_LearnLandsOnWriteRepo(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(qText), &qResp))
 	row := factByTitle(t, qResp, "LensWrite")
 	require.Equal(t, writtenPath, row.File, "learned fact must appear at its bare write-repo path")
-	require.NotContains(t, row.File, kbScheme, "write-repo row must be bare")
+	require.NotContains(t, row.File, federate.KBScheme, "write-repo row must be bare")
 }
 
 // TestLensE2E_UpdateReadMountPathRejected: the write-target invariant (RFC §6.2).
@@ -348,7 +349,7 @@ func TestLensE2E_UpdateReadMountPathRejected(t *testing.T) {
 	var resp queryResponse
 	require.NoError(t, json.Unmarshal([]byte(text), &resp))
 	rowB := factByTitle(t, resp, "Bravo")
-	require.Truef(t, strings.HasPrefix(rowB.File, qualifyPath(id12(repoB.ID()), "")),
+	require.Truef(t, strings.HasPrefix(rowB.File, federate.QualifyPath(federate.ID12(repoB.ID()), "")),
 		"beta row must be kb://-qualified: %s", rowB.File)
 
 	// Update through the lens on the read-mount path → read-only mount error.
@@ -383,7 +384,7 @@ func TestLensE2E_UpdateWriteRepoBarePathSucceeds(t *testing.T) {
 	var resp queryResponse
 	require.NoError(t, json.Unmarshal([]byte(text), &resp))
 	rowA := factByTitle(t, resp, "Alpha")
-	require.NotContainsf(t, rowA.File, kbScheme, "write-repo row must be bare: %s", rowA.File)
+	require.NotContainsf(t, rowA.File, federate.KBScheme, "write-repo row must be bare: %s", rowA.File)
 
 	// Update through the lens on the bare write-repo path → succeeds.
 	result, upText := viaLens(t, m, lens, UpdateHandler(), map[string]any{
@@ -434,20 +435,20 @@ func TestLensE2E_ReposMountsMatchQualifiedIDs(t *testing.T) {
 	}
 	require.Contains(t, byName, "alpha")
 	require.Contains(t, byName, "beta")
-	require.Equal(t, id12(repoA.ID()), byName["alpha"].ID)
-	require.Equal(t, id12(repoB.ID()), byName["beta"].ID)
+	require.Equal(t, federate.ID12(repoA.ID()), byName["alpha"].ID)
+	require.Equal(t, federate.ID12(repoB.ID()), byName["beta"].ID)
 	require.Equal(t, "read+write", byName["alpha"].Role, "the write repo is read+write")
 	require.Equal(t, "read", byName["beta"].Role, "a foreign mount is read-only")
 
-	// The qualified prefix used in query rows must be id12 of the mount's ID.
+	// The qualified prefix used in query rows must be federate.ID12 of the mount's ID.
 	_, qText := viaLens(t, m, lens, QueryHandler(), map[string]any{"type": []any{"policy"}})
 	var qResp queryResponse
 	require.NoError(t, json.Unmarshal([]byte(qText), &qResp))
 	rowB := factByTitle(t, qResp, "Bravo")
-	require.True(t, strings.HasPrefix(rowB.File, kbScheme))
-	gotID := strings.TrimPrefix(rowB.File, kbScheme)
+	require.True(t, strings.HasPrefix(rowB.File, federate.KBScheme))
+	gotID := strings.TrimPrefix(rowB.File, federate.KBScheme)
 	gotID = gotID[:strings.Index(gotID, "/")]
-	require.Equal(t, id12(byName["beta"].ID), gotID,
-		"the kb://<id>/ prefix on beta's rows must equal id12 of beta's knomit_repos ID")
+	require.Equal(t, federate.ID12(byName["beta"].ID), gotID,
+		"the kb://<id>/ prefix on beta's rows must equal federate.ID12 of beta's knomit_repos ID")
 	require.Len(t, gotID, 12, "wire IDs are the 12-hex prefix")
 }

--- a/internal/mcp/lens_endtoend_test.go
+++ b/internal/mcp/lens_endtoend_test.go
@@ -411,6 +411,59 @@ func TestLensE2E_UpdateWriteRepoBarePathSucceeds(t *testing.T) {
 		"the update must be visible on re-read of the write repo's fact")
 }
 
+// TestLensE2E_UpdateReadsInvalidatesCursor proves the M-2 read-set-rebind guard
+// through the FULL control-plane path: a cursor minted over the lens's original
+// read set {alpha, beta} must die once the lens's reads are edited via
+// Manager.UpdateLens (the PATCH persistence path) so the middleware now mints a
+// binding over a different read set. The rejection is byte-identical to expiry so
+// a caller cannot probe how the lens's mounts changed (lenses RFC §7.3).
+func TestLensE2E_UpdateReadsInvalidatesCursor(t *testing.T) {
+	m, _, _, ctxA, ctxB, lens := newLensE2E(t)
+
+	// Enough facts on both mounts to force a multi-page fused result → a cursor.
+	seedFedMany(t, ctxA, 15, "Alpha", "alpha body ", "store")
+	seedFedMany(t, ctxB, 15, "Bravo", "bravo body ", "ui")
+
+	// Fingerprint BEFORE the edit — the binding the middleware currently mints.
+	before, ok, err := m.Registry().Get(lens)
+	require.NoError(t, err)
+	require.True(t, ok)
+	bBefore, err := repos.NewBindingOfLens(m, before)
+	require.NoError(t, err)
+
+	// Mint a cursor through a real lens MCP session.
+	result, text := viaLens(t, m, lens, QueryHandler(), map[string]any{"type": []any{"policy"}, "limit": 5})
+	require.Falsef(t, result.IsError, "query failed: %s", text)
+	var resp queryResponse
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+	require.NotNil(t, resp.Cursor, "multi-page federated query must return a cursor")
+	cursor := *resp.Cursor
+
+	// Edit the lens's reads via the manager path (PATCH's persistence layer):
+	// drop the foreign mount beta. The write repo (alpha) is preserved; the read
+	// set shrinks, so only the read-set fingerprint diverges.
+	_, err = m.UpdateLens(context.Background(), repos.Lens{
+		Name: lens, Write: "alpha", Reads: nil, UpdatedAt: 2,
+	})
+	require.NoError(t, err)
+
+	after, ok, err := m.Registry().Get(lens)
+	require.NoError(t, err)
+	require.True(t, ok)
+	bAfter, err := repos.NewBindingOfLens(m, after)
+	require.NoError(t, err)
+	require.Equal(t, bBefore.Name(), bAfter.Name(), "the edit must keep the same binding name")
+	require.NotEqual(t, federate.ReadSetFingerprint(bBefore), federate.ReadSetFingerprint(bAfter),
+		"dropping a read mount must change the read-set fingerprint")
+
+	// Resuming the old cursor through the edited lens is rejected byte-identically
+	// to expiry — the middleware now mints bAfter, whose fingerprint mismatches.
+	rebindResult, rebindText := viaLens(t, m, lens, QueryHandler(), map[string]any{"cursor": cursor})
+	require.Truef(t, rebindResult.IsError, "resuming after a read-set edit must be rejected: %s", rebindText)
+	require.Contains(t, rebindText, "session expired or not found — omit cursor to start a new query",
+		"the rejection must be byte-identical to the expiry error (RFC §7.3)")
+}
+
 // TestLensE2E_ReposMountsMatchQualifiedIDs: knomit_repos through the lens lists
 // every mount, and each mount's ID is exactly the 12-hex prefix that
 // qualifies that mount's rows in a federated query — the discovery contract

--- a/internal/mcp/query.go
+++ b/internal/mcp/query.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 	"knomit/internal/store"
 	"strings"
@@ -229,7 +230,7 @@ func mountLabel(rt repos.ReadTarget) string {
 // shared resume path so body hydration and pagination match relevance mode.
 func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcpgo.CallToolRequest, pageSize, maxResults int, includeBody bool) (*mcpgo.CallToolResult, error) {
 	q := parseQueryFilters(req)
-	targets, err := readTargetsFor(b, q.Path)
+	targets, err := federate.ReadTargetsFor(b, q.Path)
 	if err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
@@ -242,7 +243,7 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 	var wg sync.WaitGroup
 	for i, t := range targets {
 		wg.Add(1)
-		go func(i int, t fanTarget) {
+		go func(i int, t federate.Target) {
 			defer wg.Done()
 			// A panic here (e.g. nil-svc mount) must become this mount's error, not
 			// crash the process — net/http recovers only the request goroutine.
@@ -268,18 +269,18 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 	// directly comparable across mounts (a k-way timestamp merge is correct), but
 	// per-mount relevance ranks are NOT comparable across mounts (RFC §7.1) —
 	// they must be fused by reciprocal rank fusion, exactly as the relevance
-	// path does. fuseRRF's N=1 identity also restores lens-of-one byte-identity,
+	// path does. federate.FuseRRF's N=1 identity also restores lens-of-one byte-identity,
 	// which a global timestamp re-sort would silently break. So: text query →
 	// RRF; text-less recency → committed_at merge.
-	var order []mountRef
+	var order []federate.MountRef
 	if q.Text != "" {
-		order = fuseRRF(listLens(lists))
+		order = federate.FuseRRF(listLens(lists))
 		if len(order) > maxResults {
 			order = order[:maxResults]
 		}
 	} else {
 		// Text-less recency: each mount's list is already committed_at-DESC
-		// (RecentFacts), the precondition mergeRecent relies on.
+		// (RecentFacts), the precondition federate.MergeRecent relies on.
 		stamps := make([][]int64, len(targets))
 		for i, list := range lists {
 			stamps[i] = make([]int64, len(list))
@@ -287,7 +288,7 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 				stamps[i][j] = e.CommittedAt
 			}
 		}
-		order = mergeRecent(stamps, maxResults)
+		order = federate.MergeRecent(stamps, maxResults)
 	}
 	if len(order) == 0 {
 		return marshalQueryResponse(queryResponse{Facts: []factOutput{}, Cursor: nil, HasMore: false})
@@ -297,7 +298,7 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 	// through the shared resume path, so body hydration + paging match relevance
 	// mode. Each row's WIRE path (bare for the write mount, kb://-qualified for a
 	// foreign mount — RFC §6.2 uniformity) carries the mount identity on resume.
-	sess, err := sWrite.toolSession.CreateToolSession(ctx, "query", b.WriteMountBranch(), "", b.Name(), readSetFingerprint(b))
+	sess, err := sWrite.toolSession.CreateToolSession(ctx, "query", b.WriteMountBranch(), "", b.Name(), federate.ReadSetFingerprint(b))
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("session error: %v", err)), nil
 	}
@@ -367,7 +368,7 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 	if !hasAnyFilter(q) {
 		return mcpgo.NewToolResultError("at least one of text, entities, domain, applies_to, path, type, origin, or min_confidence is required"), nil
 	}
-	targets, err := readTargetsFor(b, q.Path)
+	targets, err := federate.ReadTargetsFor(b, q.Path)
 	if err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
@@ -380,7 +381,7 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 	var wg sync.WaitGroup
 	for i, t := range targets {
 		wg.Add(1)
-		go func(i int, t fanTarget) {
+		go func(i int, t federate.Target) {
 			defer wg.Done()
 			// A panic here (e.g. nil-svc mount) must become this mount's error, not
 			// crash the process — net/http recovers only the request goroutine.
@@ -398,7 +399,7 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 		}
 	}
 
-	order := fuseRRF(listLens(lists))
+	order := federate.FuseRRF(listLens(lists))
 	if len(order) > maxResults {
 		order = order[:maxResults]
 	}
@@ -412,7 +413,7 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 	// may be non-monotonic; that is the faithful representation of per-repo
 	// relevance. File is the wire path: bare for the write repo, kb://-qualified
 	// for a foreign mount (RFC §6.2 uniformity).
-	renderRow := func(ref mountRef) factOutput {
+	renderRow := func(ref federate.MountRef) factOutput {
 		r := lists[ref.Mount][ref.Rank]
 		out := buildFactOutput(r, includeBody)
 		out.File = wirePath(b, targets[ref.Mount].RT, r.Path)
@@ -432,7 +433,7 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 
 	// Snapshot the remainder ([pageSize:]) into the write repo's session DB; the
 	// first page is rendered directly (full bodies available, no re-fetch).
-	sess, err := sWrite.toolSession.CreateToolSession(ctx, "query", b.WriteMountBranch(), "", b.Name(), readSetFingerprint(b))
+	sess, err := sWrite.toolSession.CreateToolSession(ctx, "query", b.WriteMountBranch(), "", b.Name(), federate.ReadSetFingerprint(b))
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("session error: %v", err)), nil
 	}
@@ -466,7 +467,7 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 	return marshalQueryResponse(queryResponse{Facts: page, Cursor: &cursor, HasMore: true})
 }
 
-// listLens returns each list's length, the shape fuseRRF consumes.
+// listLens returns each list's length, the shape federate.FuseRRF consumes.
 func listLens[T any](lists [][]T) []int {
 	ns := make([]int, len(lists))
 	for i, l := range lists {
@@ -481,7 +482,7 @@ func wirePath(b *repos.Binding, rt repos.ReadTarget, rel string) string {
 	if rt.RI == b.Write() {
 		return rel
 	}
-	return qualifyPath(id12(rt.RI.ID()), rel)
+	return federate.QualifyPath(federate.ID12(rt.RI.ID()), rel)
 }
 
 // queryResume serves the next page from a frozen session snapshot, routing each
@@ -511,7 +512,7 @@ func queryResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, cursor 
 	// indistinguishable from expiry BY DESIGN (lenses RFC §7.3): a caller must not
 	// be able to tell a re-pinned read set — or a branch change — from an expired
 	// cursor, or it could probe how a shared name's read mounts changed.
-	if sess.ReadSet != readSetFingerprint(b) {
+	if sess.ReadSet != federate.ReadSetFingerprint(b) {
 		return mcpgo.NewToolResultError("session expired or not found — omit cursor to start a new query"), nil
 	}
 
@@ -538,7 +539,7 @@ func queryResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, cursor 
 			if err := json.Unmarshal([]byte(it.State), &st); err != nil {
 				return mcpgo.NewToolResultError(fmt.Sprintf("page decode error: %v", err)), nil
 			}
-			id, rel, qualified, perr := parseQualifiedPath(it.Path)
+			id, rel, qualified, perr := federate.ParseQualifiedPath(it.Path)
 			if perr != nil {
 				return mcpgo.NewToolResultError(fmt.Sprintf("page decode error: %v", perr)), nil
 			}

--- a/internal/mcp/query_federation_test.go
+++ b/internal/mcp/query_federation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 	"knomit/internal/retrieval"
 	"knomit/internal/store"
@@ -143,9 +144,9 @@ func TestQueryFederation_QualifiedPaths(t *testing.T) {
 
 	// A is the write repo → bare path, no scheme.
 	require.Equal(t, pathA, rowA.File)
-	require.NotContains(t, rowA.File, kbScheme)
-	// B is a foreign read mount → kb://<id12(B)>/<path>.
-	require.Equal(t, qualifyPath(id12(repoB.ID()), pathB), rowB.File)
+	require.NotContains(t, rowA.File, federate.KBScheme)
+	// B is a foreign read mount → kb://<federate.ID12(B)>/<path>.
+	require.Equal(t, federate.QualifyPath(federate.ID12(repoB.ID()), pathB), rowB.File)
 
 	// Refs are returned exactly as stored — never rewritten to qualified form.
 	require.Equal(t, []string{"kb/decisions/a/ref.md"}, rowA.Frontmatter.Refs)
@@ -156,7 +157,7 @@ func TestQueryFederation_QualifiedPaths(t *testing.T) {
 // write mount (A) matches zero facts while a foreign read mount (B) returns
 // rows. The query must succeed, return only B's rows (each kb://-qualified to
 // B), and not error — an empty write list must neither shrink the fused set to
-// nothing nor fail the call. fuseRRF's empty-list handling is unit-tested; this
+// nothing nor fail the call. federate.FuseRRF's empty-list handling is unit-tested; this
 // pins the same behavior through the live goroutine fan-out.
 func TestQueryFederation_EmptyWriteMount(t *testing.T) {
 	repoA, _ := fedRepo(t)
@@ -174,7 +175,7 @@ func TestQueryFederation_EmptyWriteMount(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(text), &resp))
 	require.Lenf(t, resp.Facts, 1, "only the non-empty mount's rows may appear: %s", text)
 	require.Equal(t, "Bravo", resp.Facts[0].Title)
-	require.Equal(t, qualifyPath(id12(repoB.ID()), pathB), resp.Facts[0].File,
+	require.Equal(t, federate.QualifyPath(federate.ID12(repoB.ID()), pathB), resp.Facts[0].File,
 		"the B row must be kb://-qualified to repo B")
 }
 
@@ -199,7 +200,7 @@ func TestQueryFederation_EmptyReadMount(t *testing.T) {
 	require.Lenf(t, resp.Facts, 1, "only the non-empty mount's rows may appear: %s", text)
 	require.Equal(t, "Alpha", resp.Facts[0].Title)
 	require.Equal(t, pathA, resp.Facts[0].File)
-	require.NotContains(t, resp.Facts[0].File, kbScheme, "the A (write mount) row must be bare")
+	require.NotContains(t, resp.Facts[0].File, federate.KBScheme, "the A (write mount) row must be bare")
 }
 
 // TestQueryFederation_LensOfOneUnchanged: a lens-of-one produces byte-for-byte
@@ -221,7 +222,7 @@ func TestQueryFederation_LensOfOneUnchanged(t *testing.T) {
 	_, lensText := queryVia(t, b, map[string]any{"type": []any{"policy"}})
 
 	require.Equal(t, directText, lensText, "lens-of-one must be byte-for-byte identical to a direct query")
-	require.NotContains(t, lensText, kbScheme, "lens-of-one output must never be kb://-qualified")
+	require.NotContains(t, lensText, federate.KBScheme, "lens-of-one output must never be kb://-qualified")
 }
 
 // TestQueryFederation_QualifiedPathFilterRestrictsMount: a kb://-qualified path
@@ -237,7 +238,7 @@ func TestQueryFederation_QualifiedPathFilterRestrictsMount(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
 	)
-	filter := qualifyPath(id12(repoB.ID()), "kb/")
+	filter := federate.QualifyPath(federate.ID12(repoB.ID()), "kb/")
 	result, text := queryVia(t, b, map[string]any{"path": filter})
 	require.Falsef(t, result.IsError, "query failed: %s", text)
 
@@ -245,11 +246,11 @@ func TestQueryFederation_QualifiedPathFilterRestrictsMount(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(text), &resp))
 	require.NotEmpty(t, resp.Facts, "the qualified mount's facts must be returned")
 	for _, f := range resp.Facts {
-		require.Truef(t, strings.HasPrefix(f.File, qualifyPath(id12(repoB.ID()), "")),
+		require.Truef(t, strings.HasPrefix(f.File, federate.QualifyPath(federate.ID12(repoB.ID()), "")),
 			"every row must be qualified to repo B: %s", f.File)
 		require.Equal(t, "Bravo", f.Title, "only B's facts may appear")
 	}
-	require.Equal(t, qualifyPath(id12(repoB.ID()), pathB), resp.Facts[0].File)
+	require.Equal(t, federate.QualifyPath(federate.ID12(repoB.ID()), pathB), resp.Facts[0].File)
 }
 
 // TestQueryFederation_UnmountedPathFilterErrors: a qualified filter naming a repo
@@ -261,7 +262,7 @@ func TestQueryFederation_UnmountedPathFilterErrors(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
 	)
-	result, text := queryVia(t, b, map[string]any{"path": qualifyPath("aaaaaaaaaaaa", "kb/")})
+	result, text := queryVia(t, b, map[string]any{"path": federate.QualifyPath("aaaaaaaaaaaa", "kb/")})
 	require.True(t, result.IsError, "unmounted qualified filter must error")
 	require.Contains(t, text, "not mounted")
 }
@@ -281,7 +282,7 @@ func TestQueryFederation_PagesAcrossMounts(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
 	)
-	qualPrefix := qualifyPath(id12(repoB.ID()), "")
+	qualPrefix := federate.QualifyPath(federate.ID12(repoB.ID()), "")
 
 	seen := map[string]bool{}
 	qualified, bare := 0, 0
@@ -290,7 +291,7 @@ func TestQueryFederation_PagesAcrossMounts(t *testing.T) {
 			require.Falsef(t, seen[f.File], "row %s returned twice across pages", f.File)
 			seen[f.File] = true
 			require.Greater(t, f.Score, 0.0, "score must be present on every page (incl. resumed)")
-			if strings.HasPrefix(f.File, kbScheme) {
+			if strings.HasPrefix(f.File, federate.KBScheme) {
 				require.Truef(t, strings.HasPrefix(f.File, qualPrefix), "B row must be qualified to repo B: %s", f.File)
 				require.Truef(t, strings.HasPrefix(f.Title, "Bravo"), "qualified row must carry B's own title: %s", f.Title)
 				qualified++
@@ -346,7 +347,7 @@ func TestQueryFederation_ResumeHydratesFromCorrectMount(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
 	)
-	qualPrefix := qualifyPath(id12(repoB.ID()), "")
+	qualPrefix := federate.QualifyPath(federate.ID12(repoB.ID()), "")
 
 	result, text := queryVia(t, b, map[string]any{"type": []any{"policy"}, "include_body": true})
 	require.Falsef(t, result.IsError, "query failed: %s", text)
@@ -441,7 +442,7 @@ func TestQueryFederation_RecentMergesByTimestamp(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
 	)
-	qualPrefix := qualifyPath(id12(repoB.ID()), "")
+	qualPrefix := federate.QualifyPath(federate.ID12(repoB.ID()), "")
 	want := []string{"Bravo 1", "Alpha 1", "Bravo 0", "Alpha 0"}
 
 	var gotTitles []string
@@ -449,7 +450,7 @@ func TestQueryFederation_RecentMergesByTimestamp(t *testing.T) {
 		if strings.HasPrefix(f.Title, "Bravo") {
 			require.Truef(t, strings.HasPrefix(f.File, qualPrefix), "B row must be kb://-qualified: %s", f.File)
 		} else {
-			require.NotContainsf(t, f.File, kbScheme, "A row must be bare: %s", f.File)
+			require.NotContainsf(t, f.File, federate.KBScheme, "A row must be bare: %s", f.File)
 		}
 		gotTitles = append(gotTitles, f.Title)
 	}
@@ -641,5 +642,5 @@ func TestQueryFederation_RecentWithTextPreservesRelevanceOrder(t *testing.T) {
 		"older-but-stronger match must come first — relevance order, not recency")
 	require.Equal(t, "weak-target beta", resp.Facts[1].Title,
 		"newer weak match must come last despite its later commit")
-	require.NotContains(t, resp.Facts[0].File, kbScheme, "lens-of-one rows must be bare (never kb://-qualified)")
+	require.NotContains(t, resp.Facts[0].File, federate.KBScheme, "lens-of-one rows must be bare (never kb://-qualified)")
 }

--- a/internal/mcp/query_maxresults_test.go
+++ b/internal/mcp/query_maxresults_test.go
@@ -53,9 +53,9 @@ func TestQuery_MaxResults_CapsSnapshotDepth(t *testing.T) {
 // TestQuery_MaxResults_RecentLensOfOnePagesAndOrders exercises the recency
 // handler end-to-end for a lens-of-one: sort=recent + max_results + cursor
 // paging, asserting committed_at exposure and DESC ordering across pages. NOTE
-// this does NOT pin mergeRecent's cross-mount cap — with a single mount the
+// this does NOT pin federate.MergeRecent's cross-mount cap — with a single mount the
 // per-mount SQL LIMIT (q.Limit = maxResults, search_query.go) already bounds the
-// snapshot to max_results, so mergeRecent trims nothing. The mergeRecent cap is
+// snapshot to max_results, so federate.MergeRecent trims nothing. The federate.MergeRecent cap is
 // pinned separately by TestQuery_MaxResults_RecentCapsAcrossMounts below, where
 // each mount stays under max_results but the union exceeds it.
 func TestQuery_MaxResults_RecentLensOfOnePagesAndOrders(t *testing.T) {
@@ -96,17 +96,17 @@ func TestQuery_MaxResults_RecentLensOfOnePagesAndOrders(t *testing.T) {
 	}
 }
 
-// TestQuery_MaxResults_RecentCapsAcrossMounts pins mergeRecent's cross-mount cap
+// TestQuery_MaxResults_RecentCapsAcrossMounts pins federate.MergeRecent's cross-mount cap
 // (federate.go: `if len(out) > max { out = out[:max] }`), which no handler-level
 // test exercised. The trap the reviewer found: with a single mount the per-mount
-// SQL LIMIT already bounds the snapshot, so mergeRecent's cap is dead weight and
+// SQL LIMIT already bounds the snapshot, so federate.MergeRecent's cap is dead weight and
 // removing it changes nothing. This test defeats that by using a genuine
 // two-mount lens where each mount holds FEWER facts than max_results (so the
 // per-mount SQL LIMIT never trims) but the UNION exceeds it — only the
 // cross-mount cap can bound the result. Seed 2 mounts x 2 recency facts,
-// sort=recent (no text → the mergeRecent path, not RRF), max_results=3, page to
+// sort=recent (no text → the federate.MergeRecent path, not RRF), max_results=3, page to
 // exhaustion: the fused union must hold exactly 3 rows, committed_at-DESC. A
-// regression dropping the mergeRecent cap returns all 4 and fails here.
+// regression dropping the federate.MergeRecent cap returns all 4 and fails here.
 func TestQuery_MaxResults_RecentCapsAcrossMounts(t *testing.T) {
 	repoA, ctxA := fedRepo(t)
 	repoB, ctxB := fedRepo(t)
@@ -143,7 +143,7 @@ func TestQuery_MaxResults_RecentCapsAcrossMounts(t *testing.T) {
 	}
 
 	require.Len(t, rows, maxResults,
-		"sort=recent over a multi-mount lens must cap the fused union at max_results via mergeRecent")
+		"sort=recent over a multi-mount lens must cap the fused union at max_results via federate.MergeRecent")
 	for i := 1; i < len(rows); i++ {
 		require.GreaterOrEqualf(t, rows[i-1].Frontmatter.CommittedAt, rows[i].Frontmatter.CommittedAt,
 			"fused recent rows must be committed_at-DESC across pages: row %d (%d) precedes row %d (%d)",

--- a/internal/mcp/query_readset_test.go
+++ b/internal/mcp/query_readset_test.go
@@ -8,6 +8,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 	"knomit/internal/store"
 )
@@ -48,7 +49,7 @@ func TestQueryResume_RejectsReadSetRebind(t *testing.T) {
 	)
 	require.Equal(t, b1.Name(), b2.Name(), "the rebind must keep the same binding name")
 	require.Equal(t, b1.WriteMountBranch(), b2.WriteMountBranch(), "and the same write-mount branch")
-	require.NotEqual(t, readSetFingerprint(b1), readSetFingerprint(b2), "only the read set changed")
+	require.NotEqual(t, federate.ReadSetFingerprint(b1), federate.ReadSetFingerprint(b2), "only the read set changed")
 
 	rebindResult, rebindText := queryVia(t, b2, map[string]any{"cursor": cursor})
 	require.True(t, rebindResult.IsError, "resuming against a re-pinned read set must be rejected")
@@ -62,7 +63,7 @@ func TestQueryResume_RejectsReadSetRebind(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
 	)
-	require.Equal(t, readSetFingerprint(b1), readSetFingerprint(b1again), "an identical rebuild has an identical fingerprint")
+	require.Equal(t, federate.ReadSetFingerprint(b1), federate.ReadSetFingerprint(b1again), "an identical rebuild has an identical fingerprint")
 	okResult, okText := queryVia(t, b1again, map[string]any{"cursor": cursor})
 	require.Falsef(t, okResult.IsError, "resuming an identical rebuilt binding must succeed: %s", okText)
 	var okResp queryResponse
@@ -105,7 +106,7 @@ func TestExplainResume_RejectsReadSetRebind(t *testing.T) {
 		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
 		repos.ReadTarget{RI: repoB, Branch: "main"},
 	)
-	require.NotEqual(t, readSetFingerprint(b1), readSetFingerprint(b2))
+	require.NotEqual(t, federate.ReadSetFingerprint(b1), federate.ReadSetFingerprint(b2))
 	ctx2 := repos.WithBinding(context.Background(), b2)
 	var mreq mcpgo.CallToolRequest
 	mreq.Params.Arguments = map[string]any{"file": rootPath, "cursor": *resp.Cursor}
@@ -151,7 +152,7 @@ func TestQueryResume_RetriesPastUnreadableWindow(t *testing.T) {
 	var sessID string
 	repoA.WithRead(func(svc *store.Service) {
 		ts := svc.ToolSession()
-		sess, cerr := ts.CreateToolSession(context.Background(), "query", b.WriteMountBranch(), "", b.Name(), readSetFingerprint(b))
+		sess, cerr := ts.CreateToolSession(context.Background(), "query", b.WriteMountBranch(), "", b.Name(), federate.ReadSetFingerprint(b))
 		require.NoError(t, cerr)
 		sessID = sess.ID
 		require.NoError(t, ts.EnqueuePaths(context.Background(), sess.ID, []store.QueueItem{

--- a/internal/mcp/refs_as_given_test.go
+++ b/internal/mcp/refs_as_given_test.go
@@ -8,6 +8,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 )
 
@@ -95,7 +96,7 @@ func TestLearn_KbRefsStoredAsGiven(t *testing.T) {
 
 	// The kb:// ref names B's REAL mounted id — exactly what an agent copies out
 	// of a federated query result. The src:// ref is a non-.md external ref.
-	kbRef := qualifyPath(id12(repoB.ID()), "kb/x/y/z.md") // kb://<id12(B)>/kb/x/y/z.md
+	kbRef := federate.QualifyPath(federate.ID12(repoB.ID()), "kb/x/y/z.md") // kb://<federate.ID12(B)>/kb/x/y/z.md
 	srcRef := "src://other/path@abc123"
 	given := []string{kbRef, srcRef}
 
@@ -150,7 +151,7 @@ func TestUpdate_KbRefsReplacedVerbatim(t *testing.T) {
 	// Start with an unrelated external ref, then replace wholesale.
 	path := learnFactVia(t, b, "seed-upd", "mission/store", "UpdHolder", []string{"src://old/ref@000000"})
 
-	newKbRef := qualifyPath(id12(repoB.ID()), "kb/a/b/c.md")
+	newKbRef := federate.QualifyPath(federate.ID12(repoB.ID()), "kb/a/b/c.md")
 	newSrcRef := "src://new/ref@def456"
 	replacement := []string{newKbRef, newSrcRef}
 	updateRefsVia(t, b, path, "swap-refs", replacement)

--- a/internal/mcp/repos.go
+++ b/internal/mcp/repos.go
@@ -6,6 +6,7 @@ import (
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 )
 
@@ -51,7 +52,7 @@ func ReposHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToo
 			}
 			resp.Mounts = append(resp.Mounts, reposMount{
 				Name:        rt.RI.Name(),
-				ID:          id12(rt.RI.ID()),
+				ID:          federate.ID12(rt.RI.ID()),
 				Branch:      rt.Branch,
 				Role:        role,
 				Source:      rt.Source,

--- a/internal/mcp/repos_test.go
+++ b/internal/mcp/repos_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 )
 
@@ -40,10 +41,10 @@ func TestReposHandler_ListsMounts(t *testing.T) {
 	require.Equal(t, "read+write", resp.Mounts[0].Role)
 	require.Equal(t, "agent/test", resp.Mounts[0].WriteBranch,
 		"the read+write row surfaces the write target (agent branch)")
-	// The mount id is the 12-hex wire form (id12), matching kb://<id>/… paths
+	// The mount id is the 12-hex wire form (federate.ID12), matching kb://<id>/… paths
 	// and the AfterInitialize instructions mount table — not the full hash (M-3).
 	require.Len(t, resp.Mounts[0].ID, 12)
-	require.Equal(t, id12(ri.ID()), resp.Mounts[0].ID)
+	require.Equal(t, federate.ID12(ri.ID()), resp.Mounts[0].ID)
 }
 
 // TestReposHandler_ReadOnlyView pins the discovery contract for a read-only
@@ -112,14 +113,14 @@ func TestReposHandler_WriteBranchSurfacesAgentTarget(t *testing.T) {
 		byID[m.ID] = m
 	}
 
-	w := byID[id12(writeRepo.ID())]
+	w := byID[federate.ID12(writeRepo.ID())]
 	require.Equal(t, "read+write", w.Role)
 	require.Equal(t, "main", w.Branch, "branch column shows the pinned READ branch")
 	require.Equal(t, writeRepo.AgentBranch(), w.WriteBranch,
 		"write_branch shows the agent branch writes actually target, not the read branch")
 	require.NotEqual(t, w.Branch, w.WriteBranch, "the misleading case: read branch != write target")
 
-	r := byID[id12(readRepo.ID())]
+	r := byID[federate.ID12(readRepo.ID())]
 	require.Equal(t, "read", r.Role)
 	require.Empty(t, r.WriteBranch, "read mounts carry no write_branch")
 }

--- a/internal/mcp/retract.go
+++ b/internal/mcp/retract.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -49,7 +50,7 @@ func RetractHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallT
 		if file == "" {
 			return mcpgo.NewToolResultError("file is required"), nil
 		}
-		file, err := writeRepoPath(b, file)
+		file, err := federate.WriteRepoPath(b, file)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/update.go
+++ b/internal/mcp/update.go
@@ -10,6 +10,7 @@ import (
 
 	"knomit/internal/fact"
 	factpkg "knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -81,7 +82,7 @@ func UpdateHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 		if file == "" {
 			return mcpgo.NewToolResultError("file is required"), nil
 		}
-		file, err := writeRepoPath(b, file)
+		file, err := federate.WriteRepoPath(b, file)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/write_path_test.go
+++ b/internal/mcp/write_path_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/fact"
+	"knomit/internal/federate"
 	"knomit/internal/repos"
 )
 
@@ -78,7 +79,7 @@ func factExistsAt(t *testing.T, ri *repos.RepoInstance, path string) bool {
 func TestUpdate_QualifiedToWriteRepoEquivalentToBare(t *testing.T) {
 	b, repoA, _, pathA, _ := twoRepoWriteBinding(t)
 
-	qualified := qualifyPath(id12(repoA.ID()), pathA)
+	qualified := federate.QualifyPath(federate.ID12(repoA.ID()), pathA)
 	result, text := updateVia(t, b, map[string]any{
 		"file":        qualified,
 		"moment_name": "bump",
@@ -97,7 +98,7 @@ func TestUpdate_QualifiedToWriteRepoEquivalentToBare(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(text), &resp))
 	require.Equal(t, pathA, resp.File)
-	require.NotContains(t, resp.File, kbScheme)
+	require.NotContains(t, resp.File, federate.KBScheme)
 	require.NotEmpty(t, resp.Commit)
 }
 
@@ -107,7 +108,7 @@ func TestUpdate_QualifiedToReadMountIsReadOnlyError(t *testing.T) {
 	b, _, repoB, _, pathB := twoRepoWriteBinding(t)
 
 	before := readFactAt(t, repoB, pathB)
-	qualified := qualifyPath(id12(repoB.ID()), pathB)
+	qualified := federate.QualifyPath(federate.ID12(repoB.ID()), pathB)
 	result, text := updateVia(t, b, map[string]any{
 		"file":        qualified,
 		"moment_name": "bump",
@@ -115,7 +116,7 @@ func TestUpdate_QualifiedToReadMountIsReadOnlyError(t *testing.T) {
 	})
 	require.True(t, result.IsError, "update to a read mount must be rejected")
 	require.Contains(t, text, "read-only mount")
-	require.Contains(t, text, id12(repoB.ID()))
+	require.Contains(t, text, federate.ID12(repoB.ID()))
 
 	// B's fact is untouched — re-read to prove.
 	require.Equal(t, before.Confidence, readFactAt(t, repoB, pathB).Confidence,
@@ -128,7 +129,7 @@ func TestUpdate_UnmountedIDErrors(t *testing.T) {
 	b, _, _, _, _ := twoRepoWriteBinding(t)
 
 	result, text := updateVia(t, b, map[string]any{
-		"file":        qualifyPath("ffffffffffff", "kb/x.md"),
+		"file":        federate.QualifyPath("ffffffffffff", "kb/x.md"),
 		"moment_name": "bump",
 		"updates":     map[string]any{"confidence": 0.11},
 	})
@@ -143,7 +144,7 @@ func TestRetract_QualifiedToWriteRepoEquivalentToBare(t *testing.T) {
 	b, repoA, _, pathA, _ := twoRepoWriteBinding(t)
 	require.True(t, factExistsAt(t, repoA, pathA), "precondition: fact exists")
 
-	qualified := qualifyPath(id12(repoA.ID()), pathA)
+	qualified := federate.QualifyPath(federate.ID12(repoA.ID()), pathA)
 	result, text := retractVia(t, b, map[string]any{
 		"file":        qualified,
 		"moment_name": "drop",
@@ -159,7 +160,7 @@ func TestRetract_QualifiedToWriteRepoEquivalentToBare(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(text), &resp))
 	require.Equal(t, pathA, resp.File)
-	require.NotContains(t, resp.File, kbScheme)
+	require.NotContains(t, resp.File, federate.KBScheme)
 	require.NotEmpty(t, resp.Commit)
 }
 
@@ -168,14 +169,14 @@ func TestRetract_QualifiedToWriteRepoEquivalentToBare(t *testing.T) {
 func TestRetract_QualifiedToReadMountIsReadOnlyError(t *testing.T) {
 	b, _, repoB, _, pathB := twoRepoWriteBinding(t)
 
-	qualified := qualifyPath(id12(repoB.ID()), pathB)
+	qualified := federate.QualifyPath(federate.ID12(repoB.ID()), pathB)
 	result, text := retractVia(t, b, map[string]any{
 		"file":        qualified,
 		"moment_name": "drop",
 	})
 	require.True(t, result.IsError, "retract to a read mount must be rejected")
 	require.Contains(t, text, "read-only mount")
-	require.Contains(t, text, id12(repoB.ID()))
+	require.Contains(t, text, federate.ID12(repoB.ID()))
 
 	require.True(t, factExistsAt(t, repoB, pathB),
 		"a rejected retract must not delete the read mount's fact")
@@ -187,7 +188,7 @@ func TestRetract_UnmountedIDErrors(t *testing.T) {
 	b, _, _, _, _ := twoRepoWriteBinding(t)
 
 	result, text := retractVia(t, b, map[string]any{
-		"file":        qualifyPath("ffffffffffff", "kb/x.md"),
+		"file":        federate.QualifyPath("ffffffffffff", "kb/x.md"),
 		"moment_name": "drop",
 	})
 	require.True(t, result.IsError, "retract to an unmounted ID must be rejected")

--- a/internal/repos/lens.go
+++ b/internal/repos/lens.go
@@ -27,6 +27,10 @@ var (
 	ErrLensNameEmpty = errors.New("lens name required")
 	// ErrLensWriteEmpty is returned by Create when the write repo is empty.
 	ErrLensWriteEmpty = errors.New("lens write repo required")
+	// ErrLensNotFound is returned by Update when the lens name does not exist.
+	// Delete stays idempotent (no such error); Update needs a not-found signal
+	// because it mutates a row that must already be there.
+	ErrLensNotFound = errors.New("lens not found")
 	// ErrLensDescriptionTooLong is returned when a lens description exceeds
 	// MaxLensDescriptionBytes. Description is display-only metadata, so the cap
 	// is a pure input check independent of the live repo set.
@@ -219,6 +223,63 @@ func (r *LensRegistry) Create(l Lens) (Lens, error) {
 	}
 	if err := tx.Commit(); err != nil {
 		return Lens{}, fmt.Errorf("create lens: %w", err)
+	}
+	return l, nil
+}
+
+// Update replaces an existing lens's write repo, description, and read mounts in
+// a single transaction, returning the normalized form persisted. created_at is
+// immutable — only write_repo, description, and updated_at are rewritten. The
+// caller stamps UpdatedAt (the registry never reads the clock). An unknown name
+// returns ErrLensNotFound; the whole update is atomic (reads are delete+reinsert
+// inside the same tx, so a mid-update failure leaves the old mounts intact).
+func (r *LensRegistry) Update(l Lens) (Lens, error) {
+	if l.Name == "" {
+		return Lens{}, ErrLensNameEmpty
+	}
+	if l.Write == "" {
+		return Lens{}, ErrLensWriteEmpty
+	}
+	l = l.normalize()
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return Lens{}, fmt.Errorf("update lens: %w", err)
+	}
+	defer tx.Rollback()
+
+	res, err := tx.Exec(
+		`UPDATE lenses SET write_repo = ?, description = ?, updated_at = ? WHERE name = ?`,
+		l.Write, l.Description, l.UpdatedAt, l.Name,
+	)
+	if err != nil {
+		return Lens{}, fmt.Errorf("update lens: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return Lens{}, fmt.Errorf("update lens: %w", err)
+	}
+	if n == 0 {
+		return Lens{}, fmt.Errorf("%w: %q", ErrLensNotFound, l.Name)
+	}
+	// Wholesale replace the read mounts: drop all rows, reinsert the new set.
+	if _, err := tx.Exec(`DELETE FROM lens_reads WHERE lens_name = ?`, l.Name); err != nil {
+		return Lens{}, fmt.Errorf("update lens reads: %w", err)
+	}
+	for _, lr := range l.Reads {
+		var source any
+		if lr.Source != "" {
+			source = lr.Source
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO lens_reads (lens_name, repo, branch, source) VALUES (?, ?, ?, ?)`,
+			l.Name, lr.Repo, lr.Branch, source,
+		); err != nil {
+			return Lens{}, fmt.Errorf("update lens reads: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return Lens{}, fmt.Errorf("update lens: %w", err)
 	}
 	return l, nil
 }

--- a/internal/repos/lens.go
+++ b/internal/repos/lens.go
@@ -27,9 +27,17 @@ var (
 	ErrLensNameEmpty = errors.New("lens name required")
 	// ErrLensWriteEmpty is returned by Create when the write repo is empty.
 	ErrLensWriteEmpty = errors.New("lens write repo required")
+	// ErrLensDescriptionTooLong is returned when a lens description exceeds
+	// MaxLensDescriptionBytes. Description is display-only metadata, so the cap
+	// is a pure input check independent of the live repo set.
+	ErrLensDescriptionTooLong = errors.New("lens description too long")
 	// ErrRepoInUseByLens blocks Archive/Purge of a lens-referenced repo.
 	ErrRepoInUseByLens = errors.New("repo is referenced by a lens; delete the lens first")
 )
+
+// MaxLensDescriptionBytes caps a lens description (free markdown text, rendered
+// client-side). Byte length, not rune count: it bounds stored + wire size.
+const MaxLensDescriptionBytes = 4096
 
 // LensRead is one read mount of a lens.
 type LensRead struct {
@@ -42,11 +50,12 @@ type LensRead struct {
 // target the write repo's own agent branch (RFC decision 19), so there is no
 // write-branch field. Reads always include the write repo after normalize.
 type Lens struct {
-	Name      string
-	Write     string
-	Reads     []LensRead
-	CreatedAt int64
-	UpdatedAt int64
+	Name        string
+	Write       string
+	Description string // free markdown text, display-only; ignored by normalize
+	Reads       []LensRead
+	CreatedAt   int64
+	UpdatedAt   int64
 }
 
 // normalize returns a copy whose Reads are deduped by Repo (first occurrence
@@ -72,10 +81,11 @@ func (l Lens) normalize() Lens {
 
 const lensSchema = `
 CREATE TABLE IF NOT EXISTS lenses (
-    name       TEXT PRIMARY KEY,
-    write_repo TEXT NOT NULL,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
+    name        TEXT PRIMARY KEY,
+    write_repo  TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS lens_reads (
     lens_name TEXT NOT NULL REFERENCES lenses(name) ON DELETE CASCADE,
@@ -105,6 +115,16 @@ func OpenLensRegistry(path string) (*LensRegistry, error) {
 		db.Close()
 		return nil, fmt.Errorf("lens registry schema: %w", err)
 	}
+	// Upgrade control.dbs created before the description column existed. The
+	// column is already in lensSchema, so on a fresh DB this ALTER fails with
+	// "duplicate column name" — the ONE error we ignore. Any other ALTER failure
+	// (locked DB, corruption) fails the open rather than silently continuing.
+	if _, err := db.Exec(`ALTER TABLE lenses ADD COLUMN description TEXT NOT NULL DEFAULT ''`); err != nil {
+		if !strings.Contains(err.Error(), "duplicate column name") {
+			db.Close()
+			return nil, fmt.Errorf("lens registry migrate description: %w", err)
+		}
+	}
 	return &LensRegistry{db: db}, nil
 }
 
@@ -115,7 +135,7 @@ func (r *LensRegistry) Close() error {
 
 // List returns all lenses sorted by name.
 func (r *LensRegistry) List() ([]Lens, error) {
-	rows, err := r.db.Query(`SELECT name, write_repo, created_at, updated_at FROM lenses ORDER BY name`)
+	rows, err := r.db.Query(`SELECT name, write_repo, description, created_at, updated_at FROM lenses ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("list lenses: %w", err)
 	}
@@ -123,7 +143,7 @@ func (r *LensRegistry) List() ([]Lens, error) {
 	var out []Lens
 	for rows.Next() {
 		var l Lens
-		if err := rows.Scan(&l.Name, &l.Write, &l.CreatedAt, &l.UpdatedAt); err != nil {
+		if err := rows.Scan(&l.Name, &l.Write, &l.Description, &l.CreatedAt, &l.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("list lenses: %w", err)
 		}
 		out = append(out, l)
@@ -177,8 +197,8 @@ func (r *LensRegistry) Create(l Lens) (Lens, error) {
 	defer tx.Rollback()
 
 	if _, err := tx.Exec(
-		`INSERT INTO lenses (name, write_repo, created_at, updated_at) VALUES (?, ?, ?, ?)`,
-		l.Name, l.Write, l.CreatedAt, l.UpdatedAt,
+		`INSERT INTO lenses (name, write_repo, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		l.Name, l.Write, l.Description, l.CreatedAt, l.UpdatedAt,
 	); err != nil {
 		if isUniqueViolation(err) {
 			return Lens{}, fmt.Errorf("%w: %q", ErrLensExists, l.Name)
@@ -207,8 +227,8 @@ func (r *LensRegistry) Create(l Lens) (Lens, error) {
 func (r *LensRegistry) Get(name string) (Lens, bool, error) {
 	var l Lens
 	err := r.db.QueryRow(
-		`SELECT name, write_repo, created_at, updated_at FROM lenses WHERE name = ?`, name,
-	).Scan(&l.Name, &l.Write, &l.CreatedAt, &l.UpdatedAt)
+		`SELECT name, write_repo, description, created_at, updated_at FROM lenses WHERE name = ?`, name,
+	).Scan(&l.Name, &l.Write, &l.Description, &l.CreatedAt, &l.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Lens{}, false, nil
 	}

--- a/internal/repos/lens_test.go
+++ b/internal/repos/lens_test.go
@@ -1,6 +1,7 @@
 package repos
 
 import (
+	"database/sql"
 	"path/filepath"
 	"testing"
 
@@ -114,6 +115,80 @@ func TestLensRegistry_CreateValidation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = r.Create(Lens{Name: "dup", Write: "other"})
 	require.ErrorIs(t, err, ErrLensExists)
+}
+
+// Description round-trips through Create → Get → List. It is display metadata,
+// so normalize() must leave it untouched.
+func TestLensRegistry_DescriptionRoundTrips(t *testing.T) {
+	r := openTestRegistry(t)
+	stored, err := r.Create(Lens{
+		Name:        "docs",
+		Write:       "work",
+		Description: "A **markdown** description.",
+		Reads:       []LensRead{{Repo: "shared"}},
+		CreatedAt:   1, UpdatedAt: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "A **markdown** description.", stored.Description)
+
+	got, ok, err := r.Get("docs")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "A **markdown** description.", got.Description)
+
+	lenses, err := r.List()
+	require.NoError(t, err)
+	require.Len(t, lenses, 1)
+	require.Equal(t, "A **markdown** description.", lenses[0].Description)
+}
+
+// A control.db created by the OLD schema (no description column) upgrades in
+// place: OpenLensRegistry adds the column, pre-existing rows read back with an
+// empty description, and new descriptions round-trip.
+func TestLensRegistry_UpgradesOldSchemaInPlace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "control.db")
+
+	// Hand-build the pre-description schema and seed a row.
+	old, err := sql.Open("sqlite3", path+"?_foreign_keys=on")
+	require.NoError(t, err)
+	_, err = old.Exec(`
+CREATE TABLE lenses (
+    name       TEXT PRIMARY KEY,
+    write_repo TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+CREATE TABLE lens_reads (
+    lens_name TEXT NOT NULL REFERENCES lenses(name) ON DELETE CASCADE,
+    repo      TEXT NOT NULL,
+    branch    TEXT NOT NULL DEFAULT '',
+    source    TEXT,
+    PRIMARY KEY (lens_name, repo)
+);`)
+	require.NoError(t, err)
+	_, err = old.Exec(`INSERT INTO lenses (name, write_repo, created_at, updated_at) VALUES ('legacy', 'work', 3, 4)`)
+	require.NoError(t, err)
+	_, err = old.Exec(`INSERT INTO lens_reads (lens_name, repo, branch) VALUES ('legacy', 'work', '')`)
+	require.NoError(t, err)
+	require.NoError(t, old.Close())
+
+	// Open through the registry: the ALTER runs, upgrading in place.
+	r, err := OpenLensRegistry(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	got, ok, err := r.Get("legacy")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "", got.Description) // pre-existing row, default ''
+
+	// A new lens with a description round-trips after the upgrade.
+	_, err = r.Create(Lens{Name: "fresh", Write: "work", Description: "new", CreatedAt: 5, UpdatedAt: 6})
+	require.NoError(t, err)
+	got, ok, err = r.Get("fresh")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "new", got.Description)
 }
 
 func TestLensRegistry_GetAbsent(t *testing.T) {

--- a/internal/repos/lens_update_test.go
+++ b/internal/repos/lens_update_test.go
@@ -1,0 +1,214 @@
+package repos
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ---------- LensRegistry.Update (registry-layer mechanics) ----------
+
+// namesOf returns the read-mount repo names of a lens, in stored (sorted) order.
+func namesOf(reads []LensRead) []string {
+	out := make([]string, len(reads))
+	for i, r := range reads {
+		out[i] = r.Repo
+	}
+	return out
+}
+
+func TestLensRegistry_Update_ReplaceReads(t *testing.T) {
+	m := newLifecycleManager(t)
+	reg := m.Registry()
+
+	_, err := reg.Create(Lens{Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "beta"}}, CreatedAt: 1, UpdatedAt: 1})
+	require.NoError(t, err)
+
+	// Wholesale replace: beta drops out, gamma comes in. normalize folds the
+	// write repo (alpha) back in and sorts.
+	updated, err := reg.Update(Lens{Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "gamma"}}, CreatedAt: 1, UpdatedAt: 2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "gamma"}, namesOf(updated.Reads))
+
+	got, ok, err := reg.Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"alpha", "gamma"}, namesOf(got.Reads), "beta must be gone; gamma present")
+}
+
+func TestLensRegistry_Update_ChangeWrite(t *testing.T) {
+	m := newLifecycleManager(t)
+	reg := m.Registry()
+
+	_, err := reg.Create(Lens{Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "beta"}}, CreatedAt: 1, UpdatedAt: 1})
+	require.NoError(t, err)
+
+	updated, err := reg.Update(Lens{Name: "eng", Write: "gamma", Reads: []LensRead{{Repo: "beta"}}, CreatedAt: 1, UpdatedAt: 2})
+	require.NoError(t, err)
+	require.Equal(t, "gamma", updated.Write)
+	require.Equal(t, []string{"beta", "gamma"}, namesOf(updated.Reads), "new write repo folds into reads")
+
+	got, _, err := reg.Get("eng")
+	require.NoError(t, err)
+	require.Equal(t, "gamma", got.Write)
+}
+
+func TestLensRegistry_Update_DescriptionAndReadsRoundTrip(t *testing.T) {
+	m := newLifecycleManager(t)
+	reg := m.Registry()
+
+	_, err := reg.Create(Lens{Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "beta"}}, CreatedAt: 1, UpdatedAt: 1})
+	require.NoError(t, err)
+
+	// Same read set, new description: mounts survive verbatim, description updates.
+	updated, err := reg.Update(Lens{Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "beta"}}, Description: "team kb", CreatedAt: 1, UpdatedAt: 2})
+	require.NoError(t, err)
+	require.Equal(t, "team kb", updated.Description)
+	require.Equal(t, []string{"alpha", "beta"}, namesOf(updated.Reads))
+
+	got, _, err := reg.Get("eng")
+	require.NoError(t, err)
+	require.Equal(t, "team kb", got.Description)
+	require.Equal(t, []string{"alpha", "beta"}, namesOf(got.Reads))
+}
+
+func TestLensRegistry_Update_PreservesCreatedAt(t *testing.T) {
+	m := newLifecycleManager(t)
+	reg := m.Registry()
+
+	_, err := reg.Create(Lens{Name: "eng", Write: "alpha", CreatedAt: 100, UpdatedAt: 100})
+	require.NoError(t, err)
+
+	_, err = reg.Update(Lens{Name: "eng", Write: "alpha", CreatedAt: 100, UpdatedAt: 200})
+	require.NoError(t, err)
+
+	got, _, err := reg.Get("eng")
+	require.NoError(t, err)
+	require.Equal(t, int64(100), got.CreatedAt, "created_at is immutable across Update")
+	require.Equal(t, int64(200), got.UpdatedAt)
+}
+
+func TestLensRegistry_Update_UnknownLens(t *testing.T) {
+	m := newLifecycleManager(t)
+	reg := m.Registry()
+
+	_, err := reg.Update(Lens{Name: "ghost", Write: "alpha", UpdatedAt: 1})
+	require.ErrorIs(t, err, ErrLensNotFound)
+	require.ErrorContains(t, err, "ghost")
+}
+
+func TestLensRegistry_Update_EmptyWrite(t *testing.T) {
+	m := newLifecycleManager(t)
+	reg := m.Registry()
+
+	_, err := reg.Update(Lens{Name: "eng", Write: "", UpdatedAt: 1})
+	require.ErrorIs(t, err, ErrLensWriteEmpty)
+}
+
+// ---------- Manager.UpdateLens (validation parity with CreateLens) ----------
+
+// seedLens makes members and persists a starting lens via the validated path.
+func seedLens(t *testing.T, m *Manager) {
+	t.Helper()
+	makeLensRepo(t, m, "alpha")
+	makeLensRepo(t, m, "beta")
+	_, err := m.CreateLens(context.Background(), Lens{
+		Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "beta"}},
+	})
+	require.NoError(t, err)
+}
+
+func TestManager_UpdateLens_PersistsAfterValidation(t *testing.T) {
+	m := newLifecycleManager(t)
+	seedLens(t, m)
+	makeLensRepo(t, m, "gamma")
+
+	stored, err := m.UpdateLens(context.Background(), Lens{
+		Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "gamma"}}, Description: "d",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "gamma"}, namesOf(stored.Reads))
+	require.Equal(t, "d", stored.Description)
+
+	got, ok, err := m.Registry().Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{"alpha", "gamma"}, namesOf(got.Reads), "beta replaced by gamma")
+}
+
+func TestManager_UpdateLens_UnknownMember(t *testing.T) {
+	m := newLifecycleManager(t)
+	seedLens(t, m)
+
+	_, err := m.UpdateLens(context.Background(), Lens{
+		Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "ghost"}},
+	})
+	require.ErrorIs(t, err, ErrRepoNotFound)
+
+	// The rejected update must not have mutated the persisted lens.
+	got, _, err := m.Registry().Get("eng")
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "beta"}, namesOf(got.Reads))
+}
+
+func TestManager_UpdateLens_Replica(t *testing.T) {
+	m := newLifecycleManager(t)
+	seedLens(t, m)
+	cloneLensRepo(t, m, "alpha", "alpha_clone")
+
+	_, err := m.UpdateLens(context.Background(), Lens{
+		Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "alpha_clone"}},
+	})
+	require.ErrorIs(t, err, ErrReplicaInLens)
+
+	got, _, err := m.Registry().Get("eng")
+	require.NoError(t, err)
+	require.Equal(t, []string{"alpha", "beta"}, namesOf(got.Reads), "rejected update leaves mounts intact")
+}
+
+func TestManager_UpdateLens_BranchUnknown(t *testing.T) {
+	m := newLifecycleManager(t)
+	seedLens(t, m)
+
+	_, err := m.UpdateLens(context.Background(), Lens{
+		Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "beta", Branch: "nope"}},
+	})
+	require.ErrorIs(t, err, ErrLensBranchUnknown)
+}
+
+func TestManager_UpdateLens_EmptyWrite(t *testing.T) {
+	m := newLifecycleManager(t)
+	seedLens(t, m)
+
+	_, err := m.UpdateLens(context.Background(), Lens{Name: "eng", Write: ""})
+	require.ErrorIs(t, err, ErrLensWriteEmpty)
+}
+
+func TestManager_UpdateLens_DescriptionCap(t *testing.T) {
+	m := newLifecycleManager(t)
+	seedLens(t, m)
+
+	_, err := m.UpdateLens(context.Background(), Lens{
+		Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "beta"}},
+		Description: strings.Repeat("x", MaxLensDescriptionBytes+1),
+	})
+	require.ErrorIs(t, err, ErrLensDescriptionTooLong)
+
+	// Exactly at the cap is accepted.
+	_, err = m.UpdateLens(context.Background(), Lens{
+		Name: "eng", Write: "alpha", Reads: []LensRead{{Repo: "beta"}},
+		Description: strings.Repeat("x", MaxLensDescriptionBytes),
+	})
+	require.NoError(t, err)
+}
+
+func TestManager_UpdateLens_UnknownLens(t *testing.T) {
+	m := newLifecycleManager(t)
+	makeLensRepo(t, m, "alpha")
+
+	// Validation passes (alpha exists), but no lens row named "eng" exists yet.
+	_, err := m.UpdateLens(context.Background(), Lens{Name: "eng", Write: "alpha"})
+	require.ErrorIs(t, err, ErrLensNotFound)
+}

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -298,6 +298,9 @@ func (m *Manager) CreateLens(ctx context.Context, l Lens) (Lens, error) {
 	if l.Write == "" {
 		return Lens{}, ErrLensWriteEmpty
 	}
+	if len(l.Description) > MaxLensDescriptionBytes {
+		return Lens{}, fmt.Errorf("%w: %d bytes (max %d)", ErrLensDescriptionTooLong, len(l.Description), MaxLensDescriptionBytes)
+	}
 
 	// Reserve the name in repo Create's in-flight set (origin empty → name only),
 	// giving P2 its repo/lens mutual exclusion. release runs after m.mu.Unlock.

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -322,6 +322,44 @@ func (m *Manager) CreateLens(ctx context.Context, l Lens) (Lens, error) {
 	return m.registry.Create(l)
 }
 
+// UpdateLens re-validates an edited lens definition against the live repo set,
+// then persists it via LensRegistry.Update. It mirrors CreateLens's concurrency
+// discipline for the same reason (P1, no dangling member): membership validation
+// and the persist run under a single m.mu.Lock, and Archive checks RefsRepo +
+// removes the repo under the SAME m.mu, so the two are serialized. Either Archive
+// runs first (a newly-added member is gone → ErrRepoNotFound) or this update
+// persists first (Archive's RefsRepo then sees the new mount → ErrRepoInUseByLens).
+// A member can never be archived between the membership check and the persist.
+//
+// Unlike CreateLens it does NOT reserve the name in m.creating: the lens already
+// exists and its name is immutable, so there is no new repo/lens name to race
+// (P2). A repo Create for the lens's name still loses to the existing lens via
+// its own registry re-check, independent of this call.
+//
+// The write repo and description are pure input, checked up front. The name is
+// re-validated (grammar) but never changed — the caller passes the existing name.
+func (m *Manager) UpdateLens(ctx context.Context, l Lens) (Lens, error) {
+	if !isValidRepoName(l.Name) {
+		return Lens{}, fmt.Errorf("%w: %q", ErrInvalidLensName, l.Name)
+	}
+	if l.Write == "" {
+		return Lens{}, ErrLensWriteEmpty
+	}
+	if len(l.Description) > MaxLensDescriptionBytes {
+		return Lens{}, fmt.Errorf("%w: %d bytes (max %d)", ErrLensDescriptionTooLong, len(l.Description), MaxLensDescriptionBytes)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.validateLensLocked(ctx, l); err != nil {
+		return Lens{}, err
+	}
+	if m.registry == nil {
+		return Lens{}, fmt.Errorf("lens registry not open")
+	}
+	return m.registry.Update(l)
+}
+
 // Registry returns the lens registry, or nil before Start.
 func (m *Manager) Registry() *LensRegistry {
 	m.mu.RLock()

--- a/internal/store/search_graph_query.go
+++ b/internal/store/search_graph_query.go
@@ -23,9 +23,9 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 
 	// Sparse-history walk-back: edges are stored anchored to the target's
 	// actual write-commit. Resolve `commitHash` (the query anchor) into the
-	// target path's effective write-commit ≤ commitHash and filter the
-	// cypher by THAT. Without this, queries at any commit other than the
-	// exact write-commit return 0. See the historical-graph-invariant note.
+	// target path's effective write-commit ≤ commitHash. Without this, queries
+	// at any commit other than the exact write-commit return 0. See the
+	// historical-graph-invariant note.
 	effectiveCommit, ok, err := si.resolveActiveCommitForPath(ctx, branch, path, commitHash)
 	if err != nil {
 		return nil, fmt.Errorf("IncomingAtCommit: resolve effective commit: %w", err)
@@ -35,6 +35,19 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 		// there can't be any edges into it.
 		return nil, nil
 	}
+	// Match by the target fact's BLOB-version node at effectiveCommit, not by
+	// the edge's `target_commit`. See OutgoingAtCommit for the merge-commit
+	// rationale: a merge re-touches the path (so resolveActiveCommitForPath
+	// lands on the merge) but carries the same blob forward without re-anchoring
+	// the edges, so a target_commit == effectiveCommit filter drops every
+	// incoming edge at a merge-resolved anchor.
+	blobHash, err := si.rh.readBlobHashAtCommit(ctx, path, effectiveCommit)
+	if err != nil {
+		return nil, fmt.Errorf("IncomingAtCommit: blob at %s: %w", effectiveCommit, err)
+	}
+	if blobHash == "" {
+		return nil, nil
+	}
 
 	// 1. Cypher: candidate (source_path, source_title, source_commit, source_deleted) rows.
 	// Note: "commit" is a reserved SQL keyword; use alias "sc" (source commit).
@@ -42,9 +55,9 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 	// them with the retracted treatment instead of hiding the edge entirely
 	// (mirrors how OutgoingAtCommit exposes retracted targets).
 	cypherQ := fmt.Sprintf(
-		`MATCH (s:%s)-[r:%s]->(t:%s {path: "%s"}) WHERE r.target_commit = "%s" RETURN s.path AS path, s.title AS title, s.type AS type, r.source_commit AS sc, s.deleted AS deleted`,
+		`MATCH (s:%s)-[r:%s]->(t:%s {path: "%s"}) WHERE t.blob_hash = "%s" RETURN s.path AS path, s.title AS title, s.type AS type, r.source_commit AS sc, s.deleted AS deleted`,
 		NodeFact, EdgeDerivedFrom, NodeFact,
-		escapeCypherKey(path), escapeCypherKey(effectiveCommit),
+		escapeCypherKey(path), escapeCypherKey(blobHash),
 	)
 	q := `SELECT json_extract(value, '$.path'), json_extract(value, '$.title'), json_extract(value, '$.type'), json_extract(value, '$.sc'), json_extract(value, '$.deleted') FROM json_each(cypher('` + cypherQ + `'))`
 	// cypher() reads can hit the transient concurrent-translation race; retry
@@ -141,9 +154,9 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 func (si *searchIndex) OutgoingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error) {
 	// Sparse-history walk-back: edges are stored anchored to the source's
 	// actual write-commit. Resolve `commitHash` (the query anchor) into the
-	// source path's effective write-commit ≤ commitHash and filter the
-	// cypher by THAT. Without this, queries at any commit other than the
-	// exact write-commit return 0. See the historical-graph-invariant note.
+	// source path's effective write-commit ≤ commitHash. Without this, queries
+	// at any commit other than the exact write-commit return 0. See the
+	// historical-graph-invariant note.
 	effectiveCommit, ok, err := si.resolveActiveCommitForPath(ctx, branch, path, commitHash)
 	if err != nil {
 		return nil, fmt.Errorf("OutgoingAtCommit: resolve effective commit: %w", err)
@@ -153,10 +166,26 @@ func (si *searchIndex) OutgoingAtCommit(ctx context.Context, branch, path, commi
 		// no edges to surface.
 		return nil, nil
 	}
+	// Match edges by the source fact's BLOB-version node at effectiveCommit, not
+	// by the edge's `source_commit` property. A merge commit records a
+	// commit_log add/modify for the path (so resolveActiveCommitForPath lands on
+	// the merge), but carries the SAME blob forward and never re-anchors the
+	// edges — which stay on the original content-write commit. Filtering by
+	// source_commit == effectiveCommit therefore drops every edge at any anchor
+	// that resolves to a merge (i.e. at HEAD after a merge-back). The Fact node
+	// is keyed by (path, blob_hash) and the blob is stable across the merge, so
+	// matching the node finds the edges regardless of which commit anchored them.
+	blobHash, err := si.rh.readBlobHashAtCommit(ctx, path, effectiveCommit)
+	if err != nil {
+		return nil, fmt.Errorf("OutgoingAtCommit: blob at %s: %w", effectiveCommit, err)
+	}
+	if blobHash == "" {
+		return nil, nil
+	}
 	cypherQ := fmt.Sprintf(
-		`MATCH (s:%s {path: "%s"})-[r:%s]->(t:%s) WHERE r.source_commit = "%s" RETURN t.path AS path, t.title AS title, t.type AS type, r.target_commit AS tc, t.deleted AS deleted`,
+		`MATCH (s:%s {path: "%s"})-[r:%s]->(t:%s) WHERE s.blob_hash = "%s" RETURN t.path AS path, t.title AS title, t.type AS type, r.target_commit AS tc, t.deleted AS deleted`,
 		NodeFact, escapeCypherKey(path), EdgeDerivedFrom, NodeFact,
-		escapeCypherKey(effectiveCommit),
+		escapeCypherKey(blobHash),
 	)
 	q := `SELECT json_extract(value, '$.path'), json_extract(value, '$.title'), json_extract(value, '$.type'), json_extract(value, '$.tc'), json_extract(value, '$.deleted') FROM json_each(cypher('` + cypherQ + `'))`
 	// cypher() reads can hit the transient concurrent-translation race; retry

--- a/internal/store/search_graph_query_merge_test.go
+++ b/internal/store/search_graph_query_merge_test.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGraphAtCommit_ResolvesThroughMergeCommit reproduces the "empty
+// connections after a merge" bug: a fact brought into a branch via a MERGE
+// commit shows no in/out edges at HEAD.
+//
+// Mechanism: DERIVED_FROM edges are anchored to the fact's original
+// content-write commit (source_commit / target_commit on the feature branch),
+// but resolveActiveCommitForPath resolves HEAD to the MERGE commit — commit_log
+// records the merge as an add/modify of the path (fact_history diffs the merge
+// against its first parent, which lacks the fact). The old queries filtered
+// edges strictly by `r.source_commit = mergeCommit`, which never matches the
+// feature-anchored edge, so both directions returned 0. Matching the edge by
+// the fact's blob-version node (stable across the merge) fixes it.
+func TestGraphAtCommit_ResolvesThroughMergeCommit(t *testing.T) {
+	svc := newMergeTestStore(t)
+	ctx := context.Background()
+
+	// feature branch carries BOTH facts: B, then A→B (the edge is created on
+	// feature, anchored to feature's write-commits).
+	require.NoError(t, svc.Branches().CreateBranch(ctx, "feature", "main"))
+	_, err := svc.Facts().WriteFact(ctx, "feature", "kb/b.md", testFactBody("b", 0.9, nil), "b", "")
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(ctx, "feature", "kb/a.md", testFactBody("a", 0.8, []string{"kb/b.md"}), "a->b", "")
+	require.NoError(t, err)
+
+	// Diverge main so the merge is a real 3-way merge (a merge commit, not a
+	// fast-forward) that re-touches A and B into main's first-parent history.
+	writeMergeFact(t, svc, "main", "kb/x.md", "x", "diverge")
+
+	require.NoError(t, svc.Branches().MergeBranch(ctx, "feature", "main", StrategyLocalWins))
+	require.NoError(t, svc.IndexManager().Sync(ctx, "main"))
+
+	head, err := svc.Branches().HeadCommit(ctx, "main")
+	require.NoError(t, err)
+
+	si := svc.Search().(*searchIndex)
+
+	// Precondition: on main, A's effective write-commit resolves to the MERGE
+	// commit (not the feature write) — the exact condition that breaks the
+	// commit-equality edge filter.
+	eff, ok, err := si.resolveActiveCommitForPath(ctx, "main", "kb/a.md", head)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, head, eff, "precondition: A's effective write-commit on main IS the merge commit")
+
+	// OUTGOING: A→B must be surfaced at HEAD even though the edge is anchored to
+	// the feature write-commit, not the merge.
+	out, err := si.OutgoingAtCommit(ctx, "main", "kb/a.md", head)
+	require.NoError(t, err)
+	require.Len(t, out, 1, "A's outgoing edge to B must survive resolving HEAD to the merge commit")
+	require.Equal(t, "kb/b.md", out[0].Path)
+
+	// INCOMING: B←A symmetric.
+	in, err := si.IncomingAtCommit(ctx, "main", "kb/b.md", head)
+	require.NoError(t, err)
+	require.Len(t, in, 1, "B's incoming edge from A must survive resolving HEAD to the merge commit")
+	require.Equal(t, "kb/a.md", in[0].Path)
+}

--- a/internal/web/handlers_lenses_hal.go
+++ b/internal/web/handlers_lenses_hal.go
@@ -23,19 +23,21 @@ type lensReadDTO struct {
 
 // lensView is the HAL representation of a lens.
 type lensView struct {
-	Name      string        `json:"name"`
-	Write     string        `json:"write"`
-	Reads     []lensReadDTO `json:"reads"`
-	CreatedAt int64         `json:"created_at"`
-	UpdatedAt int64         `json:"updated_at"`
-	Links     hal.LinkMap   `json:"_links"`
+	Name        string        `json:"name"`
+	Write       string        `json:"write"`
+	Description string        `json:"description,omitempty"`
+	Reads       []lensReadDTO `json:"reads"`
+	CreatedAt   int64         `json:"created_at"`
+	UpdatedAt   int64         `json:"updated_at"`
+	Links       hal.LinkMap   `json:"_links"`
 }
 
 // createLensRequest is the POST body for creating a lens.
 type createLensRequest struct {
-	Name  string        `json:"name"`
-	Write string        `json:"write"`
-	Reads []lensReadDTO `json:"reads"`
+	Name        string        `json:"name"`
+	Write       string        `json:"write"`
+	Description string        `json:"description"`
+	Reads       []lensReadDTO `json:"reads"`
 }
 
 func lensViewOf(b hal.URLBuilder, l repos.Lens) lensView {
@@ -44,7 +46,7 @@ func lensViewOf(b hal.URLBuilder, l repos.Lens) lensView {
 		reads[i] = lensReadDTO{Repo: r.Repo, Branch: r.Branch, Source: r.Source}
 	}
 	return lensView{
-		Name: l.Name, Write: l.Write, Reads: reads,
+		Name: l.Name, Write: l.Write, Description: l.Description, Reads: reads,
 		CreatedAt: l.CreatedAt, UpdatedAt: l.UpdatedAt,
 		Links: hal.LinkMap{"self": {Href: b.Lens(l.Name)}},
 	}
@@ -123,7 +125,7 @@ func handleHALLensesCreate(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc 
 		}
 		now := time.Now().Unix() // the caller stamps timestamps; the registry never reads the clock
 		lens := repos.Lens{
-			Name: req.Name, Write: req.Write, Reads: reads,
+			Name: req.Name, Write: req.Write, Description: req.Description, Reads: reads,
 			CreatedAt: now, UpdatedAt: now,
 		}
 		created, err := m.CreateLens(r.Context(), lens)
@@ -195,6 +197,8 @@ func lensCreateErrStatus(err error) (int, string) {
 		return http.StatusUnprocessableEntity, "Lens pins an unknown branch"
 	case errors.Is(err, repos.ErrLensWriteEmpty):
 		return http.StatusBadRequest, "Lens write repo required"
+	case errors.Is(err, repos.ErrLensDescriptionTooLong):
+		return http.StatusUnprocessableEntity, "Lens description too long"
 	default:
 		return http.StatusInternalServerError, "Create lens failed"
 	}

--- a/internal/web/handlers_lenses_hal.go
+++ b/internal/web/handlers_lenses_hal.go
@@ -209,7 +209,7 @@ func handleHALLensPatch(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
 
 		updated, err := m.UpdateLens(r.Context(), lens)
 		if err != nil {
-			status, title := lensCreateErrStatus(err)
+			status, title := lensPatchErrStatus(err)
 			detail := err.Error()
 			// As with create, only the 500 fall-through risks leaking a wrapped
 			// SQL/driver error — scrub it and log the real cause server-side.
@@ -284,4 +284,16 @@ func lensCreateErrStatus(err error) (int, string) {
 	default:
 		return http.StatusInternalServerError, "Create lens failed"
 	}
+}
+
+// lensPatchErrStatus reuses lensCreateErrStatus's sentinel→(status,title)
+// mapping — the 4xx/422 validation arms are identical on the PATCH path — but
+// relabels the scrubbed-500 default arm so the problem title names the actual
+// operation ("Update lens failed" rather than "Create lens failed").
+func lensPatchErrStatus(err error) (int, string) {
+	status, title := lensCreateErrStatus(err)
+	if status == http.StatusInternalServerError {
+		title = "Update lens failed"
+	}
+	return status, title
 }

--- a/internal/web/handlers_lenses_hal.go
+++ b/internal/web/handlers_lenses_hal.go
@@ -40,6 +40,17 @@ type createLensRequest struct {
 	Reads       []lensReadDTO `json:"reads"`
 }
 
+// patchLensRequest is the PATCH body for editing a lens. Every field is a
+// pointer so an omitted field (JSON key absent → nil) is distinguishable from a
+// provided-but-empty one: omitted = keep the current value, provided = replace it
+// wholesale (reads replace as a set, never merge). The name is immutable and has
+// no field here.
+type patchLensRequest struct {
+	Write       *string        `json:"write"`
+	Description *string        `json:"description"`
+	Reads       *[]lensReadDTO `json:"reads"`
+}
+
 func lensViewOf(b hal.URLBuilder, l repos.Lens) lensView {
 	reads := make([]lensReadDTO, len(l.Reads))
 	for i, r := range l.Reads {
@@ -146,6 +157,73 @@ func handleHALLensesCreate(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc 
 	}
 }
 
+// handleHALLensPatch serves PATCH /api/v1/lenses/{lens}. It edits a lens's write
+// repo, read mounts, and description; the name is immutable. Omitted fields keep
+// their current value, provided fields replace wholesale. The merge starts from
+// the persisted lens (a 404 if unknown), then Manager.UpdateLens re-runs the full
+// create-time validation (member existence, replica, branch pins, description
+// cap) under the same locking discipline before persisting.
+func handleHALLensPatch(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reg := m.Registry()
+		if reg == nil {
+			hal.WriteProblem(w, http.StatusServiceUnavailable, "Lens registry unavailable",
+				"the lens registry is not open", r.URL.Path)
+			return
+		}
+		name := chi.URLParam(r, "lens")
+		current, ok, err := reg.Get(name)
+		if err != nil {
+			log.Error().Err(err).Str("path", r.URL.Path).Str("lens", name).Msg("get lens failed")
+			hal.WriteProblem(w, http.StatusInternalServerError, "Get failed", "get lens failed", r.URL.Path)
+			return
+		}
+		if !ok {
+			hal.WriteProblem(w, http.StatusNotFound, "Lens not found",
+				`no lens named "`+name+`"`, r.URL.Path)
+			return
+		}
+		var req patchLensRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid request body", err.Error(), r.URL.Path)
+			return
+		}
+
+		// Start from the persisted lens; apply only the provided fields. created_at
+		// is carried through unchanged; the caller stamps a fresh updated_at.
+		lens := current
+		lens.UpdatedAt = time.Now().Unix()
+		if req.Write != nil {
+			lens.Write = *req.Write
+		}
+		if req.Description != nil {
+			lens.Description = *req.Description
+		}
+		if req.Reads != nil {
+			reads := make([]repos.LensRead, len(*req.Reads))
+			for i, rd := range *req.Reads {
+				reads[i] = repos.LensRead{Repo: rd.Repo, Branch: rd.Branch, Source: rd.Source}
+			}
+			lens.Reads = reads
+		}
+
+		updated, err := m.UpdateLens(r.Context(), lens)
+		if err != nil {
+			status, title := lensCreateErrStatus(err)
+			detail := err.Error()
+			// As with create, only the 500 fall-through risks leaking a wrapped
+			// SQL/driver error — scrub it and log the real cause server-side.
+			if status == http.StatusInternalServerError {
+				log.Error().Err(err).Str("path", r.URL.Path).Str("lens", name).Msg("update lens failed")
+				detail = "update lens failed"
+			}
+			hal.WriteProblem(w, status, title, detail, r.URL.Path)
+			return
+		}
+		hal.WriteHAL(w, http.StatusOK, lensViewOf(b, updated))
+	}
+}
+
 // handleHALLensDelete serves DELETE /api/v1/lenses/{lens}. Get-check-then-Delete
 // so an unknown lens is a 404 rather than a silent 204 (Delete is idempotent).
 func handleHALLensDelete(m *repos.Manager) http.HandlerFunc {
@@ -199,6 +277,10 @@ func lensCreateErrStatus(err error) (int, string) {
 		return http.StatusBadRequest, "Lens write repo required"
 	case errors.Is(err, repos.ErrLensDescriptionTooLong):
 		return http.StatusUnprocessableEntity, "Lens description too long"
+	case errors.Is(err, repos.ErrLensNotFound):
+		// Reached only via PATCH, when the lens is deleted between the handler's
+		// Get and UpdateLens's persist. Create never produces it.
+		return http.StatusNotFound, "Lens not found"
 	default:
 		return http.StatusInternalServerError, "Create lens failed"
 	}

--- a/internal/web/handlers_lenses_hal_test.go
+++ b/internal/web/handlers_lenses_hal_test.go
@@ -83,9 +83,9 @@ type lensViewBody struct {
 		Source string `json:"source"`
 	} `json:"reads"`
 	Description string      `json:"description"`
-	CreatedAt  int64       `json:"created_at"`
-	UpdatedAt  int64       `json:"updated_at"`
-	Links      hal.LinkMap `json:"_links"`
+	CreatedAt   int64       `json:"created_at"`
+	UpdatedAt   int64       `json:"updated_at"`
+	Links       hal.LinkMap `json:"_links"`
 }
 
 func postLens(t *testing.T, r http.Handler, body string) *httptest.ResponseRecorder {
@@ -472,6 +472,7 @@ func TestLensCreateErrStatus(t *testing.T) {
 		{"branch unknown", repos.ErrLensBranchUnknown, http.StatusUnprocessableEntity, "Lens pins an unknown branch"},
 		{"write empty", repos.ErrLensWriteEmpty, http.StatusBadRequest, "Lens write repo required"},
 		{"description too long", repos.ErrLensDescriptionTooLong, http.StatusUnprocessableEntity, "Lens description too long"},
+		{"lens not found", repos.ErrLensNotFound, http.StatusNotFound, "Lens not found"},
 		{"unmapped", errors.New("boom"), http.StatusInternalServerError, "Create lens failed"},
 	}
 	for _, tc := range cases {

--- a/internal/web/handlers_lenses_hal_test.go
+++ b/internal/web/handlers_lenses_hal_test.go
@@ -485,6 +485,41 @@ func TestLensCreateErrStatus(t *testing.T) {
 	}
 }
 
+// TestLensPatchErrStatus pins the PATCH mapping (m13): the validation arms are
+// byte-identical to lensCreateErrStatus, but the scrubbed-500 default arm carries
+// an operation-appropriate title so a PATCH failure never reads "Create lens
+// failed".
+func TestLensPatchErrStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantTitle  string
+	}{
+		// 4xx/422 arms mirror create exactly (byte-identity is a hard constraint).
+		{"invalid name", repos.ErrInvalidLensName, http.StatusBadRequest, "Invalid lens name"},
+		{"name conflicts repo", repos.ErrLensNameConflictsRepo, http.StatusConflict, "Lens name conflicts with a repo"},
+		{"lens exists", repos.ErrLensExists, http.StatusConflict, "Lens already exists"},
+		{"create in flight", repos.ErrCreateInFlight, http.StatusConflict, "Create in flight"},
+		{"replica in lens", repos.ErrReplicaInLens, http.StatusConflict, "Replica mounts not allowed"},
+		{"repo not found", repos.ErrRepoNotFound, http.StatusUnprocessableEntity, "Lens references an unknown repo"},
+		{"branch unknown", repos.ErrLensBranchUnknown, http.StatusUnprocessableEntity, "Lens pins an unknown branch"},
+		{"write empty", repos.ErrLensWriteEmpty, http.StatusBadRequest, "Lens write repo required"},
+		{"description too long", repos.ErrLensDescriptionTooLong, http.StatusUnprocessableEntity, "Lens description too long"},
+		{"lens not found", repos.ErrLensNotFound, http.StatusNotFound, "Lens not found"},
+		// The only divergence: the unmapped 500 default arm names the PATCH op.
+		{"unmapped", errors.New("boom"), http.StatusInternalServerError, "Update lens failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, title := lensPatchErrStatus(tc.err)
+			if status != tc.wantStatus || title != tc.wantTitle {
+				t.Errorf("got (%d, %q), want (%d, %q)", status, title, tc.wantStatus, tc.wantTitle)
+			}
+		})
+	}
+}
+
 // TestHandleHALLenses_500DoesNotLeakError forces a real registry-layer failure
 // (closing the control-plane DB while Registry() stays non-nil) and asserts the
 // 500 problem detail is a generic string, never the wrapped SQL/driver error

--- a/internal/web/handlers_lenses_hal_test.go
+++ b/internal/web/handlers_lenses_hal_test.go
@@ -82,9 +82,10 @@ type lensViewBody struct {
 		Branch string `json:"branch"`
 		Source string `json:"source"`
 	} `json:"reads"`
-	CreatedAt int64       `json:"created_at"`
-	UpdatedAt int64       `json:"updated_at"`
-	Links     hal.LinkMap `json:"_links"`
+	Description string      `json:"description"`
+	CreatedAt  int64       `json:"created_at"`
+	UpdatedAt  int64       `json:"updated_at"`
+	Links      hal.LinkMap `json:"_links"`
 }
 
 func postLens(t *testing.T, r http.Handler, body string) *httptest.ResponseRecorder {
@@ -129,6 +130,85 @@ func TestHandleHALLensesCreate_Created(t *testing.T) {
 	}
 	if got.Write != "alpha" {
 		t.Errorf("persisted write: got %q", got.Write)
+	}
+}
+
+// A description POSTed on create is persisted and returned by both the single
+// GET and the list GET.
+func TestHandleHALLensesCreate_DescriptionRoundTrips(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+
+	rec := postLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}],"description":"team knowledge base"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var created lensViewBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal create: %v", err)
+	}
+	if created.Description != "team knowledge base" {
+		t.Errorf("create description: got %q", created.Description)
+	}
+
+	// Single GET.
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/lenses/eng", nil))
+	var single lensViewBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &single); err != nil {
+		t.Fatalf("unmarshal single: %v", err)
+	}
+	if single.Description != "team knowledge base" {
+		t.Errorf("single-GET description: got %q", single.Description)
+	}
+
+	// List GET.
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/lenses", nil))
+	var list struct {
+		Embedded struct {
+			Lenses []lensViewBody `json:"lenses"`
+		} `json:"_embedded"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if len(list.Embedded.Lenses) != 1 || list.Embedded.Lenses[0].Description != "team knowledge base" {
+		t.Errorf("list description: got %+v", list.Embedded.Lenses)
+	}
+}
+
+// A description over the 4 KiB cap is a well-formed request the server refuses
+// → 422 Unprocessable Entity.
+func TestHandleHALLensesCreate_DescriptionTooLong(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+
+	desc := strings.Repeat("x", 4097)
+	body, err := json.Marshal(map[string]any{
+		"name": "eng", "write": "alpha",
+		"reads":       []map[string]string{{"repo": "beta"}},
+		"description": desc,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := postLens(t, r, string(body))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q", got)
+	}
+
+	// A description exactly at the cap is accepted.
+	body, _ = json.Marshal(map[string]any{
+		"name": "eng2", "write": "alpha",
+		"reads":       []map[string]string{{"repo": "beta"}},
+		"description": strings.Repeat("x", 4096),
+	})
+	if rec := postLens(t, r, string(body)); rec.Code != http.StatusCreated {
+		t.Fatalf("at-cap status: got %d, want 201; body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -391,6 +471,7 @@ func TestLensCreateErrStatus(t *testing.T) {
 		{"repo not found", repos.ErrRepoNotFound, http.StatusUnprocessableEntity, "Lens references an unknown repo"},
 		{"branch unknown", repos.ErrLensBranchUnknown, http.StatusUnprocessableEntity, "Lens pins an unknown branch"},
 		{"write empty", repos.ErrLensWriteEmpty, http.StatusBadRequest, "Lens write repo required"},
+		{"description too long", repos.ErrLensDescriptionTooLong, http.StatusUnprocessableEntity, "Lens description too long"},
 		{"unmapped", errors.New("boom"), http.StatusInternalServerError, "Create lens failed"},
 	}
 	for _, tc := range cases {

--- a/internal/web/handlers_lenses_patch_test.go
+++ b/internal/web/handlers_lenses_patch_test.go
@@ -1,0 +1,197 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"knomit/internal/repos"
+)
+
+// patchLens issues a PATCH /lenses/{name} with the given raw JSON body.
+func patchLens(t *testing.T, r http.Handler, name, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/lenses/"+name, bytes.NewBufferString(body))
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// seedEng creates the "eng" lens (write alpha, read beta) and fails the test if
+// creation does not return 201.
+func seedEng(t *testing.T, r http.Handler) {
+	t.Helper()
+	if rec := postLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`); rec.Code != http.StatusCreated {
+		t.Fatalf("seed create: %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleHALLensPatch_ReplaceReads(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta", "gamma")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	rec := patchLens(t, r, "eng", `{"reads":[{"repo":"gamma"}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensViewBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := readRepos(body)
+	// beta replaced wholesale by gamma; write repo alpha folded in.
+	if len(got) != 2 || got["alpha"] == false || got["gamma"] == false || got["beta"] {
+		t.Errorf("reads after replace: got %v, want {alpha,gamma}", got)
+	}
+}
+
+func TestHandleHALLensPatch_ChangeWrite(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	rec := patchLens(t, r, "eng", `{"write":"beta"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensViewBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Write != "beta" {
+		t.Errorf("write: got %q, want beta", body.Write)
+	}
+}
+
+func TestHandleHALLensPatch_DescriptionOnlyKeepsMounts(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	rec := patchLens(t, r, "eng", `{"description":"just docs"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensViewBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Description != "just docs" {
+		t.Errorf("description: got %q", body.Description)
+	}
+	if body.Write != "alpha" {
+		t.Errorf("write must be untouched: got %q", body.Write)
+	}
+	got := readRepos(body)
+	if len(got) != 2 || !got["alpha"] || !got["beta"] {
+		t.Errorf("mounts must be untouched: got %v, want {alpha,beta}", got)
+	}
+}
+
+func TestHandleHALLensPatch_UnknownLens404(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	r := (&Server{Manager: m}).NewAPIRouter()
+
+	rec := patchLens(t, r, "missing", `{"description":"x"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q", got)
+	}
+}
+
+func TestHandleHALLensPatch_UnknownMember422(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	rec := patchLens(t, r, "eng", `{"reads":[{"repo":"ghost"}]}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleHALLensPatch_Replica409(t *testing.T) {
+	m, home := newTestLensManager(t, "alpha", "beta")
+	cloneRepo(t, m, home, "alpha", "alpha_clone")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	rec := patchLens(t, r, "eng", `{"reads":[{"repo":"alpha_clone"}]}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleHALLensPatch_BadBranchPin422(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	rec := patchLens(t, r, "eng", `{"reads":[{"repo":"beta","branch":"nope"}]}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleHALLensPatch_EmptyWrite400(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	rec := patchLens(t, r, "eng", `{"write":""}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleHALLensPatch_DescriptionTooLong422(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	body, err := json.Marshal(map[string]any{"description": strings.Repeat("x", 4097)})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := patchLens(t, r, "eng", string(body))
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleHALLensPatch_BadJSON400(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, r)
+
+	rec := patchLens(t, r, "eng", `{not json`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleHALLensPatch_RegistryNil503(t *testing.T) {
+	m := repos.New(context.Background(), repos.Deps{})
+	r := (&Server{Manager: m}).NewAPIRouter()
+
+	rec := patchLens(t, r, "eng", `{"description":"x"}`)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("patch: got %d, want 503", rec.Code)
+	}
+}
+
+// readRepos flattens a lens view body's read mounts into a name→present set.
+func readRepos(b lensViewBody) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range b.Reads {
+		out[r.Repo] = true
+	}
+	return out
+}

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -91,29 +91,11 @@ func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
 			return
 		}
 
-		// Optional repeatable `repo=<mount name>` narrows the fan-out. An unknown
-		// name is a well-formed request naming a nonexistent mount → 422.
-		if sel := qp["repo"]; len(sel) > 0 {
-			known := make(map[string]bool, len(b.Reads()))
-			for _, rt := range b.Reads() {
-				known[rt.RI.Name()] = true
-			}
-			want := make(map[string]bool, len(sel))
-			for _, name := range sel {
-				if !known[name] {
-					hal.WriteProblem(w, http.StatusUnprocessableEntity, "Unknown repo",
-						`no mount named "`+name+`" in lens "`+b.Name()+`"`, r.URL.Path)
-					return
-				}
-				want[name] = true
-			}
-			kept := make([]federate.Target, 0, len(targets))
-			for _, t := range targets {
-				if want[t.RT.RI.Name()] {
-					kept = append(kept, t)
-				}
-			}
-			targets = kept
+		// Optional repeatable `repo=<mount name>` narrows the fan-out (422 on an
+		// unknown mount name).
+		targets, ok := narrowByRepo(w, r, b, targets, qp["repo"])
+		if !ok {
+			return
 		}
 
 		// Fan out to every selected mount at its Binding-resolved branch. Any
@@ -134,26 +116,9 @@ func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
 			lists[i] = entries
 		}
 
-		// Dedupe by repo-relative path. The WRITE mount's copy always wins — its
-		// facts are the lens's editable, canonical rows — so it is recorded first;
-		// remaining collisions resolve in binding order. (Reads() is sorted by
-		// repo name, so the write mount is not positionally "first" in general;
-		// prioritise it explicitly.) winner maps a rel path to its target index.
-		winner := make(map[string]int)
-		record := func(isWrite bool) {
-			for i, t := range targets {
-				if (t.RT.RI == b.Write()) != isWrite {
-					continue
-				}
-				for _, e := range lists[i] {
-					if _, seen := winner[e.Path]; !seen {
-						winner[e.Path] = i
-					}
-				}
-			}
-		}
-		record(true)  // write mount first
-		record(false) // then read mounts in binding order
+		// Dedupe by repo-relative path (write mount wins, then binding order).
+		winner := writeFirstWinners(targets, b.Write(), lists,
+			func(e store.RecentFactEntry) string { return e.Path })
 
 		// Merge by committed_at across mounts (k-way timestamp merge). Each
 		// mount's list is committed_at-DESC (the text-less RecentFacts order);
@@ -230,6 +195,69 @@ func lensWirePath(b *repos.Binding, rt repos.ReadTarget, rel string) string {
 		return rel
 	}
 	return federate.QualifyPath(federate.ID12(rt.RI.ID()), rel)
+}
+
+// narrowByRepo applies the optional repeatable `repo=<mount name>` filter shared
+// by every lens union-read handler: it restricts the fan-out targets to the
+// named mounts. An unknown name is a well-formed request naming a nonexistent
+// mount → 422 (the write repo is itself a mount via Binding self-mount, so it is
+// selectable by name). When sel is empty the targets pass through unchanged.
+//
+// On the 422 path it writes the problem response and returns ok=false; the
+// caller must return immediately without writing again.
+func narrowByRepo(w http.ResponseWriter, r *http.Request, b *repos.Binding, targets []federate.Target, sel []string) ([]federate.Target, bool) {
+	if len(sel) == 0 {
+		return targets, true
+	}
+	known := make(map[string]bool, len(b.Reads()))
+	for _, rt := range b.Reads() {
+		known[rt.RI.Name()] = true
+	}
+	want := make(map[string]bool, len(sel))
+	for _, name := range sel {
+		if !known[name] {
+			hal.WriteProblem(w, http.StatusUnprocessableEntity, "Unknown repo",
+				`no mount named "`+name+`" in lens "`+b.Name()+`"`, r.URL.Path)
+			return nil, false
+		}
+		want[name] = true
+	}
+	kept := make([]federate.Target, 0, len(targets))
+	for _, t := range targets {
+		if want[t.RT.RI.Name()] {
+			kept = append(kept, t)
+		}
+	}
+	return kept, true
+}
+
+// writeFirstWinners computes the per-mount dedupe winners shared by every lens
+// union-read handler. Rows are deduped by repo-relative path (pathOf extracts it
+// from each mount's element): the WRITE mount's copy always wins — its facts are
+// the lens's editable, canonical rows — so it is recorded first; remaining
+// collisions resolve in binding order. (Reads() is sorted by repo name, so the
+// write mount is not positionally "first" in general; prioritise it explicitly.)
+// The result maps a rel path to its winning target index; a caller emits a row
+// only when its mount equals the winner, so a shadowed copy never appears even
+// if it ranks higher. Both handlers MUST agree on winners, hence one definition.
+func writeFirstWinners[T any](targets []federate.Target, write *repos.RepoInstance, lists [][]T, pathOf func(T) string) map[string]int {
+	winner := make(map[string]int)
+	record := func(isWrite bool) {
+		for i, t := range targets {
+			if (t.RT.RI == write) != isWrite {
+				continue
+			}
+			for _, e := range lists[i] {
+				p := pathOf(e)
+				if _, seen := winner[p]; !seen {
+					winner[p] = i
+				}
+			}
+		}
+	}
+	record(true)  // write mount first
+	record(false) // then read mounts in binding order
+	return winner
 }
 
 // lensSearchItem is one row of the lens union search collection. It carries the
@@ -334,29 +362,11 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.Handl
 			return
 		}
 
-		// Optional repeatable `repo=<mount name>` narrows the fan-out. An unknown
-		// name is a well-formed request naming a nonexistent mount → 422.
-		if sel := qp["repo"]; len(sel) > 0 {
-			known := make(map[string]bool, len(b.Reads()))
-			for _, rt := range b.Reads() {
-				known[rt.RI.Name()] = true
-			}
-			want := make(map[string]bool, len(sel))
-			for _, name := range sel {
-				if !known[name] {
-					hal.WriteProblem(w, http.StatusUnprocessableEntity, "Unknown repo",
-						`no mount named "`+name+`" in lens "`+b.Name()+`"`, r.URL.Path)
-					return
-				}
-				want[name] = true
-			}
-			kept := make([]federate.Target, 0, len(targets))
-			for _, t := range targets {
-				if want[t.RT.RI.Name()] {
-					kept = append(kept, t)
-				}
-			}
-			targets = kept
+		// Optional repeatable `repo=<mount name>` narrows the fan-out (422 on an
+		// unknown mount name).
+		targets, ok := narrowByRepo(w, r, b, targets, qp["repo"])
+		if !ok {
+			return
 		}
 
 		// Shared query across mounts (per-mount Path is set below). Depth is the
@@ -398,25 +408,9 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.Handl
 		// rank, never by native score, so a fused order is not a naive interleave.
 		order := federate.FuseRRF(lensListLens(lists))
 
-		// Dedupe by repo-relative path. The WRITE mount's copy always wins (its
-		// facts are the lens's editable, canonical rows), so it is recorded first;
-		// remaining collisions resolve in binding order. winner maps a rel path to
-		// its target index.
-		winner := make(map[string]int)
-		record := func(isWrite bool) {
-			for i, t := range targets {
-				if (t.RT.RI == b.Write()) != isWrite {
-					continue
-				}
-				for _, res := range lists[i] {
-					if _, seen := winner[res.Path]; !seen {
-						winner[res.Path] = i
-					}
-				}
-			}
-		}
-		record(true)  // write mount first
-		record(false) // then read mounts in binding order
+		// Dedupe by repo-relative path (write mount wins, then binding order).
+		winner := writeFirstWinners(targets, b.Write(), lists,
+			func(res store.SearchResult) string { return res.Path })
 
 		// Emit deduped rows in fused order: keep a row only when its mount is the
 		// winner for that rel path. A shadowed copy is dropped even when it ranks

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -459,6 +459,113 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.Handl
 	}
 }
 
+// lensCompletionsResponse is the union completions envelope. Flat (values),
+// consistent with the other lens union-read collections (which drop the repo
+// handler's _links.self — a lens read collection has no per-branch anchor).
+type lensCompletionsResponse struct {
+	Values []string `json:"values"`
+}
+
+// handleHALLensCompletions serves GET /lenses/{lens}/completions — the union of
+// per-mount completion values across a lens's write repo + N read mounts, plus a
+// lens-only category=repo that lists the lens's mount NAMES in binding order. It
+// is the lens twin of handleHALCompletions (handlers_completions.go): the SAME
+// category set, the SAME completionsProvider seam, the SAME case-insensitive
+// prefix matching, the SAME per-category value ordering, and — critically — the
+// SAME unknown-category error, since a bad category is forwarded to the store
+// per mount and its error flows through writeStoreError exactly as the repo
+// handler's does (500 problem+json).
+//
+// For the existing categories it fans out over federate.ReadTargetsFor and
+// unions each mount's values, de-duplicated across mounts with first-seen order
+// preserved (so the repo handler's per-category ordering survives for the first
+// mount that supplies a given value). The lens-only category=repo is served
+// entirely from the Binding without touching the store.
+func handleHALLensCompletions(provider completionsProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b := repos.BindingFromContext(r.Context())
+		qp := r.URL.Query()
+		category := qp.Get("category")
+		prefix := qp.Get("prefix")
+
+		// category=repo is lens-only: the lens's mount names in binding order
+		// (write repo first), filtered case-insensitively by prefix to mirror the
+		// store's LIKE behaviour for the value categories.
+		if category == "repo" {
+			values := filterByPrefixFold(lensMountNames(b), prefix)
+			hal.WriteHAL(w, http.StatusOK, lensCompletionsResponse{Values: values})
+			return
+		}
+
+		// Fan out over every mount (no path filter — completions are not
+		// path-scoped). Reads() always includes the write repo's self-mount, so
+		// targets is non-empty and an unknown category is guaranteed to reach a
+		// store call and surface its error, matching the repo handler.
+		targets, err := federate.ReadTargetsFor(b, "")
+		if err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+				err.Error(), r.URL.Path)
+			return
+		}
+
+		seen := make(map[string]bool)
+		values := []string{}
+		for _, t := range targets {
+			// Each mount fetches its own top-20 (mirroring the repo handler's store
+			// limit); the union below dedupes across mounts.
+			vals, err := provider.Completions(t.RT.RI, t.RT.Branch, category, prefix, 20)
+			if err != nil {
+				writeStoreError(w, r, err, "Failed to load completions", t.RT.Branch)
+				return
+			}
+			for _, v := range vals {
+				if !seen[v] {
+					seen[v] = true
+					values = append(values, v)
+				}
+			}
+		}
+		hal.WriteHAL(w, http.StatusOK, lensCompletionsResponse{Values: values})
+	}
+}
+
+// lensMountNames returns the lens's distinct mount names in binding order: the
+// write repo first, then the read mounts in Reads() order (sorted by repo name).
+// Reads() carries the write repo as a self-mount, so it is de-duplicated. This
+// is the value list for the lens-only category=repo completion.
+func lensMountNames(b *repos.Binding) []string {
+	seen := make(map[string]bool)
+	out := make([]string, 0, len(b.Reads()))
+	add := func(name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	add(b.Write().Name())
+	for _, rt := range b.Reads() {
+		add(rt.RI.Name())
+	}
+	return out
+}
+
+// filterByPrefixFold keeps values whose lower-cased form starts with the
+// lower-cased prefix, mirroring the store's case-insensitive LIKE prefix% for
+// value completions. An empty prefix passes everything through unchanged.
+func filterByPrefixFold(values []string, prefix string) []string {
+	if prefix == "" {
+		return values
+	}
+	lp := strings.ToLower(prefix)
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if strings.HasPrefix(strings.ToLower(v), lp) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 // lensListLens returns each list's length, the shape federate.FuseRRF consumes.
 func lensListLens[T any](lists [][]T) []int {
 	ns := make([]int, len(lists))

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -1,9 +1,14 @@
 package web
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/go-chi/chi/v5"
 
 	knomitfact "knomit/internal/fact"
 	"knomit/internal/federate"
@@ -185,6 +190,131 @@ func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
 
 		hal.WriteHAL(w, http.StatusOK, lensFactsResponse{Facts: page, Total: total})
 	}
+}
+
+// lensFactView is the single-fact wire body served through a lens: the repo
+// FactView (path/title/body/refs/_links) exactly as the repo single-fact
+// handler produces it, plus the lens-level source {repo,id,branch}. Because
+// FactView has a custom MarshalJSON (it hoists _links), the source cannot be
+// added by struct embedding — a promoted MarshalJSON would drop the extra
+// field — so the two objects are spliced here, preserving the repo body
+// verbatim (RFC: the lens single-fact body IS the repo body + source).
+type lensFactView struct {
+	FactView
+	Source lensFactSource
+}
+
+func (v lensFactView) MarshalJSON() ([]byte, error) {
+	inner, err := v.FactView.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	src, err := json.Marshal(v.Source)
+	if err != nil {
+		return nil, err
+	}
+	// inner is a non-empty JSON object; splice `,"source":<src>` before its
+	// closing brace to keep the repo body's field order intact.
+	out := make([]byte, 0, len(inner)+len(src)+len(`,"source":`))
+	out = append(out, inner[:len(inner)-1]...)
+	out = append(out, `,"source":`...)
+	out = append(out, src...)
+	out = append(out, '}')
+	return out, nil
+}
+
+// handleHALLensFact serves GET /lenses/{lens}/facts/{path...} — a single fact
+// read through a lens. It is the lens twin of handleHALFact: the SAME repo
+// single-fact body plus a source {repo,id,branch} block.
+//
+// Addressing (RFC §6.2): a bare kb/… path reads from the WRITE repo at its
+// Binding-resolved branch — there is NO dedupe scan, bare means the write repo,
+// period, even when a read mount shadows the same repo-relative path. A
+// kb://<id12>/kb/… path (URL-encoded by clients; decoded then split with
+// federate.ParseQualifiedPath) reads from that mount at its resolved branch.
+//
+// An unmounted id12 returns 404 with the SAME "Fact not found" shape as a
+// genuinely-missing fact — a caller must not be able to tell an unknown mount
+// from an absent fact (no mount-topology leak). A missing/retracted fact is a
+// 404 in parity with the repo handler; a real backend error surfaces as 500.
+func handleHALLensFact(b hal.URLBuilder, reader FactReader) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bind := repos.BindingFromContext(r.Context())
+
+		// chi routes the wildcard on the ESCAPED path, so a kb://-qualified path
+		// arrives percent-encoded; PathUnescape is idempotent for a bare path
+		// (no % escapes) and recovers the qualified form. On a decode error, fall
+		// back to the raw capture rather than 500 — ParseQualifiedPath will judge
+		// it.
+		raw := chi.URLParam(r, "*")
+		wire := raw
+		if dec, derr := url.PathUnescape(raw); derr == nil {
+			wire = dec
+		}
+		if wire == "" {
+			hal.WriteProblem(w, http.StatusBadRequest, "Missing fact path",
+				"fact path is required", r.URL.Path)
+			return
+		}
+
+		// Resolve the target mount + repo-relative path from the addressing.
+		id, rel, qualified, err := federate.ParseQualifiedPath(wire)
+		var (
+			ri     *repos.RepoInstance
+			branch string
+		)
+		if qualified {
+			// A malformed kb:// path or an unmounted id is indistinguishable, on
+			// the wire, from a fact that simply isn't there — same 404.
+			if err != nil {
+				lensFactNotFound(w, r, wire)
+				return
+			}
+			rt, ok := bind.ByID(id)
+			if !ok {
+				lensFactNotFound(w, r, wire)
+				return
+			}
+			ri, branch = rt.RI, rt.Branch
+		} else {
+			// Bare path: the write repo at its read-mount branch. No fan-out.
+			// rel is already the bare path from ParseQualifiedPath.
+			ri, branch = bind.Write(), bind.WriteMountBranch()
+		}
+
+		a := hal.Anchor{Branch: branch}
+		f, head, err := reader.Read(ri, a, rel, false)
+		if err != nil {
+			if errors.Is(err, errFactNotFound) {
+				lensFactNotFound(w, r, wire)
+				return
+			}
+			writeStoreError(w, r, err, "Failed to read fact", branch)
+			return
+		}
+
+		resolver := readerRefResolver{reader: reader, ri: ri, branch: branch, commit: ""}
+		view := BuildFactView(b, ri.Name(), a, head, f, resolver)
+		hal.WriteHAL(w, http.StatusOK, lensFactView{
+			FactView: view,
+			Source: lensFactSource{
+				Repo:   ri.Name(),
+				ID:     federate.ID12(ri.ID()),
+				Branch: branch,
+			},
+		})
+	}
+}
+
+// lensFactNotFound writes the uniform lens single-fact 404. It is used for every
+// not-found case — unmounted id, malformed kb:// path, missing/retracted fact —
+// so the four are byte-identical for a given requested path and none reveals
+// mount topology. The detail echoes only the path the client asked for; it
+// names no branch or mount (the repo handler names both, but doing so here
+// would leak whether an id resolved to a mount).
+func lensFactNotFound(w http.ResponseWriter, r *http.Request, wirePath string) {
+	hal.WriteProblem(w, http.StatusNotFound, "Fact not found",
+		`no fact at path "`+wirePath+`"`, r.URL.Path)
 }
 
 // lensWirePath renders a union row's path as addressed on the wire: bare for the

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -3,6 +3,7 @@ package web
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	knomitfact "knomit/internal/fact"
 	"knomit/internal/federate"
@@ -229,4 +230,246 @@ func lensWirePath(b *repos.Binding, rt repos.ReadTarget, rel string) string {
 		return rel
 	}
 	return federate.QualifyPath(federate.ID12(rt.RI.ID()), rel)
+}
+
+// lensSearchItem is one row of the lens union search collection. It carries the
+// repo SearchResult's exposed fields (mirroring the repo /search item) plus the
+// canonical qualified path and the row's source mount (same source shape as the
+// lens facts collection). No shadow metadata and no _links (flat envelope).
+type lensSearchItem struct {
+	Path       string         `json:"path"`
+	Title      string         `json:"title"`
+	Score      float64        `json:"score"`
+	Kind       string         `json:"kind,omitempty"` // omitted when epistemic (the default)
+	Type       string         `json:"type,omitempty"`
+	Domain     []string       `json:"domain,omitempty"`
+	Entities   []string       `json:"entities,omitempty"`
+	Confidence float64        `json:"confidence,omitempty"`
+	Source     lensFactSource `json:"source"`
+}
+
+// lensSearchResponse is the union search collection envelope. Flat
+// (results + total), consistent with the lens facts collection and accepted by
+// the web client's search reader (data.results fallback).
+type lensSearchResponse struct {
+	Results []lensSearchItem `json:"results"`
+	Total   int              `json:"total"`
+}
+
+// handleHALLensSearch serves GET /lenses/{lens}/search — the RRF-fused union
+// relevance search of a lens's write repo + N read mounts. It is the REST twin
+// of the MCP knomit_query relevance path (internal/mcp/query.go queryFirstCall)
+// and MUST produce the SAME fused ordering for the same lens+query: fan out over
+// federate.ReadTargetsFor, collect each mount's ranked SearchResult list, and
+// order the union with federate.FuseRRF (per-mount rank, not native score).
+//
+// After fusion, rows are deduped by repo-relative path with the WRITE mount's
+// copy winning (its facts are the lens's editable, canonical rows), exactly as
+// the facts collection dedupes. A shadowed copy is dropped even when it ranks
+// higher in the fused order than the winner. Read-mount paths are qualified
+// (kb://<id12>/…); each row carries its source {repo,id,branch}.
+func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b := repos.BindingFromContext(r.Context())
+		qp := r.URL.Query()
+
+		splitCSV := func(s string) []string {
+			if s == "" {
+				return nil
+			}
+			var out []string
+			for _, part := range strings.Split(s, ",") {
+				if part = strings.TrimSpace(part); part != "" {
+					out = append(out, part)
+				}
+			}
+			return out
+		}
+
+		// Numeric params mirror the repo /search handler, including its 400s.
+		var minConfidence float64
+		if v := qp.Get("min_confidence"); v != "" {
+			n, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+					"invalid min_confidence value", r.URL.Path)
+				return
+			}
+			minConfidence = n
+		}
+		var minSimilarity float64
+		if v := qp.Get("min_similarity"); v != "" {
+			n, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+					"invalid min_similarity value", r.URL.Path)
+				return
+			}
+			minSimilarity = n
+		}
+		limit := 50
+		if v := qp.Get("limit"); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+					"invalid limit value", r.URL.Path)
+				return
+			}
+			limit = n
+		}
+		if limit > 500 {
+			limit = 500
+		}
+		if limit < 0 {
+			limit = 0
+		}
+
+		// Ontology-aware fan-out target selection — the same seam MCP queryFirstCall
+		// uses. A kb://-qualified path restricts to one mount (filter made
+		// repo-relative); an unqualified path applies per mount.
+		targets, err := federate.ReadTargetsFor(b, qp.Get("path"))
+		if err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+				err.Error(), r.URL.Path)
+			return
+		}
+
+		// Optional repeatable `repo=<mount name>` narrows the fan-out. An unknown
+		// name is a well-formed request naming a nonexistent mount → 422.
+		if sel := qp["repo"]; len(sel) > 0 {
+			known := make(map[string]bool, len(b.Reads()))
+			for _, rt := range b.Reads() {
+				known[rt.RI.Name()] = true
+			}
+			want := make(map[string]bool, len(sel))
+			for _, name := range sel {
+				if !known[name] {
+					hal.WriteProblem(w, http.StatusUnprocessableEntity, "Unknown repo",
+						`no mount named "`+name+`" in lens "`+b.Name()+`"`, r.URL.Path)
+					return
+				}
+				want[name] = true
+			}
+			kept := make([]federate.Target, 0, len(targets))
+			for _, t := range targets {
+				if want[t.RT.RI.Name()] {
+					kept = append(kept, t)
+				}
+			}
+			targets = kept
+		}
+
+		// Shared query across mounts (per-mount Path is set below). Depth is the
+		// per-mount candidate cap; the fused union is truncated to `limit` last.
+		base := store.SearchOptions{
+			Text:           qp.Get("q"),
+			Entities:       splitCSV(qp.Get("entities")),
+			Domain:         splitCSV(qp.Get("domain")),
+			DomainExact:    qp.Get("domain_exact") == "true" || qp.Get("domain_exact") == "1",
+			IncludeTypes:   splitCSV(qp.Get("type")),
+			ExcludeTypes:   splitCSV(qp.Get("exclude_type")),
+			IncludeKinds:   splitCSV(qp.Get("kind")),
+			ExcludeKinds:   splitCSV(qp.Get("exclude_kind")),
+			IncludeOrigins: splitCSV(qp.Get("origin")),
+			EpisodeOps:     splitCSV(qp.Get("ep")),
+			MinConfidence:  minConfidence,
+			MinSimilarity:  minSimilarity,
+			Limit:          maxLensFactCandidates,
+		}
+
+		// Fan out to every selected mount at its Binding-resolved branch. Any mount
+		// error fails the whole request — a lens must never silently shrink its read
+		// set (RFC §9.1). The embedder (possibly nil when embeddings are disabled)
+		// is forwarded exactly as the repo /search handler forwards it.
+		lists := make([][]store.SearchResult, len(targets))
+		for i, t := range targets {
+			q := base
+			q.Path = t.Path
+			res, err := provider.Search(t.RT.RI, emb, t.RT.Branch, q)
+			if err != nil {
+				writeStoreError(w, r, err, "Search failed", t.RT.Branch)
+				return
+			}
+			lists[i] = res
+		}
+
+		// Fuse the per-mount ranked lists by reciprocal rank fusion — the SAME
+		// ordering MCP knomit_query produces (RFC §7.1). RRF orders by per-mount
+		// rank, never by native score, so a fused order is not a naive interleave.
+		order := federate.FuseRRF(lensListLens(lists))
+
+		// Dedupe by repo-relative path. The WRITE mount's copy always wins (its
+		// facts are the lens's editable, canonical rows), so it is recorded first;
+		// remaining collisions resolve in binding order. winner maps a rel path to
+		// its target index.
+		winner := make(map[string]int)
+		record := func(isWrite bool) {
+			for i, t := range targets {
+				if (t.RT.RI == b.Write()) != isWrite {
+					continue
+				}
+				for _, res := range lists[i] {
+					if _, seen := winner[res.Path]; !seen {
+						winner[res.Path] = i
+					}
+				}
+			}
+		}
+		record(true)  // write mount first
+		record(false) // then read mounts in binding order
+
+		// Emit deduped rows in fused order: keep a row only when its mount is the
+		// winner for that rel path. A shadowed copy is dropped even when it ranks
+		// higher than the winner (each rel path is unique within a mount, so the
+		// winner's copy appears exactly once in the fused order).
+		rows := make([]lensSearchItem, 0, len(winner))
+		for _, ref := range order {
+			res := lists[ref.Mount][ref.Rank]
+			if winner[res.Path] != ref.Mount {
+				continue
+			}
+			t := targets[ref.Mount]
+			// Mirror fact.Fact.MarshalJSON: elide Kind when it equals the default
+			// (epistemic) so the field is omitted on the wire.
+			kind := res.Kind
+			if knomitfact.Kind(kind) == knomitfact.DefaultKind {
+				kind = ""
+			}
+			rows = append(rows, lensSearchItem{
+				Path:       lensWirePath(b, t.RT, res.Path),
+				Title:      res.Title,
+				Score:      res.Score,
+				Kind:       kind,
+				Type:       res.Type,
+				Domain:     res.Domain,
+				Entities:   res.Entities,
+				Confidence: res.Confidence,
+				Source: lensFactSource{
+					Repo:   t.RT.RI.Name(),
+					ID:     federate.ID12(t.RT.RI.ID()),
+					Branch: t.RT.Branch,
+				},
+			})
+		}
+
+		// total is the full deduped union size; `limit` caps the returned page.
+		total := len(rows)
+		if limit < len(rows) {
+			rows = rows[:limit]
+		}
+		if rows == nil {
+			rows = []lensSearchItem{}
+		}
+
+		hal.WriteHAL(w, http.StatusOK, lensSearchResponse{Results: rows, Total: total})
+	}
+}
+
+// lensListLens returns each list's length, the shape federate.FuseRRF consumes.
+func lensListLens[T any](lists [][]T) []int {
+	ns := make([]int, len(lists))
+	for i, l := range lists {
+		ns[i] = len(l)
+	}
+	return ns
 }

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -1,0 +1,232 @@
+package web
+
+import (
+	"net/http"
+	"strconv"
+
+	knomitfact "knomit/internal/fact"
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+	"knomit/internal/web/hal"
+)
+
+// maxLensFactCandidates bounds the per-mount fetch depth for a lens union facts
+// collection: each mount contributes at most this many rows to the merged,
+// deduped union. It mirrors the MCP query snapshot-depth model (RFC §7.1) —
+// paging over the union walks WITHIN this materialised set.
+const maxLensFactCandidates = 500
+
+// lensFactSource identifies which mount a union row came from.
+type lensFactSource struct {
+	Repo   string `json:"repo"`
+	ID     string `json:"id"`
+	Branch string `json:"branch"`
+}
+
+// lensFactItem is one row of the lens union facts collection.
+type lensFactItem struct {
+	Path        string         `json:"path"`
+	Title       string         `json:"title"`
+	Kind        string         `json:"kind,omitempty"` // omitted when epistemic (the default)
+	Type        string         `json:"type,omitempty"`
+	CommittedAt int64          `json:"committed_at,omitempty"`
+	Operation   string         `json:"operation,omitempty"`
+	Score       float64        `json:"score"`
+	Source      lensFactSource `json:"source"`
+}
+
+// lensFactsResponse is the union facts collection envelope. It is flat
+// (facts + total), mirroring the MCP query response shape rather than the HAL
+// collection envelope — later lens read tasks (search, completions, single
+// fact) depend on this shape verbatim.
+type lensFactsResponse struct {
+	Facts []lensFactItem `json:"facts"`
+	Total int            `json:"total"`
+}
+
+// handleHALLensFacts serves GET /lenses/{lens}/facts — the recency-ordered
+// union of a lens's write repo + N read mounts. It is the REST twin of the MCP
+// queryRecent fan-out (internal/mcp/query.go): select targets via
+// federate.ReadTargetsFor, fetch each mount's RecentFacts at its pinned branch,
+// dedupe by repo-relative path (the write mount's copy wins), merge by
+// committed_at across mounts, and qualify read-mount paths (kb://<id12>/…).
+func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b := repos.BindingFromContext(r.Context())
+		qp := r.URL.Query()
+
+		limit := 50
+		if v := qp.Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		if limit > 500 {
+			limit = 500
+		}
+		offset := 0
+		if v := qp.Get("offset"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				offset = n
+			}
+		}
+
+		// `query=` is the text filter (accept `q=` as the repo-collection alias).
+		// Present it as SearchOptions.Text; RecentFacts applies it per mount.
+		text := qp.Get("query")
+		if text == "" {
+			text = qp.Get("q")
+		}
+
+		// Ontology-aware fan-out target selection — the same seam MCP queryRecent
+		// uses. A kb://-qualified path restricts to a single mount (with the
+		// filter made repo-relative); an unqualified path applies per mount,
+		// skipping mounts whose ontology lacks the topic.
+		targets, err := federate.ReadTargetsFor(b, qp.Get("path"))
+		if err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+				err.Error(), r.URL.Path)
+			return
+		}
+
+		// Optional repeatable `repo=<mount name>` narrows the fan-out. An unknown
+		// name is a well-formed request naming a nonexistent mount → 422.
+		if sel := qp["repo"]; len(sel) > 0 {
+			known := make(map[string]bool, len(b.Reads()))
+			for _, rt := range b.Reads() {
+				known[rt.RI.Name()] = true
+			}
+			want := make(map[string]bool, len(sel))
+			for _, name := range sel {
+				if !known[name] {
+					hal.WriteProblem(w, http.StatusUnprocessableEntity, "Unknown repo",
+						`no mount named "`+name+`" in lens "`+b.Name()+`"`, r.URL.Path)
+					return
+				}
+				want[name] = true
+			}
+			kept := make([]federate.Target, 0, len(targets))
+			for _, t := range targets {
+				if want[t.RT.RI.Name()] {
+					kept = append(kept, t)
+				}
+			}
+			targets = kept
+		}
+
+		// Fan out to every selected mount at its Binding-resolved branch. Any
+		// mount error fails the whole request — a lens must never silently shrink
+		// its read set (RFC §9.1).
+		lists := make([][]store.RecentFactEntry, len(targets))
+		for i, t := range targets {
+			entries, _, err := provider.RecentFacts(t.RT.RI, t.RT.Branch, store.SearchOptions{
+				Path:   t.Path,
+				Text:   text,
+				Limit:  maxLensFactCandidates,
+				Offset: 0,
+			})
+			if err != nil {
+				writeStoreError(w, r, err, "Failed to list facts", t.RT.Branch)
+				return
+			}
+			lists[i] = entries
+		}
+
+		// Dedupe by repo-relative path. The WRITE mount's copy always wins — its
+		// facts are the lens's editable, canonical rows — so it is recorded first;
+		// remaining collisions resolve in binding order. (Reads() is sorted by
+		// repo name, so the write mount is not positionally "first" in general;
+		// prioritise it explicitly.) winner maps a rel path to its target index.
+		winner := make(map[string]int)
+		record := func(isWrite bool) {
+			for i, t := range targets {
+				if (t.RT.RI == b.Write()) != isWrite {
+					continue
+				}
+				for _, e := range lists[i] {
+					if _, seen := winner[e.Path]; !seen {
+						winner[e.Path] = i
+					}
+				}
+			}
+		}
+		record(true)  // write mount first
+		record(false) // then read mounts in binding order
+
+		// Merge by committed_at across mounts (k-way timestamp merge). Each
+		// mount's list is committed_at-DESC (the text-less RecentFacts order);
+		// MergeRecent re-sorts globally, so the union is recency-ordered, not
+		// mount-grouped.
+		totalEntries := 0
+		for _, l := range lists {
+			totalEntries += len(l)
+		}
+		stamps := make([][]int64, len(targets))
+		for i, list := range lists {
+			stamps[i] = make([]int64, len(list))
+			for j, e := range list {
+				stamps[i][j] = e.CommittedAt
+			}
+		}
+		order := federate.MergeRecent(stamps, totalEntries)
+
+		// Emit deduped rows in recency order: keep a row only when its mount is
+		// the winner for that rel path (each rel path is unique within a mount,
+		// so the winner's copy appears exactly once in the merged order).
+		rows := make([]lensFactItem, 0, len(winner))
+		for _, ref := range order {
+			e := lists[ref.Mount][ref.Rank]
+			if winner[e.Path] != ref.Mount {
+				continue
+			}
+			t := targets[ref.Mount]
+			// Mirror fact.Fact.MarshalJSON: elide Kind when it equals the default
+			// (epistemic) so the field is omitted on the wire.
+			kind := e.Kind
+			if knomitfact.Kind(kind) == knomitfact.DefaultKind {
+				kind = ""
+			}
+			rows = append(rows, lensFactItem{
+				Path:        lensWirePath(b, t.RT, e.Path),
+				Title:       e.Title,
+				Kind:        kind,
+				Type:        e.Type,
+				CommittedAt: e.CommittedAt,
+				Operation:   e.Operation,
+				Score:       e.Score,
+				Source: lensFactSource{
+					Repo:   t.RT.RI.Name(),
+					ID:     federate.ID12(t.RT.RI.ID()),
+					Branch: t.RT.Branch,
+				},
+			})
+		}
+
+		// total is the post-dedupe union size; offset/limit page WITHIN it.
+		total := len(rows)
+		if offset > len(rows) {
+			offset = len(rows)
+		}
+		end := offset + limit
+		if end > len(rows) {
+			end = len(rows)
+		}
+		page := rows[offset:end]
+		if page == nil {
+			page = []lensFactItem{}
+		}
+
+		hal.WriteHAL(w, http.StatusOK, lensFactsResponse{Facts: page, Total: total})
+	}
+}
+
+// lensWirePath renders a union row's path as addressed on the wire: bare for the
+// binding's write repo, kb://<id12>/… for any read mount (RFC §6.2 uniformity),
+// mirroring internal/mcp.wirePath.
+func lensWirePath(b *repos.Binding, rt repos.ReadTarget, rel string) string {
+	if rt.RI == b.Write() {
+		return rel
+	}
+	return federate.QualifyPath(federate.ID12(rt.RI.ID()), rel)
+}

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -295,6 +295,13 @@ func handleHALLensFact(b hal.URLBuilder, reader FactReader) http.HandlerFunc {
 
 		resolver := readerRefResolver{reader: reader, ri: ri, branch: branch, commit: ""}
 		view := BuildFactView(b, ri.Name(), a, head, f, resolver)
+		// The top-level `path` echoes the canonical wire address (RFC §6.2): bare
+		// for the write repo, kb://<id12>/… for a read mount — so a client can
+		// round-trip it into another lens request and land on the SAME fact. The
+		// `_links` stay repo-scoped (repo-relative), pointing at the owning mount's
+		// own endpoints. lensWirePath renders the write repo bare (ByID includes
+		// the write repo, but rt.RI == b.Write() there → bare).
+		view.Path = lensWirePath(bind, repos.ReadTarget{RI: ri, Branch: branch}, rel)
 		hal.WriteHAL(w, http.StatusOK, lensFactView{
 			FactView: view,
 			Source: lensFactSource{

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -487,6 +488,156 @@ func TestLensSearch_UnknownLens404(t *testing.T) {
 	r := s.NewAPIRouter()
 
 	rec := getLensFacts(t, r, "/lenses/missing/search?q=x")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ── lens union completions (GET /lenses/{lens}/completions) ───────────────────
+
+// knownCompletionCategories mirrors the store's real category set (internal/
+// store/index.go Completions): a known category returns values (possibly empty),
+// and any other category is an error — exactly as the repo handler surfaces it.
+var knownCompletionCategories = map[string]bool{
+	"domain": true, "entity": true, "type": true,
+	"kind": true, "origin": true, "ep": true, "path": true,
+}
+
+// lensCompletionsStub is a per-repo completionsProvider: each mount's
+// Completions call is answered from byRepo keyed by repo name then category, so
+// a single stub drives the whole fan-out. An unrecognised category returns the
+// same error string the store raises, so the lens handler's error path matches
+// the repo handler byte-for-byte.
+type lensCompletionsStub struct {
+	byRepo map[string]map[string][]string
+}
+
+func (s *lensCompletionsStub) Completions(
+	ri *repos.RepoInstance, _, category, _ string, _ int,
+) ([]string, error) {
+	if !knownCompletionCategories[category] {
+		return nil, fmt.Errorf("unknown completion category: %s", category)
+	}
+	return s.byRepo[ri.Name()][category], nil
+}
+
+// lensCompletionsBody mirrors the union completions wire shape.
+type lensCompletionsBody struct {
+	Values []string `json:"values"`
+}
+
+func decodeLensCompletions(t *testing.T, rec *httptest.ResponseRecorder) lensCompletionsBody {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensCompletionsBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	return body
+}
+
+// category=repo is lens-only: it lists the lens's mount NAMES in binding order —
+// the write repo first, then the read mounts in Reads() order (sorted by name).
+// The write repo's self-mount is de-duplicated, so each name appears once. Here
+// write=zulu sorts LAST among the mounts, yet it leads because it is the write.
+func TestLensCompletions_RepoCategoryListsMountsInOrder(t *testing.T) {
+	m, _ := newTestLensManager(t, "zulu", "alpha", "beta")
+	s := &Server{Manager: m, completionsProvider: &lensCompletionsStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"zulu","reads":[{"repo":"alpha"},{"repo":"beta"}]}`)
+
+	body := decodeLensCompletions(t, getLensFacts(t, r, "/lenses/eng/completions?category=repo"))
+	want := []string{"zulu", "alpha", "beta"}
+	if len(body.Values) != len(want) {
+		t.Fatalf("values: got %v, want %v", body.Values, want)
+	}
+	for i := range want {
+		if body.Values[i] != want[i] {
+			t.Fatalf("order: got %v, want %v (write first, then reads in binding order)", body.Values, want)
+		}
+	}
+}
+
+// prefix= narrows category=repo, case-insensitively (an uppercase prefix still
+// matches a lower-cased mount name), matching the store's LIKE behaviour.
+func TestLensCompletions_RepoCategoryPrefixNarrows(t *testing.T) {
+	m, _ := newTestLensManager(t, "zulu", "alpha", "beta")
+	s := &Server{Manager: m, completionsProvider: &lensCompletionsStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"zulu","reads":[{"repo":"alpha"},{"repo":"beta"}]}`)
+
+	body := decodeLensCompletions(t, getLensFacts(t, r, "/lenses/eng/completions?category=repo&prefix=A"))
+	want := []string{"alpha"}
+	if len(body.Values) != len(want) || body.Values[0] != want[0] {
+		t.Fatalf("values: got %v, want %v (case-insensitive prefix narrows)", body.Values, want)
+	}
+}
+
+// category=domain unions each mount's values, de-duplicated across mounts,
+// preserving per-mount first-seen order (mounts fan out in Reads() order).
+func TestLensCompletions_DomainMergesWithoutDuplicates(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensCompletionsStub{byRepo: map[string]map[string][]string{
+		"alpha": {"domain": {"ai", "alignment"}},
+		"beta":  {"domain": {"ai", "robotics"}}, // "ai" collides with alpha's
+	}}
+	s := &Server{Manager: m, completionsProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensCompletions(t, getLensFacts(t, r, "/lenses/eng/completions?category=domain"))
+	want := []string{"ai", "alignment", "robotics"}
+	if len(body.Values) != len(want) {
+		t.Fatalf("values: got %v, want %v (union, deduped)", body.Values, want)
+	}
+	for i := range want {
+		if body.Values[i] != want[i] {
+			t.Fatalf("order: got %v, want %v", body.Values, want)
+		}
+	}
+}
+
+// An unknown category is the SAME error the repo handler gives: the store-shaped
+// error flows through writeStoreError → 500 problem+json.
+func TestLensCompletions_UnknownCategory500(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, completionsProvider: &lensCompletionsStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/completions?category=bogus")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q, want application/problem+json", got)
+	}
+}
+
+// An empty union (a known category with no values on any mount) yields
+// values:[], never null.
+func TestLensCompletions_EmptyUnion(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, completionsProvider: &lensCompletionsStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/completions?category=domain")
+	body := decodeLensCompletions(t, rec)
+	if body.Values == nil {
+		t.Error("values must be [] not null")
+	}
+}
+
+// An unknown lens is 404 (from LensMiddleware, before the handler runs).
+func TestLensCompletions_UnknownLens404(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	s := &Server{Manager: m, completionsProvider: &lensCompletionsStub{}}
+	r := s.NewAPIRouter()
+
+	rec := getLensFacts(t, r, "/lenses/missing/completions?category=repo")
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
 	}

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -656,9 +656,14 @@ type lensFactReaderStub struct {
 	byRepo map[string]map[string]knomitfact.Fact
 	head   string
 	err    error
+	reads  map[string]int // per-repo Read call count
 }
 
 func (s *lensFactReaderStub) Read(ri *repos.RepoInstance, _ hal.Anchor, path string, _ bool) (knomitfact.Fact, string, error) {
+	if s.reads == nil {
+		s.reads = map[string]int{}
+	}
+	s.reads[ri.Name()]++
 	if s.err != nil {
 		return knomitfact.Fact{}, "", s.err
 	}
@@ -730,6 +735,14 @@ func TestLensFact_BarePathReadsWriteRepo(t *testing.T) {
 	if _, ok := body.Links["self"]; !ok {
 		t.Errorf("missing _links.self; links=%+v", body.Links)
 	}
+	// No dedupe scan on a bare path: the read mount is NEVER queried — only the
+	// write repo is read. Locks in "bare means write repo, period" behaviorally.
+	if got := reader.reads["alpha"]; got != 0 {
+		t.Errorf("read mount queried %d times on a bare-path request, want 0", got)
+	}
+	if got := reader.reads["zulu"]; got != 1 {
+		t.Errorf("write repo read %d times, want exactly 1", got)
+	}
 }
 
 // A kb://<id12>/kb/... path (URL-encoded by the client) resolves to that mount,
@@ -760,6 +773,13 @@ func TestLensFact_QualifiedPathHitsMount(t *testing.T) {
 	}
 	if body.Title != "Read only" {
 		t.Errorf("title: got %q, want Read only", body.Title)
+	}
+	// The top-level path echoes the canonical QUALIFIED wire form for a read
+	// mount, so a client can round-trip it into another lens request and land on
+	// the same fact (not silently on the write repo).
+	wantPath := "kb://" + id + "/kb/y/2.md"
+	if body.Path != wantPath {
+		t.Errorf("path: got %q, want qualified %q", body.Path, wantPath)
 	}
 	if body.Source.Repo != "beta" || body.Source.ID != id || body.Source.Branch != beta.AgentBranch() {
 		t.Errorf("source: got %+v, want {beta %s %s}", body.Source, id, beta.AgentBranch())

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	knomitfact "knomit/internal/fact"
 	"knomit/internal/federate"
 	"knomit/internal/repos"
 	"knomit/internal/store"
+	"knomit/internal/web/hal"
 )
 
 // lensFactsStub is a per-repo factsCollectionProvider: each mount's RecentFacts
@@ -640,5 +643,190 @@ func TestLensCompletions_UnknownLens404(t *testing.T) {
 	rec := getLensFacts(t, r, "/lenses/missing/completions?category=repo")
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---- Single fact read through a lens (GET /lenses/{lens}/facts/{path...}) ----
+
+// lensFactReaderStub is a per-repo FactReader: Read is keyed by (repo name,
+// repo-relative path), so one stub drives the whole binding. A read that finds
+// no fact returns errFactNotFound (the sentinel the handler maps to 404); a
+// preset err short-circuits every read (exercises the 500 path).
+type lensFactReaderStub struct {
+	byRepo map[string]map[string]knomitfact.Fact
+	head   string
+	err    error
+}
+
+func (s *lensFactReaderStub) Read(ri *repos.RepoInstance, _ hal.Anchor, path string, _ bool) (knomitfact.Fact, string, error) {
+	if s.err != nil {
+		return knomitfact.Fact{}, "", s.err
+	}
+	f, ok := s.byRepo[ri.Name()][path]
+	if !ok {
+		return knomitfact.Fact{}, "", errFactNotFound
+	}
+	return f, s.head, nil
+}
+
+func (s *lensFactReaderStub) Exists(_ *repos.RepoInstance, _ string, _, _ string) bool { return true }
+
+// lensFactViewBody mirrors the single-fact wire shape: the repo FactView body
+// (path/title/body/as_of/_links) plus the lens-level source block.
+type lensFactViewBody struct {
+	Path   string      `json:"path"`
+	Title  string      `json:"title"`
+	Body   string      `json:"body"`
+	AsOf   AsOf        `json:"as_of"`
+	Links  hal.LinkMap `json:"_links"`
+	Source struct {
+		Repo   string `json:"repo"`
+		ID     string `json:"id"`
+		Branch string `json:"branch"`
+	} `json:"source"`
+}
+
+func mkFact(path, title string) knomitfact.Fact {
+	f := knomitfact.NewFact(path)
+	f.Title = title
+	f.Type = knomitfact.Type("observation")
+	return f
+}
+
+// A bare kb/... path reads from the WRITE repo — no dedupe scan — even when a
+// read mount shadows the SAME repo-relative path with different content. The
+// write repo's body wins and the source names the write repo.
+func TestLensFact_BarePathReadsWriteRepo(t *testing.T) {
+	m, _ := newTestLensManager(t, "zulu", "alpha") // write=zulu sorts after read=alpha
+	reader := &lensFactReaderStub{
+		head: "deadbeef",
+		byRepo: map[string]map[string]knomitfact.Fact{
+			"zulu":  {"kb/x/1.md": mkFact("kb/x/1.md", "Write copy")},
+			"alpha": {"kb/x/1.md": mkFact("kb/x/1.md", "Read copy")},
+		},
+	}
+	s := &Server{Manager: m, factReader: reader}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"zulu","reads":[{"repo":"alpha"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts/kb/x/1.md")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensFactViewBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if body.Path != "kb/x/1.md" {
+		t.Errorf("path: got %q, want bare kb/x/1.md", body.Path)
+	}
+	if body.Title != "Write copy" {
+		t.Errorf("title: got %q, want the WRITE repo's copy", body.Title)
+	}
+	zulu := m.Get("zulu")
+	if body.Source.Repo != "zulu" || body.Source.ID != federate.ID12(zulu.ID()) || body.Source.Branch != zulu.AgentBranch() {
+		t.Errorf("source: got %+v, want {zulu %s %s}", body.Source, federate.ID12(zulu.ID()), zulu.AgentBranch())
+	}
+	if _, ok := body.Links["self"]; !ok {
+		t.Errorf("missing _links.self; links=%+v", body.Links)
+	}
+}
+
+// A kb://<id12>/kb/... path (URL-encoded by the client) resolves to that mount,
+// returns its fact body, and carries that mount's source identity.
+func TestLensFact_QualifiedPathHitsMount(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	reader := &lensFactReaderStub{
+		head: "cafe1234",
+		byRepo: map[string]map[string]knomitfact.Fact{
+			"beta": {"kb/y/2.md": mkFact("kb/y/2.md", "Read only")},
+		},
+	}
+	s := &Server{Manager: m, factReader: reader}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	beta := m.Get("beta")
+	id := federate.ID12(beta.ID())
+	rawURL := "/lenses/eng/facts/" + url.PathEscape("kb://"+id+"/kb/y/2.md")
+
+	rec := getLensFacts(t, r, rawURL)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensFactViewBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if body.Title != "Read only" {
+		t.Errorf("title: got %q, want Read only", body.Title)
+	}
+	if body.Source.Repo != "beta" || body.Source.ID != id || body.Source.Branch != beta.AgentBranch() {
+		t.Errorf("source: got %+v, want {beta %s %s}", body.Source, id, beta.AgentBranch())
+	}
+}
+
+// A kb://<id12>/… whose id12 is not mounted in the lens returns 404 with the
+// SAME body as a genuinely-missing fact — mount topology must not leak (a
+// caller cannot tell "unknown mount" from "no such fact").
+func TestLensFact_UnknownID404MatchesNotFound(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	reader := &lensFactReaderStub{head: "cafe1234"} // no facts anywhere
+	s := &Server{Manager: m, factReader: reader}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	beta := m.Get("beta")
+	knownID := federate.ID12(beta.ID())
+	unknownID := "0123456789ab" // 12 hex, not a mounted repo id
+
+	// Missing fact at a KNOWN mount.
+	recKnown := getLensFacts(t, r, "/lenses/eng/facts/"+url.PathEscape("kb://"+knownID+"/kb/y/2.md"))
+	// Unknown mount id (same relative path).
+	recUnknown := getLensFacts(t, r, "/lenses/eng/facts/"+url.PathEscape("kb://"+unknownID+"/kb/y/2.md"))
+
+	if recKnown.Code != http.StatusNotFound {
+		t.Fatalf("known-missing status: got %d, want 404; body=%s", recKnown.Code, recKnown.Body.String())
+	}
+	if recUnknown.Code != http.StatusNotFound {
+		t.Fatalf("unknown-id status: got %d, want 404; body=%s", recUnknown.Code, recUnknown.Body.String())
+	}
+	if got := recUnknown.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q, want application/problem+json", got)
+	}
+	// The two 404 bodies address different requested paths, so they will differ
+	// in the echoed path — assert the TITLE is identical so an unknown id is
+	// indistinguishable in KIND from a missing fact (no "not mounted" tell).
+	var kb, ub struct {
+		Title  string `json:"title"`
+		Detail string `json:"detail"`
+	}
+	_ = json.Unmarshal(recKnown.Body.Bytes(), &kb)
+	_ = json.Unmarshal(recUnknown.Body.Bytes(), &ub)
+	if kb.Title != "Fact not found" || ub.Title != "Fact not found" {
+		t.Errorf("titles: known=%q unknown=%q, want both %q", kb.Title, ub.Title, "Fact not found")
+	}
+}
+
+// A retracted/missing fact on the write repo is a 404 (parity with the repo
+// single-fact handler), and a real backend error is a 500 (not masked as 404).
+func TestLensFact_MissingAndBackendError(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, factReader: &lensFactReaderStub{}} // no facts
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts/kb/gone.md")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("missing status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+
+	mErr, _ := newTestLensManager(t, "alpha", "beta")
+	sErr := &Server{Manager: mErr, factReader: &lensFactReaderStub{err: fmt.Errorf("disk on fire")}}
+	rErr := sErr.NewAPIRouter()
+	createLens(t, rErr, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+	recErr := getLensFacts(t, rErr, "/lenses/eng/facts/kb/x/1.md")
+	if recErr.Code != http.StatusInternalServerError {
+		t.Fatalf("backend-error status: got %d, want 500; body=%s", recErr.Code, recErr.Body.String())
 	}
 }

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -235,3 +235,259 @@ func TestLensFacts_EmptyMounts(t *testing.T) {
 		t.Error("facts must be [] not null")
 	}
 }
+
+// ── lens union search (GET /lenses/{lens}/search) ────────────────────────────
+
+// lensSearchStub is a per-repo searchProvider: each mount's Search call is
+// answered from byRepo keyed by the repo's name, so a single stub drives the
+// whole fan-out. It records the last SearchOptions and whether a non-nil
+// embedder was forwarded, per repo.
+type lensSearchStub struct {
+	byRepo   map[string][]store.SearchResult
+	lastOpts map[string]store.SearchOptions
+	embSeen  map[string]bool
+}
+
+func (s *lensSearchStub) Search(
+	ri *repos.RepoInstance, emb store.Embedder, _ string, opts store.SearchOptions,
+) ([]store.SearchResult, error) {
+	if s.lastOpts == nil {
+		s.lastOpts = map[string]store.SearchOptions{}
+	}
+	if s.embSeen == nil {
+		s.embSeen = map[string]bool{}
+	}
+	s.lastOpts[ri.Name()] = opts
+	s.embSeen[ri.Name()] = emb != nil
+	return s.byRepo[ri.Name()], nil
+}
+
+// sr builds a minimal search result: a repo-relative path, title, and native
+// relevance score. The score magnitude is what a naive interleave would sort
+// by; RRF ignores it and orders by per-mount rank instead.
+func sr(path, title string, score float64) store.SearchResult {
+	return store.SearchResult{
+		FactWithBody: store.FactWithBody{
+			FactRecord: store.FactRecord{Path: path, Title: title, Type: "observation"},
+		},
+		Score: score,
+	}
+}
+
+// lensSearchBody mirrors the lens union search wire shape.
+type lensSearchBody struct {
+	Results []struct {
+		Path       string   `json:"path"`
+		Title      string   `json:"title"`
+		Score      float64  `json:"score"`
+		Kind       string   `json:"kind"`
+		Type       string   `json:"type"`
+		Domain     []string `json:"domain"`
+		Entities   []string `json:"entities"`
+		Confidence float64  `json:"confidence"`
+		Source     struct {
+			Repo   string `json:"repo"`
+			ID     string `json:"id"`
+			Branch string `json:"branch"`
+		} `json:"source"`
+	} `json:"results"`
+	Total int `json:"total"`
+}
+
+func decodeLensSearch(t *testing.T, rec *httptest.ResponseRecorder) lensSearchBody {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensSearchBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	return body
+}
+
+// A duplicate relative path across the write and a read mount collapses to a
+// single row: the WRITE repo's copy, with a bare (unqualified) path — even when
+// the read mount's copy scores HIGHER (so it ranks first under fusion). The
+// shadowed higher-ranked copy must not appear at all.
+func TestLensSearch_DuplicatePathWriteWins(t *testing.T) {
+	m, _ := newTestLensManager(t, "zulu", "alpha") // write=zulu sorts after read=alpha
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{
+		"zulu":  {sr("kb/x/1.md", "Write copy", 10)},
+		"alpha": {sr("kb/x/1.md", "Read copy", 99)}, // higher score, would rank first
+	}}
+	s := &Server{Manager: m, searchProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"zulu","reads":[{"repo":"alpha"}]}`)
+
+	body := decodeLensSearch(t, getLensFacts(t, r, "/lenses/eng/search?q=x"))
+	if len(body.Results) != 1 {
+		t.Fatalf("results: got %d, want 1 (deduped); body=%+v", len(body.Results), body)
+	}
+	if body.Total != 1 {
+		t.Errorf("total: got %d, want 1", body.Total)
+	}
+	got := body.Results[0]
+	if got.Path != "kb/x/1.md" {
+		t.Errorf("path: got %q, want bare kb/x/1.md", got.Path)
+	}
+	if got.Title != "Write copy" {
+		t.Errorf("title: got %q, want the WRITE repo's copy (read copy is shadowed even though it ranks higher)", got.Title)
+	}
+	if got.Source.Repo != "zulu" {
+		t.Errorf("source.repo: got %q, want zulu (write)", got.Source.Repo)
+	}
+}
+
+// The fused order is reciprocal-rank fusion, NOT a naive interleave by native
+// score. Constructed so the two orderings disagree. Mounts fan out in Reads()
+// order — sorted by repo name — so alpha is mount 0, beta is mount 1. alpha's
+// only fact ranks #0 in its mount with a LOW native score (5); beta has a
+// high-score #0 (100) and a mid-score #1 (50). RRF interleaves by rank —
+// alpha#0, beta#0, beta#1 — so alpha's low-score fact LEADS. A naive score sort
+// would order beta-top(100), beta-second(50), alpha-top(5), putting alpha LAST.
+// This test fails under naive interleaving.
+func TestLensSearch_RRFNotNaiveInterleave(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{
+		// Reads() is sorted by repo name → alpha is mount 0, beta is mount 1.
+		"alpha": {sr("kb/a/0.md", "alpha-top", 5)}, // rank 0, LOW score
+		"beta": {
+			sr("kb/b/0.md", "beta-top", 100),
+			sr("kb/b/1.md", "beta-second", 50),
+		},
+	}}
+	s := &Server{Manager: m, searchProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensSearch(t, getLensFacts(t, r, "/lenses/eng/search?q=x"))
+	got := make([]string, len(body.Results))
+	for i, res := range body.Results {
+		got[i] = res.Title
+	}
+	want := []string{"alpha-top", "beta-top", "beta-second"}
+	if len(got) != len(want) {
+		t.Fatalf("count: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order: got %v, want %v (RRF by rank, not naive score interleave)", got, want)
+		}
+	}
+}
+
+// A fact that lives only on a read mount is qualified with kb://<id12>/… and
+// carries that mount's source identity.
+func TestLensSearch_ReadMountQualifiedPath(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{
+		"beta": {sr("kb/y/2.md", "Read only", 42)},
+	}}
+	s := &Server{Manager: m, searchProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	beta := m.Get("beta")
+	wantID := federate.ID12(beta.ID())
+	wantPath := "kb://" + wantID + "/kb/y/2.md"
+
+	body := decodeLensSearch(t, getLensFacts(t, r, "/lenses/eng/search?q=x"))
+	if len(body.Results) != 1 {
+		t.Fatalf("results: got %d, want 1; body=%+v", len(body.Results), body)
+	}
+	got := body.Results[0]
+	if got.Path != wantPath {
+		t.Errorf("path: got %q, want %q", got.Path, wantPath)
+	}
+	if got.Source.Repo != "beta" || got.Source.ID != wantID || got.Source.Branch != beta.AgentBranch() {
+		t.Errorf("source: got %+v, want {beta %s %s}", got.Source, wantID, beta.AgentBranch())
+	}
+}
+
+// repo=<name> narrows the fan-out to the named mount(s); other mounts' results
+// do not appear.
+func TestLensSearch_RepoFilterNarrows(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{
+		"alpha": {sr("kb/a/1.md", "Write fact", 100)},
+		"beta":  {sr("kb/b/2.md", "Read fact", 10)},
+	}}
+	s := &Server{Manager: m, searchProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensSearch(t, getLensFacts(t, r, "/lenses/eng/search?q=x&repo=beta"))
+	if len(body.Results) != 1 {
+		t.Fatalf("results: got %d, want 1; body=%+v", len(body.Results), body)
+	}
+	if body.Results[0].Source.Repo != "beta" {
+		t.Errorf("source.repo: got %q, want beta only", body.Results[0].Source.Repo)
+	}
+}
+
+// An unknown repo= name is a well-formed request naming a nonexistent mount → 422.
+func TestLensSearch_UnknownRepoFilter422(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, searchProvider: &lensSearchStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/search?q=x&repo=ghost")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q, want application/problem+json", got)
+	}
+}
+
+// With embeddings disabled (Server.Embedder nil), the endpoint still serves
+// results — it forwards the nil embedder to the provider exactly as the repo
+// /search handler does (keyword fallback, no query vector), never 500s.
+func TestLensSearch_EmbedderOffFallback(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{
+		"beta": {sr("kb/b/2.md", "Read fact", 10)},
+	}}
+	s := &Server{Manager: m, searchProvider: stub} // Embedder left nil
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensSearch(t, getLensFacts(t, r, "/lenses/eng/search?q=x"))
+	if len(body.Results) != 1 {
+		t.Fatalf("results: got %d, want 1; body=%+v", len(body.Results), body)
+	}
+	if stub.embSeen["beta"] {
+		t.Error("expected nil embedder forwarded to provider (embeddings disabled), but a non-nil one was seen")
+	}
+}
+
+// An empty union (no mount returns results) yields results:[] and total:0, never null.
+func TestLensSearch_EmptyMounts(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, searchProvider: &lensSearchStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/search?q=x")
+	body := decodeLensSearch(t, rec)
+	if body.Total != 0 {
+		t.Errorf("total: got %d, want 0", body.Total)
+	}
+	if body.Results == nil {
+		t.Error("results must be [] not null")
+	}
+}
+
+// An unknown lens is 404 (from LensMiddleware, before the handler runs).
+func TestLensSearch_UnknownLens404(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	s := &Server{Manager: m, searchProvider: &lensSearchStub{}}
+	r := s.NewAPIRouter()
+
+	rec := getLensFacts(t, r, "/lenses/missing/search?q=x")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -1,0 +1,237 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// lensFactsStub is a per-repo factsCollectionProvider: each mount's RecentFacts
+// call is answered from byRepo keyed by the repo's name, so a single stub drives
+// the whole fan-out. It records the last SearchOptions seen per repo.
+type lensFactsStub struct {
+	byRepo   map[string][]store.RecentFactEntry
+	lastOpts map[string]store.SearchOptions
+}
+
+func (s *lensFactsStub) RecentFacts(
+	ri *repos.RepoInstance, _ string, opts store.SearchOptions,
+) ([]store.RecentFactEntry, int, error) {
+	if s.lastOpts == nil {
+		s.lastOpts = map[string]store.SearchOptions{}
+	}
+	s.lastOpts[ri.Name()] = opts
+	e := s.byRepo[ri.Name()]
+	return e, len(e), nil
+}
+
+// lensFactsBody mirrors the union facts collection wire shape.
+type lensFactsBody struct {
+	Facts []struct {
+		Path        string  `json:"path"`
+		Title       string  `json:"title"`
+		Kind        string  `json:"kind"`
+		Type        string  `json:"type"`
+		CommittedAt int64   `json:"committed_at"`
+		Operation   string  `json:"operation"`
+		Score       float64 `json:"score"`
+		Source      struct {
+			Repo   string `json:"repo"`
+			ID     string `json:"id"`
+			Branch string `json:"branch"`
+		} `json:"source"`
+	} `json:"facts"`
+	Total int `json:"total"`
+}
+
+func createLens(t *testing.T, r http.Handler, body string) {
+	t.Helper()
+	rec := postLens(t, r, body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create lens: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func getLensFacts(t *testing.T, r http.Handler, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, url, nil))
+	return rec
+}
+
+func decodeLensFacts(t *testing.T, rec *httptest.ResponseRecorder) lensFactsBody {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensFactsBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	return body
+}
+
+// A duplicate relative path across the write and a read mount collapses to a
+// single row: the WRITE repo's copy, with a bare (unqualified) path — even when
+// the write repo's name sorts AFTER the read mount's in binding order.
+func TestLensFacts_DuplicatePathWriteWins(t *testing.T) {
+	m, _ := newTestLensManager(t, "zulu", "alpha") // write=zulu sorts after read=alpha
+	stub := &lensFactsStub{byRepo: map[string][]store.RecentFactEntry{
+		"zulu":  {{Path: "kb/x/1.md", Title: "Write copy", Type: "observation", CommittedAt: 100}},
+		"alpha": {{Path: "kb/x/1.md", Title: "Read copy", Type: "observation", CommittedAt: 200}},
+	}}
+	s := &Server{Manager: m, factsCollectionProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"zulu","reads":[{"repo":"alpha"}]}`)
+
+	body := decodeLensFacts(t, getLensFacts(t, r, "/lenses/eng/facts"))
+	if len(body.Facts) != 1 {
+		t.Fatalf("facts: got %d, want 1 (deduped); body=%+v", len(body.Facts), body)
+	}
+	if body.Total != 1 {
+		t.Errorf("total: got %d, want 1", body.Total)
+	}
+	f := body.Facts[0]
+	if f.Path != "kb/x/1.md" {
+		t.Errorf("path: got %q, want bare kb/x/1.md", f.Path)
+	}
+	if f.Title != "Write copy" {
+		t.Errorf("title: got %q, want the WRITE repo's copy", f.Title)
+	}
+	if f.Source.Repo != "zulu" {
+		t.Errorf("source.repo: got %q, want zulu (write)", f.Source.Repo)
+	}
+}
+
+// A fact that lives only on a read mount is qualified with kb://<id12>/… and
+// carries that mount's source identity.
+func TestLensFacts_ReadMountQualifiedPath(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensFactsStub{byRepo: map[string][]store.RecentFactEntry{
+		"beta": {{Path: "kb/y/2.md", Title: "Read only", Type: "policy", CommittedAt: 300}},
+	}}
+	s := &Server{Manager: m, factsCollectionProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	beta := m.Get("beta")
+	wantID := federate.ID12(beta.ID())
+	wantPath := "kb://" + wantID + "/kb/y/2.md"
+
+	body := decodeLensFacts(t, getLensFacts(t, r, "/lenses/eng/facts"))
+	if len(body.Facts) != 1 {
+		t.Fatalf("facts: got %d, want 1; body=%+v", len(body.Facts), body)
+	}
+	f := body.Facts[0]
+	if f.Path != wantPath {
+		t.Errorf("path: got %q, want %q", f.Path, wantPath)
+	}
+	if f.Source.Repo != "beta" || f.Source.ID != wantID || f.Source.Branch != beta.AgentBranch() {
+		t.Errorf("source: got %+v, want {beta %s %s}", f.Source, wantID, beta.AgentBranch())
+	}
+}
+
+// repo=<name> narrows the fan-out to the named mount(s); other mounts' facts do
+// not appear.
+func TestLensFacts_RepoFilterNarrows(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensFactsStub{byRepo: map[string][]store.RecentFactEntry{
+		"alpha": {{Path: "kb/a/1.md", Title: "Write fact", CommittedAt: 100}},
+		"beta":  {{Path: "kb/b/2.md", Title: "Read fact", CommittedAt: 200}},
+	}}
+	s := &Server{Manager: m, factsCollectionProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensFacts(t, getLensFacts(t, r, "/lenses/eng/facts?repo=beta"))
+	if len(body.Facts) != 1 {
+		t.Fatalf("facts: got %d, want 1; body=%+v", len(body.Facts), body)
+	}
+	if body.Facts[0].Source.Repo != "beta" {
+		t.Errorf("source.repo: got %q, want beta only", body.Facts[0].Source.Repo)
+	}
+}
+
+// An unknown repo= name is a well-formed request naming a nonexistent mount → 422.
+func TestLensFacts_UnknownRepoFilter422(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, factsCollectionProvider: &lensFactsStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts?repo=ghost")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q, want application/problem+json", got)
+	}
+}
+
+// Recency ordering is by committed_at ACROSS mounts, not grouped by mount.
+func TestLensFacts_RecencyOrderingAcrossMounts(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensFactsStub{byRepo: map[string][]store.RecentFactEntry{
+		// Each mount's list is committed_at-DESC, as RecentFacts returns.
+		"alpha": {
+			{Path: "kb/a/hi.md", Title: "a-300", CommittedAt: 300},
+			{Path: "kb/a/lo.md", Title: "a-100", CommittedAt: 100},
+		},
+		"beta": {
+			{Path: "kb/b/hi.md", Title: "b-400", CommittedAt: 400},
+			{Path: "kb/b/lo.md", Title: "b-200", CommittedAt: 200},
+		},
+	}}
+	s := &Server{Manager: m, factsCollectionProvider: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensFacts(t, getLensFacts(t, r, "/lenses/eng/facts"))
+	got := make([]string, len(body.Facts))
+	for i, f := range body.Facts {
+		got[i] = f.Title
+	}
+	want := []string{"b-400", "a-300", "b-200", "a-100"}
+	if len(got) != len(want) {
+		t.Fatalf("count: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order: got %v, want %v (interleaved by timestamp, not mount-grouped)", got, want)
+		}
+	}
+}
+
+// An unknown lens is 404 (from LensMiddleware, before the handler runs).
+func TestLensFacts_UnknownLens404(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	s := &Server{Manager: m, factsCollectionProvider: &lensFactsStub{}}
+	r := s.NewAPIRouter()
+
+	rec := getLensFacts(t, r, "/lenses/missing/facts")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// An empty union (no mount returns facts) yields facts:[] and total:0, never null.
+func TestLensFacts_EmptyMounts(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, factsCollectionProvider: &lensFactsStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts")
+	body := decodeLensFacts(t, rec)
+	if body.Total != 0 {
+		t.Errorf("total: got %d, want 0", body.Total)
+	}
+	if body.Facts == nil {
+		t.Error("facts must be [] not null")
+	}
+}

--- a/internal/web/handlers_lenses_stats.go
+++ b/internal/web/handlers_lenses_stats.go
@@ -1,0 +1,146 @@
+package web
+
+import (
+	"net/http"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/web/hal"
+)
+
+// round2 rounds to 2 decimal places, byte-identical to the store's per-mount
+// AvgConfidence rounding (store/index.go), so the union mean is emitted at the
+// same precision as the repo /stats endpoint.
+func round2(x float64) float64 { return float64(int(x*100+0.5)) / 100 }
+
+// lensRepoStats is one per-mount row of the lens union stats: the mount's
+// identity (id12/name/source/branch/is_write) plus its own aggregate stats
+// and commit activity.
+type lensRepoStats struct {
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Source        string         `json:"source"`
+	Branch        string         `json:"branch"`
+	IsWrite       bool           `json:"is_write"`
+	Total         int            `json:"total"`
+	AvgConfidence float64        `json:"avg_confidence"`
+	Domains       map[string]int `json:"domains"`
+	Entities      map[string]int `json:"entities"`
+	LastCommit    string         `json:"last_commit"`
+	Changes7d     int            `json:"changes_7d"`
+	Changes30d    int            `json:"changes_30d"`
+	Changes90d    int            `json:"changes_90d"`
+}
+
+// lensStatsResponse is the union stats envelope. Flat (no _links), consistent
+// with the other lens union reads.
+//
+// On dedup: total/domains/entities are EXACT sums, not approximations. Fact
+// paths are kb/<topic>/<category>/<server-generated-uuid>.md and mounts are
+// distinct repos (replica mounts are rejected at lens create), so cross-mount
+// path collisions cannot occur and the facts-union's winning-path dedup is a
+// no-op for aggregates. Aggregate StatsResults carry no per-fact paths to
+// dedup on anyway; a truly-deduped count would require fetching the fact sets
+// (up to 500 rows/mount). So we sum — cheap, and exact.
+type lensStatsResponse struct {
+	Total         int             `json:"total"`
+	RepoCount     int             `json:"repo_count"`
+	LastCommit    string          `json:"last_commit"`
+	AvgConfidence float64         `json:"avg_confidence"`
+	Domains       map[string]int  `json:"domains"`
+	Entities      map[string]int  `json:"entities"`
+	Repos         []lensRepoStats `json:"repos"`
+}
+
+// handleHALLensStats serves GET /lenses/{lens}/stats — the union stats +
+// activity roll-up of a lens's write repo + N read mounts, with a per-repo
+// breakdown. It fans out over federate.ReadTargetsFor exactly like the other
+// lens reads and reuses the repo statsProvider/activityProvider per mount —
+// no new store logic. Any mount error fails the whole request (RFC §9.1 — a
+// lens never silently shrinks its read set).
+func handleHALLensStats(statsP statsProvider, actP activityProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b := repos.BindingFromContext(r.Context())
+		qp := r.URL.Query()
+
+		// Ontology-aware fan-out target selection — the same seam the facts/
+		// search twins use. A kb://-qualified path restricts to one mount; an
+		// unqualified path applies per mount.
+		targets, err := federate.ReadTargetsFor(b, qp.Get("path"))
+		if err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+				err.Error(), r.URL.Path)
+			return
+		}
+
+		// Optional repeatable `repo=<mount name>` narrows the fan-out (422 on
+		// an unknown mount name) — the shared lens union-read filter.
+		targets, ok := narrowByRepo(w, r, b, targets, qp["repo"])
+		if !ok {
+			return
+		}
+
+		resp := lensStatsResponse{
+			Domains:  map[string]int{},
+			Entities: map[string]int{},
+			Repos:    make([]lensRepoStats, 0, len(targets)),
+		}
+		var confWeight float64 // Σ(avg_i · total_i); divided by Σ(total_i) below
+		for _, t := range targets {
+			st, err := statsP.Stats(t.RT.RI, t.RT.Branch, t.Path)
+			if err != nil {
+				writeStoreError(w, r, err, "Failed to load stats", t.RT.Branch)
+				return
+			}
+			act, err := actP.Activity(t.RT.RI, t.RT.Branch, t.Path)
+			if err != nil {
+				writeStoreError(w, r, err, "Failed to load activity", t.RT.Branch)
+				return
+			}
+			// Mirror handleHALStats: JSON must carry {} for empty maps, never
+			// null — an empty StatsResult has nil Domains/Entities.
+			domains := st.Domains
+			if domains == nil {
+				domains = map[string]int{}
+			}
+			entities := st.Entities
+			if entities == nil {
+				entities = map[string]int{}
+			}
+			resp.Total += st.Total
+			confWeight += st.AvgConfidence * float64(st.Total)
+			for d, n := range domains {
+				resp.Domains[d] += n
+			}
+			for e, n := range entities {
+				resp.Entities[e] += n
+			}
+			// last_commit is the MAX timestamp across mounts. The store emits a
+			// fixed-format UTC RFC3339 stamp, so lexicographic comparison IS
+			// chronological comparison; "" loses to any real stamp.
+			if act.LastCommit > resp.LastCommit {
+				resp.LastCommit = act.LastCommit
+			}
+			resp.Repos = append(resp.Repos, lensRepoStats{
+				ID:            federate.ID12(t.RT.RI.ID()),
+				Name:          t.RT.RI.Name(),
+				Source:        t.RT.Source,
+				Branch:        t.RT.Branch,
+				IsWrite:       t.RT.RI == b.Write(),
+				Total:         st.Total,
+				AvgConfidence: st.AvgConfidence,
+				Domains:       domains,
+				Entities:      entities,
+				LastCommit:    act.LastCommit,
+				Changes7d:     act.Changes7d,
+				Changes30d:    act.Changes30d,
+				Changes90d:    act.Changes90d,
+			})
+		}
+		resp.RepoCount = len(targets)
+		if resp.Total > 0 {
+			resp.AvgConfidence = round2(confWeight / float64(resp.Total))
+		}
+		hal.WriteHAL(w, http.StatusOK, resp)
+	}
+}

--- a/internal/web/handlers_lenses_stats_test.go
+++ b/internal/web/handlers_lenses_stats_test.go
@@ -1,0 +1,290 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+	"knomit/internal/web/hal"
+)
+
+// lensStatsStub is a per-repo statsProvider: each mount's Stats call is
+// answered from byRepo keyed by the repo's name, so a single stub drives the
+// whole fan-out. It records the last pathPrefix seen per repo so tests can
+// assert per-target path forwarding; errRepo makes that one mount fail.
+type lensStatsStub struct {
+	byRepo   map[string]store.StatsResult
+	errRepo  string
+	lastPath map[string]string
+}
+
+func (s *lensStatsStub) Stats(ri *repos.RepoInstance, _ string, pathPrefix string) (store.StatsResult, error) {
+	if s.lastPath == nil {
+		s.lastPath = map[string]string{}
+	}
+	s.lastPath[ri.Name()] = pathPrefix
+	if s.errRepo != "" && ri.Name() == s.errRepo {
+		return store.StatsResult{}, errors.New("db on fire")
+	}
+	return s.byRepo[ri.Name()], nil
+}
+
+// lensActivityStub is the per-repo activityProvider twin of lensStatsStub.
+type lensActivityStub struct {
+	byRepo   map[string]store.ActivityResult
+	errRepo  string
+	lastPath map[string]string
+}
+
+func (s *lensActivityStub) Activity(ri *repos.RepoInstance, _ string, path string) (store.ActivityResult, error) {
+	if s.lastPath == nil {
+		s.lastPath = map[string]string{}
+	}
+	s.lastPath[ri.Name()] = path
+	if s.errRepo != "" && ri.Name() == s.errRepo {
+		return store.ActivityResult{}, errors.New("git on fire")
+	}
+	return s.byRepo[ri.Name()], nil
+}
+
+// lensStatsBody mirrors the union stats wire shape.
+type lensStatsBody struct {
+	Total         int            `json:"total"`
+	RepoCount     int            `json:"repo_count"`
+	LastCommit    string         `json:"last_commit"`
+	AvgConfidence float64        `json:"avg_confidence"`
+	Domains       map[string]int `json:"domains"`
+	Entities      map[string]int `json:"entities"`
+	Repos         []struct {
+		ID            string         `json:"id"`
+		Name          string         `json:"name"`
+		Source        string         `json:"source"`
+		Branch        string         `json:"branch"`
+		IsWrite       bool           `json:"is_write"`
+		Total         int            `json:"total"`
+		AvgConfidence float64        `json:"avg_confidence"`
+		Domains       map[string]int `json:"domains"`
+		Entities      map[string]int `json:"entities"`
+		LastCommit    string         `json:"last_commit"`
+		Changes7d     int            `json:"changes_7d"`
+		Changes30d    int            `json:"changes_30d"`
+		Changes90d    int            `json:"changes_90d"`
+	} `json:"repos"`
+}
+
+func decodeLensStats(t *testing.T, rec *httptest.ResponseRecorder) lensStatsBody {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensStatsBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	return body
+}
+
+// The union roll-up sums totals/domains/entities across mounts, weights
+// avg_confidence by per-mount total, takes the MAX last_commit, and lists one
+// per-repo row per fanned-out target — is_write set on the write repo only,
+// id = the mount's id12, branch = the Binding-resolved read branch.
+func TestLensStats_UnionAggregates(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	statsStub := &lensStatsStub{byRepo: map[string]store.StatsResult{
+		"alpha": {Total: 200, AvgConfidence: 0.9, Domains: map[string]int{"go": 5, "ai": 10}, Entities: map[string]int{"chi": 3}},
+		"beta":  {Total: 50, AvgConfidence: 0.5, Domains: map[string]int{"go": 2, "web": 1}, Entities: map[string]int{"vite": 4}},
+	}}
+	actStub := &lensActivityStub{byRepo: map[string]store.ActivityResult{
+		"alpha": {LastCommit: "2026-07-19T09:00:00Z", Total: 40, Changes7d: 1, Changes30d: 2, Changes90d: 3},
+		"beta":  {LastCommit: "2026-07-20T10:00:00Z", Total: 7, Changes7d: 4, Changes30d: 5, Changes90d: 6},
+	}}
+	s := &Server{Manager: m, statsProvider: statsStub, activityProvider: actStub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/stats")
+	if got := rec.Header().Get("Content-Type"); got != hal.ContentType {
+		t.Errorf("content-type: got %q, want %q", got, hal.ContentType)
+	}
+	body := decodeLensStats(t, rec)
+
+	if body.Total != 250 {
+		t.Errorf("total: got %d, want 250 (sum across mounts)", body.Total)
+	}
+	if body.RepoCount != 2 {
+		t.Errorf("repo_count: got %d, want 2", body.RepoCount)
+	}
+	// Total-weighted mean: (0.9*200 + 0.5*50) / 250 = 0.82.
+	if diff := body.AvgConfidence - 0.82; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("avg_confidence: got %v, want 0.82 (total-weighted mean)", body.AvgConfidence)
+	}
+	if body.LastCommit != "2026-07-20T10:00:00Z" {
+		t.Errorf("last_commit: got %q, want the MAX across mounts", body.LastCommit)
+	}
+	if body.Domains["go"] != 7 || body.Domains["ai"] != 10 || body.Domains["web"] != 1 {
+		t.Errorf("domains: got %v, want merged sums {go:7 ai:10 web:1}", body.Domains)
+	}
+	if body.Entities["chi"] != 3 || body.Entities["vite"] != 4 {
+		t.Errorf("entities: got %v, want merged sums {chi:3 vite:4}", body.Entities)
+	}
+	if len(body.Repos) != 2 {
+		t.Fatalf("repos: got %d rows, want 2; body=%+v", len(body.Repos), body)
+	}
+	// Reads() is sorted by repo name → alpha (write) then beta.
+	alpha, beta := body.Repos[0], body.Repos[1]
+	if alpha.Name != "alpha" || !alpha.IsWrite {
+		t.Errorf("row 0: got %+v, want name=alpha is_write=true", alpha)
+	}
+	if beta.Name != "beta" || beta.IsWrite {
+		t.Errorf("row 1: got %+v, want name=beta is_write=false", beta)
+	}
+	alphaRI, betaRI := m.Get("alpha"), m.Get("beta")
+	if alpha.ID != federate.ID12(alphaRI.ID()) || beta.ID != federate.ID12(betaRI.ID()) {
+		t.Errorf("ids: got %q/%q, want the mounts' id12s", alpha.ID, beta.ID)
+	}
+	if alpha.Branch != alphaRI.AgentBranch() || beta.Branch != betaRI.AgentBranch() {
+		t.Errorf("branches: got %q/%q, want the resolved read branches", alpha.Branch, beta.Branch)
+	}
+	if beta.Total != 50 || beta.AvgConfidence != 0.5 || beta.LastCommit != "2026-07-20T10:00:00Z" ||
+		beta.Changes7d != 4 || beta.Changes30d != 5 || beta.Changes90d != 6 {
+		t.Errorf("beta row must carry its own stats+activity, got %+v", beta)
+	}
+}
+
+// repo=<name> narrows the fan-out to the named mount(s): the roll-up and
+// repo_count reflect only those mounts.
+func TestLensStats_RepoFilterNarrows(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	statsStub := &lensStatsStub{byRepo: map[string]store.StatsResult{
+		"alpha": {Total: 200, AvgConfidence: 0.9},
+		"beta":  {Total: 50, AvgConfidence: 0.5},
+	}}
+	actStub := &lensActivityStub{byRepo: map[string]store.ActivityResult{
+		"beta": {LastCommit: "2026-07-20T10:00:00Z"},
+	}}
+	s := &Server{Manager: m, statsProvider: statsStub, activityProvider: actStub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensStats(t, getLensFacts(t, r, "/lenses/eng/stats?repo=beta"))
+	if body.RepoCount != 1 {
+		t.Errorf("repo_count: got %d, want 1 (narrowed)", body.RepoCount)
+	}
+	if body.Total != 50 {
+		t.Errorf("total: got %d, want 50 (beta only)", body.Total)
+	}
+	if len(body.Repos) != 1 || body.Repos[0].Name != "beta" {
+		t.Fatalf("repos: got %+v, want the single beta row", body.Repos)
+	}
+}
+
+// An unknown repo= name is a well-formed request naming a nonexistent mount → 422.
+func TestLensStats_UnknownRepoFilter422(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, statsProvider: &lensStatsStub{}, activityProvider: &lensActivityStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/stats?repo=ghost")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q, want application/problem+json", got)
+	}
+}
+
+// An empty lens (no facts, no commits on any mount) yields zero totals,
+// avg_confidence 0 (no division by zero), last_commit "", NON-NULL maps at
+// both the union and per-repo levels, and a per-repo row per mount.
+func TestLensStats_EmptyMounts(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, statsProvider: &lensStatsStub{}, activityProvider: &lensActivityStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensStats(t, getLensFacts(t, r, "/lenses/eng/stats"))
+	if body.Total != 0 || body.AvgConfidence != 0 {
+		t.Errorf("empty union: got total=%d avg=%v, want 0/0", body.Total, body.AvgConfidence)
+	}
+	if body.LastCommit != "" {
+		t.Errorf("last_commit: got %q, want \"\"", body.LastCommit)
+	}
+	if body.Domains == nil || body.Entities == nil {
+		t.Error("union domains/entities must be {} not null")
+	}
+	if len(body.Repos) != 2 {
+		t.Fatalf("repos: got %d rows, want 2 (mounts still listed)", len(body.Repos))
+	}
+	for _, row := range body.Repos {
+		if row.Domains == nil || row.Entities == nil {
+			t.Errorf("row %s: domains/entities must be {} not null", row.Name)
+		}
+	}
+}
+
+// Any mount error fails the WHOLE request (RFC §9.1) — even when the failing
+// mount is a read mount and the write repo answered fine — for BOTH the stats
+// and the activity call.
+func TestLensStats_MountErrorFailsWholeRequest(t *testing.T) {
+	for name, providers := range map[string]struct {
+		stats *lensStatsStub
+		act   *lensActivityStub
+	}{
+		"stats error":    {&lensStatsStub{errRepo: "beta"}, &lensActivityStub{}},
+		"activity error": {&lensStatsStub{}, &lensActivityStub{errRepo: "beta"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			m, _ := newTestLensManager(t, "alpha", "beta")
+			s := &Server{Manager: m, statsProvider: providers.stats, activityProvider: providers.act}
+			r := s.NewAPIRouter()
+			createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+			rec := getLensFacts(t, r, "/lenses/eng/stats")
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status: got %d, want 500; body=%s", rec.Code, rec.Body.String())
+			}
+			if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+				t.Errorf("content-type: got %q, want application/problem+json", got)
+			}
+		})
+	}
+}
+
+// path= is forwarded to EVERY mount's stats AND activity providers as the
+// per-target (repo-relative) prefix.
+func TestLensStats_ForwardsPathPrefix(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	statsStub := &lensStatsStub{}
+	actStub := &lensActivityStub{}
+	s := &Server{Manager: m, statsProvider: statsStub, activityProvider: actStub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	decodeLensStats(t, getLensFacts(t, r, "/lenses/eng/stats?path=kb/meta"))
+	for _, repo := range []string{"alpha", "beta"} {
+		if got := statsStub.lastPath[repo]; got != "kb/meta" {
+			t.Errorf("stats path for %s: got %q, want kb/meta", repo, got)
+		}
+		if got := actStub.lastPath[repo]; got != "kb/meta" {
+			t.Errorf("activity path for %s: got %q, want kb/meta", repo, got)
+		}
+	}
+}
+
+// An unknown lens is 404 (from LensMiddleware, before the handler runs).
+func TestLensStats_UnknownLens404(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	s := &Server{Manager: m, statsProvider: &lensStatsStub{}, activityProvider: &lensActivityStub{}}
+	r := s.NewAPIRouter()
+
+	rec := getLensFacts(t, r, "/lenses/missing/stats")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/web/handlers_lenses_topics.go
+++ b/internal/web/handlers_lenses_topics.go
@@ -1,0 +1,168 @@
+package web
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/go-chi/chi/v5"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+	"knomit/internal/web/hal"
+)
+
+// lensTopicSource identifies which mount a union tree leaf came from. Unlike
+// lensFactSource it carries no branch: the leaf's `path` already addresses the
+// owning mount canonically, and the source badge only needs the repo name.
+type lensTopicSource struct {
+	Repo string `json:"repo"`
+	ID   string `json:"id"`
+}
+
+// lensTopicChild is one child of a unified lens tree level. Directories are
+// merged across mounts into plain {name,is_dir} nodes (shared topic
+// vocabulary — no source, no path). Fact leaves are per-mount occurrences
+// (server-uuid filenames never collide): type/title enriched from the owning
+// mount's search index, `path` the canonical wire address (bare for the write
+// mount, kb://<id12>/… for a read mount — what the frontend hands to
+// openFact), and `source` the owning mount's tag.
+type lensTopicChild struct {
+	Name   string           `json:"name"`
+	IsDir  bool             `json:"is_dir"`
+	Type   string           `json:"type,omitempty"`
+	Title  string           `json:"title,omitempty"`
+	Path   string           `json:"path,omitempty"`
+	Source *lensTopicSource `json:"source,omitempty"`
+}
+
+// lensTopicsResponse is the unified tree-level envelope. Flat (path +
+// children), consistent with the other lens union reads; `path` echoes the
+// ontology-rooted directory this level lists.
+type lensTopicsResponse struct {
+	Path     string           `json:"path"`
+	Children []lensTopicChild `json:"children"`
+}
+
+// handleHALLensTopics serves GET /lenses/{lens}/topics and
+// GET /lenses/{lens}/topics/* — ONE level of the unified, merged-by-topic
+// ontology tree across the lens's write repo + N read mounts (lazy per-level,
+// like the repo /topics browse; no eager full-tree build). It is the lens twin
+// of topicHandler (handlers_topics.go), fanned out like the facts/search/stats
+// siblings: federate.ReadTargetsFor selects the mounts (the ontology-aware
+// topic skip applies once the path is kb/<topic>/…-deep), narrowByRepo applies
+// repo= narrowing, and any mount error fails the WHOLE request (RFC §9.1 — a
+// lens never silently shrinks its read set).
+//
+// Assumption: every mount shares the server's global ontology root ("kb") —
+// knomit's ontology root is global config, not per-repo — so the single
+// dirPath below maps uniformly onto every mount. (The topic skip additionally
+// relies on the root being literally "kb": federate.topicOfPathFilter only
+// recognizes kb/<topic>/… filters.)
+func handleHALLensTopics(lister TopicLister, ontologyRoot string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b := repos.BindingFromContext(r.Context())
+
+		// nodePath is "" on the root route (no wildcard param).
+		nodePath := chi.URLParam(r, "*")
+		dirPath := ontologyRoot
+		if nodePath != "" {
+			dirPath = ontologyRoot + "/" + nodePath
+		}
+
+		// The ontology-rooted dirPath is the fan-out path filter: at the root
+		// ("kb") and one level deep ("kb/decisions") it constrains nothing (a
+		// prefix that could still match any topic), but from kb/<topic>/…
+		// onward mounts whose ontology lacks the topic are skipped — the same
+		// seam and semantics as the facts/search/stats siblings.
+		targets, err := federate.ReadTargetsFor(b, dirPath)
+		if err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+				err.Error(), r.URL.Path)
+			return
+		}
+
+		// Optional repeatable `repo=<mount name>` narrows the fan-out (422 on
+		// an unknown mount name) — the shared lens union-read filter.
+		targets, ok := narrowByRepo(w, r, b, targets, r.URL.Query()["repo"])
+		if !ok {
+			return
+		}
+
+		// Split each mount's listing into directory names (deduped by shared
+		// topic vocabulary — first-seen wins, dirs carry no per-mount payload)
+		// and leaf entries (kept per-mount for now, deduped by winner below).
+		var dirNames []string
+		dirSeen := make(map[string]bool)
+		leafLists := make([][]store.DirEntry, len(targets))
+		for i, t := range targets {
+			entries, err := lister.ListDir(t.RT.RI, t.RT.Branch, dirPath)
+			if err != nil {
+				writeStoreError(w, r, err, "Failed to list topics", t.RT.Branch)
+				return
+			}
+			var leafEntries []store.DirEntry
+			for _, e := range entries {
+				if e.IsDir {
+					if !dirSeen[e.Name] {
+						dirSeen[e.Name] = true
+						dirNames = append(dirNames, e.Name)
+					}
+					continue
+				}
+				leafEntries = append(leafEntries, e)
+			}
+			leafLists[i] = leafEntries
+		}
+
+		// A fact path CAN appear on more than one mount (a lens whose write repo
+		// is a fork of a read-mounted upstream shares the fork's fact UUIDs), so
+		// the tree must dedup leaves by the SAME write-first rule as the flat
+		// facts union (writeFirstWinners) — otherwise the two union views
+		// disagree and a shadowed read-mount copy the flat list hides becomes
+		// openable here. Within one level the repo-relative path collides iff
+		// the filename does, so the entry name is the winner key.
+		winner := writeFirstWinners(targets, b.Write(), leafLists,
+			func(e store.DirEntry) string { return e.Name })
+
+		leaves := []lensTopicChild{}
+		for i, t := range targets {
+			for _, e := range leafLists[i] {
+				if winner[e.Name] != i {
+					continue // a different mount won this repo-relative path
+				}
+				fullPath := dirPath + "/" + e.Name
+				child := lensTopicChild{
+					Name: e.Name,
+					Path: lensWirePath(b, t.RT, fullPath),
+					Source: &lensTopicSource{
+						Repo: t.RT.RI.Name(),
+						ID:   federate.ID12(t.RT.RI.ID()),
+					},
+				}
+				// Enrich with type/title from the owning mount's search index
+				// (best-effort, mirroring the repo topicHandler).
+				if fb, gerr := lister.GetByPath(t.RT.RI, t.RT.Branch, fullPath); gerr == nil && fb != nil {
+					child.Type = fb.Type
+					child.Title = fb.Title
+				}
+				leaves = append(leaves, child)
+			}
+		}
+
+		// Deterministic order mirroring the repo tree's visual order:
+		// directories first (deduped, name-sorted), then winning leaves by name
+		// (each repo-relative name now appears exactly once).
+		sort.Strings(dirNames)
+		sort.SliceStable(leaves, func(i, j int) bool {
+			return leaves[i].Name < leaves[j].Name
+		})
+		children := make([]lensTopicChild, 0, len(dirNames)+len(leaves))
+		for _, name := range dirNames {
+			children = append(children, lensTopicChild{Name: name, IsDir: true})
+		}
+		children = append(children, leaves...)
+
+		hal.WriteHAL(w, http.StatusOK, lensTopicsResponse{Path: dirPath, Children: children})
+	}
+}

--- a/internal/web/handlers_lenses_topics_test.go
+++ b/internal/web/handlers_lenses_topics_test.go
@@ -1,0 +1,340 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+	"knomit/internal/web/hal"
+)
+
+// lensTopicsStub is a per-repo TopicLister: each mount's ListDir/GetByPath is
+// answered from maps keyed by the repo's name, so one stub drives the whole
+// fan-out. It records the last dirPath ListDir saw per repo (which doubles as
+// a "was this mount fanned out to at all" probe for the narrowing/skip tests);
+// errRepo makes that one mount's ListDir fail.
+type lensTopicsStub struct {
+	dirsByRepo  map[string][]store.DirEntry
+	factsByRepo map[string]map[string]*store.FactWithBody // repo → fullPath → fact
+	errRepo     string
+	listPaths   map[string]string
+}
+
+func (s *lensTopicsStub) ListDir(ri *repos.RepoInstance, _ string, path string) ([]store.DirEntry, error) {
+	if s.listPaths == nil {
+		s.listPaths = map[string]string{}
+	}
+	s.listPaths[ri.Name()] = path
+	if s.errRepo != "" && ri.Name() == s.errRepo {
+		return nil, errors.New("git on fire")
+	}
+	return s.dirsByRepo[ri.Name()], nil
+}
+
+func (s *lensTopicsStub) GetByPath(ri *repos.RepoInstance, _ string, path string) (*store.FactWithBody, error) {
+	if m := s.factsByRepo[ri.Name()]; m != nil {
+		if fb, ok := m[path]; ok {
+			return fb, nil
+		}
+	}
+	return nil, nil
+}
+
+// lensTopicsBody mirrors the unified tree-level wire shape.
+type lensTopicsBody struct {
+	Path     string `json:"path"`
+	Children []struct {
+		Name   string `json:"name"`
+		IsDir  bool   `json:"is_dir"`
+		Type   string `json:"type"`
+		Title  string `json:"title"`
+		Path   string `json:"path"`
+		Source *struct {
+			Repo string `json:"repo"`
+			ID   string `json:"id"`
+		} `json:"source"`
+	} `json:"children"`
+}
+
+func decodeLensTopics(t *testing.T, rec *httptest.ResponseRecorder) lensTopicsBody {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensTopicsBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	return body
+}
+
+// One tree level merged across mounts: same-named directories collapse into a
+// single plain node (no source/path/type/title); fact leaves are kept
+// per-mount, enriched via GetByPath, tagged with {repo,id}, and addressed
+// canonically (bare for the write mount, kb://<id12>/… for a read mount).
+// Order: directories first (deduped, name-sorted), then leaves name-sorted.
+func TestLensTopics_UnionMergedLevel(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensTopicsStub{
+		dirsByRepo: map[string][]store.DirEntry{
+			"alpha": {{Name: "gotchas", IsDir: true}, {Name: "decisions", IsDir: true}, {Name: "aaa.md", IsDir: false}},
+			"beta":  {{Name: "decisions", IsDir: true}, {Name: "bbb.md", IsDir: false}},
+		},
+		factsByRepo: map[string]map[string]*store.FactWithBody{
+			"alpha": {"kb/aaa.md": {FactRecord: store.FactRecord{Title: "Alpha fact", Type: "decision"}}},
+			"beta":  {"kb/bbb.md": {FactRecord: store.FactRecord{Title: "Beta fact", Type: "gotcha"}}},
+		},
+	}
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/topics")
+	if got := rec.Header().Get("Content-Type"); got != hal.ContentType {
+		t.Errorf("content-type: got %q, want %q", got, hal.ContentType)
+	}
+	body := decodeLensTopics(t, rec)
+
+	if body.Path != "kb" {
+		t.Errorf("path: got %q, want kb", body.Path)
+	}
+	// Both mounts listed the ROOT dirPath (the global ontology root).
+	for _, repo := range []string{"alpha", "beta"} {
+		if got := stub.listPaths[repo]; got != "kb" {
+			t.Errorf("ListDir path for %s: got %q, want kb", repo, got)
+		}
+	}
+	names := make([]string, len(body.Children))
+	for i, c := range body.Children {
+		names[i] = c.Name
+	}
+	want := []string{"decisions", "gotchas", "aaa.md", "bbb.md"}
+	if len(names) != len(want) {
+		t.Fatalf("children: got %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("children order: got %v, want %v", names, want)
+		}
+	}
+	// Dir nodes are plain: merged silently, no source, no wire path, no enrichment.
+	for _, c := range body.Children[:2] {
+		if !c.IsDir || c.Source != nil || c.Path != "" || c.Type != "" || c.Title != "" {
+			t.Errorf("dir node %q must be plain {name,is_dir}, got %+v", c.Name, c)
+		}
+	}
+	alphaRI, betaRI := m.Get("alpha"), m.Get("beta")
+	// Write-mount leaf: BARE canonical path + alpha source + per-mount enrichment.
+	aaa := body.Children[2]
+	if aaa.IsDir || aaa.Path != "kb/aaa.md" || aaa.Type != "decision" || aaa.Title != "Alpha fact" {
+		t.Errorf("write leaf: got %+v", aaa)
+	}
+	if aaa.Source == nil || aaa.Source.Repo != "alpha" || aaa.Source.ID != federate.ID12(alphaRI.ID()) {
+		t.Errorf("write leaf source: got %+v", aaa.Source)
+	}
+	// Read-mount leaf: kb://<id12>/… canonical path + beta source.
+	bbb := body.Children[3]
+	wantID := federate.ID12(betaRI.ID())
+	if bbb.IsDir || bbb.Path != "kb://"+wantID+"/kb/bbb.md" || bbb.Type != "gotcha" || bbb.Title != "Beta fact" {
+		t.Errorf("read leaf: got %+v (want path kb://%s/kb/bbb.md)", bbb, wantID)
+	}
+	if bbb.Source == nil || bbb.Source.Repo != "beta" || bbb.Source.ID != wantID {
+		t.Errorf("read leaf source: got %+v", bbb.Source)
+	}
+}
+
+// A fact path present on BOTH mounts (a fork whose upstream is read-mounted
+// shares the fork's fact UUIDs) dedups to a SINGLE leaf, the write mount's
+// copy winning — so the tree agrees with the flat facts union (writeFirstWinners)
+// instead of showing the shadowed read-mount copy the flat list hides.
+func TestLensTopics_SharedLeafDedupsWriteWins(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensTopicsStub{
+		dirsByRepo: map[string][]store.DirEntry{
+			// beta (read) is fanned out first in binding order, but the write
+			// mount alpha must still win the shared "dup.md".
+			"alpha": {{Name: "dup.md", IsDir: false}},
+			"beta":  {{Name: "dup.md", IsDir: false}, {Name: "beta-only.md", IsDir: false}},
+		},
+		factsByRepo: map[string]map[string]*store.FactWithBody{
+			"alpha": {"kb/dup.md": {FactRecord: store.FactRecord{Title: "Alpha copy", Type: "decision"}}},
+			"beta":  {"kb/dup.md": {FactRecord: store.FactRecord{Title: "Beta copy", Type: "gotcha"}}},
+		},
+	}
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensTopics(t, getLensFacts(t, r, "/lenses/eng/topics"))
+	// dup.md appears ONCE (alpha wins); beta-only.md is the second leaf.
+	names := []string{}
+	for _, c := range body.Children {
+		names = append(names, c.Name)
+	}
+	if len(names) != 2 || names[0] != "beta-only.md" || names[1] != "dup.md" {
+		t.Fatalf("children: got %v, want [beta-only.md dup.md] (dup deduped)", names)
+	}
+	dup := body.Children[1]
+	if dup.Source == nil || dup.Source.Repo != "alpha" || dup.Path != "kb/dup.md" || dup.Title != "Alpha copy" {
+		t.Errorf("dup leaf must be the WRITE mount's copy (bare path, alpha source), got %+v", dup)
+	}
+}
+
+// The wildcard route drills one level: dirPath = ontologyRoot + "/" + nodePath
+// on every mount, and the response path echoes it.
+func TestLensTopics_NodePathListsSubdirectory(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensTopicsStub{
+		dirsByRepo: map[string][]store.DirEntry{
+			"alpha": {{Name: "lens", IsDir: true}},
+			"beta":  {{Name: "lens", IsDir: true}},
+		},
+	}
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensTopics(t, getLensFacts(t, r, "/lenses/eng/topics/decisions"))
+	if body.Path != "kb/decisions" {
+		t.Errorf("path: got %q, want kb/decisions", body.Path)
+	}
+	for _, repo := range []string{"alpha", "beta"} {
+		if got := stub.listPaths[repo]; got != "kb/decisions" {
+			t.Errorf("ListDir path for %s: got %q, want kb/decisions", repo, got)
+		}
+	}
+	if len(body.Children) != 1 || body.Children[0].Name != "lens" || !body.Children[0].IsDir {
+		t.Fatalf("children: got %+v, want the single merged dir \"lens\"", body.Children)
+	}
+}
+
+// repo=<name> narrows the fan-out to the named mount(s): the other mounts are
+// not listed AT ALL (narrowing happens before ListDir).
+func TestLensTopics_RepoFilterNarrows(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensTopicsStub{
+		dirsByRepo: map[string][]store.DirEntry{
+			"alpha": {{Name: "a.md", IsDir: false}},
+			"beta":  {{Name: "b.md", IsDir: false}},
+		},
+	}
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensTopics(t, getLensFacts(t, r, "/lenses/eng/topics?repo=beta"))
+	if len(body.Children) != 1 || body.Children[0].Name != "b.md" {
+		t.Fatalf("children: got %+v, want only beta's leaf", body.Children)
+	}
+	if _, called := stub.listPaths["alpha"]; called {
+		t.Error("alpha must not be listed when repo=beta narrows the fan-out")
+	}
+}
+
+// An unknown repo= name is a well-formed request naming a nonexistent mount → 422.
+func TestLensTopics_UnknownRepoFilter422(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: &lensTopicsStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/topics?repo=ghost")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q, want application/problem+json", got)
+	}
+}
+
+// Drilling into kb/<topic>/… skips mounts whose ontology lacks the topic —
+// the same decision-17 semantics as the facts/search/stats siblings. alpha is
+// a "default"-preset repo (topics include `technology`); beta is a
+// "code"-preset repo (invariants/architecture/… — NO `technology`).
+func TestLensTopics_TopicSkipUnderDeepPath(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	if _, err := m.Create(context.Background(), repos.CreateSpec{
+		Name: "beta", Mode: "preset", OntologyPreset: "code",
+	}, nil); err != nil {
+		t.Fatalf("create code-preset repo: %v", err)
+	}
+	stub := &lensTopicsStub{
+		dirsByRepo: map[string][]store.DirEntry{
+			"alpha": {{Name: "x.md", IsDir: false}},
+			"beta":  {{Name: "y.md", IsDir: false}},
+		},
+	}
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensTopics(t, getLensFacts(t, r, "/lenses/eng/topics/technology/software"))
+	if _, called := stub.listPaths["beta"]; called {
+		t.Error("beta (ontology lacks `technology`) must be SKIPPED under a deep path")
+	}
+	if got := stub.listPaths["alpha"]; got != "kb/technology/software" {
+		t.Errorf("alpha ListDir path: got %q, want kb/technology/software", got)
+	}
+	if len(body.Children) != 1 || body.Children[0].Name != "x.md" {
+		t.Fatalf("children: got %+v, want only alpha's leaf", body.Children)
+	}
+}
+
+// Any mount error fails the WHOLE request (RFC §9.1) — even when the failing
+// mount is a read mount and the write repo answered fine.
+func TestLensTopics_MountErrorFailsWholeRequest(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensTopicsStub{
+		dirsByRepo: map[string][]store.DirEntry{
+			"alpha": {{Name: "a.md", IsDir: false}},
+		},
+		errRepo: "beta",
+	}
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: stub}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/topics")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/problem+json" {
+		t.Errorf("content-type: got %q, want application/problem+json", got)
+	}
+}
+
+// An empty level serializes children as [] — never null.
+func TestLensTopics_EmptyLevel(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: &lensTopicsStub{}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/topics")
+	body := decodeLensTopics(t, rec)
+	if len(body.Children) != 0 {
+		t.Fatalf("children: got %+v, want none", body.Children)
+	}
+	if !strings.Contains(rec.Body.String(), `"children":[]`) {
+		t.Errorf("children must serialize as [] not null; body=%s", rec.Body.String())
+	}
+}
+
+// An unknown lens is 404 (from LensMiddleware, before the handler runs).
+func TestLensTopics_UnknownLens404(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	s := &Server{Manager: m, OntologyRoot: "kb", topicLister: &lensTopicsStub{}}
+	r := s.NewAPIRouter()
+
+	rec := getLensFacts(t, r, "/lenses/missing/topics")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/web/readonly_test.go
+++ b/internal/web/readonly_test.go
@@ -27,6 +27,7 @@ func TestIsMutatingRequest(t *testing.T) {
 		{"POST", "/api/v1/lenses/myview/mcp/messages", false},
 		// Lens REST CRUD must stay gated — only the /mcp subtree bypasses.
 		{"POST", "/api/v1/lenses", true},
+		{"PATCH", "/api/v1/lenses/myview", true},
 		{"DELETE", "/api/v1/lenses/myview", true},
 		// A fact whose name ends in "mcp" must still be gated (not the MCP route).
 		{"PUT", "/api/v1/repos/core/branches/main/facts/kb/x/mcp", true},
@@ -102,5 +103,13 @@ func TestReadOnlyRouter_FactRouteBypassRegression(t *testing.T) {
 	h.ServeHTTP(lensDelete, httptest.NewRequest("DELETE", "/api/v1/lenses/myview", nil))
 	if lensDelete.Code != http.StatusForbidden {
 		t.Errorf("DELETE lens REST path: got status %d, want 403 (CRUD must stay gated)", lensDelete.Code)
+	}
+
+	// PATCH (mount/write/description edit) is a mutating REST route and must be
+	// gated just like POST/DELETE.
+	lensPatch := httptest.NewRecorder()
+	h.ServeHTTP(lensPatch, httptest.NewRequest("PATCH", "/api/v1/lenses/myview", nil))
+	if lensPatch.Code != http.StatusForbidden {
+		t.Errorf("PATCH lens REST path: got status %d, want 403 (CRUD must stay gated)", lensPatch.Code)
 	}
 }

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -278,6 +278,10 @@ func (s *Server) NewAPIRouter() chi.Router {
 		"/lenses/{lens}/search",
 		handleHALLensSearch(sp, s.Embedder),
 	)
+	r.With(repos.LensMiddleware(s.Manager)).Get(
+		"/lenses/{lens}/completions",
+		handleHALLensCompletions(cop),
+	)
 	r.With(repos.LensMiddleware(s.Manager)).HandleFunc(
 		"/lenses/{lens}/mcp",
 		mcpDispatch.ServeHTTP,

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -274,6 +274,10 @@ func (s *Server) NewAPIRouter() chi.Router {
 		"/lenses/{lens}/facts",
 		handleHALLensFacts(fcp),
 	)
+	r.With(repos.LensMiddleware(s.Manager)).Get(
+		"/lenses/{lens}/search",
+		handleHALLensSearch(sp, s.Embedder),
+	)
 	r.With(repos.LensMiddleware(s.Manager)).HandleFunc(
 		"/lenses/{lens}/mcp",
 		mcpDispatch.ServeHTTP,

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -270,6 +270,10 @@ func (s *Server) NewAPIRouter() chi.Router {
 		"/repos/{repo}/branches/{branch}/mcp/*",
 		mcpDispatch.ServeHTTP,
 	)
+	r.With(repos.LensMiddleware(s.Manager)).Get(
+		"/lenses/{lens}/facts",
+		handleHALLensFacts(fcp),
+	)
 	r.With(repos.LensMiddleware(s.Manager)).HandleFunc(
 		"/lenses/{lens}/mcp",
 		mcpDispatch.ServeHTTP,

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -275,6 +275,10 @@ func (s *Server) NewAPIRouter() chi.Router {
 		handleHALLensFacts(fcp),
 	)
 	r.With(repos.LensMiddleware(s.Manager)).Get(
+		"/lenses/{lens}/facts/*",
+		handleHALLensFact(b, factReader),
+	)
+	r.With(repos.LensMiddleware(s.Manager)).Get(
 		"/lenses/{lens}/search",
 		handleHALLensSearch(sp, s.Embedder),
 	)

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -287,6 +287,18 @@ func (s *Server) NewAPIRouter() chi.Router {
 		"/lenses/{lens}/completions",
 		handleHALLensCompletions(cop),
 	)
+	r.With(repos.LensMiddleware(s.Manager)).Get(
+		"/lenses/{lens}/stats",
+		handleHALLensStats(sp2, ap),
+	)
+	r.With(repos.LensMiddleware(s.Manager)).Get(
+		"/lenses/{lens}/topics",
+		handleHALLensTopics(topicLister, s.OntologyRoot),
+	)
+	r.With(repos.LensMiddleware(s.Manager)).Get(
+		"/lenses/{lens}/topics/*",
+		handleHALLensTopics(topicLister, s.OntologyRoot),
+	)
 	r.With(repos.LensMiddleware(s.Manager)).HandleFunc(
 		"/lenses/{lens}/mcp",
 		mcpDispatch.ServeHTTP,

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -57,6 +57,7 @@ func (s *Server) NewAPIRouter() chi.Router {
 	r.Get("/lenses", handleHALLenses(b, s.Manager))
 	r.Post("/lenses", handleHALLensesCreate(b, s.Manager))
 	r.Get("/lenses/{lens}", handleHALLens(b, s.Manager))
+	r.Patch("/lenses/{lens}", handleHALLensPatch(b, s.Manager))
 	r.Delete("/lenses/{lens}", handleHALLensDelete(s.Manager))
 	r.Get("/archived", handleHALArchived(b, s.Manager))
 	r.Post("/archived/{id}/restore", handleHALArchivedRestore(b, s.Manager))

--- a/web/src/App.resolveLens.test.ts
+++ b/web/src/App.resolveLens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { resolveLens } from './App';
+import { resolveLens, refreshContextAfterChange } from './App';
 import type { Action } from './state';
 import type { Lens, RepoInfo } from './api';
 
@@ -34,5 +34,71 @@ describe('resolveLens — App-level lens resolution', () => {
     await resolveLens('deleted', repos(), dispatch, vi.fn().mockRejectedValue(new Error('gone')));
     expect(actions.some(a => a.type === 'SET_NOTICE')).toBe(true);
     expect(actions.some(a => a.type === 'SET_CONTEXT')).toBe(false);
+  });
+
+  // I3: a slow failing resolve for lens A must not yank the user out of lens B
+  // (or a repo) they've since switched to. The guard suppresses the whole
+  // fallback (no notice, no console, no context change) when A is no longer current.
+  it('does not fall back when the lens context drifted while the resolve was in flight (I3)', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    const getLens = vi.fn().mockRejectedValue(new Error('slow 404'));
+    await resolveLens('A', repos('core', 'work'), dispatch, getLens, () => false);
+    expect(actions).toEqual([]);
+  });
+
+  it('still falls back when the failing lens is the current one (guard passes)', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    await resolveLens('A', repos('core'), dispatch, vi.fn().mockRejectedValue(new Error('gone')), () => true);
+    expect(actions).toContainEqual({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'core' } });
+  });
+});
+
+// I4: after the RepoManager reports a create/delete/edit, re-sync the browse
+// surface. A mutated active lens re-resolves (refreshing state.lens); a deleted
+// browsed lens falls back with the notice; a repo context switches off a removed
+// active repo.
+describe('refreshContextAfterChange — post-mutation resync', () => {
+  it('re-resolves the active lens so edited mounts refresh state.lens (I4)', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    const edited: Lens = { name: 'eng', write: 'core', reads: [{ repo: 'core' }, { repo: 'docs' }, { repo: 'infra' }] };
+    const getLens = vi.fn().mockResolvedValue(edited);
+    await refreshContextAfterChange(dispatch, { kind: 'lens', name: 'eng' }, 'core', {
+      listLenses: vi.fn().mockResolvedValue([edited]),
+      repos: vi.fn().mockResolvedValue(repos('core', 'docs', 'infra')),
+      getLens,
+    });
+    expect(getLens).toHaveBeenCalledWith('eng');
+    expect(actions).toContainEqual({ type: 'SET_LENS', lens: edited });
+    // No fallback/notice while the lens still exists.
+    expect(actions.some(a => a.type === 'SET_CONTEXT')).toBe(false);
+    expect(actions.some(a => a.type === 'SET_NOTICE')).toBe(false);
+  });
+
+  it('falls back with a notice when the browsed lens was deleted (I4)', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    const getLens = vi.fn();
+    await refreshContextAfterChange(dispatch, { kind: 'lens', name: 'gone' }, 'core', {
+      listLenses: vi.fn().mockResolvedValue([]), // no longer listed
+      repos: vi.fn().mockResolvedValue(repos('core', 'work')),
+      getLens,
+    });
+    expect(actions.some(a => a.type === 'SET_NOTICE')).toBe(true);
+    expect(actions).toContainEqual({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'core' } });
+    // A deleted lens isn't in the list → no wasted getLens round-trip.
+    expect(getLens).not.toHaveBeenCalled();
+  });
+
+  it('switches off an archived active repo in a repo context (existing behavior)', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    await refreshContextAfterChange(dispatch, { kind: 'repo', repo: 'gone' }, 'gone', {
+      listLenses: vi.fn().mockResolvedValue([]),
+      repos: vi.fn().mockResolvedValue(repos('core', 'work')),
+    });
+    expect(actions).toContainEqual({ type: 'SET_REPO', repo: 'core' });
   });
 });

--- a/web/src/App.resolveLens.test.ts
+++ b/web/src/App.resolveLens.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveLens } from './App';
+import type { Action } from './state';
+import type { Lens, RepoInfo } from './api';
+
+const repos = (...names: string[]): RepoInfo[] => names.map(name => ({ name }));
+
+describe('resolveLens — App-level lens resolution', () => {
+  it('dispatches SET_LENS when the lens resolves', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    const lens: Lens = { name: 'dev', write: 'work', reads: [{ repo: 'work' }] };
+    await resolveLens('dev', repos('core', 'work'), dispatch, vi.fn().mockResolvedValue(lens));
+    expect(actions).toEqual([{ type: 'SET_LENS', lens }]);
+  });
+
+  it('falls back to the first repo and surfaces a notice when the lens is gone', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    const getLens = vi.fn().mockRejectedValue(new Error('404 not found'));
+    await resolveLens('deleted', repos('core', 'work'), dispatch, getLens);
+
+    // A user-visible notice + a console error, then a fall back to the first repo.
+    expect(actions.some(a => a.type === 'SET_NOTICE')).toBe(true);
+    expect(actions.some(a => a.type === 'CONSOLE_LOG' && a.level === 'error')).toBe(true);
+    expect(actions).toContainEqual({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'core' } });
+    // Never dispatches SET_LENS on failure.
+    expect(actions.some(a => a.type === 'SET_LENS')).toBe(false);
+  });
+
+  it('surfaces the notice but does not fall back when no repos exist', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    await resolveLens('deleted', repos(), dispatch, vi.fn().mockRejectedValue(new Error('gone')));
+    expect(actions.some(a => a.type === 'SET_NOTICE')).toBe(true);
+    expect(actions.some(a => a.type === 'SET_CONTEXT')).toBe(false);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,7 @@
 import { useReducer, useEffect, useState, useRef } from 'react';
 import type { Dispatch } from 'react';
-import { reducer, init, isReadOnly, isLive, selectTrail, selectAnchorCommit, currentPath, openFactSource } from './state';
+import { reducer, init, isReadOnly, isLive, selectTrail, currentPath, factHistoryAnchor, edgeAnchorCommit } from './state';
 import type { Action, BrowseContext } from './state';
-import { displayLensPath } from './utils';
 import { api, apiUrl, fetchVersion } from './api';
 import type { RepoInfo, Lens } from './api';
 import { pageview, track } from './telemetry';
@@ -83,12 +82,14 @@ export default function App() {
   // navigation through these so a single action model drives now and history.
   const tt = useTimeTravel(state, dispatch);
 
-  // The anchor at which EdgesRail fetches edges: the history/diff anchor when
-  // not live, else the repo HEAD commit. Reading edges at HEAD resolves the
-  // fact's current edge set — correct immediately on load, no callback needed.
+  // The commit at which EdgesRail fetches edges: the history/diff anchor when
+  // not live, else the OPEN FACT's mount live HEAD (edgeAnchorCommit). In a repo
+  // context that's state.headCommit; in a lens context it's '' (non-anchored live
+  // HEAD) so a read-mount fact's edges resolve on its own mount instead of being
+  // anchored on the write repo's head — a commit absent from the mount → no edges.
   // (In-body ref hops anchor to the referrer fact's own commit instead — see
   // RightPanel's onRefClick — so they pin the version the referrer reasoned over.)
-  const liveEdgeAnchor = selectAnchorCommit(state) ?? state.headCommit;
+  const liveEdgeAnchor = edgeAnchorCommit(state);
 
   // Splitter between Library (left) and RightPanel. Width restored from
   // localStorage on mount; persisted on drag-end so transient frames during a
@@ -533,16 +534,16 @@ export default function App() {
                 />
               </div>
               {state.factPath && (() => {
-                // Edges of the open fact anchor on its SOURCE MOUNT (openFactSource)
-                // with the RELATIVE path — a lens read-mount fact's connections
-                // resolve through that mount's repo-scoped explain endpoint, not the
-                // browse surface's repo. Repo context: {state.repo, state.branch}.
-                const edgeSrc = openFactSource(state);
+                // Edges of the open fact anchor on its SOURCE MOUNT + RELATIVE path
+                // (factHistoryAnchor) — a lens read-mount fact's connections resolve
+                // through that mount's repo-scoped explain endpoint, not the browse
+                // surface's repo. Repo context: {state.repo, state.branch, bare-path}.
+                const edge = factHistoryAnchor(state);
                 return (
                   <EdgesRail
-                    repo={edgeSrc.repo}
-                    branch={edgeSrc.branch}
-                    factPath={displayLensPath(state.factPath)}
+                    repo={edge.repo}
+                    branch={edge.branch}
+                    factPath={edge.path}
                     anchorCommit={liveEdgeAnchor}
                     history={!isLive(state)}
                     onHop={tt.hopEdge}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -422,6 +422,7 @@ export default function App() {
               }
             }).catch(() => {});
           }}
+          onBrowse={() => {}}  // Task 12 wires SET_CONTEXT to switch the browse surface
         />
       </ErrorBoundary>
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useReducer, useEffect, useState, useRef } from 'react';
 import type { Dispatch } from 'react';
-import { reducer, init, isReadOnly, isLive, selectTrail, currentPath, factHistoryAnchor, edgeAnchorCommit } from './state';
+import { reducer, init, isReadOnly, isLive, selectTrail, currentPath, factHistoryAnchor, edgeAnchorCommit, lensResolutionPending } from './state';
 import type { Action, BrowseContext } from './state';
 import { api, apiUrl, fetchVersion } from './api';
 import type { RepoInfo, Lens } from './api';
@@ -193,8 +193,8 @@ export default function App() {
         // repo (or no) context picks a repo from the live list as before.
         const last = loadLastContext();
         if (last?.kind === 'lens') {
+          // Resolution is owned by the lensResolutionPending effect below.
           dispatch({ type: 'SET_CONTEXT', context: last });
-          void resolveLens(last.name, list, dispatch, api.getLens, isCurrentLens);
           return;
         }
         const next = pickRepo('', list, last?.kind === 'repo' ? last.repo : null);
@@ -203,6 +203,20 @@ export default function App() {
       .catch(() => { if (!cancelled) setReposLoaded(true); });
     return () => { cancelled = true; };
   }, []);
+
+  // Lens resolution — single owner. Every surface that enters a lens context
+  // (TopBar switcher, manager Browse, bootstrap restore) only dispatches
+  // SET_CONTEXT; this effect notices a context whose lens doc isn't resolved
+  // yet (lensResolutionPending) and fetches it, falling back to a repo if the
+  // lens is gone. Gated on reposLoaded so the fallback list is real; the
+  // SET_LENS reducer guard + isCurrentLens keep late/stale resolutions inert.
+  // Same-name re-resolution after an edit goes through refreshContextAfterChange.
+  useEffect(() => {
+    if (!reposLoaded || !lensResolutionPending(state)) return;
+    if (state.context.kind !== 'lens') return; // narrows the type; implied by the check above
+    void resolveLens(state.context.name, repos, dispatch, api.getLens, isCurrentLens);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.context, state.lens, repos, reposLoaded]);
 
   // Fetch the lens list on mount for the TopBar context switcher's Lenses group.
   // Owned here (like repos) and threaded down; refreshed when the repo manager
@@ -524,12 +538,10 @@ export default function App() {
               .catch(() => {});
           }}
           onBrowse={(ctx: BrowseContext) => {
-            // Switch the browse surface and close the manager. A lens context is
-            // entered immediately, then its doc resolved (falling back to a repo
-            // if the lens is gone).
+            // Switch the browse surface and close the manager. Lens resolution
+            // is owned by the lensResolutionPending effect.
             setRepoMgrOpen(false);
             dispatch({ type: 'SET_CONTEXT', context: ctx });
-            if (ctx.kind === 'lens') void resolveLens(ctx.name, repos, dispatch, api.getLens, isCurrentLens);
           }}
         />
       </ErrorBoundary>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,11 +56,18 @@ export async function resolveLens(
   fallbackRepos: RepoInfo[],
   dispatch: Dispatch<Action>,
   getLens: (name: string) => Promise<import('./api').Lens> = api.getLens,
+  // I3: resolveLens is fire-and-forget, so a slow failing getLens(A) can reject
+  // after the user already switched to lens B (or a repo). The SET_LENS success
+  // path is reducer-guarded (it no-ops when the context drifted), but the failure
+  // fallback dispatches SET_CONTEXT unconditionally — which would yank the user
+  // out of B. Gate the whole fallback on the resolve still being the current lens.
+  isCurrentLens: (name: string) => boolean = () => true,
 ): Promise<void> {
   try {
     const lens = await getLens(name);
     dispatch({ type: 'SET_LENS', lens });
   } catch (err) {
+    if (!isCurrentLens(name)) return; // context drifted — a newer surface owns the app
     dispatch({ type: 'SET_NOTICE', text: `Lens "${name}" is unavailable — showing a repo instead.` });
     dispatch({ type: 'CONSOLE_LOG', level: 'error', message: `[lens] ${name}: ${String(err)}` });
     const fallback = fallbackRepos[0];
@@ -68,8 +75,54 @@ export async function resolveLens(
   }
 }
 
+// refreshContextAfterChange re-syncs the browse surface after a repo/lens
+// mutation reported by the RepoManager (I4). It re-fetches both lists and:
+//   - lens context, lens still exists → re-run resolveLens so edited mounts
+//     refresh state.lens (reads/write/description);
+//   - lens context, lens gone → fall back to the first repo with the same
+//     deleted-lens notice resolveLens uses, so no dead empty library is left;
+//   - repo context → keep the prior behavior: if the active repo was
+//     archived/removed, switch to a remaining one (prefer core).
+// Returns the fetched lists so the caller can update its local component state.
+export async function refreshContextAfterChange(
+  dispatch: Dispatch<Action>,
+  context: BrowseContext,
+  currentRepo: string,
+  deps: {
+    listLenses?: () => Promise<Lens[]>;
+    repos?: () => Promise<RepoInfo[]>;
+    getLens?: (name: string) => Promise<Lens>;
+  } = {},
+  isCurrentLens: (name: string) => boolean = () => true,
+): Promise<{ lenses: Lens[]; repos: RepoInfo[] }> {
+  const listLenses = deps.listLenses ?? api.listLenses;
+  const listRepos = deps.repos ?? api.repos;
+  const getLens = deps.getLens ?? api.getLens;
+  const [lenses, repoList] = await Promise.all([listLenses(), listRepos()]);
+  if (context.kind === 'lens') {
+    if (lenses.some(l => l.name === context.name)) {
+      await resolveLens(context.name, repoList, dispatch, getLens, isCurrentLens);
+    } else {
+      dispatch({ type: 'SET_NOTICE', text: `Lens "${context.name}" is unavailable — showing a repo instead.` });
+      const fallback = repoList[0];
+      if (fallback) dispatch({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: fallback.name } });
+    }
+  } else if (repoList.length && !repoList.some(r => r.name === currentRepo)) {
+    const next = repoList.find(r => r.name === 'core') ?? repoList[0];
+    dispatch({ type: 'SET_REPO', repo: next.name });
+  }
+  return { lenses, repos: repoList };
+}
+
 export default function App() {
   const [state, dispatch] = useReducer(reducer, init);
+  // Latest-state ref for async callbacks that resolve after the context may have
+  // drifted (resolveLens fallback guard I3, onChanged refresh I4). Reads the
+  // committed context at resolution time, not the stale closure value.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const isCurrentLens = (name: string) =>
+    stateRef.current.context.kind === 'lens' && stateRef.current.context.name === name;
   const { navigate } = useNavigationManager(state, dispatch);
   const version = useVersion();
   const [repos, setRepos] = useState<RepoInfo[]>([]);
@@ -141,7 +194,7 @@ export default function App() {
         const last = loadLastContext();
         if (last?.kind === 'lens') {
           dispatch({ type: 'SET_CONTEXT', context: last });
-          void resolveLens(last.name, list, dispatch);
+          void resolveLens(last.name, list, dispatch, api.getLens, isCurrentLens);
           return;
         }
         const next = pickRepo('', list, last?.kind === 'repo' ? last.repo : null);
@@ -462,16 +515,13 @@ export default function App() {
           hideRemoteConfig={state.serverReadOnly}
           onClose={() => setRepoMgrOpen(false)}
           onChanged={() => {
-            api.listLenses().then(setLenses).catch(() => {});
-            api.repos().then(list => {
-              setRepos(list);
-              // If the active repo was archived/removed, switch to a remaining
-              // one (prefer core) so the app never points at a gone repo.
-              if (list.length && !list.some(r => r.name === state.repo)) {
-                const next = list.find(r => r.name === 'core') ?? list[0];
-                dispatch({ type: 'SET_REPO', repo: next.name });
-              }
-            }).catch(() => {});
+            // Re-sync after a repo/lens mutation. In a lens context this
+            // re-resolves the browsed lens (so edited mounts refresh state.lens)
+            // or falls back with a notice if it was deleted; in a repo context it
+            // switches off an archived/removed active repo (I4).
+            void refreshContextAfterChange(dispatch, stateRef.current.context, stateRef.current.repo, {}, isCurrentLens)
+              .then(({ lenses: ls, repos: rs }) => { setLenses(ls); setRepos(rs); })
+              .catch(() => {});
           }}
           onBrowse={(ctx: BrowseContext) => {
             // Switch the browse surface and close the manager. A lens context is
@@ -479,7 +529,7 @@ export default function App() {
             // if the lens is gone).
             setRepoMgrOpen(false);
             dispatch({ type: 'SET_CONTEXT', context: ctx });
-            if (ctx.kind === 'lens') void resolveLens(ctx.name, repos, dispatch);
+            if (ctx.kind === 'lens') void resolveLens(ctx.name, repos, dispatch, api.getLens, isCurrentLens);
           }}
         />
       </ErrorBoundary>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,14 @@
 import { useReducer, useEffect, useState, useRef } from 'react';
+import type { Dispatch } from 'react';
 import { reducer, init, isReadOnly, isLive, selectTrail, selectAnchorCommit, currentPath } from './state';
+import type { Action, BrowseContext } from './state';
 import { api, apiUrl, fetchVersion } from './api';
+import type { RepoInfo } from './api';
 import { pageview, track } from './telemetry';
 import { useNavigationManager } from './useNavigationManager';
 import { useTimeTravel } from './useTimeTravel';
 import { bootstrapStatusWithRetry } from './bootstrap';
-import { pickRepo, loadLastRepo, saveLastRepo } from './repoSelection';
-import type { RepoInfo } from './api';
+import { pickRepo, loadLastContext, saveLastContext } from './repoSelection';
 import { TopBar } from './TopBar';
 import { RepoManager } from './RepoManager';
 import { ErrorBoundary } from './ErrorBoundary';
@@ -41,6 +43,29 @@ function loadLeftPanelWidth(): number {
 function clampLeftPanelWidth(px: number): number {
   const max = Math.max(LEFT_PANEL_MIN, Math.floor(window.innerWidth * LEFT_PANEL_MAX_FRACTION));
   return Math.max(LEFT_PANEL_MIN, Math.min(max, Math.round(px)));
+}
+
+// resolveLens fetches the lens doc for a lens context and dispatches SET_LENS.
+// On failure (e.g. the lens was deleted out from under a persisted context) it
+// surfaces the error via the notice banner + console and falls back to the
+// first available repo, so the app never strands in a broken lens context.
+// Exported (with an injectable getLens) so the failure→fallback path is unit
+// testable without mounting the whole App.
+export async function resolveLens(
+  name: string,
+  fallbackRepos: RepoInfo[],
+  dispatch: Dispatch<Action>,
+  getLens: (name: string) => Promise<import('./api').Lens> = api.getLens,
+): Promise<void> {
+  try {
+    const lens = await getLens(name);
+    dispatch({ type: 'SET_LENS', lens });
+  } catch (err) {
+    dispatch({ type: 'SET_NOTICE', text: `Lens "${name}" is unavailable — showing a repo instead.` });
+    dispatch({ type: 'CONSOLE_LOG', level: 'error', message: `[lens] ${name}: ${String(err)}` });
+    const fallback = fallbackRepos[0];
+    if (fallback) dispatch({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: fallback.name } });
+  }
 }
 
 export default function App() {
@@ -107,8 +132,17 @@ export default function App() {
         if (cancelled) return;
         setRepos(list);
         setReposLoaded(true);
-        const next = pickRepo('', list, loadLastRepo());
-        if (next) dispatch({ type: 'SET_REPO', repo: next });
+        // Restore the last browse context. A persisted lens is entered
+        // immediately, then resolved (falling back to a repo if it's gone). A
+        // repo (or no) context picks a repo from the live list as before.
+        const last = loadLastContext();
+        if (last?.kind === 'lens') {
+          dispatch({ type: 'SET_CONTEXT', context: last });
+          void resolveLens(last.name, list, dispatch);
+          return;
+        }
+        const next = pickRepo('', list, last?.kind === 'repo' ? last.repo : null);
+        if (next) dispatch({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: next } });
       })
       .catch(() => { if (!cancelled) setReposLoaded(true); });
     return () => { cancelled = true; };
@@ -123,10 +157,11 @@ export default function App() {
     return () => { alive = false; };
   }, []);
 
-  // Remember the user's repo choice so reloads land on the same repo.
+  // Remember the user's browse context (repo | lens) so reloads land on the
+  // same surface.
   useEffect(() => {
-    saveLastRepo(state.repo);
-  }, [state.repo]);
+    saveLastContext(state.context);
+  }, [state.context]);
 
   // --- Anonymous usage telemetry. Every call below is a no-op unless a host
   // (the public demo's reverse proxy) defined window.knomitTelemetry; stock
@@ -422,7 +457,14 @@ export default function App() {
               }
             }).catch(() => {});
           }}
-          onBrowse={() => {}}  // Task 12 wires SET_CONTEXT to switch the browse surface
+          onBrowse={(ctx: BrowseContext) => {
+            // Switch the browse surface and close the manager. A lens context is
+            // entered immediately, then its doc resolved (falling back to a repo
+            // if the lens is gone).
+            setRepoMgrOpen(false);
+            dispatch({ type: 'SET_CONTEXT', context: ctx });
+            if (ctx.kind === 'lens') void resolveLens(ctx.name, repos, dispatch);
+          }}
         />
       </ErrorBoundary>
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,8 @@
 import { useReducer, useEffect, useState, useRef } from 'react';
 import type { Dispatch } from 'react';
-import { reducer, init, isReadOnly, isLive, selectTrail, selectAnchorCommit, currentPath } from './state';
+import { reducer, init, isReadOnly, isLive, selectTrail, selectAnchorCommit, currentPath, openFactSource } from './state';
 import type { Action, BrowseContext } from './state';
+import { displayLensPath } from './utils';
 import { api, apiUrl, fetchVersion } from './api';
 import type { RepoInfo, Lens } from './api';
 import { pageview, track } from './telemetry';
@@ -531,16 +532,23 @@ export default function App() {
                   onHopRef={tt.hopEdge}
                 />
               </div>
-              {state.factPath && (
-                <EdgesRail
-                  repo={state.repo}
-                  branch={state.branch}
-                  factPath={state.factPath}
-                  anchorCommit={liveEdgeAnchor}
-                  history={!isLive(state)}
-                  onHop={tt.hopEdge}
-                />
-              )}
+              {state.factPath && (() => {
+                // Edges of the open fact anchor on its SOURCE MOUNT (openFactSource)
+                // with the RELATIVE path — a lens read-mount fact's connections
+                // resolve through that mount's repo-scoped explain endpoint, not the
+                // browse surface's repo. Repo context: {state.repo, state.branch}.
+                const edgeSrc = openFactSource(state);
+                return (
+                  <EdgesRail
+                    repo={edgeSrc.repo}
+                    branch={edgeSrc.branch}
+                    factPath={displayLensPath(state.factPath)}
+                    anchorCommit={liveEdgeAnchor}
+                    history={!isLive(state)}
+                    onHop={tt.hopEdge}
+                  />
+                );
+              })()}
             </div>
           </div>
         </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import type { Dispatch } from 'react';
 import { reducer, init, isReadOnly, isLive, selectTrail, selectAnchorCommit, currentPath } from './state';
 import type { Action, BrowseContext } from './state';
 import { api, apiUrl, fetchVersion } from './api';
-import type { RepoInfo } from './api';
+import type { RepoInfo, Lens } from './api';
 import { pageview, track } from './telemetry';
 import { useNavigationManager } from './useNavigationManager';
 import { useTimeTravel } from './useTimeTravel';
@@ -73,6 +73,7 @@ export default function App() {
   const { navigate } = useNavigationManager(state, dispatch);
   const version = useVersion();
   const [repos, setRepos] = useState<RepoInfo[]>([]);
+  const [lenses, setLenses] = useState<Lens[]>([]);
   const [reposLoaded, setReposLoaded] = useState(false);
   const [repoMgrOpen, setRepoMgrOpen] = useState(false);
 
@@ -145,6 +146,18 @@ export default function App() {
         if (next) dispatch({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: next } });
       })
       .catch(() => { if (!cancelled) setReposLoaded(true); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Fetch the lens list on mount for the TopBar context switcher's Lenses group.
+  // Owned here (like repos) and threaded down; refreshed when the repo manager
+  // reports a change (lens create/delete). Best-effort: an empty list just hides
+  // the Lenses group.
+  useEffect(() => {
+    let cancelled = false;
+    api.listLenses()
+      .then(list => { if (!cancelled) setLenses(list); })
+      .catch(() => { /* best-effort: no Lenses group on failure */ });
     return () => { cancelled = true; };
   }, []);
 
@@ -408,7 +421,7 @@ export default function App() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', width: '100vw', background: '#141414', color: '#eee', fontFamily: 'var(--k-font-body)', overflow: 'hidden' }}>
-      <TopBar state={state} repos={repos} dispatch={dispatch} onManageRepos={() => setRepoMgrOpen(true)} leftWidth={leftPanelWidth} />
+      <TopBar state={state} repos={repos} lenses={lenses} dispatch={dispatch} onManageRepos={() => setRepoMgrOpen(true)} leftWidth={leftPanelWidth} />
       {state.indexState === 'indexing' && (
         <div data-testid="indexing-banner" style={{ background: '#1c2b1c', color: '#9c9', fontSize: 12, padding: '4px 14px', borderBottom: '1px solid #2a3a2a', flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
           <span>⟳ Indexing{state.indexTotal > 0 ? ` ${state.indexPercent}% (${state.indexDone}/${state.indexTotal})` : '…'}</span>
@@ -447,6 +460,7 @@ export default function App() {
           hideRemoteConfig={state.serverReadOnly}
           onClose={() => setRepoMgrOpen(false)}
           onChanged={() => {
+            api.listLenses().then(setLenses).catch(() => {});
             api.repos().then(list => {
               setRepos(list);
               // If the active repo was archived/removed, switch to a remaining

--- a/web/src/CreateLensForm.test.tsx
+++ b/web/src/CreateLensForm.test.tsx
@@ -123,6 +123,20 @@ describe('CreateLensForm', () => {
     expect(screen.queryByTestId('lens-branch-ops')).toBeNull();
   });
 
+  it('select all is scoped to the visible rows when a filter is active', () => {
+    // >8 repos so the search filter renders; write defaults to the first (r0).
+    const many = Array.from({ length: 10 }, (_, i) => ({ name: `r${i}` }));
+    render(<CreateLensForm repos={many} lenses={[]} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    // Filter to just r1 (r1 matches; r2..r9 and the r1x-style names are hidden).
+    fireEvent.change(screen.getByTestId('lens-read-search'), { target: { value: 'r1' } });
+    fireEvent.click(screen.getByTestId('lens-select-all'));
+    // The visible match r1 mounted; a filtered-out repo (r5) stayed off.
+    expect(screen.getByTestId('lens-branch-r1')).toBeInTheDocument();
+    // Clear the filter to reveal r5's row and confirm it never got a branch select.
+    fireEvent.change(screen.getByTestId('lens-read-search'), { target: { value: '' } });
+    expect(screen.queryByTestId('lens-branch-r5')).toBeNull();
+  });
+
   // ── redesign: preview ──
 
   it('preview reflects pinned read branches', async () => {

--- a/web/src/CreateLensForm.test.tsx
+++ b/web/src/CreateLensForm.test.tsx
@@ -6,6 +6,9 @@ import { api } from './api';
 vi.mock('./api', () => ({
   api: {
     createLens: vi.fn().mockResolvedValue({ name: 'dev', write: 'work', reads: [] }),
+    // Branch picker fetches these when a read repo is toggled on.
+    listBranchNames: vi.fn().mockResolvedValue(['agent/dev', 'main']),
+    getAgentBranch: vi.fn().mockResolvedValue('agent/dev'),
   },
 }));
 
@@ -21,10 +24,14 @@ describe('CreateLensForm', () => {
     fireEvent.change(screen.getByTestId('lens-name'), { target: { value: 'dev' } });
     // Pick a write repo other than the default first entry.
     fireEvent.change(screen.getByTestId('lens-write'), { target: { value: 'work' } });
-    // Toggle two read repos; give one of them a branch override.
+    // Toggle a read repo, wait for its branch list to load, then pin it to a
+    // non-agent branch via the dropdown. (Query while only core's select
+    // exists so the 'main' option is unambiguous.)
     fireEvent.click(screen.getByTestId('lens-read-core'));
-    fireEvent.click(screen.getByTestId('lens-read-ops'));
+    await screen.findByRole('option', { name: 'main' });
     fireEvent.change(screen.getByTestId('lens-branch-core'), { target: { value: 'main' } });
+    // Second read repo left at its default (agent branch, sent unpinned).
+    fireEvent.click(screen.getByTestId('lens-read-ops'));
 
     fireEvent.click(screen.getByTestId('lens-create'));
 

--- a/web/src/CreateLensForm.test.tsx
+++ b/web/src/CreateLensForm.test.tsx
@@ -67,4 +67,90 @@ describe('CreateLensForm', () => {
     fireEvent.click(createBtn);
     expect(api.createLens).not.toHaveBeenCalled();
   });
+
+  // ── redesign: live name validation ──
+
+  const lenses = [{ name: 'dev', write: 'work', reads: [] }];
+
+  it('disables Create and explains when the name collides with a repo', () => {
+    render(<CreateLensForm repos={repos} lenses={[]} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    fireEvent.change(screen.getByTestId('lens-name'), { target: { value: 'core' } });
+    expect((screen.getByTestId('lens-create') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByTestId('lens-name-status')).toHaveTextContent(/already exists/i);
+  });
+
+  it('disables Create and explains when the name collides with a lens', () => {
+    render(<CreateLensForm repos={repos} lenses={lenses} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    fireEvent.change(screen.getByTestId('lens-name'), { target: { value: 'dev' } });
+    expect((screen.getByTestId('lens-create') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByTestId('lens-name-status')).toHaveTextContent(/already exists/i);
+  });
+
+  it('rejects names outside the a–z 0–9 - _ pattern', () => {
+    render(<CreateLensForm repos={repos} lenses={[]} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    fireEvent.change(screen.getByTestId('lens-name'), { target: { value: 'Bad Name!' } });
+    expect((screen.getByTestId('lens-create') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByTestId('lens-name-status')).toBeInTheDocument();
+  });
+
+  it('shows "available" for a valid, non-colliding name and enables Create', () => {
+    render(<CreateLensForm repos={repos} lenses={lenses} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    fireEvent.change(screen.getByTestId('lens-name'), { target: { value: 'fresh' } });
+    expect(screen.getByTestId('lens-name-status')).toHaveTextContent(/available/i);
+    expect((screen.getByTestId('lens-create') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  // ── redesign: pinned write row + checkbox reads ──
+
+  it('renders the write repo as a pinned first row that is not toggleable', () => {
+    render(<CreateLensForm repos={repos} lenses={[]} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    // Default write is the first repo, 'core'.
+    const pinned = screen.getByTestId('lens-read-core') as HTMLButtonElement;
+    expect(pinned.disabled).toBe(true);
+    expect(screen.getByText(/always read/i)).toBeInTheDocument();
+  });
+
+  it('select all toggles every read repo on and off', () => {
+    render(<CreateLensForm repos={repos} lenses={[]} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    // write=core; the toggleable reads are work + ops (off → no branch select).
+    expect(screen.queryByTestId('lens-branch-work')).toBeNull();
+    expect(screen.queryByTestId('lens-branch-ops')).toBeNull();
+    fireEvent.click(screen.getByTestId('lens-select-all'));
+    expect(screen.getByTestId('lens-branch-work')).toBeInTheDocument();
+    expect(screen.getByTestId('lens-branch-ops')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('lens-select-all'));
+    expect(screen.queryByTestId('lens-branch-work')).toBeNull();
+    expect(screen.queryByTestId('lens-branch-ops')).toBeNull();
+  });
+
+  // ── redesign: preview ──
+
+  it('preview reflects pinned read branches', async () => {
+    render(<CreateLensForm repos={repos} lenses={[]} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    // Write repo appears in the preview from the start.
+    expect(screen.getByTestId('lens-preview')).toHaveTextContent('core');
+    fireEvent.click(screen.getByTestId('lens-read-work'));
+    await screen.findByRole('option', { name: 'main' });
+    fireEvent.change(screen.getByTestId('lens-branch-work'), { target: { value: 'main' } });
+    expect(screen.getByTestId('lens-preview')).toHaveTextContent('@main');
+  });
+
+  // ── redesign: description ──
+
+  it('includes description in the payload only when non-empty', async () => {
+    render(<CreateLensForm repos={repos} lenses={[]} onDone={() => {}} onError={() => {}} onCancel={() => {}} />);
+    fireEvent.change(screen.getByTestId('lens-name'), { target: { value: 'dev' } });
+    fireEvent.change(screen.getByTestId('lens-description'), { target: { value: 'eng lens' } });
+    fireEvent.click(screen.getByTestId('lens-create'));
+    await waitFor(() => expect(api.createLens).toHaveBeenCalled());
+    const body = (api.createLens as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(body.description).toBe('eng lens');
+  });
+
+  it('calls onCancel from the Cancel button', () => {
+    const onCancel = vi.fn();
+    render(<CreateLensForm repos={repos} lenses={[]} onDone={() => {}} onError={() => {}} onCancel={onCancel} />);
+    fireEvent.click(screen.getByTestId('lens-cancel'));
+    expect(onCancel).toHaveBeenCalled();
+  });
 });

--- a/web/src/CreateLensForm.tsx
+++ b/web/src/CreateLensForm.tsx
@@ -1,35 +1,54 @@
-import { useState } from 'react';
-import { api, type RepoInfo, type LensRead } from './api';
+import { useEffect, useState } from 'react';
+import { api, type RepoInfo, type Lens, type LensRead } from './api';
+import { LENS, repoHue } from './utils';
+import { LayersIcon, GitBranchIcon } from './icons';
 
-// BranchData is the per-read-repo branch picker state: the existing branch
-// names, the repo's agent branch (shown as the default), and load status.
+// BranchData is the per-repo branch picker state: the existing branch names,
+// the repo's agent branch (shown as the default), and load status.
 interface BranchData { names: string[]; agent: string; loading: boolean; error: boolean }
 
-// CreateLensForm composes a lens: a name, one write repo (facts land here),
-// and any number of read repos (each optionally pinned to a branch). Mirrors
-// CreateRepoForm's busy/error handling. The write repo is implicitly also a
-// read mount on the server, so we neither force it into `reads` nor forbid it.
-export function CreateLensForm({ repos, onDone, onError }: {
+// A small inline checkmark for the filled checkbox — icons.tsx has no plain
+// check glyph, and this is the only place that needs one.
+const Check = ({ color }: { color: string }) => (
+  <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+// Dot is the deterministic per-repo hue swatch shown beside each repo name.
+const Dot = ({ repo }: { repo: string }) => (
+  <span style={{ width: 7, height: 7, borderRadius: '50%', background: repoHue(repo), flexShrink: 0 }} />
+);
+
+// CreateLensForm composes a lens: a name, one write repo (facts land here), and
+// any number of read repos (each optionally pinned to a branch). The write repo
+// is implicitly also a read mount on the server, so it renders as a pinned,
+// always-on first row (locked to its agent branch) — never toggled into `reads`.
+export function CreateLensForm({ repos, lenses = [], onDone, onError, onCancel }: {
   repos: RepoInfo[];
+  lenses?: Lens[];
   onDone: (name: string) => void;
   onError: (m: string) => void;
+  onCancel?: () => void;
 }) {
   const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
   const [write, setWrite] = useState(repos[0]?.name ?? '');
-  // reads maps a toggled repo name → its branch pin. '' means "the repo's agent
-  // branch, resolved at bind time" (see repos.LensRead) — the default. A
-  // non-empty value is an explicit pin to an existing branch.
+  // reads maps a toggled read repo → its branch pin. '' means "the repo's agent
+  // branch, resolved at bind time" (the default); a non-empty value is an
+  // explicit pin. The write repo is never a key here (it's always read).
   const [reads, setReads] = useState<Record<string, string>>({});
-  // branchData caches each toggled repo's selectable branches. We can't create
-  // branches on the fly, so the picker only offers branches that already exist;
-  // `agent` is that repo's agent branch, shown as the default choice.
+  // branchData caches each repo's selectable branches (the picker can't create
+  // branches, only offer existing ones). `agent` is the default choice.
   const [branchData, setBranchData] = useState<Record<string, BranchData>>({});
+  const [search, setSearch] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
 
-  // loadBranches fetches the existing branches and agent branch for a repo the
-  // moment it is toggled on, so the dropdown reflects only readable branches.
+  // loadBranches fetches the existing branches and agent branch for a repo, so
+  // the dropdown (or the write row's locked label) reflects only real branches.
   const loadBranches = async (repo: string) => {
+    if (!repo) return;
     setBranchData(prev => ({ ...prev, [repo]: { names: [], agent: '', loading: true, error: false } }));
     try {
       const [names, agent] = await Promise.all([api.listBranchNames(repo), api.getAgentBranch(repo)]);
@@ -39,6 +58,23 @@ export function CreateLensForm({ repos, onDone, onError }: {
     }
   };
 
+  // The write repo's branch is shown locked to its agent branch, so load it
+  // whenever the write target changes (once — the cache persists).
+  useEffect(() => {
+    if (write && !branchData[write]) void loadBranches(write);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [write]);
+
+  const changeWrite = (next: string) => {
+    setWrite(next);
+    // A repo that becomes the write target is read implicitly — drop any
+    // explicit read pin so it isn't double-counted or sent in `reads`.
+    setReads(prev => {
+      if (!(next in prev)) return prev;
+      const n = { ...prev }; delete n[next]; return n;
+    });
+  };
+
   const toggleRead = (repo: string) => {
     setReads(prev => {
       const next = { ...prev };
@@ -46,7 +82,6 @@ export function CreateLensForm({ repos, onDone, onError }: {
       else next[repo] = '';
       return next;
     });
-    // Fetch on toggle-on (once); the branch cache persists across re-toggles.
     if (!(repo in reads) && !branchData[repo]) void loadBranches(repo);
   };
 
@@ -54,14 +89,46 @@ export function CreateLensForm({ repos, onDone, onError }: {
     setReads(prev => ({ ...prev, [repo]: branch }));
   };
 
+  // The toggleable read repos are every repo except the write target.
+  const others = repos.filter(r => r.name !== write);
+  const allOn = others.length > 0 && others.every(r => r.name in reads);
+
+  const toggleAll = () => {
+    if (allOn) { setReads({}); return; }
+    setReads(prev => {
+      const n = { ...prev };
+      for (const r of others) if (!(r.name in n)) n[r.name] = '';
+      return n;
+    });
+    for (const r of others) if (!branchData[r.name]) void loadBranches(r.name);
+  };
+
+  // ── live name validation ──
+  const nameTrim = name.trim();
+  const repoNames = new Set(repos.map(r => r.name));
+  const lensNames = new Set(lenses.map(l => l.name));
+  const patternOk = /^[a-z0-9_-]+$/.test(nameTrim);
+  let nameError = '';
+  if (nameTrim === '') nameError = '';
+  else if (!patternOk) nameError = 'Use only a–z, 0–9, - and _';
+  else if (repoNames.has(nameTrim)) nameError = `A repo named "${nameTrim}" already exists`;
+  else if (lensNames.has(nameTrim)) nameError = `A lens named "${nameTrim}" already exists`;
+  const nameValid = nameTrim !== '' && nameError === '';
+
   const submit = async () => {
     setErr(''); onError(''); setBusy(true);
-    // Assemble reads: omit an empty branch so the server picks its default.
-    const readList: LensRead[] = Object.entries(reads).map(([repo, branch]) =>
-      branch.trim() ? { repo, branch: branch.trim() } : { repo });
+    // Assemble reads: omit an empty branch so the server picks its default;
+    // defensively skip the write repo (it's read implicitly).
+    const readList: LensRead[] = Object.entries(reads)
+      .filter(([repo]) => repo !== write)
+      .map(([repo, branch]) => branch.trim() ? { repo, branch: branch.trim() } : { repo });
+    const body: { name: string; write: string; reads: LensRead[]; description?: string } =
+      { name: nameTrim, write, reads: readList };
+    const desc = description.trim();
+    if (desc) body.description = desc;
     try {
-      await api.createLens({ name, write, reads: readList });
-      onDone(name);
+      await api.createLens(body);
+      onDone(nameTrim);
     } catch (e) {
       setErr(String(e));
       onError(String(e));
@@ -70,58 +137,132 @@ export function CreateLensForm({ repos, onDone, onError }: {
     }
   };
 
+  const selectedCount = 1 + others.filter(r => r.name in reads).length;
+  const filteredOthers = search.trim()
+    ? others.filter(r => r.name.toLowerCase().includes(search.trim().toLowerCase()))
+    : others;
+  const readEntries = others.filter(r => r.name in reads);
+
   return (
     <div>
-      <h3 style={{ margin: '0 0 14px', fontSize: 16 }}>New lens</h3>
+      <h3 style={{ margin: '0 0 4px', fontSize: 16 }}>New lens</h3>
+      <div style={{ fontSize: 12.5, color: '#777', lineHeight: 1.5, marginBottom: 6 }}>
+        A lens unions several repos for <b style={{ color: '#bbb' }}>reading</b> and points writes at one of them.
+      </div>
 
       <label style={label}>Name</label>
-      <input data-testid="lens-name" style={input} placeholder="e.g. dev (a–z, 0–9, -, _)" value={name} disabled={busy}
-        onChange={e => setName(e.target.value)} />
+      <div style={{ position: 'relative' }}>
+        <span style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none', display: 'flex' }}>
+          <LayersIcon color={LENS.accent} size={13} />
+        </span>
+        <input data-testid="lens-name" style={{ ...input, paddingLeft: 28 }} placeholder="e.g. dev (a–z, 0–9, -, _)"
+          value={name} disabled={busy} onChange={e => setName(e.target.value)} />
+      </div>
+      <div data-testid="lens-name-status" style={{ ...hint, color: nameError ? '#f88' : nameValid ? '#7c9' : '#666', display: 'flex', alignItems: 'center', gap: 5 }}>
+        {nameError
+          ? nameError
+          : nameValid
+            ? <><Check color="#7c9" /> available · a–z, 0–9, -, _</>
+            : 'a–z, 0–9, - and _'}
+      </div>
 
-      <label style={label}>Write repo</label>
+      <label style={label}>Description <span style={{ color: '#555' }}>(optional)</span></label>
+      <textarea data-testid="lens-description" style={{ ...input, minHeight: 44, resize: 'vertical', fontFamily: 'inherit' }}
+        placeholder="What is this lens for?" value={description} disabled={busy}
+        onChange={e => setDescription(e.target.value)} />
+
+      <label style={label}>Write target</label>
       <select data-testid="lens-write" style={input} value={write} disabled={busy}
-        onChange={e => setWrite(e.target.value)}>
+        onChange={e => changeWrite(e.target.value)}>
         {repos.map(r => <option key={r.name} value={r.name}>{r.name}</option>)}
       </select>
-      <div style={hint}>New facts written through this lens land in the write repo.</div>
+      <div style={hint}>Every new fact written through this lens lands on <b style={{ color: '#bbb' }}>{write || '…'}</b>'s agent branch.</div>
 
-      <label style={label}>Read repos</label>
-      <div style={hint}>Reads through this lens union facts from every selected repo.</div>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginTop: 16 }}>
+        <label style={{ ...label, marginTop: 0 }}>Read mounts</label>
+        <span style={{ fontSize: 11, color: '#777' }}>
+          {selectedCount} of {repos.length} · <span data-testid="lens-select-all" style={{ color: LENS.accent, cursor: 'pointer' }} onClick={toggleAll}>select all</span>
+        </span>
+      </div>
+
+      {repos.length > 8 && (
+        <input data-testid="lens-read-search" style={{ ...input, marginTop: 4 }} placeholder="Filter repos…"
+          value={search} disabled={busy} onChange={e => setSearch(e.target.value)} />
+      )}
+
       <div style={{ marginTop: 6 }}>
-        {repos.map(r => {
+        {/* Pinned write-as-read row: always on, locked to the agent branch. */}
+        {write && (
+          <div style={row(true)}>
+            <button type="button" data-testid={`lens-read-${write}`} style={checkbox(true)} disabled aria-label={`${write} (write repo, always read)`}>
+              <Check color={LENS.text} />
+            </button>
+            <Dot repo={write} />
+            <span style={{ fontSize: 13, color: '#eee', minWidth: 76 }}>{write}</span>
+            <span style={writeBadge}>WRITE · always read</span>
+            <div style={{ flex: 1 }} />
+            <span style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 12, color: '#8af' }}>
+              <GitBranchIcon color="#8af" size={12} />
+              <span style={{ fontFamily: 'var(--k-font-mono)', fontSize: 11, color: '#8af' }}>
+                {branchData[write]?.agent || (branchData[write]?.loading ? '…' : 'agent branch')}
+              </span>
+            </span>
+          </div>
+        )}
+
+        {/* Toggleable read rows. */}
+        {filteredOthers.map(r => {
           const on = r.name in reads;
+          const bd = branchData[r.name];
+          const agentLabel = bd?.agent ? `Agent branch — ${bd.agent}` : 'Agent branch';
+          const otherBranches = (bd?.names ?? []).filter(n => n !== bd?.agent);
           return (
-            <div key={r.name} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-              <button type="button" data-testid={`lens-read-${r.name}`} style={toggle(on)} disabled={busy}
-                onClick={() => toggleRead(r.name)}>{r.name}</button>
-              {on && (() => {
-                const bd = branchData[r.name];
-                // Default option maps to '' (agent branch, resolved at bind
-                // time). Every OTHER existing branch is offered as an explicit
-                // pin — the agent branch itself is not repeated below the
-                // default. We never allow typing a name that doesn't exist.
-                const agentLabel = bd?.agent ? `Agent branch — ${bd.agent}` : 'Agent branch';
-                const others = (bd?.names ?? []).filter(n => n !== bd?.agent);
-                return (
-                  <select data-testid={`lens-branch-${r.name}`} style={{ ...input, flex: 1, marginTop: 0 }}
-                    value={reads[r.name]} disabled={busy || bd?.loading}
-                    onChange={e => setBranch(r.name, e.target.value)}>
-                    <option value="">{bd?.loading ? 'loading branches…' : `${agentLabel} (default)`}</option>
-                    {others.map(n => <option key={n} value={n}>{n}</option>)}
-                  </select>
-                );
-              })()}
+            <div key={r.name} style={row(on)}>
+              <button type="button" data-testid={`lens-read-${r.name}`} style={checkbox(on)} disabled={busy}
+                onClick={() => toggleRead(r.name)} aria-label={r.name} aria-pressed={on}>
+                {on && <Check color={LENS.text} />}
+              </button>
+              <Dot repo={r.name} />
+              <span style={{ fontSize: 13, color: on ? '#eee' : '#aaa', minWidth: 76 }}>{r.name}</span>
+              <div style={{ flex: 1 }} />
+              {on && (
+                <select data-testid={`lens-branch-${r.name}`} style={{ ...input, width: 'auto', flexShrink: 0, marginTop: 0, maxWidth: 200 }}
+                  value={reads[r.name]} disabled={busy || bd?.loading}
+                  onChange={e => setBranch(r.name, e.target.value)}>
+                  <option value="">{bd?.loading ? 'loading branches…' : `${agentLabel} (default)`}</option>
+                  {otherBranches.map(n => <option key={n} value={n}>{n}</option>)}
+                </select>
+              )}
             </div>
           );
         })}
       </div>
 
+      {/* Preview: the resolved read union + write target, repo names hue-colored. */}
+      <div data-testid="lens-preview" style={previewBox}>
+        <div style={{ color: '#888', textTransform: 'uppercase', fontSize: 10, letterSpacing: 1, marginBottom: 2 }}>Preview</div>
+        <div>
+          Reads union <b style={{ color: repoHue(write) }}>{write || '…'}</b>
+          {readEntries.map(r => (
+            <span key={r.name}>
+              {' + '}
+              <b style={{ color: repoHue(r.name) }}>{r.name}</b>
+              {reads[r.name] && <span style={{ fontFamily: 'var(--k-font-mono)', color: '#888' }}>@{reads[r.name]}</span>}
+            </span>
+          ))}
+          . Writes → <b style={{ color: repoHue(write) }}>{write || '…'}</b>.
+        </div>
+      </div>
+
       {err && <div style={{ color: '#f88', fontSize: 13, marginTop: 8 }}>{err}</div>}
 
-      <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
-        <button type="button" data-testid="lens-create" style={btn(busy || !name || !write, 'primary')}
-          disabled={busy || !name || !write} onClick={submit}>
+      <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+        <button type="button" data-testid="lens-create" style={btn(busy || !nameValid || !write, 'primary')}
+          disabled={busy || !nameValid || !write} onClick={submit}>
           {busy ? 'Creating…' : 'Create lens'}
+        </button>
+        <button type="button" data-testid="lens-cancel" style={btn(busy)} disabled={busy} onClick={() => onCancel?.()}>
+          Cancel
         </button>
       </div>
     </div>
@@ -131,5 +272,19 @@ export function CreateLensForm({ repos, onDone, onError }: {
 const label: React.CSSProperties = { fontSize: 12, color: '#888', marginBottom: 4, marginTop: 12, display: 'block' };
 const hint: React.CSSProperties = { fontSize: 12, color: '#666', marginTop: 4 };
 const input: React.CSSProperties = { width: '100%', boxSizing: 'border-box', background: '#111', border: '1px solid #333', color: '#eee', padding: '6px 8px', borderRadius: 4, fontSize: 13 };
-const toggle = (active: boolean): React.CSSProperties => ({ minWidth: 90, background: active ? '#1d4ed8' : '#2a2a2a', color: '#eee', border: '1px solid #333', borderRadius: 4, padding: '6px 12px', fontSize: 13, cursor: 'pointer', textAlign: 'left' });
+const writeBadge: React.CSSProperties = { fontSize: 10, color: '#7c9', background: '#1a2e1a', border: '1px solid #2a4a2a', padding: '1px 6px', borderRadius: 3, letterSpacing: '0.03em' };
+const previewBox: React.CSSProperties = { marginTop: 12, padding: '9px 11px', background: '#0f0f0f', border: '1px solid #242424', borderRadius: 6, fontSize: 12, color: '#aaa', lineHeight: 1.6 };
+
+// row: one read-mount row — filled when on, deep/inert when off.
+const row = (on: boolean): React.CSSProperties => ({
+  display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 6, marginBottom: 4,
+  background: on ? LENS.soft : '#0f0f0f', border: '1px solid ' + (on ? LENS.border : '#242424'),
+});
+// checkbox: 16×16 box, filled with the lens accent (and a light check) when on.
+const checkbox = (on: boolean): React.CSSProperties => ({
+  width: 16, height: 16, borderRadius: 4, flexShrink: 0, padding: 0,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  background: on ? LENS.accent : 'transparent', border: '1.5px solid ' + (on ? LENS.accent : '#444'),
+  cursor: 'pointer',
+});
 const btn = (disabled: boolean, variant: 'primary' | 'secondary' = 'secondary'): React.CSSProperties => ({ background: disabled ? '#222' : variant === 'primary' ? '#1d4ed8' : '#2a2a2a', color: disabled ? '#666' : '#eee', border: '1px solid #333', borderRadius: 4, padding: '6px 14px', fontSize: 13, cursor: disabled ? 'default' : 'pointer' });

--- a/web/src/CreateLensForm.tsx
+++ b/web/src/CreateLensForm.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { api, type RepoInfo, type LensRead } from './api';
 
+// BranchData is the per-read-repo branch picker state: the existing branch
+// names, the repo's agent branch (shown as the default), and load status.
+interface BranchData { names: string[]; agent: string; loading: boolean; error: boolean }
+
 // CreateLensForm composes a lens: a name, one write repo (facts land here),
 // and any number of read repos (each optionally pinned to a branch). Mirrors
 // CreateRepoForm's busy/error handling. The write repo is implicitly also a
@@ -12,10 +16,28 @@ export function CreateLensForm({ repos, onDone, onError }: {
 }) {
   const [name, setName] = useState('');
   const [write, setWrite] = useState(repos[0]?.name ?? '');
-  // reads maps a toggled repo name → its optional branch override.
+  // reads maps a toggled repo name → its branch pin. '' means "the repo's agent
+  // branch, resolved at bind time" (see repos.LensRead) — the default. A
+  // non-empty value is an explicit pin to an existing branch.
   const [reads, setReads] = useState<Record<string, string>>({});
+  // branchData caches each toggled repo's selectable branches. We can't create
+  // branches on the fly, so the picker only offers branches that already exist;
+  // `agent` is that repo's agent branch, shown as the default choice.
+  const [branchData, setBranchData] = useState<Record<string, BranchData>>({});
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
+
+  // loadBranches fetches the existing branches and agent branch for a repo the
+  // moment it is toggled on, so the dropdown reflects only readable branches.
+  const loadBranches = async (repo: string) => {
+    setBranchData(prev => ({ ...prev, [repo]: { names: [], agent: '', loading: true, error: false } }));
+    try {
+      const [names, agent] = await Promise.all([api.listBranchNames(repo), api.getAgentBranch(repo)]);
+      setBranchData(prev => ({ ...prev, [repo]: { names, agent, loading: false, error: false } }));
+    } catch {
+      setBranchData(prev => ({ ...prev, [repo]: { names: [], agent: '', loading: false, error: true } }));
+    }
+  };
 
   const toggleRead = (repo: string) => {
     setReads(prev => {
@@ -24,6 +46,8 @@ export function CreateLensForm({ repos, onDone, onError }: {
       else next[repo] = '';
       return next;
     });
+    // Fetch on toggle-on (once); the branch cache persists across re-toggles.
+    if (!(repo in reads) && !branchData[repo]) void loadBranches(repo);
   };
 
   const setBranch = (repo: string, branch: string) => {
@@ -70,11 +94,23 @@ export function CreateLensForm({ repos, onDone, onError }: {
             <div key={r.name} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
               <button type="button" data-testid={`lens-read-${r.name}`} style={toggle(on)} disabled={busy}
                 onClick={() => toggleRead(r.name)}>{r.name}</button>
-              {on && (
-                <input data-testid={`lens-branch-${r.name}`} style={{ ...input, flex: 1, marginTop: 0 }}
-                  placeholder="branch (optional)" value={reads[r.name]} disabled={busy}
-                  onChange={e => setBranch(r.name, e.target.value)} />
-              )}
+              {on && (() => {
+                const bd = branchData[r.name];
+                // Default option maps to '' (agent branch, resolved at bind
+                // time). Every OTHER existing branch is offered as an explicit
+                // pin — the agent branch itself is not repeated below the
+                // default. We never allow typing a name that doesn't exist.
+                const agentLabel = bd?.agent ? `Agent branch — ${bd.agent}` : 'Agent branch';
+                const others = (bd?.names ?? []).filter(n => n !== bd?.agent);
+                return (
+                  <select data-testid={`lens-branch-${r.name}`} style={{ ...input, flex: 1, marginTop: 0 }}
+                    value={reads[r.name]} disabled={busy || bd?.loading}
+                    onChange={e => setBranch(r.name, e.target.value)}>
+                    <option value="">{bd?.loading ? 'loading branches…' : `${agentLabel} (default)`}</option>
+                    {others.map(n => <option key={n} value={n}>{n}</option>)}
+                  </select>
+                );
+              })()}
             </div>
           );
         })}

--- a/web/src/CreateLensForm.tsx
+++ b/web/src/CreateLensForm.tsx
@@ -89,18 +89,31 @@ export function CreateLensForm({ repos, lenses = [], onDone, onError, onCancel }
     setReads(prev => ({ ...prev, [repo]: branch }));
   };
 
-  // The toggleable read repos are every repo except the write target.
+  // The toggleable read repos are every repo except the write target. When a
+  // search filter is active, "select all" is scoped to the *visible* rows
+  // (select-all-visible) — it never mounts repos the user filtered out of view,
+  // nor clears hidden selections.
   const others = repos.filter(r => r.name !== write);
-  const allOn = others.length > 0 && others.every(r => r.name in reads);
+  const filteredOthers = search.trim()
+    ? others.filter(r => r.name.toLowerCase().includes(search.trim().toLowerCase()))
+    : others;
+  const allOn = filteredOthers.length > 0 && filteredOthers.every(r => r.name in reads);
 
   const toggleAll = () => {
-    if (allOn) { setReads({}); return; }
+    if (allOn) {
+      setReads(prev => {
+        const n = { ...prev };
+        for (const r of filteredOthers) delete n[r.name];
+        return n;
+      });
+      return;
+    }
     setReads(prev => {
       const n = { ...prev };
-      for (const r of others) if (!(r.name in n)) n[r.name] = '';
+      for (const r of filteredOthers) if (!(r.name in n)) n[r.name] = '';
       return n;
     });
-    for (const r of others) if (!branchData[r.name]) void loadBranches(r.name);
+    for (const r of filteredOthers) if (!branchData[r.name]) void loadBranches(r.name);
   };
 
   // ── live name validation ──
@@ -138,9 +151,6 @@ export function CreateLensForm({ repos, lenses = [], onDone, onError, onCancel }
   };
 
   const selectedCount = 1 + others.filter(r => r.name in reads).length;
-  const filteredOthers = search.trim()
-    ? others.filter(r => r.name.toLowerCase().includes(search.trim().toLowerCase()))
-    : others;
   const readEntries = others.filter(r => r.name in reads);
 
   return (

--- a/web/src/CreateRepoForm.tsx
+++ b/web/src/CreateRepoForm.tsx
@@ -75,7 +75,11 @@ export function CreateRepoForm({ onDone, onCancel }: { onDone: (name: string) =>
       <h3 style={{ margin: '0 0 14px', fontSize: 16 }}>New repository</h3>
 
       <label style={label}>Name</label>
+      {/* autoCapitalize/autoCorrect/spellCheck off: the desktop WKWebView otherwise
+          capitalizes/substitutes the typed name (e.g. "test" → "Test"), which fails
+          the lowercase-only isValidRepoName check with a confusing 400. */}
       <input data-testid="create-name" style={input} placeholder="e.g. work (a–z, 0–9, -, _)" value={name} disabled={busy}
+        autoCapitalize="off" autoCorrect="off" spellCheck={false}
         onChange={e => setName(e.target.value)} />
 
       <label style={label}>Create from</label>

--- a/web/src/EdgesRail.anchor.test.tsx
+++ b/web/src/EdgesRail.anchor.test.tsx
@@ -1,0 +1,57 @@
+// Task 17 fix: the App→EdgesRail seam for a read-mount lens fact in LIVE mode.
+// App feeds EdgesRail the fact's MOUNT repo/branch + relative path (factHistoryAnchor)
+// and an edge anchor of "" (edgeAnchorCommit in a lens context) — so the edges
+// fetch must hit the mount's live-HEAD explain URL, NOT a commit-anchored URL
+// carrying the WRITE repo's head sha (which doesn't exist in the read mount →
+// empty edges in the default view). Uses the REAL api.explain, spying on fetch to
+// observe the exact URL — this pins the commit dimension the props-only coverage missed.
+import { it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { EdgesRail } from './EdgesRail';
+import { edgeAnchorCommit, factHistoryAnchor, init } from './state';
+import type { AppState } from './state';
+import type { Lens, LensSource } from './api';
+
+const urls: string[] = [];
+
+beforeEach(() => {
+  urls.length = 0;
+  vi.stubGlobal('fetch', vi.fn((url: unknown) => {
+    urls.push(String(url));
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ _embedded: { refs: [] } }) } as Response);
+  }));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const lens: Lens = { name: 'eng', write: 'core', reads: [{ repo: 'core' }, { repo: 'docs' }] };
+const readSource: LensSource = { repo: 'docs', id: 'docsid123456', branch: 'main' };
+
+// The state App would hold: a lens context, live, with a docs read-mount fact
+// open. state.headCommit is the WRITE repo (core) head — the sha that must NOT
+// leak into the mount's explain URL.
+const liveReadMountState: AppState = {
+  ...init,
+  context: { kind: 'lens', name: 'eng' },
+  lens,
+  repo: 'core', branch: 'agent/main', headCommit: 'coreHEADsha',
+  factPath: 'kb://docsid123456/kb/api/auth.md',
+  factSource: readSource,
+  asOf: { mode: 'live' },
+};
+
+it('live read-mount fact: edges fetch hits the MOUNT at live HEAD, with NO commit sha', async () => {
+  // Derive the props exactly as App does.
+  const edge = factHistoryAnchor(liveReadMountState);
+  const anchor = edgeAnchorCommit(liveReadMountState);
+  expect(anchor).toBe(''); // guard: the App-side derivation dropped the write head
+
+  render(<EdgesRail repo={edge.repo} branch={edge.branch} factPath={edge.path} anchorCommit={anchor} history={false} onHop={() => {}} />);
+  await waitFor(() => expect(urls.length).toBeGreaterThan(0));
+
+  // Mount repo + branch, non-commit-anchored (live HEAD).
+  expect(urls.some(u => u.includes('/repos/docs/branches/main/facts/kb/api/auth.md/incoming'))).toBe(true);
+  // Never a commit-anchored URL, and never the write repo's head sha.
+  expect(urls.every(u => !u.includes('/commits/'))).toBe(true);
+  expect(urls.every(u => !u.includes('coreHEADsha'))).toBe(true);
+  expect(urls.every(u => !u.includes('/repos/core/'))).toBe(true);
+});

--- a/web/src/FactDiffView.test.tsx
+++ b/web/src/FactDiffView.test.tsx
@@ -73,6 +73,24 @@ describe('FactDiffView', () => {
     });
   });
 
+  it('diffs a read-mount lens fact against its source mount with the relative path (C1)', async () => {
+    (api.factDiff as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      from: { ...baseFact }, to: { ...baseFact },
+    });
+    const lens = { name: 'eng', write: 'core', reads: [{ repo: 'core' }, { repo: 'docs' }] };
+    render(<FactDiffView state={makeState({
+      context: { kind: 'lens', name: 'eng' },
+      lens,
+      factPath: 'kb://docsid123456/kb/api/auth.md',
+      factSource: { repo: 'docs', id: 'docsid123456', branch: 'main' },
+    })} dispatch={vi.fn()} />);
+    await waitFor(() => expect(api.factDiff).toHaveBeenCalled());
+    // No clearMocks beforeEach in this file — assert on the latest call.
+    const call = (api.factDiff as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    // Mount repo/branch + the kb://<id12>/-stripped relative path, not the browse surface.
+    expect(call.slice(0, 3)).toEqual(['docs', 'main', 'kb/api/auth.md']);
+  });
+
   it('aborts in-flight request on factPath change', async () => {
     let abortCalled = false;
     (api.factDiff as unknown as ReturnType<typeof vi.fn>).mockImplementation(

--- a/web/src/FactDiffView.tsx
+++ b/web/src/FactDiffView.tsx
@@ -3,6 +3,7 @@ import type { Dispatch } from 'react';
 import { api } from './api';
 import type { Fact } from './api';
 import type { Action, AppState } from './state';
+import { factHistoryAnchor } from './state';
 import { unifiedDiff } from './diff';
 
 interface Props {
@@ -23,13 +24,20 @@ export function FactDiffView({ state, dispatch }: Props) {
   const from = asOf.mode === 'diff' ? asOf.from : '';
   const to   = asOf.mode === 'diff' ? asOf.to   : '';
 
+  // Diff reads anchor on the open fact's SOURCE MOUNT + RELATIVE path
+  // (factHistoryAnchor), not the browse surface — so a lens read-mount fact
+  // diffs against the mount that owns it (its commits live there), with the
+  // kb://<id12>/ qualifier stripped. Repo context collapses to
+  // {state.repo, state.branch, bare path} — byte-identical to the old inline args.
+  const anchor = factHistoryAnchor(state);
+
   useEffect(() => {
     if (!inDiff) return;
     ctrlRef.current?.abort();
     const ctrl = new AbortController();
     ctrlRef.current = ctrl;
     setError(null);
-    api.factDiff(state.repo, state.branch, state.factPath, from, to, ctrl.signal)
+    api.factDiff(anchor.repo, anchor.branch, anchor.path, from, to, ctrl.signal)
       .then(({ from: f, to: t }) => {
         if (ctrl.signal.aborted) return;
         setFromFact(f);
@@ -41,7 +49,7 @@ export function FactDiffView({ state, dispatch }: Props) {
         setError(String(e));
       });
     return () => ctrl.abort();
-  }, [inDiff, state.repo, state.branch, state.factPath, from, to]);
+  }, [inDiff, anchor.repo, anchor.branch, anchor.path, from, to]);
 
   if (!inDiff) return null;
   if (error) return <div style={{ padding: 24, color: '#f44' }}>{error}</div>;

--- a/web/src/FilterBar.anchor.test.tsx
+++ b/web/src/FilterBar.anchor.test.tsx
@@ -1,0 +1,68 @@
+// Task 17: `at:`/`vs:` anchor tokens are per-fact in a lens. In a lens context
+// with NO open fact there is no mount to anchor against, so dropping into
+// history would strand the left panel on nothing — the FilterBar warns (existing
+// warnings channel) and does NOT dispatch SET_AS_OF. With an open fact the
+// anchor resolves as usual. Repo context is byte-identical to before.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { FilterBar } from './FilterBar';
+import { init } from './state';
+import type { AppState } from './state';
+import type { Lens } from './api';
+
+vi.mock('./api', async () => {
+  const actual = await vi.importActual<typeof import('./api')>('./api');
+  return {
+    ...actual,
+    api: {
+      completions: vi.fn().mockResolvedValue({ values: [] }),
+      lensCompletions: vi.fn().mockResolvedValue({ values: [] }),
+    },
+  };
+});
+
+const lens: Lens = { name: 'eng', write: 'core', reads: [{ repo: 'core' }, { repo: 'docs' }] };
+
+function lensState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    ...init, repo: 'core', branch: 'agent/main', headCommit: 'aaaaaaa',
+    context: { kind: 'lens', name: 'eng' }, lens, ...overrides,
+  };
+}
+function repoState(overrides: Partial<AppState> = {}): AppState {
+  return { ...init, repo: 'core', branch: 'agent/main', headCommit: 'aaaaaaa', ...overrides };
+}
+
+function typeAndEnter(value: string) {
+  const input = document.getElementById('filter-input') as HTMLInputElement;
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+}
+
+describe('FilterBar — at:/vs: anchor is per-fact in a lens', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lens context, NO open fact: warns and does NOT dispatch SET_AS_OF', () => {
+    const dispatch = vi.fn();
+    render(<FilterBar state={lensState({ factPath: null })} dispatch={dispatch} />);
+    typeAndEnter('at:b812d40');
+    const actions = dispatch.mock.calls.map(c => c[0]);
+    expect(actions.some((a: any) => a.type === 'SET_AS_OF')).toBe(false);
+    expect(actions.some((a: any) =>
+      a.type === 'CONSOLE_LOG' && /open a fact first — time anchors are per-fact in a lens/.test(a.message))).toBe(true);
+  });
+
+  it('lens context, open fact: dispatches SET_AS_OF (per-fact anchor resolves)', () => {
+    const dispatch = vi.fn();
+    render(<FilterBar state={lensState({ factPath: 'kb://docsid123456/kb/a.md' })} dispatch={dispatch} />);
+    typeAndEnter('at:b812d40');
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_AS_OF', asOf: { mode: 'history', commit: 'b812d40' } });
+  });
+
+  it('repo context: at: dispatches SET_AS_OF even with no open fact (byte-identical)', () => {
+    const dispatch = vi.fn();
+    render(<FilterBar state={repoState({ factPath: null })} dispatch={dispatch} />);
+    typeAndEnter('at:b812d40');
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_AS_OF', asOf: { mode: 'history', commit: 'b812d40' } });
+  });
+});

--- a/web/src/FilterBar.lens.test.tsx
+++ b/web/src/FilterBar.lens.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Keep the real parseFilterQuery; stub only the `api` object so completions
+// fetches are observable and never hit the network.
+vi.mock('./api', async () => {
+  const actual = await vi.importActual<typeof import('./api')>('./api');
+  return {
+    ...actual,
+    api: {
+      completions: vi.fn().mockResolvedValue({ values: ['kb', 'kb/ops'] }),
+      lensCompletions: vi.fn().mockResolvedValue({ values: ['infra', 'docs'] }),
+    },
+  };
+});
+
+import { FilterBar } from './FilterBar';
+import { parseFilterQuery } from './api';
+import { init } from './state';
+import type { AppState } from './state';
+import type { Lens } from './api';
+import { repoHue } from './utils';
+
+const lens: Lens = {
+  name: 'eng',
+  write: 'core',
+  reads: [{ repo: 'core' }, { repo: 'docs' }, { repo: 'infra' }],
+};
+
+function lensState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    ...init,
+    repo: 'core',
+    branch: 'agent/main',
+    headCommit: 'aaaaaaa',
+    context: { kind: 'lens', name: 'eng' },
+    lens,
+    lensSources: null,
+    ...overrides,
+  };
+}
+
+function repoState(overrides: Partial<AppState> = {}): AppState {
+  return { ...init, repo: 'core', branch: 'agent/main', headCommit: 'aaaaaaa', ...overrides };
+}
+
+// jsdom serializes inline `color` as `rgb(r, g, b)`.
+function hexToRgb(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+describe('parseFilterQuery — repo: facet is context-aware', () => {
+  it('parses repo:infra as a chip when allowRepo is set (lens context)', () => {
+    const r = parseFilterQuery('repo:infra', undefined, { allowRepo: true });
+    expect(r.chips).toEqual([{ category: 'repo', value: 'infra' }]);
+    expect(r.text).toBe('');
+  });
+
+  it('leaves repo:infra as free text by default (repo context)', () => {
+    const r = parseFilterQuery('repo:infra');
+    expect(r.chips).toEqual([]);
+    expect(r.text).toBe('repo:infra');
+  });
+
+  it('does not disturb the other categories in lens context', () => {
+    const r = parseFilterQuery('domain:ai repo:infra path:kb/ops', undefined, { allowRepo: true });
+    // Bare tokens are extracted in left-to-right string order.
+    expect(r.chips).toEqual([
+      { category: 'domain', value: 'ai' },
+      { category: 'repo', value: 'infra' },
+      { category: 'path', value: 'kb/ops' },
+    ]);
+  });
+});
+
+describe('FilterBar — repo: facet (lens context only)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('offers a Repo category in the picker only in lens context', () => {
+    const { unmount } = render(<FilterBar state={repoState()} dispatch={vi.fn()} />);
+    fireEvent.click(screen.getByTitle('Add filter'));
+    expect(screen.queryByText('Repo')).toBeNull();
+    unmount();
+
+    render(<FilterBar state={lensState()} dispatch={vi.fn()} />);
+    fireEvent.click(screen.getByTitle('Add filter'));
+    expect(screen.getByText('Repo')).toBeInTheDocument();
+  });
+
+  it('fetches completions for repo: via api.lensCompletions', async () => {
+    const { api } = await import('./api');
+    render(<FilterBar state={lensState()} dispatch={vi.fn()} />);
+    const input = document.getElementById('filter-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'repo:inf' } });
+    await waitFor(() => expect(api.lensCompletions).toHaveBeenCalledWith('eng', 'repo', 'inf'));
+    expect(api.completions).not.toHaveBeenCalled();
+    // 'docs' has no 'inf' substring so it renders as a single (unsplit) text node.
+    await waitFor(() => expect(screen.getByText('docs')).toBeInTheDocument());
+  });
+
+  it('does not recognise repo: as a facet in repo context (free text)', async () => {
+    const { api } = await import('./api');
+    render(<FilterBar state={repoState()} dispatch={vi.fn()} />);
+    const input = document.getElementById('filter-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'repo:inf' } });
+    // No prefix match → no completion fetch of any kind.
+    await new Promise(r => setTimeout(r, 200));
+    expect(api.lensCompletions).not.toHaveBeenCalled();
+    expect(api.completions).not.toHaveBeenCalled();
+  });
+
+  it('Enter commits repo:infra to a repo chip in lens context', () => {
+    const dispatch = vi.fn();
+    render(<FilterBar state={lensState()} dispatch={dispatch} />);
+    const input = document.getElementById('filter-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'repo:infra' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(dispatch).toHaveBeenCalledWith({ type: 'ADD_FILTER', chip: { category: 'repo', value: 'infra' } });
+  });
+
+  it('Enter does NOT commit a repo chip in repo context', () => {
+    const dispatch = vi.fn();
+    render(<FilterBar state={repoState()} dispatch={dispatch} />);
+    const input = document.getElementById('filter-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'repo:infra' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'ADD_FILTER', chip: expect.objectContaining({ category: 'repo' }) }),
+    );
+  });
+
+  it('renders a repo chip in the deterministic repo hue', () => {
+    render(<FilterBar state={lensState({ filters: [{ category: 'repo', value: 'infra' }] })} dispatch={vi.fn()} />);
+    const chip = screen.getByTestId('repo-chip');
+    expect(chip.getAttribute('data-repo')).toBe('infra');
+    expect(chip.textContent).toContain('repo:infra');
+    expect(chip.style.color).toBe(hexToRgb(repoHue('infra')));
+  });
+});

--- a/web/src/FilterBar.lens.test.tsx
+++ b/web/src/FilterBar.lens.test.tsx
@@ -101,6 +101,27 @@ describe('FilterBar — repo: facet (lens context only)', () => {
     await waitFor(() => expect(screen.getByText('docs')).toBeInTheDocument());
   });
 
+  it('fetches ALL category completions via api.lensCompletions in lens context (union across mounts)', async () => {
+    // Regression: only the repo category was routed through the lens endpoint;
+    // domain/entity/path/etc hit the repo endpoint with state.repo (the write
+    // repo), silently hiding every read mount's values from autocomplete.
+    const { api } = await import('./api');
+    render(<FilterBar state={lensState()} dispatch={vi.fn()} />);
+    const input = document.getElementById('filter-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'domain:se' } });
+    await waitFor(() => expect(api.lensCompletions).toHaveBeenCalledWith('eng', 'domain', 'se'));
+    expect(api.completions).not.toHaveBeenCalled();
+  });
+
+  it('domain completions in repo context still use the repo endpoint', async () => {
+    const { api } = await import('./api');
+    render(<FilterBar state={repoState()} dispatch={vi.fn()} />);
+    const input = document.getElementById('filter-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'domain:se' } });
+    await waitFor(() => expect(api.completions).toHaveBeenCalled());
+    expect(api.lensCompletions).not.toHaveBeenCalled();
+  });
+
   it('does not recognise repo: as a facet in repo context (free text)', async () => {
     const { api } = await import('./api');
     render(<FilterBar state={repoState()} dispatch={vi.fn()} />);

--- a/web/src/FilterBar.tsx
+++ b/web/src/FilterBar.tsx
@@ -51,12 +51,14 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
   // Track whether the input is focused — used to distinguish user clearing vs onBlur clearing
   const focusedRef = useRef(false);
 
-  // fetchCompletions routes the lens-only `repo` facet to the lens completions
-  // endpoint (which lists the lens's mount names); every other category uses the
-  // repo/branch completions endpoint exactly as before.
+  // fetchCompletions: in a lens context EVERY category goes to the lens
+  // completions endpoint — it unions values across all mounts (and serves the
+  // lens-only `repo` category). Routing only `repo` there and the rest to the
+  // repo endpoint would suggest write-repo values only, silently hiding
+  // read-mount domains/entities/paths. Repo context is unchanged.
   const fetchCompletions = (category: FilterChip['category'] | string, prefix: string): Promise<{ values: string[] }> =>
-    category === 'repo'
-      ? api.lensCompletions(lensName, 'repo', prefix)
+    isLens
+      ? api.lensCompletions(lensName, String(category), prefix)
       : api.completions(state.repo, state.branch, category, prefix);
 
   // Scroll selected suggestion into view
@@ -216,7 +218,7 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
   function drillIntoPath(dir: string) {
     setPathPrefix(dir);
     setCategorySearch('');
-    api.completions(state.repo, state.branch, 'path', dir + '/').then(res => {
+    fetchCompletions('path', dir + '/').then(res => {
       setCategoryValues(res.values || []);
     }).catch(() => setCategoryValues([]));
   }

--- a/web/src/FilterBar.tsx
+++ b/web/src/FilterBar.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Dispatch } from 'react';
 import type { AppState, Action, FilterChip } from './state';
-import { isLive, selectTrail } from './state';
+import { isLive, isLensContext, selectTrail } from './state';
 import { api, parseFilterQuery } from './api';
-import { chipColors } from './utils';
+import { chipColors, repoHue, repoHueBg, repoHueBorder } from './utils';
 import { TrailBreadcrumb } from './TrailBreadcrumb';
 
 interface Props {
@@ -21,12 +21,19 @@ const FACT_CATEGORIES: { key: FilterChip['category']; label: string }[] = [
   { key: 'path',   label: 'Path' },
 ];
 
-// Match a trailing prefix token at end of input
+// The lens-only source facet, appended to the picker only in lens context.
+const REPO_CATEGORY: { key: FilterChip['category']; label: string } = { key: 'repo', label: 'Repo' };
+
+// Match a trailing prefix token at end of input. In lens context `repo` joins
+// the recognised prefixes so the autocomplete + chip machinery covers it.
 const FACT_PREFIX_RE = /(?:^|\s)(domain|entity|type|kind|origin|path):(\S*)$/;
+const LENS_PREFIX_RE = /(?:^|\s)(domain|entity|type|kind|origin|path|repo):(\S*)$/;
 
 export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
-  const CATEGORIES = FACT_CATEGORIES;
-  const PREFIX_RE = FACT_PREFIX_RE;
+  const isLens   = isLensContext(state);
+  const lensName = state.context.kind === 'lens' ? state.context.name : '';
+  const CATEGORIES = isLens ? [...FACT_CATEGORIES, REPO_CATEGORY] : FACT_CATEGORIES;
+  const PREFIX_RE = isLens ? LENS_PREFIX_RE : FACT_PREFIX_RE;
 
   const [inputValue, setInputValue]               = useState('');
   const [suggestions, setSuggestions]             = useState<string[]>([]);
@@ -44,6 +51,14 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
   // Track whether the input is focused — used to distinguish user clearing vs onBlur clearing
   const focusedRef = useRef(false);
 
+  // fetchCompletions routes the lens-only `repo` facet to the lens completions
+  // endpoint (which lists the lens's mount names); every other category uses the
+  // repo/branch completions endpoint exactly as before.
+  const fetchCompletions = (category: FilterChip['category'] | string, prefix: string): Promise<{ values: string[] }> =>
+    category === 'repo'
+      ? api.lensCompletions(lensName, 'repo', prefix)
+      : api.completions(state.repo, state.branch, category, prefix);
+
   // Scroll selected suggestion into view
   useEffect(() => {
     suggestRefs.current[suggestIdx]?.scrollIntoView({ block: 'nearest' });
@@ -59,7 +74,7 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
       window.clearTimeout(debounceRef.current);
       debounceRef.current = window.setTimeout(async () => {
         try {
-          const res = await api.completions(state.repo, state.branch, category, prefix);
+          const res = await fetchCompletions(category, prefix);
           setSuggestions(res.values || []);
           setSuggestIdx(0);
         } catch {
@@ -142,7 +157,7 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
     }
 
     if (e.key === 'Enter' || e.key === ' ') {
-      const { chips, text, asOf, warnings } = parseFilterQuery(inputValue, () => state.headCommit);
+      const { chips, text, asOf, warnings } = parseFilterQuery(inputValue, () => state.headCommit, { allowRepo: isLens });
       warnings.forEach(w => dispatch({ type: 'CONSOLE_LOG', level: 'error', message: `[filter] ${w}` }));
       if (asOf || chips.length > 0) {
         e.preventDefault();
@@ -183,7 +198,7 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
     setCategorySearch('');
     if (cat === 'path') setPathPrefix(prefix);
     try {
-      const res = await api.completions(state.repo, state.branch, cat, prefix);
+      const res = await fetchCompletions(cat, prefix);
       setCategoryValues(res.values || []);
     } catch {
       setCategoryValues([]);
@@ -364,7 +379,7 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
                       ? pathPrefix + '/' + e.target.value
                       : e.target.value;
                     const seq = ++catSearchSeqRef.current;
-                    api.completions(state.repo, state.branch, activeCategory, prefix).then(res => {
+                    fetchCompletions(activeCategory, prefix).then(res => {
                       if (seq === catSearchSeqRef.current) setCategoryValues(res.values || []);
                     }).catch(() => {});
                   }}
@@ -435,9 +450,16 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
 
       {/* Chips */}
       {state.filters.map((chip, i) => {
-        const colors = chipColors[chip.category] || chipColors.path;
+        // The lens-only `repo` facet is coloured by the mount's deterministic
+        // hue (matching the source badges), not the static per-category palette.
+        const isRepo = chip.category === 'repo';
+        const colors = isRepo
+          ? { bg: repoHueBg(chip.value), text: repoHue(chip.value), close: repoHue(chip.value) }
+          : (chipColors[chip.category] || chipColors.path);
         return (
-          <span key={i} style={{
+          <span key={i}
+            {...(isRepo ? { 'data-testid': 'repo-chip', 'data-repo': chip.value } : {})}
+            style={{
             background: colors.bg,
             color: colors.text,
             padding: '2px 8px',
@@ -447,6 +469,7 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
             alignItems: 'center',
             gap: 4,
             userSelect: 'none',
+            ...(isRepo ? { border: `1px solid ${repoHueBorder(chip.value)}` } : {}),
           }}>
             {chip.category === 'path' ? (
               <span style={{ display: 'inline-flex', alignItems: 'center' }}>

--- a/web/src/FilterBar.tsx
+++ b/web/src/FilterBar.tsx
@@ -281,6 +281,7 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
       <TrailBreadcrumb
         repo={state.repo}
         branch={state.branch}
+        lensName={state.context.kind === 'lens' ? state.context.name : undefined}
         trail={selectTrail(state)}
         onJump={onJumpTrail!}
       />

--- a/web/src/FilterBar.tsx
+++ b/web/src/FilterBar.tsx
@@ -161,7 +161,15 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
       warnings.forEach(w => dispatch({ type: 'CONSOLE_LOG', level: 'error', message: `[filter] ${w}` }));
       if (asOf || chips.length > 0) {
         e.preventDefault();
-        if (asOf) dispatch({ type: 'SET_AS_OF', asOf });
+        // Time anchors are per-fact in a lens (openFactSource): without an open
+        // fact there's no mount to anchor against, so dropping into history would
+        // strand the left panel on nothing. Warn and drop the anchor; any chips
+        // still apply. Repo context is unaffected — asOf always dispatches there.
+        if (asOf && isLens && !state.factPath) {
+          dispatch({ type: 'CONSOLE_LOG', level: 'error', message: '[filter] open a fact first — time anchors are per-fact in a lens' });
+        } else if (asOf) {
+          dispatch({ type: 'SET_AS_OF', asOf });
+        }
         chips.forEach(chip => dispatch({ type: 'ADD_FILTER', chip }));
         setInputValue(text);
       } else if (e.key === 'Enter' && inputValue.trim()) {

--- a/web/src/FilterBar.tsx
+++ b/web/src/FilterBar.tsx
@@ -285,6 +285,7 @@ export function FilterBar({ state, dispatch, onJumpTrail }: Props) {
         branch={state.branch}
         lensName={state.context.kind === 'lens' ? state.context.name : undefined}
         trail={selectTrail(state)}
+        titles={state.factTitles}
         onJump={onJumpTrail!}
       />
     );

--- a/web/src/LeftPanel.lens.test.tsx
+++ b/web/src/LeftPanel.lens.test.tsx
@@ -1,0 +1,57 @@
+// Task 17: per-fact history anchored on the open fact's source mount. LeftPanel
+// feeds TimelineNav the temporal anchor. In a repo context that stays
+// {state.repo, state.branch} + the bare path (byte-identical to before). In a
+// lens context it must anchor on the OPEN FACT's source mount and pass the
+// RELATIVE path (the kb://<id12>/ qualifier stripped) so the mount's repo-scoped
+// history endpoints resolve.
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { LeftPanel } from './LeftPanel';
+import { init } from './state';
+import type { AppState, AsOf } from './state';
+import type { Lens, LensSource } from './api';
+
+// Capture the props TimelineNav receives so we can assert the anchor + path.
+const timelineProps: any[] = [];
+vi.mock('./Library', () => ({ Library: () => <div>LIBRARY</div> }));
+vi.mock('./TimelineNav', () => ({
+  TimelineNav: (props: any) => { timelineProps.push(props); return <div>TIMELINE</div>; },
+}));
+
+const lens: Lens = { name: 'eng', write: 'core', reads: [{ repo: 'core' }, { repo: 'docs' }] };
+const readSource: LensSource = { repo: 'docs', id: 'docsid123456', branch: 'main' };
+const writeSource: LensSource = { repo: 'core', id: 'coreid123456', branch: 'agent/main' };
+
+function lensState(factPath: string, factSource: LensSource, asOf: AsOf): AppState {
+  return {
+    ...init, repo: 'core', branch: 'agent/main',
+    context: { kind: 'lens', name: 'eng' }, lens, factPath, factSource, asOf,
+  };
+}
+
+const props = () => ({ dispatch: vi.fn(), navigate: vi.fn(), onScrub: vi.fn(), onOpenFileAt: vi.fn(), onReturnToLive: vi.fn() });
+
+beforeEach(() => { timelineProps.length = 0; });
+
+it('lens read-mount fact: anchors TimelineNav on the mount + relative path (kb://<id>/ stripped)', () => {
+  render(<LeftPanel state={lensState('kb://docsid123456/kb/api/auth.md', readSource, { mode: 'history', commit: 'c1' })} {...props()} />);
+  const p = timelineProps.at(-1);
+  expect(p.repo).toBe('docs');
+  expect(p.branch).toBe('main');
+  expect(p.factPath).toBe('kb/api/auth.md');
+});
+
+it('lens write-repo fact: anchors on the write mount, bare path passes through', () => {
+  render(<LeftPanel state={lensState('kb/ops/rollback.md', writeSource, { mode: 'history', commit: 'c1' })} {...props()} />);
+  const p = timelineProps.at(-1);
+  expect(p.repo).toBe('core');
+  expect(p.branch).toBe('agent/main');
+  expect(p.factPath).toBe('kb/ops/rollback.md');
+});
+
+it('repo context: still {state.repo, state.branch} + the bare path (byte-identical)', () => {
+  const s = { ...init, repo: 'r', branch: 'b', factPath: 'kb/a.md', asOf: { mode: 'history', commit: 'c1' } as AsOf } as AppState;
+  render(<LeftPanel state={s} {...props()} />);
+  const p = timelineProps.at(-1);
+  expect(p).toMatchObject({ repo: 'r', branch: 'b', factPath: 'kb/a.md' });
+});

--- a/web/src/LeftPanel.test.tsx
+++ b/web/src/LeftPanel.test.tsx
@@ -6,7 +6,9 @@ vi.mock('./Library', () => ({ Library: () => <div>LIBRARY</div> }));
 vi.mock('./TimelineNav', () => ({ TimelineNav: () => <div>TIMELINE</div> }));
 
 it('shows Library when live, TimelineNav when history', () => {
-  const base = { /* minimal AppState */ } as any;
+  // Minimal AppState: context is required now that LeftPanel derives the
+  // TimelineNav anchor via openFactSource (Task 17).
+  const base = { context: { kind: 'repo', repo: 'r' } } as any;
   const { rerender } = render(<LeftPanel state={{ ...base, asOf: { mode: 'live' }, factPath: 'kb/a.md' }} dispatch={vi.fn()} navigate={vi.fn()} onScrub={vi.fn()} onOpenFileAt={vi.fn()} />);
   expect(screen.getByText('LIBRARY')).toBeInTheDocument();
   rerender(<LeftPanel state={{ ...base, asOf: { mode: 'history', commit: 'c1' }, factPath: 'kb/a.md' }} dispatch={vi.fn()} navigate={vi.fn()} onScrub={vi.fn()} onOpenFileAt={vi.fn()} />);

--- a/web/src/LeftPanel.tsx
+++ b/web/src/LeftPanel.tsx
@@ -1,6 +1,7 @@
 import { type Dispatch } from 'react';
 import type { AppState, Action } from './state';
-import { isLive, selectAnchorCommit } from './state';
+import { isLive, selectAnchorCommit, openFactSource } from './state';
+import { displayLensPath } from './utils';
 import type { NavRequest } from './useNavigationManager';
 import { Library } from './Library';
 import { TimelineNav } from './TimelineNav';
@@ -28,6 +29,11 @@ const TRANSITION = prefersReducedMotion ? 'none' : 'transform 320ms ease';
 export function LeftPanel({ state, dispatch, navigate, onScrub, onOpenFileAt, onReturnToLive }: Props) {
   const live = isLive(state);
   const anchorCommit = selectAnchorCommit(state);
+  // The open fact's history is anchored on its SOURCE MOUNT (openFactSource):
+  // {state.repo, state.branch} in a repo context, the fact's read mount in a
+  // lens context. The mount's repo-scoped history endpoints need the RELATIVE
+  // path, so strip the kb://<id12>/ qualifier (a no-op on bare repo/write paths).
+  const src = openFactSource(state);
 
   // No-op defaults so callers (e.g. App before Task 17) don't need to supply
   // these props while the real callbacks aren't wired yet.
@@ -68,9 +74,9 @@ export function LeftPanel({ state, dispatch, navigate, onScrub, onOpenFileAt, on
       >
         {!live && state.factPath && anchorCommit ? (
           <TimelineNav
-            repo={state.repo}
-            branch={state.branch}
-            factPath={state.factPath}
+            repo={src.repo}
+            branch={src.branch}
+            factPath={displayLensPath(state.factPath)}
             activeCommit={anchorCommit}
             onScrub={handleScrub}
             onOpenFileAt={handleOpenFileAt}

--- a/web/src/LeftPanel.tsx
+++ b/web/src/LeftPanel.tsx
@@ -1,7 +1,6 @@
 import { type Dispatch } from 'react';
 import type { AppState, Action } from './state';
-import { isLive, selectAnchorCommit, openFactSource } from './state';
-import { displayLensPath } from './utils';
+import { isLive, selectAnchorCommit, factHistoryAnchor } from './state';
 import type { NavRequest } from './useNavigationManager';
 import { Library } from './Library';
 import { TimelineNav } from './TimelineNav';
@@ -29,11 +28,10 @@ const TRANSITION = prefersReducedMotion ? 'none' : 'transform 320ms ease';
 export function LeftPanel({ state, dispatch, navigate, onScrub, onOpenFileAt, onReturnToLive }: Props) {
   const live = isLive(state);
   const anchorCommit = selectAnchorCommit(state);
-  // The open fact's history is anchored on its SOURCE MOUNT (openFactSource):
-  // {state.repo, state.branch} in a repo context, the fact's read mount in a
-  // lens context. The mount's repo-scoped history endpoints need the RELATIVE
-  // path, so strip the kb://<id12>/ qualifier (a no-op on bare repo/write paths).
-  const src = openFactSource(state);
+  // The open fact's history is anchored on its SOURCE MOUNT + RELATIVE path
+  // (factHistoryAnchor): {state.repo, state.branch, bare-path} in a repo context,
+  // the fact's read mount + kb://<id12>/-stripped path in a lens context.
+  const hist = factHistoryAnchor(state);
 
   // No-op defaults so callers (e.g. App before Task 17) don't need to supply
   // these props while the real callbacks aren't wired yet.
@@ -74,9 +72,9 @@ export function LeftPanel({ state, dispatch, navigate, onScrub, onOpenFileAt, on
       >
         {!live && state.factPath && anchorCommit ? (
           <TimelineNav
-            repo={src.repo}
-            branch={src.branch}
-            factPath={displayLensPath(state.factPath)}
+            repo={hist.repo}
+            branch={hist.branch}
+            factPath={hist.path}
             activeCommit={anchorCommit}
             onScrub={handleScrub}
             onOpenFileAt={handleOpenFileAt}

--- a/web/src/Library.lens.test.tsx
+++ b/web/src/Library.lens.test.tsx
@@ -254,6 +254,55 @@ describe('Library — sources dropdown', () => {
   });
 });
 
+// I5: the lens union list is infinite-scroll paged like repo Recent. This
+// describe sets a custom listLensFacts implementation, so it runs LAST — the
+// per-file mock impl persists across tests (no restoreMocks in config).
+describe('Library — lens union paging (I5)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('first page 50 / total 120 → sentinel loads offset 50 and appends', async () => {
+    const { api } = await import('./api');
+    const page = (start: number, n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        path: `kb/p${start + i}.md`, title: `T${start + i}`, type: 'process',
+        committed_at: start + i, source: { repo: 'infra', id: 'aaaaaaaaaaaa', branch: 'agent/main' },
+      }));
+    (api.listLensFacts as ReturnType<typeof vi.fn>).mockImplementation(async (_lens: string, opts: { offset: number }) => {
+      if (opts.offset === 0) return { facts: page(0, 50), total: 120 };
+      if (opts.offset === 50) return { facts: page(50, 50), total: 120 };
+      return { facts: [], total: 120 };
+    });
+
+    // Hold IntersectionObserver callbacks so we can drive the sentinel by hand.
+    const observerCallbacks: IntersectionObserverCallback[] = [];
+    const origIO = window.IntersectionObserver;
+    window.IntersectionObserver = class {
+      constructor(cb: IntersectionObserverCallback) { observerCallbacks.push(cb); }
+      observe() {} disconnect() {} unobserve() {} takeRecords() { return []; }
+      root = null; rootMargin = ''; thresholds = [];
+    } as unknown as typeof IntersectionObserver;
+
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-item').length).toBe(50));
+    // Sentinel is present in lens context now.
+    expect(screen.getByTestId('recent-sentinel')).toBeTruthy();
+
+    // Fire the sentinel intersection → loadMore fetches the next page.
+    expect(observerCallbacks.length).toBeGreaterThan(0);
+    observerCallbacks[observerCallbacks.length - 1](
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    await waitFor(() => expect(screen.getAllByTestId('lens-item').length).toBe(100));
+    const offsets = (api.listLensFacts as ReturnType<typeof vi.fn>).mock.calls.map(c => c[1].offset);
+    expect(offsets).toContain(0);
+    expect(offsets).toContain(50);
+
+    window.IntersectionObserver = origIO;
+  });
+});
+
 // jsdom serializes an element's inline `color` as `rgb(r, g, b)`. Convert a
 // #rrggbb hue for comparison.
 function hexToRgb(hex: string): string {

--- a/web/src/Library.lens.test.tsx
+++ b/web/src/Library.lens.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { Library } from './Library';
+import { init } from './state';
+import type { AppState } from './state';
+import type { Lens } from './api';
+import { repoHue } from './utils';
+
+// Whole-module api mock. In lens context the Library must use the lens
+// endpoints; the repo endpoints (browse/recent/search) are mocked too so a
+// leak into them is observable (they must NOT be called in lens context).
+vi.mock('./api', () => ({
+  api: {
+    browse: vi.fn().mockResolvedValue({ path: 'kb', children: [] }),
+    recent: vi.fn().mockResolvedValue({ facts: [], total: 0 }),
+    search: vi.fn().mockResolvedValue({ results: [] }),
+    listLensFacts: vi.fn().mockResolvedValue({
+      facts: [
+        { path: 'kb/ops/rollback.md', title: 'Rollback runbook', type: 'process', committed_at: 100, source: { repo: 'infra', id: 'aaaaaaaaaaaa', branch: 'agent/main' } },
+        { path: 'kb://bbbbbbbbbbbb/kb/api/auth.md', title: 'Auth flow', type: 'concept', committed_at: 90, source: { repo: 'docs', id: 'bbbbbbbbbbbb', branch: 'main' } },
+      ],
+      total: 2,
+    }),
+    lensSearch: vi.fn().mockResolvedValue([
+      { path: 'kb://bbbbbbbbbbbb/kb/api/auth.md', title: 'Auth flow', type: 'concept', source: { repo: 'docs', id: 'bbbbbbbbbbbb', branch: 'main' } },
+    ]),
+    getLensFact: vi.fn().mockResolvedValue({
+      path: 'kb://bbbbbbbbbbbb/kb/api/auth.md', title: 'Auth flow', body: 'b',
+      domain: [], entities: [], refs: [], confidence: 1, sources: 1,
+      source: { repo: 'docs', id: 'bbbbbbbbbbbb', branch: 'main' },
+    }),
+  },
+}));
+
+const lens: Lens = {
+  name: 'eng',
+  write: 'core',
+  reads: [{ repo: 'core' }, { repo: 'docs' }, { repo: 'infra' }],
+};
+
+function lensState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    ...init,
+    repo: 'core',
+    branch: 'agent/main',
+    headCommit: 'aaaaaaa',
+    context: { kind: 'lens', name: 'eng' },
+    lens,
+    lensSources: null,
+    librarySort: 'recent',
+    ...overrides,
+  };
+}
+
+function repoState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    ...init,
+    repo: 'core',
+    branch: 'agent/main',
+    headCommit: 'aaaaaaa',
+    librarySort: 'recent',
+    ...overrides,
+  };
+}
+
+describe('Library — lens read path', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('reads the union via api.listLensFacts, never the repo endpoints', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-item').length).toBe(2));
+    expect(api.listLensFacts).toHaveBeenCalledTimes(1);
+    const [name, opts] = (api.listLensFacts as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(name).toBe('eng');
+    expect(opts.repos).toBeUndefined(); // null selection → all mounts → no repos param
+    // Repo endpoints must stay untouched in lens context.
+    expect(api.recent).not.toHaveBeenCalled();
+    expect(api.browse).not.toHaveBeenCalled();
+    expect(api.search).not.toHaveBeenCalled();
+  });
+
+  it('renders a stable-hued source badge on every union row', async () => {
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-item').length).toBe(2));
+    const badges = screen.getAllByTestId('source-badge');
+    expect(badges.length).toBe(2);
+    const infra = badges.find(b => b.getAttribute('data-repo') === 'infra')!;
+    expect(infra).toBeTruthy();
+    expect(infra.textContent).toContain('infra');
+    // The badge colors are the deterministic per-repo hue (stable across calls).
+    expect(infra.style.color).toBe(hexToRgb(repoHue('infra')));
+  });
+
+  it('strips the kb://<id12>/ qualifier from the displayed path (badge carries the repo)', async () => {
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-item').length).toBe(2));
+    const rows = screen.getAllByTestId('lens-item');
+    // The read-mount row keeps the RAW canonical path as its identity…
+    const authRow = rows.find(r => r.getAttribute('data-path') === 'kb://bbbbbbbbbbbb/kb/api/auth.md')!;
+    expect(authRow).toBeTruthy();
+    // …but the displayed breadcrumb shows the stripped path, never the id12.
+    const shown = authRow.querySelector('[data-testid="lens-item-path"]')!;
+    expect(shown.textContent).toBe('kb/api/auth.md');
+    expect(authRow.textContent).not.toContain('bbbbbbbbbbbb');
+    expect(authRow.textContent).not.toContain('kb://');
+  });
+
+  it('row click opens the fact via getLensFact with the RAW path and stores its source', async () => {
+    const { api } = await import('./api');
+    const dispatch = vi.fn();
+    const navigate = vi.fn();
+    render(<Library state={lensState()} dispatch={dispatch} navigate={navigate} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-item').length).toBe(2));
+    const rows = screen.getAllByTestId('lens-item');
+    const authRow = rows.find(r => r.getAttribute('data-path') === 'kb://bbbbbbbbbbbb/kb/api/auth.md')!;
+    fireEvent.click(authRow);
+    // Opens the fact through the lens with the RAW canonical path.
+    expect(api.getLensFact).toHaveBeenCalledWith('eng', 'kb://bbbbbbbbbbbb/kb/api/auth.md');
+    // Mirrors the repo open flow so RightPanel renders the fact.
+    expect(navigate).toHaveBeenCalledWith({ view: 'library', factPath: 'kb://bbbbbbbbbbbb/kb/api/auth.md' });
+    // Stores the source mount once getLensFact resolves.
+    await waitFor(() => expect(dispatch).toHaveBeenCalledWith({
+      type: 'SET_FACT_SOURCE',
+      source: { repo: 'docs', id: 'bbbbbbbbbbbb', branch: 'main' },
+    }));
+  });
+
+  it('re-sends the repos param and refetches when lensSources changes', async () => {
+    const { api } = await import('./api');
+    const { rerender } = render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.listLensFacts).toHaveBeenCalledTimes(1));
+    // Uncheck a mount → explicit subset selection re-fetches with repos=[…].
+    rerender(<Library state={lensState({ lensSources: ['core', 'infra'] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.listLensFacts).toHaveBeenCalledTimes(2));
+    const lastCall = (api.listLensFacts as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    expect(lastCall[1].repos).toEqual(['core', 'infra']);
+  });
+
+  it('an empty lensSources selection shows an empty state and issues no fetch', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState({ lensSources: [] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.queryAllByTestId('lens-item').length).toBe(0));
+    expect(api.listLensFacts).not.toHaveBeenCalled();
+    expect(screen.getByText(/no sources selected/i)).toBeTruthy();
+  });
+
+  it('free-text search reads via api.lensSearch, not api.search', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState({ freeText: 'auth' })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-item').length).toBe(1));
+    expect(api.lensSearch).toHaveBeenCalledWith('eng', 'auth', undefined);
+    expect(api.search).not.toHaveBeenCalled();
+    // Search rows still carry a source badge.
+    expect(screen.getAllByTestId('source-badge').length).toBe(1);
+  });
+});
+
+describe('Library — sources dropdown', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('renders only in lens context', async () => {
+    const { rerender } = render(<Library state={repoState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('left-panel'));
+    expect(screen.queryByTestId('sources-dropdown')).toBeNull();
+    rerender(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('sources-dropdown')).toBeTruthy());
+  });
+
+  it('closed control labels "All mounts · N" for the null (all) selection', async () => {
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('sources-dropdown'));
+    expect(screen.getByTestId('sources-label').textContent).toMatch(/All mounts.*3/);
+  });
+
+  it('closed control labels "<n> of N mounts" when filtered', async () => {
+    render(<Library state={lensState({ lensSources: ['infra'] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('sources-dropdown'));
+    expect(screen.getByTestId('sources-label').textContent).toMatch(/1 of 3 mounts/);
+  });
+
+  it('lists one checklist row per lens.reads mount and toggling dispatches SET_LENS_SOURCES', async () => {
+    const dispatch = vi.fn();
+    render(<Library state={lensState()} dispatch={dispatch} navigate={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('sources-dropdown'));
+    fireEvent.click(screen.getByTestId('sources-dropdown'));
+    const options = screen.getAllByTestId('source-option');
+    expect(options.map(o => o.getAttribute('data-repo'))).toEqual(['core', 'docs', 'infra']);
+    // All-on to start; unchecking 'docs' yields the remaining mounts in order.
+    const docs = options.find(o => o.getAttribute('data-repo') === 'docs')!;
+    fireEvent.click(docs);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_LENS_SOURCES', repos: ['core', 'infra'] });
+  });
+});
+
+// jsdom serializes an element's inline `color` as `rgb(r, g, b)`. Convert a
+// #rrggbb hue for comparison.
+function hexToRgb(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgb(${r}, ${g}, ${b})`;
+}

--- a/web/src/Library.lens.test.tsx
+++ b/web/src/Library.lens.test.tsx
@@ -106,7 +106,7 @@ describe('Library — lens read path', () => {
     expect(authRow.textContent).not.toContain('kb://');
   });
 
-  it('row click opens the fact via getLensFact with the RAW path and stores its source', async () => {
+  it('row click navigates with the RAW canonical path and does NOT prefetch/dispatch the source (RightPanel owns the fetch)', async () => {
     const { api } = await import('./api');
     const dispatch = vi.fn();
     const navigate = vi.fn();
@@ -115,15 +115,14 @@ describe('Library — lens read path', () => {
     const rows = screen.getAllByTestId('lens-item');
     const authRow = rows.find(r => r.getAttribute('data-path') === 'kb://bbbbbbbbbbbb/kb/api/auth.md')!;
     fireEvent.click(authRow);
-    // Opens the fact through the lens with the RAW canonical path.
-    expect(api.getLensFact).toHaveBeenCalledWith('eng', 'kb://bbbbbbbbbbbb/kb/api/auth.md');
-    // Mirrors the repo open flow so RightPanel renders the fact.
+    // Navigates with the RAW canonical path so RightPanel can read it through the lens.
     expect(navigate).toHaveBeenCalledWith({ view: 'library', factPath: 'kb://bbbbbbbbbbbb/kb/api/auth.md' });
-    // Stores the source mount once getLensFact resolves.
-    await waitFor(() => expect(dispatch).toHaveBeenCalledWith({
-      type: 'SET_FACT_SOURCE',
-      source: { repo: 'docs', id: 'bbbbbbbbbbbb', branch: 'main' },
-    }));
+    // Single-owner: the Library no longer prefetches the fact or dispatches the
+    // source — RightPanel's guarded fetch does, avoiding the rapid-re-open race.
+    expect(api.getLensFact).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_FACT_SOURCE' }),
+    );
   });
 
   it('re-sends the repos param and refetches when lensSources changes', async () => {

--- a/web/src/Library.lens.test.tsx
+++ b/web/src/Library.lens.test.tsx
@@ -149,10 +149,72 @@ describe('Library — lens read path', () => {
     const { api } = await import('./api');
     render(<Library state={lensState({ freeText: 'auth' })} dispatch={vi.fn()} navigate={vi.fn()} />);
     await waitFor(() => expect(screen.getAllByTestId('lens-item').length).toBe(1));
-    expect(api.lensSearch).toHaveBeenCalledWith('eng', 'auth', undefined);
+    // The union relevance search forwards the current path scope (root 'kb' by
+    // default) alongside the query; repos stays undefined for the null selection.
+    expect(api.lensSearch).toHaveBeenCalledWith('eng', 'auth', undefined, expect.objectContaining({ path: 'kb' }));
     expect(api.search).not.toHaveBeenCalled();
     // Search rows still carry a source badge.
     expect(screen.getAllByTestId('source-badge').length).toBe(1);
+  });
+});
+
+describe('Library — repo: chip intersection', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  const repoChip = (value: string) => ({ category: 'repo' as const, value });
+
+  it('a repo: chip with the null (all) selection narrows the fan-out to the chip repos', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState({ filters: [repoChip('infra')] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.listLensFacts).toHaveBeenCalledTimes(1));
+    expect((api.listLensFacts as ReturnType<typeof vi.fn>).mock.calls[0][1].repos).toEqual(['infra']);
+    // A repo: chip is a fan-out scope, not a content filter — it must NOT flip
+    // the list into relevance/search mode.
+    expect(api.lensSearch).not.toHaveBeenCalled();
+  });
+
+  it('intersects repo: chips with the sources dropdown selection', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState({ lensSources: ['core', 'infra'], filters: [repoChip('infra')] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.listLensFacts).toHaveBeenCalledTimes(1));
+    expect((api.listLensFacts as ReturnType<typeof vi.fn>).mock.calls[0][1].repos).toEqual(['infra']);
+  });
+
+  it('multiple repo: chips are OR among themselves before intersecting', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState({ filters: [repoChip('docs'), repoChip('infra')] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.listLensFacts).toHaveBeenCalledTimes(1));
+    // Order follows the lens mount order (core, docs, infra).
+    expect((api.listLensFacts as ReturnType<typeof vi.fn>).mock.calls[0][1].repos).toEqual(['docs', 'infra']);
+  });
+
+  it('an empty repo:/sources intersection shows an empty state and issues no fetch', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState({ lensSources: ['core', 'infra'], filters: [repoChip('docs')] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('left-panel'));
+    expect(screen.queryAllByTestId('lens-item').length).toBe(0);
+    expect(api.listLensFacts).not.toHaveBeenCalled();
+    expect(api.lensSearch).not.toHaveBeenCalled();
+    expect(screen.getByText(/no sources match/i)).toBeTruthy();
+  });
+
+  it('removing a repo: chip refetches without the repo narrowing', async () => {
+    const { api } = await import('./api');
+    const { rerender } = render(<Library state={lensState({ filters: [repoChip('infra')] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.listLensFacts).toHaveBeenCalledTimes(1));
+    rerender(<Library state={lensState({ filters: [] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.listLensFacts).toHaveBeenCalledTimes(2));
+    expect((api.listLensFacts as ReturnType<typeof vi.fn>).mock.calls.at(-1)![1].repos).toBeUndefined();
+  });
+
+  it('forwards path scope + content filter chips through the lens relevance search', async () => {
+    const { api } = await import('./api');
+    render(<Library
+      state={lensState({ freeText: 'auth', filters: [{ category: 'path', value: 'kb/api' }, { category: 'kind', value: 'policy' }] })}
+      dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.lensSearch).toHaveBeenCalled());
+    const call = (api.lensSearch as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    expect(call[3]).toEqual(expect.objectContaining({ path: 'kb/api', kinds: ['policy'] }));
   });
 });
 

--- a/web/src/Library.lensTree.test.tsx
+++ b/web/src/Library.lensTree.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { Library } from './Library';
+import { init } from './state';
+import type { AppState } from './state';
+import type { Lens } from './api';
+
+// Whole-module api mock. In lens+path mode the Library must read the unified
+// tree via lensBrowse; every other list endpoint is mocked too so a leak into
+// them is observable.
+vi.mock('./api', () => ({
+  api: {
+    browse: vi.fn().mockResolvedValue({ path: 'kb', children: [{ name: 'decisions', is_dir: true }] }),
+    recent: vi.fn().mockResolvedValue({ facts: [], total: 0 }),
+    search: vi.fn().mockResolvedValue({ results: [] }),
+    listLensFacts: vi.fn().mockResolvedValue({ facts: [], total: 0 }),
+    lensSearch: vi.fn().mockResolvedValue([]),
+    lensBrowse: vi.fn().mockResolvedValue({
+      path: 'kb',
+      children: [
+        { name: 'decisions', is_dir: true },
+        { name: 'aaa.md', is_dir: false, type: 'decision', title: 'Write fact', path: 'kb/aaa.md', source: { repo: 'core', id: 'aaaaaaaaaaaa' } },
+        { name: 'bbb.md', is_dir: false, type: 'gotcha', title: 'Docs fact', path: 'kb://bbbbbbbbbbbb/kb/bbb.md', source: { repo: 'docs', id: 'bbbbbbbbbbbb' } },
+      ],
+    }),
+  },
+}));
+
+const lens: Lens = {
+  name: 'eng',
+  write: 'core',
+  reads: [{ repo: 'core' }, { repo: 'docs' }],
+};
+
+function lensState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    ...init,
+    repo: 'core',
+    branch: 'agent/main',
+    headCommit: 'aaaaaaa',
+    context: { kind: 'lens', name: 'eng' },
+    lens,
+    lensSources: null,
+    librarySort: 'path',
+    ...overrides,
+  };
+}
+
+function repoState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    ...init,
+    repo: 'core',
+    branch: 'agent/main',
+    headCommit: 'aaaaaaa',
+    librarySort: 'path',
+    ...overrides,
+  };
+}
+
+describe('Library — lens tree browse (Path sort)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('reads the unified tree via api.lensBrowse, not listLensFacts/browse', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-tree-entry').length).toBe(3));
+    expect(api.lensBrowse).toHaveBeenCalledTimes(1);
+    // Root path 'kb', the state's ontologyRoot, and no repos param (null selection).
+    expect(api.lensBrowse).toHaveBeenCalledWith('eng', 'kb', 'kb', undefined);
+    expect(api.listLensFacts).not.toHaveBeenCalled();
+    expect(api.browse).not.toHaveBeenCalled();
+    expect(api.search).not.toHaveBeenCalled();
+    expect(api.lensSearch).not.toHaveBeenCalled();
+  });
+
+  it('renders merged dirs plain and fact leaves with source badges', async () => {
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-tree-entry').length).toBe(3));
+    const rows = screen.getAllByTestId('lens-tree-entry');
+    // Server order preserved: merged dir first, then leaves.
+    expect(rows.map(r => r.getAttribute('data-name'))).toEqual(['decisions', 'aaa.md', 'bbb.md']);
+    expect(rows[0].getAttribute('data-isdir')).toBe('true');
+    // Leaves carry a badge in the source repo's hue; the dir row has none.
+    const badges = screen.getAllByTestId('source-badge');
+    expect(badges.map(b => b.getAttribute('data-repo'))).toEqual(['core', 'docs']);
+    expect(rows[0].querySelector('[data-testid="source-badge"]')).toBeNull();
+    // Leaf rows show the enriched title.
+    expect(rows[1].textContent).toContain('Write fact');
+    expect(rows[2].textContent).toContain('Docs fact');
+  });
+
+  it('a directory row navigates one level deeper (path chip, matching the repo tree)', async () => {
+    const dispatch = vi.fn();
+    render(<Library state={lensState()} dispatch={dispatch} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-tree-entry').length).toBe(3));
+    const dir = screen.getAllByTestId('lens-tree-entry')[0];
+    fireEvent.click(dir);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'ADD_FILTER', chip: { category: 'path', value: 'kb/decisions' } });
+  });
+
+  it('a fact leaf opens with the RAW canonical qualified path', async () => {
+    const navigate = vi.fn();
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={navigate} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-tree-entry').length).toBe(3));
+    const leaf = screen.getAllByTestId('lens-tree-entry')
+      .find(r => r.getAttribute('data-path') === 'kb://bbbbbbbbbbbb/kb/bbb.md')!;
+    fireEvent.click(leaf);
+    expect(navigate).toHaveBeenCalledWith({ view: 'library', factPath: 'kb://bbbbbbbbbbbb/kb/bbb.md' });
+  });
+
+  it('forwards the repos narrowing to lensBrowse', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState({ lensSources: ['core'] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.lensBrowse).toHaveBeenCalledTimes(1));
+    expect(api.lensBrowse).toHaveBeenCalledWith('eng', 'kb', 'kb', ['core']);
+  });
+
+  it('an empty scope shows the empty state and issues no fetch', async () => {
+    const { api } = await import('./api');
+    render(<Library state={lensState({ lensSources: [] })} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => screen.getByTestId('left-panel'));
+    expect(screen.queryAllByTestId('lens-tree-entry').length).toBe(0);
+    expect(api.lensBrowse).not.toHaveBeenCalled();
+    expect(screen.getByText(/no sources selected/i)).toBeTruthy();
+  });
+
+  it('lens+path is not infinite-scroll paged (no sentinel)', async () => {
+    render(<Library state={lensState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getAllByTestId('lens-tree-entry').length).toBe(3));
+    expect(screen.queryByTestId('recent-sentinel')).toBeNull();
+  });
+
+  it('repo-context Path browse still uses api.browse, never lensBrowse', async () => {
+    const { api } = await import('./api');
+    render(<Library state={repoState()} dispatch={vi.fn()} navigate={vi.fn()} />);
+    await waitFor(() => expect(api.browse).toHaveBeenCalledTimes(1));
+    expect(api.browse).toHaveBeenCalledWith('core', 'agent/main', 'kb', 'kb');
+    expect(api.lensBrowse).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId('dir-entry').length).toBe(1);
+  });
+});

--- a/web/src/Library.tsx
+++ b/web/src/Library.tsx
@@ -3,15 +3,47 @@ import { useAsync } from './hooks';
 import { EmptyState, LoadingSpinner } from './ui';
 import type { Dispatch } from 'react';
 import { api } from './api';
-import type { DirChild, RecentFactEntry } from './api';
+import type { DirChild, RecentFactEntry, LensSource } from './api';
 import type { AppState, Action } from './state';
-import { currentPath, isLive } from './state';
-import { typeStyles, defaultTypeStyle, relativeTimeEpoch } from './utils';
+import { currentPath, isLive, isLensContext } from './state';
+import { typeStyles, defaultTypeStyle, relativeTimeEpoch, repoHue, repoHueBg, repoHueBorder } from './utils';
 import { TypeIcon, FolderIcon } from './icons';
 import { LibraryHeader } from './LibraryHeader';
+import { SourcesDropdown } from './SourcesDropdown';
 import type { NavRequest } from './useNavigationManager';
 
 type RowItem = { name: string; fullPath: string; is_dir: boolean };
+
+// LensRow is one row of a lens union list: the RAW canonical path (its
+// identity + what fact-open uses), a display title/type, and the source mount.
+type LensRow = { path: string; title: string; type?: string; source: LensSource };
+
+// displayLensPath strips the `kb://<id12>/` qualifier from a read-mount path so
+// the displayed breadcrumb never shows the opaque mount id — the source badge
+// already names the mount. Bare write-repo paths pass through unchanged.
+function displayLensPath(path: string): string {
+  return path.replace(/^kb:\/\/[^/]+\//, '');
+}
+
+// SourceBadge is the one persistent visual difference between a union row and a
+// single-repo row: a small mono pill in the mount's deterministic hue.
+function SourceBadge({ repo }: { repo: string }) {
+  const c = repoHue(repo);
+  return (
+    <span
+      data-testid="source-badge"
+      data-repo={repo}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 10,
+        color: c, background: repoHueBg(repo), border: `1px solid ${repoHueBorder(repo)}`,
+        borderRadius: 3, padding: '0 5px', fontFamily: 'var(--k-font-mono)', lineHeight: 1.6, flexShrink: 0,
+      }}
+    >
+      <span style={{ width: 5, height: 5, borderRadius: '50%', background: c, flexShrink: 0 }} />
+      {repo}
+    </span>
+  );
+}
 
 interface Props {
   state: AppState;
@@ -43,12 +75,19 @@ export function Library({ state, dispatch, navigate }: Props) {
   const searchActive = hasNonPathFilters || !!state.freeText;
   const effectiveSort = searchActive ? 'relevance' : state.librarySort;
 
+  // Lens context reads the union via the lens endpoints instead of the repo
+  // ones. `lensName` is the active lens; the repo effects below early-return in
+  // lens context so a read never leaks onto a repo endpoint.
+  const isLens = isLensContext(state);
+  const lensName = state.context.kind === 'lens' ? state.context.name : '';
+
   const [children, setChildren] = useState<DirChild[]>([]);
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   // ── Path sort: api.browse for directory entries ──
   useAsync((stale) => {
+    if (isLens) return; // lens context reads via the lens effect below
     if (effectiveSort !== 'path') return;
     api.browse(state.repo, state.branch, path, state.ontologyRoot).then(r => {
       if (stale()) return;
@@ -65,7 +104,7 @@ export function Library({ state, dispatch, navigate }: Props) {
         setSelectedIdx(-1);
       }
     }).catch(() => { if (!stale()) setChildren([]); });
-  }, [path, state.headCommit, effectiveSort, state.repo, state.branch, state.ontologyRoot, state.factPath]);
+  }, [path, state.headCommit, effectiveSort, state.repo, state.branch, state.ontologyRoot, state.factPath, isLens]);
 
   // ── Recent sort: api.recent for chrono entries (infinite-scroll paged) ──
   const [facts, setFacts] = useState<RecentFactEntry[]>([]);
@@ -94,6 +133,7 @@ export function Library({ state, dispatch, navigate }: Props) {
   const filtersKey = state.filters.map(f => `${f.category}:${f.value}`).join('\0');
 
   useAsync((stale) => {
+    if (isLens) return; // lens context reads via the lens effect below
     if (effectiveSort !== 'recent') return;
     setLoading(true);
     setFacts([]);
@@ -116,7 +156,7 @@ export function Library({ state, dispatch, navigate }: Props) {
         dispatch({ type: 'AMEND_NAV', factPath: loaded[0].path });
       }
     }).catch(() => { if (!stale()) { setFacts([]); setLoading(false); } });
-  }, [path, state.headCommit, state.freeText, state.repo, state.branch, typeFilter, filtersKey, effectiveSort]);
+  }, [path, state.headCommit, state.freeText, state.repo, state.branch, typeFilter, filtersKey, effectiveSort, isLens]);
 
   // Recent mode highlights by index only (path/relevance sync inside their
   // fetch). Keep the highlighted row tied to the open fact so any factPath
@@ -136,6 +176,7 @@ export function Library({ state, dispatch, navigate }: Props) {
   const loadingRef = useRef(loading);
   loadingRef.current = loading;
   const loadMore = useCallback(() => {
+    if (isLens) return; // lens list isn't paged here
     if (effectiveSort !== 'recent') return;
     if (loadingRef.current || facts.length >= total) return;
     setLoading(true);
@@ -150,7 +191,7 @@ export function Library({ state, dispatch, navigate }: Props) {
       setFacts(prev => [...prev, ...(r.facts || [])]);
       setLoading(false);
     }).catch(() => setLoading(false));
-  }, [effectiveSort, facts.length, total, state.repo, state.branch, path, state.freeText, typeFilter, kinds, origins, domains, entities, eps]);
+  }, [isLens, effectiveSort, facts.length, total, state.repo, state.branch, path, state.freeText, typeFilter, kinds, origins, domains, entities, eps]);
 
   useEffect(() => {
     if (effectiveSort !== 'recent') return;
@@ -167,6 +208,7 @@ export function Library({ state, dispatch, navigate }: Props) {
 
   // ── Relevance sort: api.search for free-text results ──
   useAsync((stale) => {
+    if (isLens) return; // lens context reads via the lens effect below
     if (effectiveSort !== 'relevance') {
       dispatch({ type: 'SET_SEARCHING', value: false });
       return;
@@ -197,14 +239,75 @@ export function Library({ state, dispatch, navigate }: Props) {
         dispatch({ type: 'AMEND_NAV', factPath: items[0].fullPath });
       }
     }).catch(() => { if (!stale()) { setChildren([]); dispatch({ type: 'SET_SEARCHING', value: false }); } });
-  }, [path, state.headCommit, state.freeText, effectiveSort, state.repo, state.branch, filtersKey]);
+  }, [path, state.headCommit, state.freeText, effectiveSort, state.repo, state.branch, filtersKey, isLens]);
+
+  // ── Lens union list: api.listLensFacts (recent/path) or api.lensSearch
+  // (relevance). `lensSources` narrows the fan-out: null = all mounts (no repos
+  // param), an explicit subset re-sends repos=[…] and refetches, and [] means
+  // "none selected" → an empty list (NOT a fetch, since an empty repos array
+  // would otherwise read as "all" server-side). ──
+  const [lensRows, setLensRows] = useState<LensRow[]>([]);
+  const [lensLoading, setLensLoading] = useState(false);
+  const lensSources = state.lensSources;
+  const noneSelected = Array.isArray(lensSources) && lensSources.length === 0;
+  // Stable dep key so the effect refetches when the selection changes.
+  const lensSourcesKey = lensSources === null ? ' ALL' : lensSources.join('');
+
+  useAsync((stale) => {
+    if (!isLens) return;
+    if (noneSelected) { setLensRows([]); setLensLoading(false); return; }
+    const repos = lensSources ?? undefined;
+    setLensLoading(true);
+    setLensRows([]);
+    if (effectiveSort === 'relevance') {
+      dispatch({ type: 'SET_SEARCHING', value: true });
+      api.lensSearch(lensName, state.freeText, repos).then(results => {
+        if (stale()) return;
+        dispatch({ type: 'SET_SEARCHING', value: false });
+        setLensRows(results.map(r => ({ path: r.path, title: r.title, type: r.type, source: r.source })));
+        setLensLoading(false);
+      }).catch(() => { if (!stale()) { setLensRows([]); setLensLoading(false); dispatch({ type: 'SET_SEARCHING', value: false }); } });
+      return;
+    }
+    dispatch({ type: 'SET_SEARCHING', value: false });
+    api.listLensFacts(lensName, { path, query: state.freeText || undefined, limit: 50, offset: 0, repos }).then(r => {
+      if (stale()) return;
+      setLensRows((r.facts || []).map(f => ({ path: f.path, title: f.title, type: f.type, source: f.source })));
+      setLensLoading(false);
+    }).catch(() => { if (!stale()) { setLensRows([]); setLensLoading(false); } });
+  }, [isLens, lensName, path, state.freeText, effectiveSort, lensSourcesKey, noneSelected, state.headCommit]);
+
+  // Keep the highlighted lens row tied to the open fact (mirrors the repo
+  // Recent behavior) so returning to a fact re-selects its row.
+  useEffect(() => {
+    if (!isLens) return;
+    if (!state.factPath) { setSelectedIdx(-1); return; }
+    const idx = lensRows.findIndex(r => r.path === state.factPath);
+    if (idx >= 0) setSelectedIdx(idx);
+  }, [isLens, state.factPath, lensRows]);
+
+  // openFact is the single fact-open chokepoint. In a repo context it just
+  // navigates (unchanged). In a lens context it additionally reads the fact
+  // through the lens with its RAW canonical path to learn the source mount and
+  // stores it via SET_FACT_SOURCE, then navigates so RightPanel renders it.
+  const openFact = useCallback((fullPath: string) => {
+    if (isLens) {
+      api.getLensFact(lensName, fullPath)
+        .then(f => dispatch({ type: 'SET_FACT_SOURCE', source: f.source }))
+        .catch(() => { /* fact-open surfaces its own error via RightPanel */ });
+    }
+    navigate({ view: 'library', factPath: fullPath });
+  }, [isLens, lensName, dispatch, navigate]);
 
   const activeList: RowItem[] = useMemo(() => {
+    if (isLens) {
+      return lensRows.map(r => ({ name: displayLensPath(r.path), fullPath: r.path, is_dir: false }));
+    }
     if (effectiveSort === 'recent') {
       return facts.map(f => ({ name: f.path.split('/').pop() || f.path, fullPath: f.path, is_dir: false }));
     }
     return children.map(c => ({ name: c.name, fullPath: c.fullPath || '', is_dir: c.is_dir }));
-  }, [effectiveSort, facts, children]);
+  }, [isLens, lensRows, effectiveSort, facts, children]);
 
   const moveSelection = useCallback((delta: 1 | -1) => {
     const len = activeList.length;
@@ -214,9 +317,9 @@ export function Library({ state, dispatch, navigate }: Props) {
     itemRefs.current[next]?.scrollIntoView({ block: 'nearest' });
     const item = activeList[next];
     if (item && !item.is_dir) {
-      navigate({ view: 'library', factPath: item.fullPath || `${path}/${item.name}` });
+      openFact(item.fullPath || `${path}/${item.name}`);
     }
-  }, [activeList, selectedIdx, path, navigate]);
+  }, [activeList, selectedIdx, path, openFact]);
 
   const activateSelected = useCallback(() => {
     const item = activeList[selectedIdx];
@@ -224,9 +327,9 @@ export function Library({ state, dispatch, navigate }: Props) {
     if (item.is_dir) {
       dispatch({ type: 'NAVIGATE', path: `${path}/${item.name}` });
     } else {
-      navigate({ view: 'library', factPath: item.fullPath || `${path}/${item.name}` });
+      openFact(item.fullPath || `${path}/${item.name}`);
     }
-  }, [activeList, selectedIdx, path, dispatch, navigate]);
+  }, [activeList, selectedIdx, path, dispatch, openFact]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -263,8 +366,11 @@ export function Library({ state, dispatch, navigate }: Props) {
 
   return (
     <div data-testid="left-panel" data-sort={effectiveSort} style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      {isLens && state.lens && (
+        <SourcesDropdown lens={state.lens} selection={state.lensSources} dispatch={dispatch} />
+      )}
       <LibraryHeader
-        count={effectiveSort === 'recent' ? facts.length : children.length}
+        count={isLens ? lensRows.length : effectiveSort === 'recent' ? facts.length : children.length}
         scoped={hasPathChip}
         sort={effectiveSort}
         searchActive={searchActive}
@@ -274,7 +380,46 @@ export function Library({ state, dispatch, navigate }: Props) {
         <ReadOnlyBanner message="Showing live library · history views not yet supported by backend" />
       )}
       <div ref={containerRef} style={{ flex: 1, overflowY: 'auto' }}>
-        {(effectiveSort === 'path' || effectiveSort === 'relevance') && children.map((c, i) => {
+        {isLens && (
+          <>
+            {lensRows.length === 0 && !lensLoading && (
+              <EmptyState message={
+                noneSelected ? 'No sources selected.'
+                  : state.freeText ? 'No facts match the search.'
+                  : 'No facts in this lens.'
+              } />
+            )}
+            {lensRows.map((f, i) => {
+              const ts = (f.type && typeStyles[f.type]) || defaultTypeStyle;
+              return (
+                <div
+                  key={f.path}
+                  data-testid="lens-item"
+                  data-path={f.path}
+                  ref={el => { itemRefs.current[i] = el; }}
+                  onClick={() => { setSelectedIdx(i); openFact(f.path); }}
+                  style={{
+                    padding: '6px 12px', cursor: 'pointer',
+                    background: i === selectedIdx ? '#2a2a3a' : 'transparent',
+                    borderBottom: '1px solid #1a1a1a',
+                    borderLeft: `2px solid ${i === selectedIdx ? repoHue(f.source.repo) : 'transparent'}`,
+                  }}
+                >
+                  <div style={{ fontSize: 12.5, color: '#ddd', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ flexShrink: 0, display: 'flex', alignItems: 'center' }}><TypeIcon type={f.type || ''} color={ts.color} size={12} /></span>
+                    {f.title}
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 3, paddingLeft: 18 }}>
+                    <SourceBadge repo={f.source.repo} />
+                    <span data-testid="lens-item-path" style={{ fontFamily: 'var(--k-font-mono)', fontSize: 10, color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{displayLensPath(f.path)}</span>
+                  </div>
+                </div>
+              );
+            })}
+            {lensLoading && <LoadingSpinner />}
+          </>
+        )}
+        {!isLens && (effectiveSort === 'path' || effectiveSort === 'relevance') && children.map((c, i) => {
           const ts = (c.type && typeStyles[c.type]) || defaultTypeStyle;
           return (
             <div
@@ -289,7 +434,7 @@ export function Library({ state, dispatch, navigate }: Props) {
                 if (c.is_dir) {
                   dispatch({ type: 'ADD_FILTER', chip: { category: 'path', value: `${path}/${c.name}` } });
                 } else {
-                  navigate({ view: 'library', factPath: c.fullPath || `${path}/${c.name}` });
+                  openFact(c.fullPath || `${path}/${c.name}`);
                 }
               }}
               style={{
@@ -312,8 +457,8 @@ export function Library({ state, dispatch, navigate }: Props) {
             </div>
           );
         })}
-        {(effectiveSort === 'path' || effectiveSort === 'relevance') && children.length === 0 && <EmptyState message={effectiveSort === 'relevance' ? 'No facts match the search.' : 'No items in this path.'} />}
-        {effectiveSort === 'recent' && (
+        {!isLens && (effectiveSort === 'path' || effectiveSort === 'relevance') && children.length === 0 && <EmptyState message={effectiveSort === 'relevance' ? 'No facts match the search.' : 'No items in this path.'} />}
+        {!isLens && effectiveSort === 'recent' && (
           <>
             {facts.length === 0 && !loading && (
               <EmptyState message={state.freeText ? 'No facts match the search.' : 'No facts in this path.'} />
@@ -325,7 +470,7 @@ export function Library({ state, dispatch, navigate }: Props) {
                   key={f.path}
                   data-testid="chrono-item"
                   data-path={f.path}
-                  onClick={() => { setSelectedIdx(i); navigate({ view: 'library', factPath: f.path }); }}
+                  onClick={() => { setSelectedIdx(i); openFact(f.path); }}
                   style={{
                     padding: '6px 12px', cursor: 'pointer',
                     background: i === selectedIdx ? '#2a2a3a' : 'transparent',

--- a/web/src/Library.tsx
+++ b/web/src/Library.tsx
@@ -312,18 +312,16 @@ export function Library({ state, dispatch, navigate }: Props) {
     if (idx >= 0) setSelectedIdx(idx);
   }, [isLens, state.factPath, lensRows]);
 
-  // openFact is the single fact-open chokepoint. In a repo context it just
-  // navigates (unchanged). In a lens context it additionally reads the fact
-  // through the lens with its RAW canonical path to learn the source mount and
-  // stores it via SET_FACT_SOURCE, then navigates so RightPanel renders it.
+  // openFact is the fact-open chokepoint: it navigates with the RAW canonical
+  // path (bare for the write repo, kb://<id12>/… for a read mount). It does NOT
+  // fetch the fact or dispatch SET_FACT_SOURCE — RightPanel is the single owner
+  // of that fetch, with stale() guards. Prefetching+dispatching here as well
+  // races under rapid re-open (keyboard moveSelection): a slow earlier response
+  // could land after a newer fact opened, and RightPanel (keyed on factPath)
+  // wouldn't correct the mismatched source.
   const openFact = useCallback((fullPath: string) => {
-    if (isLens) {
-      api.getLensFact(lensName, fullPath)
-        .then(f => dispatch({ type: 'SET_FACT_SOURCE', source: f.source }))
-        .catch(() => { /* fact-open surfaces its own error via RightPanel */ });
-    }
     navigate({ view: 'library', factPath: fullPath });
-  }, [isLens, lensName, dispatch, navigate]);
+  }, [navigate]);
 
   const activeList: RowItem[] = useMemo(() => {
     if (isLens) {

--- a/web/src/Library.tsx
+++ b/web/src/Library.tsx
@@ -6,7 +6,7 @@ import { api } from './api';
 import type { DirChild, RecentFactEntry, LensSource } from './api';
 import type { AppState, Action } from './state';
 import { currentPath, isLive, isLensContext } from './state';
-import { typeStyles, defaultTypeStyle, relativeTimeEpoch, repoHue, repoHueBg, repoHueBorder } from './utils';
+import { typeStyles, defaultTypeStyle, relativeTimeEpoch, repoHue, repoHueBg, repoHueBorder, displayLensPath } from './utils';
 import { TypeIcon, FolderIcon } from './icons';
 import { LibraryHeader } from './LibraryHeader';
 import { SourcesDropdown } from './SourcesDropdown';
@@ -17,13 +17,6 @@ type RowItem = { name: string; fullPath: string; is_dir: boolean };
 // LensRow is one row of a lens union list: the RAW canonical path (its
 // identity + what fact-open uses), a display title/type, and the source mount.
 type LensRow = { path: string; title: string; type?: string; source: LensSource };
-
-// displayLensPath strips the `kb://<id12>/` qualifier from a read-mount path so
-// the displayed breadcrumb never shows the opaque mount id — the source badge
-// already names the mount. Bare write-repo paths pass through unchanged.
-function displayLensPath(path: string): string {
-  return path.replace(/^kb:\/\/[^/]+\//, '');
-}
 
 // SourceBadge is the one persistent visual difference between a union row and a
 // single-repo row: a small mono pill in the mount's deterministic hue.

--- a/web/src/Library.tsx
+++ b/web/src/Library.tsx
@@ -165,43 +165,6 @@ export function Library({ state, dispatch, navigate }: Props) {
     if (idx >= 0) setSelectedIdx(idx);
   }, [state.factPath, facts, effectiveSort]);
 
-  // Infinite scroll: when the sentinel at the bottom of the Recent list scrolls
-  // into view, fetch the next page and append. loadingRef keeps the callback
-  // identity stable so the IntersectionObserver doesn't reconnect on every
-  // loading-state flip (which would re-fire the trigger and double-load).
-  const loadingRef = useRef(loading);
-  loadingRef.current = loading;
-  const loadMore = useCallback(() => {
-    if (isLens) return; // lens list isn't paged here
-    if (effectiveSort !== 'recent') return;
-    if (loadingRef.current || facts.length >= total) return;
-    setLoading(true);
-    api.recent(state.repo, state.branch, path, state.freeText, 50, facts.length, {
-      typeFilter,
-      kinds: kinds.length ? kinds : undefined,
-      origins: origins.length ? origins : undefined,
-      domains: domains.length ? domains : undefined,
-      entities: entities.length ? entities : undefined,
-      eps: eps.length ? eps : undefined,
-    }).then(r => {
-      setFacts(prev => [...prev, ...(r.facts || [])]);
-      setLoading(false);
-    }).catch(() => setLoading(false));
-  }, [isLens, effectiveSort, facts.length, total, state.repo, state.branch, path, state.freeText, typeFilter, kinds, origins, domains, entities, eps]);
-
-  useEffect(() => {
-    if (effectiveSort !== 'recent') return;
-    const sentinel = sentinelRef.current;
-    const root = containerRef.current;
-    if (!sentinel || !root) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => { if (entry.isIntersecting) loadMore(); },
-      { root, threshold: 0.1 }
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [effectiveSort, loadMore]);
-
   // ── Relevance sort: api.search for free-text results ──
   useAsync((stale) => {
     if (isLens) return; // lens context reads via the lens effect below
@@ -267,14 +230,15 @@ export function Library({ state, dispatch, navigate }: Props) {
   // empty repos array would otherwise read as "all mounts" server-side).
   const emptyScope = noneSelected || (constrained && effectiveRepos.length === 0);
   // Stable dep key so the effect refetches when either narrowing changes.
-  const reposKey = reposParam === undefined ? ' ALL' : reposParam.join('');
+  const reposKey = reposParam === undefined ? ' ALL' : reposParam.join('\0');
 
   useAsync((stale) => {
     if (!isLens) return;
-    if (emptyScope) { setLensRows([]); setLensLoading(false); return; }
+    if (emptyScope) { setLensRows([]); setTotal(0); setLensLoading(false); return; }
     const repos = reposParam;
     setLensLoading(true);
     setLensRows([]);
+    setTotal(0);
     if (effectiveSort === 'relevance') {
       dispatch({ type: 'SET_SEARCHING', value: true });
       // The lens search handler accepts the full content-filter set the repo
@@ -299,6 +263,8 @@ export function Library({ state, dispatch, navigate }: Props) {
     api.listLensFacts(lensName, { path, query: state.freeText || undefined, limit: 50, offset: 0, repos }).then(r => {
       if (stale()) return;
       setLensRows((r.facts || []).map(f => ({ path: f.path, title: f.title, type: f.type, source: f.source })));
+      // Keep total so the infinite-scroll sentinel can page the union (I5).
+      setTotal(r.total);
       setLensLoading(false);
     }).catch(() => { if (!stale()) { setLensRows([]); setLensLoading(false); } });
   }, [isLens, lensName, path, state.freeText, effectiveSort, reposKey, emptyScope, filtersKey, state.headCommit]);
@@ -311,6 +277,62 @@ export function Library({ state, dispatch, navigate }: Props) {
     const idx = lensRows.findIndex(r => r.path === state.factPath);
     if (idx >= 0) setSelectedIdx(idx);
   }, [isLens, state.factPath, lensRows]);
+
+  // Infinite scroll: when the sentinel at the bottom of a paged list scrolls into
+  // view, fetch the next page and append. The *Ref mirrors keep the callback
+  // identity stable so the IntersectionObserver doesn't reconnect on every
+  // loading-state flip (which would re-fire the trigger and double-load). Defined
+  // after the lens union declarations so it can page either list.
+  const loadingRef = useRef(loading);
+  loadingRef.current = loading;
+  const lensLoadingRef = useRef(lensLoading);
+  lensLoadingRef.current = lensLoading;
+  // A paged list shows the sentinel: repo Recent, or a lens union in a
+  // non-relevance sort (lensSearch results aren't paged; an empty scope has none).
+  const paged = isLens ? (effectiveSort !== 'relevance' && !emptyScope) : effectiveSort === 'recent';
+  const loadMore = useCallback(() => {
+    if (isLens) {
+      // Lens union paging (I5): fetch the next offset with the SAME params
+      // (path/query/repos intersection) and append. Relevance/empty scopes and a
+      // fully-loaded union don't page.
+      if (effectiveSort === 'relevance' || emptyScope) return;
+      if (lensLoadingRef.current || lensRows.length >= total) return;
+      setLensLoading(true);
+      api.listLensFacts(lensName, { path, query: state.freeText || undefined, limit: 50, offset: lensRows.length, repos: reposParam })
+        .then(r => {
+          setLensRows(prev => [...prev, ...(r.facts || []).map(f => ({ path: f.path, title: f.title, type: f.type, source: f.source }))]);
+          setLensLoading(false);
+        }).catch(() => setLensLoading(false));
+      return;
+    }
+    if (effectiveSort !== 'recent') return;
+    if (loadingRef.current || facts.length >= total) return;
+    setLoading(true);
+    api.recent(state.repo, state.branch, path, state.freeText, 50, facts.length, {
+      typeFilter,
+      kinds: kinds.length ? kinds : undefined,
+      origins: origins.length ? origins : undefined,
+      domains: domains.length ? domains : undefined,
+      entities: entities.length ? entities : undefined,
+      eps: eps.length ? eps : undefined,
+    }).then(r => {
+      setFacts(prev => [...prev, ...(r.facts || [])]);
+      setLoading(false);
+    }).catch(() => setLoading(false));
+  }, [isLens, effectiveSort, emptyScope, lensRows.length, lensName, reposKey, facts.length, total, state.repo, state.branch, path, state.freeText, typeFilter, kinds, origins, domains, entities, eps]);
+
+  useEffect(() => {
+    if (!paged) return;
+    const sentinel = sentinelRef.current;
+    const root = containerRef.current;
+    if (!sentinel || !root) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) loadMore(); },
+      { root, threshold: 0.1 }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [paged, loadMore]);
 
   // openFact is the fact-open chokepoint: it navigates with the RAW canonical
   // path (bare for the write repo, kb://<id12>/… for a read mount). It does NOT
@@ -441,6 +463,9 @@ export function Library({ state, dispatch, navigate }: Props) {
                 </div>
               );
             })}
+            {/* Infinite-scroll sentinel — shared with repo Recent; only one list
+                mounts at a time. Pages the union when more rows exist (I5). */}
+            <div ref={sentinelRef} data-testid="recent-sentinel" style={{ height: 1 }} />
             {lensLoading && <LoadingSpinner />}
           </>
         )}

--- a/web/src/Library.tsx
+++ b/web/src/Library.tsx
@@ -3,7 +3,7 @@ import { useAsync } from './hooks';
 import { EmptyState, LoadingSpinner } from './ui';
 import type { Dispatch } from 'react';
 import { api } from './api';
-import type { DirChild, RecentFactEntry, LensSource } from './api';
+import type { DirChild, LensDirChild, RecentFactEntry, LensSource } from './api';
 import type { AppState, Action } from './state';
 import { currentPath, isLive, isLensContext } from './state';
 import { typeStyles, defaultTypeStyle, relativeTimeEpoch, repoHue, repoHueBg, repoHueBorder, displayLensPath } from './utils';
@@ -206,6 +206,7 @@ export function Library({ state, dispatch, navigate }: Props) {
   // "none selected" → an empty list (NOT a fetch, since an empty repos array
   // would otherwise read as "all" server-side). ──
   const [lensRows, setLensRows] = useState<LensRow[]>([]);
+  const [lensTree, setLensTree] = useState<LensDirChild[]>([]);
   const [lensLoading, setLensLoading] = useState(false);
   const lensSources = state.lensSources;
   const noneSelected = Array.isArray(lensSources) && lensSources.length === 0;
@@ -234,10 +235,11 @@ export function Library({ state, dispatch, navigate }: Props) {
 
   useAsync((stale) => {
     if (!isLens) return;
-    if (emptyScope) { setLensRows([]); setTotal(0); setLensLoading(false); return; }
+    if (emptyScope) { setLensRows([]); setLensTree([]); setTotal(0); setLensLoading(false); return; }
     const repos = reposParam;
     setLensLoading(true);
     setLensRows([]);
+    setLensTree([]);
     setTotal(0);
     if (effectiveSort === 'relevance') {
       dispatch({ type: 'SET_SEARCHING', value: true });
@@ -259,6 +261,18 @@ export function Library({ state, dispatch, navigate }: Props) {
       }).catch(() => { if (!stale()) { setLensRows([]); setLensLoading(false); dispatch({ type: 'SET_SEARCHING', value: false }); } });
       return;
     }
+    if (effectiveSort === 'path') {
+      // Unified tree browse: ONE lazy level per call (the lens twin of
+      // api.browse), honoring the same repos narrowing as the flat union.
+      // Not paged — no sentinel, no offset.
+      dispatch({ type: 'SET_SEARCHING', value: false });
+      api.lensBrowse(lensName, path, state.ontologyRoot, repos).then(r => {
+        if (stale()) return;
+        setLensTree(r.children || []);
+        setLensLoading(false);
+      }).catch(() => { if (!stale()) { setLensTree([]); setLensLoading(false); } });
+      return;
+    }
     dispatch({ type: 'SET_SEARCHING', value: false });
     api.listLensFacts(lensName, { path, query: state.freeText || undefined, limit: 50, offset: 0, repos }).then(r => {
       if (stale()) return;
@@ -267,16 +281,21 @@ export function Library({ state, dispatch, navigate }: Props) {
       setTotal(r.total);
       setLensLoading(false);
     }).catch(() => { if (!stale()) { setLensRows([]); setLensLoading(false); } });
-  }, [isLens, lensName, path, state.freeText, effectiveSort, reposKey, emptyScope, filtersKey, state.headCommit]);
+  }, [isLens, lensName, path, state.freeText, effectiveSort, reposKey, emptyScope, filtersKey, state.headCommit, state.ontologyRoot]);
 
   // Keep the highlighted lens row tied to the open fact (mirrors the repo
   // Recent behavior) so returning to a fact re-selects its row.
   useEffect(() => {
     if (!isLens) return;
     if (!state.factPath) { setSelectedIdx(-1); return; }
+    if (effectiveSort === 'path') {
+      const idx = lensTree.findIndex(c => !c.is_dir && c.path === state.factPath);
+      if (idx >= 0) setSelectedIdx(idx);
+      return;
+    }
     const idx = lensRows.findIndex(r => r.path === state.factPath);
     if (idx >= 0) setSelectedIdx(idx);
-  }, [isLens, state.factPath, lensRows]);
+  }, [isLens, state.factPath, lensRows, lensTree, effectiveSort]);
 
   // Infinite scroll: when the sentinel at the bottom of a paged list scrolls into
   // view, fetch the next page and append. The *Ref mirrors keep the callback
@@ -289,13 +308,15 @@ export function Library({ state, dispatch, navigate }: Props) {
   lensLoadingRef.current = lensLoading;
   // A paged list shows the sentinel: repo Recent, or a lens union in a
   // non-relevance sort (lensSearch results aren't paged; an empty scope has none).
-  const paged = isLens ? (effectiveSort !== 'relevance' && !emptyScope) : effectiveSort === 'recent';
+  const paged = isLens
+    ? (effectiveSort !== 'relevance' && effectiveSort !== 'path' && !emptyScope)
+    : effectiveSort === 'recent';
   const loadMore = useCallback(() => {
     if (isLens) {
       // Lens union paging (I5): fetch the next offset with the SAME params
       // (path/query/repos intersection) and append. Relevance/empty scopes and a
       // fully-loaded union don't page.
-      if (effectiveSort === 'relevance' || emptyScope) return;
+      if (effectiveSort === 'relevance' || effectiveSort === 'path' || emptyScope) return;
       if (lensLoadingRef.current || lensRows.length >= total) return;
       setLensLoading(true);
       api.listLensFacts(lensName, { path, query: state.freeText || undefined, limit: 50, offset: lensRows.length, repos: reposParam })
@@ -346,6 +367,9 @@ export function Library({ state, dispatch, navigate }: Props) {
   }, [navigate]);
 
   const activeList: RowItem[] = useMemo(() => {
+    if (isLens && effectiveSort === 'path') {
+      return lensTree.map(c => ({ name: c.name, fullPath: c.is_dir ? '' : (c.path || ''), is_dir: c.is_dir }));
+    }
     if (isLens) {
       return lensRows.map(r => ({ name: displayLensPath(r.path), fullPath: r.path, is_dir: false }));
     }
@@ -353,7 +377,7 @@ export function Library({ state, dispatch, navigate }: Props) {
       return facts.map(f => ({ name: f.path.split('/').pop() || f.path, fullPath: f.path, is_dir: false }));
     }
     return children.map(c => ({ name: c.name, fullPath: c.fullPath || '', is_dir: c.is_dir }));
-  }, [isLens, lensRows, effectiveSort, facts, children]);
+  }, [isLens, lensRows, lensTree, effectiveSort, facts, children]);
 
   const moveSelection = useCallback((delta: 1 | -1) => {
     const len = activeList.length;
@@ -416,7 +440,7 @@ export function Library({ state, dispatch, navigate }: Props) {
         <SourcesDropdown lens={state.lens} selection={state.lensSources} dispatch={dispatch} />
       )}
       <LibraryHeader
-        count={isLens ? lensRows.length : effectiveSort === 'recent' ? facts.length : children.length}
+        count={isLens ? (effectiveSort === 'path' ? lensTree.length : lensRows.length) : effectiveSort === 'recent' ? facts.length : children.length}
         scoped={hasPathChip}
         sort={effectiveSort}
         searchActive={searchActive}
@@ -426,7 +450,58 @@ export function Library({ state, dispatch, navigate }: Props) {
         <ReadOnlyBanner message="Showing live library · history views not yet supported by backend" />
       )}
       <div ref={containerRef} style={{ flex: 1, overflowY: 'auto' }}>
-        {isLens && (
+        {isLens && effectiveSort === 'path' && (
+          <>
+            {lensTree.length === 0 && !lensLoading && (
+              <EmptyState message={
+                noneSelected ? 'No sources selected.'
+                  : emptyScope ? 'No sources match the repo: filter.'
+                  : 'No items in this path.'
+              } />
+            )}
+            {lensTree.map((c, i) => {
+              const ts = (c.type && typeStyles[c.type]) || defaultTypeStyle;
+              return (
+                <div
+                  key={c.is_dir ? `dir:${c.name}` : (c.path || c.name)}
+                  data-testid="lens-tree-entry"
+                  data-name={c.name}
+                  data-isdir={String(c.is_dir)}
+                  data-path={c.path || ''}
+                  ref={el => { itemRefs.current[i] = el; }}
+                  onClick={() => {
+                    setSelectedIdx(i);
+                    if (c.is_dir) {
+                      dispatch({ type: 'ADD_FILTER', chip: { category: 'path', value: `${path}/${c.name}` } });
+                    } else {
+                      openFact(c.path || `${path}/${c.name}`);
+                    }
+                  }}
+                  style={{
+                    padding: '8px 12px', cursor: 'pointer',
+                    background: i === selectedIdx ? '#2a2a3a' : 'transparent',
+                    borderBottom: '1px solid #222',
+                    display: 'flex', alignItems: 'center', gap: 8,
+                  }}
+                >
+                  {c.is_dir ? (
+                    <span style={{ flexShrink: 0, display: 'flex', alignItems: 'center', opacity: 0.7 }}>
+                      <FolderIcon color="#7c9" size={12} />
+                    </span>
+                  ) : (
+                    <span data-testid="fact-type-icon" style={{ flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+                      <TypeIcon type={c.type || ''} color={ts.color} size={12} />
+                    </span>
+                  )}
+                  <span style={{ fontSize: 13, color: '#ddd', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{c.title || c.name}</span>
+                  {!c.is_dir && c.source && <SourceBadge repo={c.source.repo} />}
+                </div>
+              );
+            })}
+            {lensLoading && <LoadingSpinner />}
+          </>
+        )}
+        {isLens && effectiveSort !== 'path' && (
           <>
             {lensRows.length === 0 && !lensLoading && (
               <EmptyState message={

--- a/web/src/Library.tsx
+++ b/web/src/Library.tsx
@@ -71,7 +71,10 @@ function ReadOnlyBanner({ message }: { message: string }) {
 
 export function Library({ state, dispatch, navigate }: Props) {
   const path = currentPath(state);
-  const hasNonPathFilters = state.filters.some(f => f.category !== 'path');
+  // `repo` chips are a lens fan-out scope, not a content filter — they narrow
+  // WHICH mounts are read, not HOW rows rank, so they must not flip the list
+  // into relevance mode the way a domain/kind/etc chip does.
+  const hasNonPathFilters = state.filters.some(f => f.category !== 'path' && f.category !== 'repo');
   const searchActive = hasNonPathFilters || !!state.freeText;
   const effectiveSort = searchActive ? 'relevance' : state.librarySort;
 
@@ -250,18 +253,48 @@ export function Library({ state, dispatch, navigate }: Props) {
   const [lensLoading, setLensLoading] = useState(false);
   const lensSources = state.lensSources;
   const noneSelected = Array.isArray(lensSources) && lensSources.length === 0;
-  // Stable dep key so the effect refetches when the selection changes.
-  const lensSourcesKey = lensSources === null ? ' ALL' : lensSources.join('');
+
+  // The `repos` param is the INTERSECTION of two independent narrowings: the
+  // sources dropdown (state.lensSources; null = all mounts) and the repo: filter
+  // chips (OR among themselves; none = all mounts). All mount names come from
+  // the lens's read set (which carries the write repo as a self-mount).
+  const allMounts = useMemo(() => (state.lens ? state.lens.reads.map(r => r.repo) : []), [state.lens]);
+  const chipRepos = useMemo(() => state.filters.filter(f => f.category === 'repo').map(f => f.value), [state.filters]);
+  const sourcesSel = lensSources ?? allMounts;
+  const chipSel = chipRepos.length ? chipRepos : allMounts;
+  // Preserve mount order; drop chip values that aren't real mounts (an unknown
+  // mount would 422 server-side — an empty intersection here shows empty state).
+  const effectiveRepos = allMounts.filter(m => sourcesSel.includes(m) && chipSel.includes(m));
+  // Send a repos param only when SOMETHING narrows the union; otherwise omit it
+  // so the server fans out to every mount (the null-selection contract).
+  const constrained = lensSources !== null || chipRepos.length > 0;
+  const reposParam = constrained ? effectiveRepos : undefined;
+  // An empty scope — no sources selected, or a repo:/sources intersection that
+  // excludes every mount — is a valid "nothing to show" state, never a fetch (an
+  // empty repos array would otherwise read as "all mounts" server-side).
+  const emptyScope = noneSelected || (constrained && effectiveRepos.length === 0);
+  // Stable dep key so the effect refetches when either narrowing changes.
+  const reposKey = reposParam === undefined ? ' ALL' : reposParam.join('');
 
   useAsync((stale) => {
     if (!isLens) return;
-    if (noneSelected) { setLensRows([]); setLensLoading(false); return; }
-    const repos = lensSources ?? undefined;
+    if (emptyScope) { setLensRows([]); setLensLoading(false); return; }
+    const repos = reposParam;
     setLensLoading(true);
     setLensRows([]);
     if (effectiveSort === 'relevance') {
       dispatch({ type: 'SET_SEARCHING', value: true });
-      api.lensSearch(lensName, state.freeText, repos).then(results => {
+      // The lens search handler accepts the full content-filter set the repo
+      // /search does (the facts handler does not) — forward path scope + chips.
+      api.lensSearch(lensName, state.freeText, repos, {
+        path,
+        types: types.length ? types : undefined,
+        kinds: kinds.length ? kinds : undefined,
+        origins: origins.length ? origins : undefined,
+        eps: eps.length ? eps : undefined,
+        domains: domains.length ? domains : undefined,
+        entities: entities.length ? entities : undefined,
+      }).then(results => {
         if (stale()) return;
         dispatch({ type: 'SET_SEARCHING', value: false });
         setLensRows(results.map(r => ({ path: r.path, title: r.title, type: r.type, source: r.source })));
@@ -275,7 +308,7 @@ export function Library({ state, dispatch, navigate }: Props) {
       setLensRows((r.facts || []).map(f => ({ path: f.path, title: f.title, type: f.type, source: f.source })));
       setLensLoading(false);
     }).catch(() => { if (!stale()) { setLensRows([]); setLensLoading(false); } });
-  }, [isLens, lensName, path, state.freeText, effectiveSort, lensSourcesKey, noneSelected, state.headCommit]);
+  }, [isLens, lensName, path, state.freeText, effectiveSort, reposKey, emptyScope, filtersKey, state.headCommit]);
 
   // Keep the highlighted lens row tied to the open fact (mirrors the repo
   // Recent behavior) so returning to a fact re-selects its row.
@@ -385,6 +418,7 @@ export function Library({ state, dispatch, navigate }: Props) {
             {lensRows.length === 0 && !lensLoading && (
               <EmptyState message={
                 noneSelected ? 'No sources selected.'
+                  : emptyScope ? 'No sources match the repo: filter.'
                   : state.freeText ? 'No facts match the search.'
                   : 'No facts in this lens.'
               } />

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -12,6 +12,7 @@ vi.mock('./api', () => ({
       { name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }] },
     ]),
     getLens: vi.fn().mockResolvedValue({ name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }] }),
+    createLens: vi.fn().mockResolvedValue({ name: 'newlens', write: 'core', reads: [] }),
     updateLens: vi.fn().mockResolvedValue({ name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }] }),
     deleteLens: vi.fn().mockResolvedValue(undefined),
     listBranchNames: vi.fn().mockResolvedValue([]),
@@ -242,6 +243,42 @@ describe('RepoManager', () => {
     render(<RepoManager {...baseProps} />);
     fireEvent.click(screen.getByTestId('repomgr-new-lens'));
     expect(screen.getByTestId('lens-name')).toBeInTheDocument();
+  });
+
+  // onChanged is the ONLY hook that refreshes App's lens list feeding the TopBar
+  // switcher — the local refresh() only updates this dialog. All three lens
+  // mutation paths (create/delete/save) must fire it so the switcher stays live.
+  it('fires onChanged on lens create (so the app lens list / TopBar refreshes)', async () => {
+    const onChanged = vi.fn();
+    render(<RepoManager {...baseProps} onChanged={onChanged} />);
+    fireEvent.click(screen.getByTestId('repomgr-new-lens'));
+    fireEvent.change(screen.getByTestId('lens-name'), { target: { value: 'newlens' } });
+    fireEvent.click(screen.getByTestId('lens-create'));
+    await waitFor(() => expect(api.createLens).toHaveBeenCalled());
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('fires onChanged on lens delete', async () => {
+    const onChanged = vi.fn();
+    render(<RepoManager {...baseProps} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    fireEvent.click(await screen.findByTestId('lens-delete'));
+    fireEvent.click(await screen.findByTestId('lens-delete-confirm'));
+    await waitFor(() => expect(api.deleteLens).toHaveBeenCalled());
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('fires onChanged on lens edit-save', async () => {
+    const onChanged = vi.fn();
+    render(<RepoManager {...baseProps} onChanged={onChanged} repos={[{ name: 'core' }, { name: 'work' }, { name: 'docs' }]} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    fireEvent.click(await screen.findByTestId('lens-edit'));
+    fireEvent.click(screen.getByTestId('lens-read-docs'));
+    fireEvent.click(screen.getByTestId('lens-edit-save'));
+    await waitFor(() => expect(api.updateLens).toHaveBeenCalled());
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
   });
 
   it('hideRemoteConfig hides the remote status panel', async () => {

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -53,7 +53,7 @@ describe('RepoManager', () => {
     await waitFor(() => expect(api.getOrigin).toHaveBeenCalledWith('core'));
     // The Remote status section renders inline within the same dialog.
     await waitFor(() => expect(screen.getByText('Remote')).toBeInTheDocument());
-    expect(screen.getByText('⟳ Rebuild index')).toBeInTheDocument();
+    expect(screen.getByText('Rebuild index')).toBeInTheDocument();
   });
 
   it('renders the kb.md description in the detail pane', async () => {
@@ -95,9 +95,9 @@ describe('RepoManager', () => {
 
   it('rebuild gives immediate feedback and a completion message', async () => {
     render(<RepoManager {...baseProps} />);
-    await waitFor(() => expect(screen.getByText('⟳ Rebuild index')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Rebuild index')).toBeInTheDocument());
 
-    fireEvent.click(screen.getByText('⟳ Rebuild index'));
+    fireEvent.click(screen.getByText('Rebuild index'));
     await waitFor(() => expect(api.rebuild).toHaveBeenCalledWith('core', 'agent/test'));
     // Visible confirmation that the background rebuild kicked off (the bug: none).
     await waitFor(() => expect(screen.getByTestId('rebuild-status')).toHaveTextContent('Rebuild started'));
@@ -160,7 +160,7 @@ describe('RepoManager', () => {
     await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
     fireEvent.click(screen.getByTestId('lens-copy'));
-    expect(writeText).toHaveBeenCalledWith('knomit init --lens dev');
+    expect(writeText).toHaveBeenCalledWith('knomit-bridge claude init --lens dev');
   });
 
   it('renders the lens description via the RepoDescription clamp/Show-more treatment', async () => {

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -12,7 +12,9 @@ vi.mock('./api', () => ({
       { name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }] },
     ]),
     getLens: vi.fn().mockResolvedValue({ name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }] }),
+    updateLens: vi.fn().mockResolvedValue({ name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }] }),
     deleteLens: vi.fn().mockResolvedValue(undefined),
+    listBranchNames: vi.fn().mockResolvedValue([]),
     getAgentBranch: vi.fn().mockResolvedValue('agent/test'),
     getRepo: vi.fn().mockResolvedValue({ name: 'core' }),
     getOrigin: vi.fn().mockResolvedValue(null),
@@ -32,6 +34,7 @@ describe('RepoManager', () => {
     hideRemoteConfig: false,
     onClose: () => {},
     onChanged: () => {},
+    onBrowse: () => {},
   };
 
   it('lists active repos and the archived list', async () => {
@@ -121,6 +124,79 @@ describe('RepoManager', () => {
     await waitFor(() => expect(api.deleteLens).toHaveBeenCalledWith('dev'));
   });
 
+  it('lens Browse button fires onBrowse with the lens context', async () => {
+    const onBrowse = vi.fn();
+    render(<RepoManager {...baseProps} onBrowse={onBrowse} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    fireEvent.click(screen.getByTestId('lens-browse'));
+    expect(onBrowse).toHaveBeenCalledWith({ kind: 'lens', name: 'dev' });
+  });
+
+  it('repo Browse button fires onBrowse with the repo context', async () => {
+    const onBrowse = vi.fn();
+    render(<RepoManager {...baseProps} onBrowse={onBrowse} />);
+    // Detail pane defaults to the current repo (core).
+    await waitFor(() => expect(screen.getByTestId('repo-browse')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repo-browse'));
+    expect(onBrowse).toHaveBeenCalledWith({ kind: 'repo', repo: 'core' });
+  });
+
+  it('does not double-list the write repo in the read mounts', async () => {
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    // The write repo (work) shows exactly once in the mount list, tagged write · read.
+    const workRows = screen.getAllByTestId('lens-detail-read-work');
+    expect(workRows).toHaveLength(1);
+    expect(workRows[0]).toHaveTextContent(/write.*read/i);
+  });
+
+  it('copies the init command to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    fireEvent.click(screen.getByTestId('lens-copy'));
+    expect(writeText).toHaveBeenCalledWith('knomit init --lens dev');
+  });
+
+  it('renders the lens description markdown when present', async () => {
+    (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }],
+      description: '# Dev lens\n\nEngineering read union.',
+    });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    await waitFor(() => expect(screen.getByTestId('lens-description')).toHaveTextContent('Engineering read union.'));
+  });
+
+  it('edits mounts, saves via updateLens, and re-renders the new mounts', async () => {
+    (api.updateLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'dev', write: 'work',
+      reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }, { repo: 'docs' }],
+    });
+    render(<RepoManager {...baseProps} repos={[{ name: 'core' }, { name: 'work' }, { name: 'docs' }]} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+
+    // Enter edit mode, mount 'docs', and save.
+    fireEvent.click(screen.getByTestId('lens-edit'));
+    fireEvent.click(screen.getByTestId('lens-read-docs'));
+    fireEvent.click(screen.getByTestId('lens-edit-save'));
+
+    await waitFor(() => expect(api.updateLens).toHaveBeenCalledWith('dev', expect.objectContaining({
+      reads: expect.arrayContaining([{ repo: 'core', branch: 'main' }, { repo: 'docs' }]),
+    })));
+    // The write repo is never sent in reads (it is read implicitly).
+    const sentReads = (api.updateLens as ReturnType<typeof vi.fn>).mock.calls[0][1].reads;
+    expect(sentReads.some((r: { repo: string }) => r.repo === 'work')).toBe(false);
+    // Detail re-renders with the returned mount set.
+    await waitFor(() => expect(screen.getByTestId('lens-detail-read-docs')).toBeInTheDocument());
+  });
+
   it('opens the New lens form from the Lenses section', async () => {
     render(<RepoManager {...baseProps} />);
     fireEvent.click(screen.getByTestId('repomgr-new-lens'));
@@ -143,6 +219,7 @@ describe('RepoManager', () => {
         hideRemoteConfig
         onClose={() => {}}
         onChanged={() => {}}
+        onBrowse={() => {}}
       />,
     );
     // RemoteStatus renders a "Remote" section label; assert it is absent.

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -162,15 +162,30 @@ describe('RepoManager', () => {
     expect(writeText).toHaveBeenCalledWith('knomit init --lens dev');
   });
 
-  it('renders the lens description markdown when present', async () => {
-    (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
-      name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }],
-      description: '# Dev lens\n\nEngineering read union.',
-    });
-    render(<RepoManager {...baseProps} />);
-    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
-    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
-    await waitFor(() => expect(screen.getByTestId('lens-description')).toHaveTextContent('Engineering read union.'));
+  it('renders the lens description via the RepoDescription clamp/Show-more treatment', async () => {
+    // Mirror the repo-description overflow fake: prove the lens reuses the same
+    // clamped component (data-testid=repo-description) with a working Show more toggle.
+    const sh = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+    const ch = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 500 });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 132 });
+    try {
+      (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+        name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }],
+        description: '# Dev lens\n\n' + 'Engineering read union.\n'.repeat(40),
+      });
+      render(<RepoManager {...baseProps} />);
+      await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+      await waitFor(() => expect(screen.getByTestId('repo-description')).toHaveTextContent('Engineering read union.'));
+      const toggle = await screen.findByTestId('repo-description-toggle');
+      expect(toggle).toHaveTextContent('Show more');
+      fireEvent.click(toggle);
+      expect(toggle).toHaveTextContent('Show less');
+    } finally {
+      if (sh) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', sh);
+      if (ch) Object.defineProperty(HTMLElement.prototype, 'clientHeight', ch);
+    }
   });
 
   it('edits mounts, saves via updateLens, and re-renders the new mounts', async () => {
@@ -195,6 +210,32 @@ describe('RepoManager', () => {
     expect(sentReads.some((r: { repo: string }) => r.repo === 'work')).toBe(false);
     // Detail re-renders with the returned mount set.
     await waitFor(() => expect(screen.getByTestId('lens-detail-read-docs')).toBeInTheDocument());
+  });
+
+  it('edit dropdown filters each read repo against its OWN agent branch, not the write repo', async () => {
+    // docs' own agent branch is 'agent/x'; the write repo (work) resolves to 'agent/w'.
+    (api.getAgentBranch as ReturnType<typeof vi.fn>).mockImplementation((repo: string) =>
+      Promise.resolve(repo === 'docs' ? 'agent/x' : 'agent/w'));
+    // docs carries a real branch literally named after the write repo's agent branch.
+    (api.listBranchNames as ReturnType<typeof vi.fn>).mockImplementation((repo: string) =>
+      Promise.resolve(repo === 'docs' ? ['agent/x', 'main', 'agent/w'] : []));
+    render(<RepoManager {...baseProps} repos={[{ name: 'core' }, { name: 'work' }, { name: 'docs' }]} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+
+    fireEvent.click(screen.getByTestId('lens-edit'));
+    fireEvent.click(screen.getByTestId('lens-read-docs'));
+
+    // Explicit-pin options exclude docs' own agent branch ('agent/x' is the
+    // default option) but keep a real branch that merely shares the write
+    // repo's agent-branch name ('agent/w').
+    // Retry until both branch names and docs' agent branch have resolved.
+    await waitFor(() => {
+      const opts = Array.from(screen.getByTestId('lens-branch-docs').querySelectorAll('option')).map(o => o.getAttribute('value'));
+      expect(opts).toContain('main');
+      expect(opts).toContain('agent/w');
+      expect(opts).not.toContain('agent/x');
+    });
   });
 
   it('opens the New lens form from the Lenses section', async () => {

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -192,7 +192,9 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
             {view.kind === 'newLens' && (
               <CreateLensForm
                 repos={repos}
+                lenses={lenses}
                 onDone={(name) => { refresh(); setSel({ kind: 'lens', name }); }}
+                onCancel={() => setSel({ kind: 'repo', name: currentRepo })}
                 onError={setErr}
               />
             )}

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -8,13 +8,12 @@ import { RemoteStatus } from './RemoteStatus';
 import { RemoteConnectWizard } from './RemoteConnectWizard';
 import { LENS, repoHue } from './utils';
 import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon, LayersIcon, PencilIcon, TrashIcon, CopyIcon } from './icons';
+import type { BrowseContext } from './state';
 
 // BrowseContext names the surface a Browse action should switch the app to:
-// a whole repo, or a lens's read union. Task 12 consumes this via SET_CONTEXT;
-// here RepoManager only fires it through the onBrowse callback.
-export type BrowseContext =
-  | { kind: 'repo'; repo: string }
-  | { kind: 'lens'; name: string };
+// a whole repo, or a lens's read union. The canonical definition lives in
+// state.ts (SET_CONTEXT consumes it); re-exported here for existing importers.
+export type { BrowseContext };
 
 interface Props {
   open: boolean;

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -198,8 +198,8 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 name={view.name}
                 repos={repos}
                 readOnly={readOnly}
-                onDeleted={() => { refresh(); setSel(null); }}
-                onSaved={refresh}
+                onDeleted={() => { onChanged(); refresh(); setSel(null); }}
+                onSaved={() => { onChanged(); refresh(); }}
                 onBrowse={onBrowse}
                 onError={setErr}
               />
@@ -208,7 +208,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
               <CreateLensForm
                 repos={repos}
                 lenses={lenses}
-                onDone={(name) => { refresh(); setSel({ kind: 'lens', name }); }}
+                onDone={(name) => { onChanged(); refresh(); setSel({ kind: 'lens', name }); }}
                 onCancel={() => setSel({ kind: 'repo', name: currentRepo })}
                 onError={setErr}
               />

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -441,6 +441,10 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
   // The write repo is never a key (it is read implicitly). null = not editing.
   const [editReads, setEditReads] = useState<Record<string, string> | null>(null);
   const [branchNames, setBranchNames] = useState<Record<string, string[]>>({});
+  // agentBranches caches each read repo's OWN agent branch, so the per-row
+  // dropdown can offer it as the "(default)" option and filter it out of the
+  // explicit-pin list — never the write repo's agent branch (a different repo).
+  const [agentBranches, setAgentBranches] = useState<Record<string, string>>({});
 
   useEffect(() => {
     setLens(initial);
@@ -480,14 +484,18 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
   };
 
   // ── edit mode ──
-  const loadBranches = (repo: string) => {
+  // loadBranchData fetches a read repo's selectable branch names AND its own
+  // agent branch (the default pin) together, cached so each is fetched once.
+  const loadBranchData = (repo: string) => {
     if (branchNames[repo]) return;
     api.listBranchNames(repo).then(names => setBranchNames(prev => ({ ...prev, [repo]: names }))).catch(() => {});
+    api.getAgentBranch(repo).then(b => setAgentBranches(prev => ({ ...prev, [repo]: b }))).catch(() => {});
   };
   const beginEdit = () => {
-    // Seed from the current reads, dropping the write repo (read implicitly).
+    // Seed from the current reads, dropping the write repo (read implicitly),
+    // and preload each mounted repo's branch data for its dropdown.
     const seed: Record<string, string> = {};
-    for (const r of reads) if (r.repo !== write) seed[r.repo] = r.branch ?? '';
+    for (const r of reads) if (r.repo !== write) { seed[r.repo] = r.branch ?? ''; loadBranchData(r.repo); }
     setEditReads(seed);
   };
   const toggleRead = (repo: string) => {
@@ -495,7 +503,7 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
       if (!prev) return prev;
       const next = { ...prev };
       if (repo in next) delete next[repo];
-      else { next[repo] = ''; loadBranches(repo); }
+      else { next[repo] = ''; loadBranchData(repo); }
       return next;
     });
   };
@@ -584,14 +592,7 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
         </div>
       </div>
 
-      {lens?.description && (
-        <div data-testid="lens-description" style={descBox}>
-          <div style={descLabel}>Description</div>
-          <div style={{ color: '#bbb', fontSize: 13, lineHeight: 1.6 }}>
-            <ReactMarkdown>{lens.description}</ReactMarkdown>
-          </div>
-        </div>
-      )}
+      {lens?.description && <RepoDescription markdown={lens.description} />}
 
       {/* Edit mode: toggle read mounts and pin branches, reusing the lens form's
           checkbox-row language. The write repo is a locked, always-on row. */}
@@ -608,7 +609,7 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
           )}
           {repos.filter(r => r.name !== write).map(r => {
             const on = r.name in editReads;
-            const others = (branchNames[r.name] ?? []).filter(n => n !== writeBranch);
+            const others = (branchNames[r.name] ?? []).filter(n => n !== agentBranches[r.name]);
             return (
               <div key={r.name} style={editRow(on)}>
                 <button type="button" data-testid={`lens-read-${r.name}`} style={editCheckbox(on)} disabled={busy}

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -6,8 +6,8 @@ import { CreateRepoForm } from './CreateRepoForm';
 import { CreateLensForm } from './CreateLensForm';
 import { RemoteStatus } from './RemoteStatus';
 import { RemoteConnectWizard } from './RemoteConnectWizard';
-import { LENS, repoHue } from './utils';
-import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon, LayersIcon, PencilIcon, TrashIcon, CopyIcon } from './icons';
+import { LENS, repoHue, repoHueBg, repoHueBorder } from './utils';
+import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon, LayersIcon, PencilIcon, TrashIcon, CopyIcon, WrenchIcon } from './icons';
 import type { BrowseContext } from './state';
 
 // BrowseContext names the surface a Browse action should switch the app to:
@@ -270,22 +270,43 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
   return (
     <div>
       <div style={detailHead}>
-        <div>
-          <h3 style={{ margin: 0, fontSize: 16 }}>{name}</h3>
-          <div style={{ fontFamily: 'var(--k-font-mono)', fontSize: 12, color: '#777', marginTop: 2 }}>{agentBranch || '…'}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={repoIconBox(name)}><BookIcon color={repoHue(name)} size={16} /></span>
+          <div>
+            <h3 style={{ margin: 0, fontSize: 16 }}>{name}</h3>
+            <div style={{ fontSize: 12, color: '#777', marginTop: 1 }}>repository</div>
+          </div>
         </div>
         <button type="button" data-testid="repo-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'repo', repo: name })}>
           <BookIcon color={LENS.text} size={13} /> Browse
         </button>
       </div>
+
+      {/* Agent branch — where this repo's facts are written (mirrors the lens
+          write-target box, tinted blue to match the branch chip). */}
+      <div style={{ ...descBox, background: '#141c26', borderColor: '#28405c' }}>
+        <div style={{ ...descLabel, color: '#6a86b0' }}>Agent branch</div>
+        <div data-testid="repo-detail-branch" style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, flexWrap: 'wrap' }}>
+          <RepoDot repo={name} />
+          <b style={{ color: '#eee' }}>{name}</b>
+          <BranchChip branch={agentBranch || '…'} />
+          <span style={{ color: '#777', fontSize: 12 }}>— new facts are written here</span>
+        </div>
+      </div>
+
+      <ConnectPanel kind="repo" name={name} agentBranch={agentBranch} />
+
       {description && <RepoDescription markdown={description} />}
-      <div style={{ display: 'flex', gap: 8, marginTop: 14, flexWrap: 'wrap' }}>
-        <button type="button" style={btn(readOnly || rebuilding)} disabled={readOnly || rebuilding} onClick={rebuild}>
-          {rebuilding ? 'Rebuilding…' : '⟳ Rebuild index'}
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 16, flexWrap: 'wrap' }}>
+        <button type="button" style={{ ...btn(readOnly || rebuilding), display: 'flex', alignItems: 'center', gap: 6 }}
+          disabled={readOnly || rebuilding} onClick={rebuild}>
+          <WrenchIcon color={readOnly || rebuilding ? '#666' : '#bbb'} size={13} /> {rebuilding ? 'Rebuilding…' : 'Rebuild index'}
         </button>
-        <button type="button" style={btn(!canArchive || busy, 'danger')} disabled={!canArchive || busy} onClick={archive}
+        <button type="button" style={{ ...btn(!canArchive || busy, 'danger'), display: 'flex', alignItems: 'center', gap: 6 }}
+          disabled={!canArchive || busy} onClick={archive}
           title={name === 'core' ? 'the default repo cannot be archived' : undefined}>
-          ⌦ Archive
+          <ArchiveIcon color={!canArchive || busy ? '#666' : '#f88'} size={13} /> Archive
         </button>
       </div>
       {rebuildMsg && (
@@ -435,7 +456,6 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
   const [writeBranch, setWriteBranch] = useState('');
   const [busy, setBusy] = useState(false);
   const [confirming, setConfirming] = useState(false);
-  const [copied, setCopied] = useState(false);
   // Edit mode: reads maps a mounted read repo → its branch pin ('' = default).
   // The write repo is never a key (it is read implicitly). null = not editing.
   const [editReads, setEditReads] = useState<Record<string, string> | null>(null);
@@ -472,14 +492,6 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
     try { await api.deleteLens(name); onDeleted(); }
     catch (e) { onError(`delete failed: ${String(e)}`); }
     finally { setBusy(false); setConfirming(false); }
-  };
-
-  const copyInit = async () => {
-    try {
-      await navigator.clipboard.writeText(`knomit init --lens ${name}`);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch { /* clipboard unavailable — nothing to recover */ }
   };
 
   // ── edit mode ──
@@ -577,19 +589,7 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
         })}
       </div>
 
-      {/* Connect an agent — the init command + MCP endpoint. */}
-      <div style={descBox}>
-        <div style={descLabel}>Connect an agent</div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, background: '#0c0c0c', border: '1px solid #222', borderRadius: 5, padding: '7px 10px' }}>
-          <code style={{ fontFamily: 'var(--k-font-mono)', fontSize: 12, color: '#7c9', flex: 1 }}>knomit init --lens {name}</code>
-          <button type="button" data-testid="lens-copy" title="Copy" aria-label="Copy init command" style={copyBtn} onClick={copyInit}>
-            <CopyIcon color={copied ? '#7c9' : '#888'} size={13} />
-          </button>
-        </div>
-        <div style={{ fontSize: 12, color: '#666', marginTop: 6 }}>
-          MCP endpoint <code style={{ fontFamily: 'var(--k-font-mono)', color: '#aaa' }}>/api/v1/lenses/{name}/mcp</code>
-        </div>
-      </div>
+      <ConnectPanel kind="lens" name={name} />
 
       {lens?.description && <RepoDescription markdown={lens.description} />}
 
@@ -683,6 +683,66 @@ const CheckMark = ({ color }: { color: string }) => (
   </svg>
 );
 
+// ConnectPanel renders the "Connect an agent" card for a repo or a lens. It
+// covers BOTH client families, because they wire up differently:
+//   • Claude Code uses the `knomit-bridge claude init` scaffolding (skills +
+//     hooks + .mcp.json).
+//   • Claude Cowork, Claude Desktop, and any other stdio MCP client just
+//     register knomit-bridge as an mcpServers entry — no `claude init`.
+// The scope arg is --lens <name> for a lens, --repo <name> for a repo.
+function ConnectPanel({ kind, name, agentBranch }: { kind: 'repo' | 'lens'; name: string; agentBranch?: string }) {
+  const [copied, setCopied] = useState<'cc' | 'mcp' | null>(null);
+  const arg = kind === 'lens' ? '--lens' : '--repo';
+  const initCmd = `knomit-bridge claude init ${arg} ${name}`;
+  const mcpJson = `{
+  "mcpServers": {
+    "knomit": {
+      "command": "knomit-bridge",
+      "args": ["${arg}", "${name}"]
+    }
+  }
+}`;
+  const endpoint = kind === 'lens'
+    ? `/api/v1/lenses/${name}/mcp`
+    : `/api/v1/repos/${name}/branches/${agentBranch || '<agent-branch>'}/mcp`;
+
+  const copy = (text: string, which: 'cc' | 'mcp') => {
+    navigator.clipboard.writeText(text)
+      .then(() => { setCopied(which); setTimeout(() => setCopied(null), 1500); })
+      .catch(() => { /* clipboard unavailable — nothing to recover */ });
+  };
+
+  return (
+    <div style={descBox}>
+      <div style={descLabel}>Connect an agent</div>
+
+      {/* Claude Code — the init scaffolding. */}
+      <div style={connectClient}>Claude Code<span style={connectHint}>scaffolds skills + hooks</span></div>
+      <div style={codeRow}>
+        <code style={codeText}>{initCmd}</code>
+        <button type="button" data-testid={`${kind}-copy`} title="Copy" aria-label="Copy Claude Code command"
+          style={copyBtn} onClick={() => copy(initCmd, 'cc')}>
+          <CopyIcon color={copied === 'cc' ? '#7c9' : '#888'} size={13} />
+        </button>
+      </div>
+
+      {/* Claude Cowork / Desktop / other MCP clients — raw mcpServers wiring. */}
+      <div style={{ ...connectClient, marginTop: 12 }}>Cowork · Desktop · other MCP clients<span style={connectHint}>add to mcpServers config</span></div>
+      <div style={{ ...codeRow, alignItems: 'flex-start' }}>
+        <pre style={{ ...codeText, margin: 0, whiteSpace: 'pre', overflowX: 'auto' }}>{mcpJson}</pre>
+        <button type="button" data-testid={`${kind}-copy-mcp`} title="Copy" aria-label="Copy mcpServers config"
+          style={copyBtn} onClick={() => copy(mcpJson, 'mcp')}>
+          <CopyIcon color={copied === 'mcp' ? '#7c9' : '#888'} size={13} />
+        </button>
+      </div>
+
+      <div style={{ fontSize: 12, color: '#666', marginTop: 8 }}>
+        MCP endpoint <code style={{ fontFamily: 'var(--k-font-mono)', color: '#aaa' }}>{endpoint}</code>
+      </div>
+    </div>
+  );
+}
+
 // ── styles ──
 const overlay: React.CSSProperties = { position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', zIndex: 1000, display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 24 };
 const panel: React.CSSProperties = { background: '#161616', border: '1px solid #333', borderRadius: 8, width: 'min(900px, 96vw)', height: 'min(620px, 90vh)', color: '#eee', display: 'flex', flexDirection: 'column' };
@@ -732,6 +792,21 @@ const lensIconBox: React.CSSProperties = {
   display: 'flex', alignItems: 'center', justifyContent: 'center',
 };
 const copyBtn: React.CSSProperties = { background: 'none', border: 'none', padding: 2, cursor: 'pointer', display: 'flex', alignItems: 'center' };
+// repoIconBox mirrors lensIconBox but tinted in the repo's own deterministic
+// hue (RepoDot's palette), so a repo detail reads as structurally identical to
+// a lens detail while staying colour-coded per repo.
+const repoIconBox = (repo: string): React.CSSProperties => ({
+  width: 30, height: 30, borderRadius: 7, flexShrink: 0,
+  background: repoHueBg(repo), border: '1px solid ' + repoHueBorder(repo),
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+});
+// connectClient labels a client family inside the Connect panel; connectHint is
+// the muted "· what it does" trailer.
+const connectClient: React.CSSProperties = { fontSize: 12, color: '#ccc', fontWeight: 600, marginBottom: 6, display: 'flex', alignItems: 'center', gap: 7 };
+const connectHint: React.CSSProperties = { fontSize: 11, color: '#666', fontWeight: 400 };
+// codeRow / codeText: the dark snippet box shared by both Connect blocks.
+const codeRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8, background: '#0c0c0c', border: '1px solid #222', borderRadius: 5, padding: '7px 10px' };
+const codeText: React.CSSProperties = { fontFamily: 'var(--k-font-mono)', fontSize: 12, color: '#7c9', flex: 1, lineHeight: 1.5 };
 const writeReadTag: React.CSSProperties = { fontSize: 10, color: '#7c9', background: '#1a2e1a', border: '1px solid #2a4a2a', padding: '1px 7px', borderRadius: 3, letterSpacing: '0.03em' };
 const readTag: React.CSSProperties = { fontSize: 10, color: '#777', border: '1px solid #333', padding: '1px 7px', borderRadius: 3, letterSpacing: '0.03em' };
 // editRow / editCheckbox mirror CreateLensForm's row/checkbox (LENS tokens).

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -1,12 +1,20 @@
 import { createPortal } from 'react-dom';
 import { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { api, type ArchivedRepo, type RepoInfo, type Lens } from './api';
+import { api, type ArchivedRepo, type RepoInfo, type Lens, type LensRead } from './api';
 import { CreateRepoForm } from './CreateRepoForm';
 import { CreateLensForm } from './CreateLensForm';
 import { RemoteStatus } from './RemoteStatus';
 import { RemoteConnectWizard } from './RemoteConnectWizard';
-import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon } from './icons';
+import { LENS, repoHue } from './utils';
+import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon, LayersIcon, PencilIcon, TrashIcon, CopyIcon } from './icons';
+
+// BrowseContext names the surface a Browse action should switch the app to:
+// a whole repo, or a lens's read union. Task 12 consumes this via SET_CONTEXT;
+// here RepoManager only fires it through the onBrowse callback.
+export type BrowseContext =
+  | { kind: 'repo'; repo: string }
+  | { kind: 'lens'; name: string };
 
 interface Props {
   open: boolean;
@@ -16,6 +24,7 @@ interface Props {
   hideRemoteConfig: boolean;
   onClose: () => void;
   onChanged: () => void;             // parent re-fetches the repo list
+  onBrowse: (ctx: BrowseContext) => void;  // switch the app to browse a repo/lens
 }
 
 type Selection =
@@ -26,7 +35,7 @@ type Selection =
   | { kind: 'newLens' }
   | null;
 
-export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConfig, onClose, onChanged }: Props) {
+export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConfig, onClose, onChanged, onBrowse }: Props) {
   const [archived, setArchived] = useState<ArchivedRepo[]>([]);
   const [lenses, setLenses] = useState<Lens[]>([]);
   const [sel, setSel] = useState<Selection>(null);
@@ -69,7 +78,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
     <div style={overlay} role="dialog" aria-label="Repo Manager">
       <div style={panel}>
         <header style={head}>
-          <h2 style={{ margin: 0, fontSize: 18 }}>Repositories</h2>
+          <h2 style={{ margin: 0, fontSize: 18 }}>Manage</h2>
           <button type="button" style={closeBtn} onClick={onClose} aria-label="Close">✕</button>
         </header>
         {err && <div style={errBox}>{err}</div>}
@@ -121,7 +130,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
             ))}
 
             <div style={sectionHeader}>
-              <GitBranchIcon color="#9a8" size={13} />
+              <LayersIcon color={LENS.accent} size={13} />
               <span style={sectionTitle}>Lenses</span>
               <button
                 type="button"
@@ -142,7 +151,10 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 style={listItem(view.kind === 'lens' && view.name === l.name)}
                 onClick={() => setSel({ kind: 'lens', name: l.name })}
               >
-                {l.name}
+                <span style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                  <span style={{ width: 7, height: 7, borderRadius: '50%', background: LENS.accent, flexShrink: 0 }} />
+                  {l.name}
+                </span>
               </button>
             ))}
           </nav>
@@ -159,6 +171,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 onArchived={() => { onChanged(); refresh(); setSel(null); }}
                 onConnect={() => setConnecting(view.name)}
                 onChanged={onChanged}
+                onBrowse={onBrowse}
                 onError={setErr}
               />
             )}
@@ -184,8 +197,11 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 key={view.name}
                 lens={lenses.find(l => l.name === view.name)}
                 name={view.name}
+                repos={repos}
                 readOnly={readOnly}
                 onDeleted={() => { refresh(); setSel(null); }}
+                onSaved={refresh}
+                onBrowse={onBrowse}
                 onError={setErr}
               />
             )}
@@ -206,9 +222,10 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
   );
 }
 
-function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, onConnect, onChanged, onError }: {
+function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, onConnect, onChanged, onBrowse, onError }: {
   name: string; canArchive: boolean; readOnly: boolean; hideRemoteConfig: boolean;
-  onArchived: () => void; onConnect: () => void; onChanged: () => void; onError: (m: string) => void;
+  onArchived: () => void; onConnect: () => void; onChanged: () => void;
+  onBrowse: (ctx: BrowseContext) => void; onError: (m: string) => void;
 }) {
   const [agentBranch, setAgentBranch] = useState('');
   const [description, setDescription] = useState('');
@@ -258,6 +275,9 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
           <h3 style={{ margin: 0, fontSize: 16 }}>{name}</h3>
           <div style={{ fontFamily: 'var(--k-font-mono)', fontSize: 12, color: '#777', marginTop: 2 }}>{agentBranch || '…'}</div>
         </div>
+        <button type="button" data-testid="repo-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'repo', repo: name })}>
+          <BookIcon color={LENS.text} size={13} /> Browse
+        </button>
       </div>
       {description && <RepoDescription markdown={description} />}
       <div style={{ display: 'flex', gap: 8, marginTop: 14, flexWrap: 'wrap' }}>
@@ -400,25 +420,49 @@ function ArchivedDetail({ info, readOnly, activeNames, onRestored, onPurged, onE
 }
 
 // LensDetail shows a lens's write target and its read mounts (with branch
-// pins), plus a delete button. The lens object is passed from the parent's
-// list (already fetched); getLens is used only as a fallback refresh.
-function LensDetail({ lens: initial, name, readOnly, onDeleted, onError }: {
-  lens?: Lens; name: string; readOnly: boolean;
-  onDeleted: () => void; onError: (m: string) => void;
+// pins), a connect snippet, plus edit/delete actions. The lens object is passed
+// from the parent's list (already fetched); getLens refreshes the full detail
+// (e.g. to pull the description, which the list view may omit).
+//
+// The edit-mounts UI is built inline with the same style language as
+// CreateLensForm (checkbox rows, LENS tokens) rather than importing its row
+// component: that form's rows are tightly coupled to its own reads/branchData
+// state, so extraction would force a risky refactor for no shared behavior.
+function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, onBrowse, onError }: {
+  lens?: Lens; name: string; repos: RepoInfo[]; readOnly: boolean;
+  onDeleted: () => void; onSaved: () => void; onBrowse: (ctx: BrowseContext) => void; onError: (m: string) => void;
 }) {
   const [lens, setLens] = useState<Lens | undefined>(initial);
+  const [writeBranch, setWriteBranch] = useState('');
   const [busy, setBusy] = useState(false);
   const [confirming, setConfirming] = useState(false);
+  const [copied, setCopied] = useState(false);
+  // Edit mode: reads maps a mounted read repo → its branch pin ('' = default).
+  // The write repo is never a key (it is read implicitly). null = not editing.
+  const [editReads, setEditReads] = useState<Record<string, string> | null>(null);
+  const [branchNames, setBranchNames] = useState<Record<string, string[]>>({});
 
   useEffect(() => {
     setLens(initial);
-    // Fetch full detail if the list entry was thin (e.g. reads missing).
-    if (!initial || !initial.reads) {
-      let cancelled = false;
-      api.getLens(name).then(l => { if (!cancelled) setLens(l); }).catch(() => {});
-      return () => { cancelled = true; };
-    }
+    setEditReads(null);
+    // Always refresh the full detail — the list view can omit the description,
+    // and getLens returns the canonical reads set.
+    let cancelled = false;
+    api.getLens(name).then(l => { if (!cancelled) setLens(l); }).catch(() => {});
+    return () => { cancelled = true; };
   }, [name, initial]);
+
+  const write = lens?.write ?? '';
+  const reads = lens?.reads ?? [];
+
+  // The write repo's default branch drives the write-target chip and the
+  // write row's fallback label when no explicit pin is set.
+  useEffect(() => {
+    if (!write) return;
+    let cancelled = false;
+    api.getAgentBranch(write).then(b => { if (!cancelled) setWriteBranch(b); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [write]);
 
   const del = async () => {
     onError(''); setBusy(true);
@@ -427,38 +471,183 @@ function LensDetail({ lens: initial, name, readOnly, onDeleted, onError }: {
     finally { setBusy(false); setConfirming(false); }
   };
 
-  const reads = lens?.reads ?? [];
+  const copyInit = async () => {
+    try {
+      await navigator.clipboard.writeText(`knomit init --lens ${name}`);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch { /* clipboard unavailable — nothing to recover */ }
+  };
+
+  // ── edit mode ──
+  const loadBranches = (repo: string) => {
+    if (branchNames[repo]) return;
+    api.listBranchNames(repo).then(names => setBranchNames(prev => ({ ...prev, [repo]: names }))).catch(() => {});
+  };
+  const beginEdit = () => {
+    // Seed from the current reads, dropping the write repo (read implicitly).
+    const seed: Record<string, string> = {};
+    for (const r of reads) if (r.repo !== write) seed[r.repo] = r.branch ?? '';
+    setEditReads(seed);
+  };
+  const toggleRead = (repo: string) => {
+    setEditReads(prev => {
+      if (!prev) return prev;
+      const next = { ...prev };
+      if (repo in next) delete next[repo];
+      else { next[repo] = ''; loadBranches(repo); }
+      return next;
+    });
+  };
+  const setBranch = (repo: string, branch: string) => {
+    setEditReads(prev => (prev ? { ...prev, [repo]: branch } : prev));
+  };
+  const save = async () => {
+    if (!editReads) return;
+    onError(''); setBusy(true);
+    const readList: LensRead[] = Object.entries(editReads)
+      .filter(([repo]) => repo !== write)
+      .map(([repo, branch]) => branch.trim() ? { repo, branch: branch.trim() } : { repo });
+    try {
+      const updated = await api.updateLens(name, { reads: readList });
+      setLens(updated);
+      setEditReads(null);
+      onSaved();
+    } catch (e) { onError(`save failed: ${String(e)}`); }
+    finally { setBusy(false); }
+  };
 
   return (
     <div>
       <div style={detailHead}>
-        <div>
-          <h3 style={{ margin: 0, fontSize: 16 }}>{name}</h3>
-          <div style={{ fontSize: 12, color: '#777', marginTop: 2 }}>lens</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={lensIconBox}><LayersIcon color={LENS.accent} size={16} /></span>
+          <div>
+            <h3 style={{ margin: 0, fontSize: 16 }}>{name}</h3>
+            <div style={{ fontSize: 12, color: '#777', marginTop: 1 }}>
+              lens · {reads.length} mount{reads.length === 1 ? '' : 's'} · writes to {write || '…'}
+            </div>
+          </div>
+        </div>
+        <button type="button" data-testid="lens-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'lens', name })}>
+          <LayersIcon color={LENS.text} size={13} /> Browse
+        </button>
+      </div>
+
+      {/* Write target — the one repo new facts land in. */}
+      <div style={{ ...descBox, background: '#1a2a1a', borderColor: '#2a4a2a' }}>
+        <div style={{ ...descLabel, color: '#6a9a6a' }}>Write target</div>
+        <div data-testid="lens-detail-write" style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, flexWrap: 'wrap' }}>
+          <RepoDot repo={write} />
+          <b style={{ color: '#eee' }}>{write || '…'}</b>
+          <BranchChip branch={reads.find(r => r.repo === write)?.branch || writeBranch || 'agent branch'} />
+          <span style={{ color: '#777', fontSize: 12 }}>— all new facts land here</span>
         </div>
       </div>
 
+      {/* Read mounts — the resolved union, in server order. The write repo shows
+          here (tagged write · read), never as a separate line. */}
       <div style={descBox}>
-        <div style={descLabel}>Write</div>
-        <div data-testid="lens-detail-write" style={{ color: '#bbb', fontSize: 13 }}>{lens?.write ?? '…'}</div>
-      </div>
-
-      <div style={descBox}>
-        <div style={descLabel}>Reads</div>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div style={descLabel}>Read mounts (union)</div>
+          <span style={{ fontSize: 11, color: '#777' }}>resolved top → bottom</span>
+        </div>
         {reads.length === 0 && <div style={{ color: '#555', fontSize: 13 }}>None</div>}
-        {reads.map((r, i) => (
-          <div key={`${r.repo}-${i}`} data-testid={`lens-detail-read-${r.repo}`} style={{ color: '#bbb', fontSize: 13, marginTop: i ? 4 : 0 }}>
-            {r.repo}
-            {r.branch && <span style={{ fontFamily: 'var(--k-font-mono)', color: '#888' }}> · {r.branch}</span>}
-            {r.source && <span style={{ color: '#888' }}> ({r.source})</span>}
-          </div>
-        ))}
+        {reads.map((r, i) => {
+          const isWrite = r.repo === write;
+          return (
+            <div key={`${r.repo}-${i}`} data-testid={`lens-detail-read-${r.repo}`}
+              style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '8px 2px', borderBottom: i === reads.length - 1 ? 'none' : '1px solid #242424' }}>
+              <RepoDot repo={r.repo} />
+              <span style={{ fontSize: 13, color: '#eee', minWidth: 70 }}>{r.repo}</span>
+              <BranchChip branch={r.branch || (isWrite ? writeBranch : '') || 'agent branch'} />
+              <div style={{ flex: 1 }} />
+              {isWrite
+                ? <span style={writeReadTag}>write · read</span>
+                : <span style={readTag}>read</span>}
+            </div>
+          );
+        })}
       </div>
 
-      {!confirming && (
+      {/* Connect an agent — the init command + MCP endpoint. */}
+      <div style={descBox}>
+        <div style={descLabel}>Connect an agent</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, background: '#0c0c0c', border: '1px solid #222', borderRadius: 5, padding: '7px 10px' }}>
+          <code style={{ fontFamily: 'var(--k-font-mono)', fontSize: 12, color: '#7c9', flex: 1 }}>knomit init --lens {name}</code>
+          <button type="button" data-testid="lens-copy" title="Copy" aria-label="Copy init command" style={copyBtn} onClick={copyInit}>
+            <CopyIcon color={copied ? '#7c9' : '#888'} size={13} />
+          </button>
+        </div>
+        <div style={{ fontSize: 12, color: '#666', marginTop: 6 }}>
+          MCP endpoint <code style={{ fontFamily: 'var(--k-font-mono)', color: '#aaa' }}>/api/v1/lenses/{name}/mcp</code>
+        </div>
+      </div>
+
+      {lens?.description && (
+        <div data-testid="lens-description" style={descBox}>
+          <div style={descLabel}>Description</div>
+          <div style={{ color: '#bbb', fontSize: 13, lineHeight: 1.6 }}>
+            <ReactMarkdown>{lens.description}</ReactMarkdown>
+          </div>
+        </div>
+      )}
+
+      {/* Edit mode: toggle read mounts and pin branches, reusing the lens form's
+          checkbox-row language. The write repo is a locked, always-on row. */}
+      {editReads && (
+        <div style={{ ...descBox, borderColor: LENS.border }}>
+          <div style={descLabel}>Edit read mounts</div>
+          {write && (
+            <div style={editRow(true)}>
+              <span style={editCheckbox(true)}><CheckMark color={LENS.text} /></span>
+              <RepoDot repo={write} />
+              <span style={{ fontSize: 13, color: '#eee', minWidth: 76 }}>{write}</span>
+              <span style={writeReadTag}>write · always read</span>
+            </div>
+          )}
+          {repos.filter(r => r.name !== write).map(r => {
+            const on = r.name in editReads;
+            const others = (branchNames[r.name] ?? []).filter(n => n !== writeBranch);
+            return (
+              <div key={r.name} style={editRow(on)}>
+                <button type="button" data-testid={`lens-read-${r.name}`} style={editCheckbox(on)} disabled={busy}
+                  onClick={() => toggleRead(r.name)} aria-label={r.name} aria-pressed={on}>
+                  {on && <CheckMark color={LENS.text} />}
+                </button>
+                <RepoDot repo={r.name} />
+                <span style={{ fontSize: 13, color: on ? '#eee' : '#aaa', minWidth: 76 }}>{r.name}</span>
+                <div style={{ flex: 1 }} />
+                {on && (
+                  <select data-testid={`lens-branch-${r.name}`}
+                    style={{ background: '#111', border: '1px solid #333', color: '#eee', padding: '5px 7px', borderRadius: 4, fontSize: 12, maxWidth: 200 }}
+                    value={editReads[r.name]} disabled={busy} onChange={e => setBranch(r.name, e.target.value)}>
+                    <option value="">agent branch (default)</option>
+                    {others.map(n => <option key={n} value={n}>{n}</option>)}
+                  </select>
+                )}
+              </div>
+            );
+          })}
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            <button type="button" data-testid="lens-edit-save" style={btn(busy, 'primary')} disabled={busy} onClick={save}>
+              {busy ? 'Saving…' : 'Save mounts'}
+            </button>
+            <button type="button" data-testid="lens-edit-cancel" style={btn(busy)} disabled={busy} onClick={() => setEditReads(null)}>Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {!confirming && !editReads && (
         <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
-          <button type="button" data-testid="lens-delete" style={btn(readOnly || busy, 'danger')} disabled={readOnly || busy}
-            onClick={() => setConfirming(true)}>🗑 Delete lens</button>
+          <button type="button" data-testid="lens-edit" style={{ ...btn(readOnly || busy), display: 'flex', alignItems: 'center', gap: 6 }}
+            disabled={readOnly || busy} onClick={beginEdit}>
+            <PencilIcon color={readOnly || busy ? '#666' : '#bbb'} size={13} /> Edit mounts
+          </button>
+          <button type="button" data-testid="lens-delete" style={{ ...btn(readOnly || busy, 'danger'), display: 'flex', alignItems: 'center', gap: 6 }}
+            disabled={readOnly || busy} onClick={() => setConfirming(true)}>
+            <TrashIcon color={readOnly || busy ? '#666' : '#f88'} size={13} /> Delete
+          </button>
         </div>
       )}
       {confirming && (
@@ -473,6 +662,26 @@ function LensDetail({ lens: initial, name, readOnly, onDeleted, onError }: {
     </div>
   );
 }
+
+// RepoDot is the deterministic per-repo hue swatch (mirrors CreateLensForm's Dot).
+const RepoDot = ({ repo }: { repo: string }) => (
+  <span style={{ width: 8, height: 8, borderRadius: '50%', background: repoHue(repo || '?'), flexShrink: 0 }} />
+);
+
+// BranchChip renders a blue git-branch chip with a mono branch label.
+const BranchChip = ({ branch }: { branch: string }) => (
+  <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11.5, color: '#8af' }}>
+    <GitBranchIcon color="#8af" size={11} />
+    <span style={{ fontFamily: 'var(--k-font-mono)' }}>{branch}</span>
+  </span>
+);
+
+// CheckMark is the small inline check glyph for a filled edit checkbox.
+const CheckMark = ({ color }: { color: string }) => (
+  <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
 
 // ── styles ──
 const overlay: React.CSSProperties = { position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', zIndex: 1000, display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 24 };
@@ -509,3 +718,30 @@ const descFade: React.CSSProperties = { position: 'absolute', left: 0, right: 0,
 const descToggle: React.CSSProperties = { marginTop: 8, background: 'none', border: 'none', color: '#8af', fontSize: 12, cursor: 'pointer', padding: 0 };
 const confirmBox: React.CSSProperties = { marginTop: 16, padding: 14, background: '#111', border: '1px solid #333', borderRadius: 6 };
 const confirmInput: React.CSSProperties = { width: '100%', boxSizing: 'border-box', background: '#0c0c0c', border: '1px solid #333', color: '#eee', padding: '6px 8px', borderRadius: 4, fontSize: 13 };
+
+// browseBtn is the lens-accent "Browse" pill, shared by the lens and repo detail
+// panes (design handoff: LENS.accent fill, LENS.text text, 13px/600, radius 5).
+const browseBtn: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0,
+  background: LENS.accent, color: LENS.text, border: 'none', borderRadius: 5,
+  padding: '7px 12px', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+};
+const lensIconBox: React.CSSProperties = {
+  width: 30, height: 30, borderRadius: 7, flexShrink: 0,
+  background: LENS.bg, border: '1px solid ' + LENS.border,
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+};
+const copyBtn: React.CSSProperties = { background: 'none', border: 'none', padding: 2, cursor: 'pointer', display: 'flex', alignItems: 'center' };
+const writeReadTag: React.CSSProperties = { fontSize: 10, color: '#7c9', background: '#1a2e1a', border: '1px solid #2a4a2a', padding: '1px 7px', borderRadius: 3, letterSpacing: '0.03em' };
+const readTag: React.CSSProperties = { fontSize: 10, color: '#777', border: '1px solid #333', padding: '1px 7px', borderRadius: 3, letterSpacing: '0.03em' };
+// editRow / editCheckbox mirror CreateLensForm's row/checkbox (LENS tokens).
+const editRow = (on: boolean): React.CSSProperties => ({
+  display: 'flex', alignItems: 'center', gap: 10, padding: '8px 10px', borderRadius: 6, marginBottom: 4,
+  background: on ? LENS.soft : '#0f0f0f', border: '1px solid ' + (on ? LENS.border : '#242424'),
+});
+const editCheckbox = (on: boolean): React.CSSProperties => ({
+  width: 16, height: 16, borderRadius: 4, flexShrink: 0, padding: 0,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  background: on ? LENS.accent : 'transparent', border: '1.5px solid ' + (on ? LENS.accent : '#444'),
+  cursor: 'pointer',
+});

--- a/web/src/RightPanel.lens.test.tsx
+++ b/web/src/RightPanel.lens.test.tsx
@@ -119,7 +119,10 @@ describe('RightPanel — lens fact view', () => {
   });
 
   it('renders a write-repo fact read-only when off-live (history) — existing invariant', async () => {
-    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact());
+    // Off-live in a lens context now reads the anchored version through the
+    // mount's repo-scoped commit endpoint (C1), not getLensFact — factSource is
+    // already set, so no re-dispatch is needed.
+    (api.fact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact());
     render(<RightPanel state={lensState(WRITE_PATH, writeSource, { mode: 'history', commit: 'b812d40' })} dispatch={vi.fn()} />);
     const btn = await screen.findByTestId('retract-btn');
     expect(btn).toBeDisabled();
@@ -208,5 +211,31 @@ describe('RightPanel — lens fact view', () => {
     render(<RightPanel state={lensState(WRITE_PATH, writeSource)} dispatch={vi.fn()} />);
     await screen.findByTestId('fact-title');
     await waitFor(() => expect(api.factCommits).toHaveBeenCalledWith('core', 'agent/main', WRITE_PATH));
+  });
+
+  // C1: an anchored lens read (scrub/diff entered from an open fact) must fetch
+  // the VERSION at the anchor through the mount's repo-scoped commit endpoint —
+  // getLensFact ignores the anchor and always returns live, which showed the live
+  // body under an off-live UI and mis-fired the retracted badge.
+  it('reads an anchored (scrubbed) read-mount fact via the mount commit endpoint, not getLensFact (C1)', async () => {
+    (api.fact as ReturnType<typeof vi.fn>).mockResolvedValue(readFact({ commit_hash: 'ccc3333' }));
+    const dispatch = vi.fn();
+    render(<RightPanel state={lensState(READ_PATH, readSource, { mode: 'history', commit: 'ccc3333' })} dispatch={dispatch} />);
+    await screen.findByTestId('fact-title');
+    // History mode opts into ?fallback=before, anchored on the mount + relative path.
+    expect(api.fact).toHaveBeenCalledWith('docs', 'main', 'kb/api/auth.md', 'ccc3333', { fallback: 'before' });
+    expect(api.getLensFact).not.toHaveBeenCalled();
+    // factSource is already set (same fact/mount) — the anchored path never re-dispatches it.
+    expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'SET_FACT_SOURCE' }));
+  });
+
+  it('shows no retracted badge when scrubbing to a live version of a lens fact (C1 regression)', async () => {
+    // The anchored read returns the version AT the scrub commit, so commit_hash
+    // matches the anchor → no spurious "retracted at" badge (the old always-live
+    // getLensFact read returned a mismatched commit_hash and mis-fired it).
+    (api.fact as ReturnType<typeof vi.fn>).mockResolvedValue(readFact({ commit_hash: 'ccc3333' }));
+    render(<RightPanel state={lensState(READ_PATH, readSource, { mode: 'history', commit: 'ccc3333' })} dispatch={vi.fn()} />);
+    await screen.findByTestId('fact-title');
+    await waitFor(() => expect(screen.queryByTestId('retracted-version-badge')).toBeNull());
   });
 });

--- a/web/src/RightPanel.lens.test.tsx
+++ b/web/src/RightPanel.lens.test.tsx
@@ -1,0 +1,161 @@
+// Tests for RightPanel in a LENS context (Task 16): the open fact is fetched
+// through the lens (getLensFact, RAW canonical path), the meta line prefixes a
+// source-repo badge + its branch, and edit/retract controls are enabled ONLY
+// for facts that live in the lens's WRITE repo — read-mount facts render
+// read-only. Writes route through the repo-scoped api targeting the write repo
+// and its agent branch. A failed fetch surfaces the error and never leaves a
+// stale factSource paired with the new factPath (the m30 regression).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { RightPanel } from './RightPanel';
+import { init, READ_ONLY_TITLE } from './state';
+import type { AppState, AsOf } from './state';
+import type { Lens, LensSource } from './api';
+
+vi.mock('./api', () => ({
+  api: {
+    fact: vi.fn(),               // must NOT be called in lens context
+    getLensFact: vi.fn(),
+    updateFact: vi.fn().mockResolvedValue({ path: 'kb/ops/rollback.md', title: 'x', body: 'x', domain: [], entities: [], refs: [], confidence: 1, sources: 1 }),
+    retractFact: vi.fn().mockResolvedValue(undefined),
+    factDiff: vi.fn().mockResolvedValue({ from: null, to: null }),
+    stats: vi.fn().mockResolvedValue(null),
+    activity: vi.fn().mockResolvedValue(null),
+    commitDetail: vi.fn().mockResolvedValue(null),
+    factCommits: vi.fn().mockResolvedValue({ entries: [] }),
+  },
+}));
+
+import { api } from './api';
+
+const lens: Lens = {
+  name: 'eng',
+  write: 'core',
+  reads: [{ repo: 'core' }, { repo: 'docs' }],
+};
+
+const WRITE_PATH = 'kb/ops/rollback.md';
+const READ_PATH = 'kb://docsid123456/kb/api/auth.md';
+
+const writeSource: LensSource = { repo: 'core', id: 'coreid123456', branch: 'agent/main' };
+const readSource: LensSource = { repo: 'docs', id: 'docsid123456', branch: 'main' };
+
+function writeFact(extra: Record<string, unknown> = {}) {
+  return {
+    path: WRITE_PATH, title: 'Rollback runbook', body: 'body', type: 'process',
+    confidence: 0.9, sources: 1, domain: [], entities: [], refs: [],
+    commit_hash: 'aaa1111', commit_date: '2026-05-01T00:00:00Z',
+    source: writeSource, ...extra,
+  };
+}
+
+function readFact(extra: Record<string, unknown> = {}) {
+  return {
+    path: READ_PATH, title: 'Auth flow', body: 'body', type: 'concept',
+    confidence: 0.9, sources: 1, domain: [], entities: [], refs: [],
+    commit_hash: 'bbb2222', commit_date: '2026-05-01T00:00:00Z',
+    source: readSource, ...extra,
+  };
+}
+
+function lensState(factPath: string, factSource: LensSource | null, asOf: AsOf = { mode: 'live' }, overrides: Partial<AppState> = {}): AppState {
+  return {
+    ...init,
+    repo: 'core',
+    branch: 'agent/main',
+    headCommit: 'aaaaaaa',
+    context: { kind: 'lens', name: 'eng' },
+    lens,
+    factPath,
+    factSource,
+    asOf,
+    ...overrides,
+  };
+}
+
+describe('RightPanel — lens fact view', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('fetches the open fact through the lens with the RAW canonical path (never api.fact)', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(readFact());
+    render(<RightPanel state={lensState(READ_PATH, readSource)} dispatch={vi.fn()} />);
+    await screen.findByTestId('fact-title');
+    expect(api.getLensFact).toHaveBeenCalledWith('eng', READ_PATH);
+    expect(api.fact).not.toHaveBeenCalled();
+  });
+
+  it('renders the source badge + branch chip on the meta line and strips the kb://<id12>/ qualifier', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(readFact());
+    const { container } = render(<RightPanel state={lensState(READ_PATH, readSource)} dispatch={vi.fn()} />);
+    await screen.findByTestId('fact-title');
+    const badge = screen.getByTestId('source-badge');
+    expect(badge.getAttribute('data-repo')).toBe('docs');
+    expect(badge.textContent).toContain('docs');
+    // Branch chip carries the mount's read branch.
+    expect(container.textContent).toContain('main');
+    // Displayed path is stripped of the opaque mount id.
+    expect(container.textContent).toContain('kb/api/auth.md');
+    expect(container.textContent).not.toContain('docsid123456');
+    expect(container.textContent).not.toContain('kb://');
+  });
+
+  it('renders a read-mount fact read-only: retract disabled with a lens-specific title', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(readFact());
+    render(<RightPanel state={lensState(READ_PATH, readSource)} dispatch={vi.fn()} />);
+    const btn = await screen.findByTestId('retract-btn');
+    expect(btn).toBeDisabled();
+    expect(btn.getAttribute('title')).toMatch(/read-only mount|edits go to core/i);
+  });
+
+  it('enables retract for a write-repo fact when live', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact());
+    render(<RightPanel state={lensState(WRITE_PATH, writeSource)} dispatch={vi.fn()} />);
+    const btn = await screen.findByTestId('retract-btn');
+    expect(btn).not.toBeDisabled();
+    expect(btn.getAttribute('title')).toBe('Retract fact');
+    expect(screen.getByTestId('source-badge').getAttribute('data-repo')).toBe('core');
+  });
+
+  it('renders a write-repo fact read-only when off-live (history) — existing invariant', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact());
+    render(<RightPanel state={lensState(WRITE_PATH, writeSource, { mode: 'history', commit: 'b812d40' })} dispatch={vi.fn()} />);
+    const btn = await screen.findByTestId('retract-btn');
+    expect(btn).toBeDisabled();
+    expect(btn.getAttribute('title')).toBe(READ_ONLY_TITLE);
+  });
+
+  it('routes an edit of a write-repo fact to the repo endpoint with the write repo + agent branch', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact({ parse_error: 'bad frontmatter' }));
+    render(<RightPanel state={lensState(WRITE_PATH, writeSource)} dispatch={vi.fn()} />);
+    const editor = await screen.findByTestId('fact-editor');
+    fireEvent.change(editor, { target: { value: 'edited content' } });
+    fireEvent.click(screen.getByTestId('fact-save-btn'));
+    await waitFor(() => expect(api.updateFact).toHaveBeenCalledWith('core', 'agent/main', WRITE_PATH, 'edited content'));
+  });
+
+  it('routes a retract of a write-repo fact to the repo endpoint with the write repo + agent branch', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact());
+    render(<RightPanel state={lensState(WRITE_PATH, writeSource)} dispatch={vi.fn()} />);
+    const btn = await screen.findByTestId('retract-btn');
+    fireEvent.click(btn);
+    fireEvent.click(await screen.findByTestId('retract-confirm-btn'));
+    await waitFor(() => expect(api.retractFact).toHaveBeenCalledWith('core', 'agent/main', WRITE_PATH));
+  });
+
+  it('surfaces a failed lens fetch and clears factSource so no stale source pairs with the new fact (m30)', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom 404'));
+    const dispatch = vi.fn();
+    render(<RightPanel state={lensState(READ_PATH, readSource)} dispatch={dispatch} />);
+    await waitFor(() => expect(screen.getByText(/boom 404/)).toBeTruthy());
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_FACT_SOURCE', source: null });
+  });
+
+  it('re-dispatches SET_FACT_SOURCE from its own fetch response (coherent with the row-click open)', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(readFact());
+    const dispatch = vi.fn();
+    render(<RightPanel state={lensState(READ_PATH, readSource)} dispatch={dispatch} />);
+    await screen.findByTestId('fact-title');
+    await waitFor(() => expect(dispatch).toHaveBeenCalledWith({ type: 'SET_FACT_SOURCE', source: readSource }));
+  });
+});

--- a/web/src/RightPanel.lens.test.tsx
+++ b/web/src/RightPanel.lens.test.tsx
@@ -17,6 +17,7 @@ vi.mock('./api', () => ({
   api: {
     fact: vi.fn(),               // must NOT be called in lens context
     getLensFact: vi.fn(),
+    getAgentBranch: vi.fn().mockResolvedValue('agent/main'),
     updateFact: vi.fn().mockResolvedValue({ path: 'kb/ops/rollback.md', title: 'x', body: 'x', domain: [], entities: [], refs: [], confidence: 1, sources: 1 }),
     retractFact: vi.fn().mockResolvedValue(undefined),
     factDiff: vi.fn().mockResolvedValue({ from: null, to: null }),
@@ -141,6 +142,36 @@ describe('RightPanel — lens fact view', () => {
     fireEvent.click(btn);
     fireEvent.click(await screen.findByTestId('retract-confirm-btn'));
     await waitFor(() => expect(api.retractFact).toHaveBeenCalledWith('core', 'agent/main', WRITE_PATH));
+  });
+
+  it('routes writes to the write repo AGENT branch, not the write mount read branch, when they diverge', async () => {
+    // The lens pins its write repo's READ mount to 'main' (a non-agent branch):
+    // factSource.branch === 'main'. state.branch is also 'main' here. Writes must
+    // still land on the write repo's AGENT branch, resolved via getAgentBranch —
+    // the only WritableBranch — never on the pinned read-mount branch.
+    const pinnedSource: LensSource = { repo: 'core', id: 'coreid123456', branch: 'main' };
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact({ source: pinnedSource }));
+    (api.getAgentBranch as ReturnType<typeof vi.fn>).mockResolvedValue('agent/main');
+    render(<RightPanel state={lensState(WRITE_PATH, pinnedSource, { mode: 'live' }, { branch: 'main' })} dispatch={vi.fn()} />);
+    const btn = await screen.findByTestId('retract-btn');
+    fireEvent.click(btn);
+    fireEvent.click(await screen.findByTestId('retract-confirm-btn'));
+    await waitFor(() => expect(api.retractFact).toHaveBeenCalledWith('core', 'agent/main', WRITE_PATH));
+    expect(api.getAgentBranch).toHaveBeenCalledWith('core');
+    // Never routed to the pinned read-mount branch.
+    expect(api.retractFact).not.toHaveBeenCalledWith('core', 'main', WRITE_PATH);
+  });
+
+  it('routes an EDIT to the write repo AGENT branch when the write mount read branch diverges', async () => {
+    const pinnedSource: LensSource = { repo: 'core', id: 'coreid123456', branch: 'main' };
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact({ source: pinnedSource, parse_error: 'bad frontmatter' }));
+    (api.getAgentBranch as ReturnType<typeof vi.fn>).mockResolvedValue('agent/main');
+    render(<RightPanel state={lensState(WRITE_PATH, pinnedSource, { mode: 'live' }, { branch: 'main' })} dispatch={vi.fn()} />);
+    const editor = await screen.findByTestId('fact-editor');
+    fireEvent.change(editor, { target: { value: 'edited content' } });
+    fireEvent.click(screen.getByTestId('fact-save-btn'));
+    await waitFor(() => expect(api.updateFact).toHaveBeenCalledWith('core', 'agent/main', WRITE_PATH, 'edited content'));
+    expect(api.updateFact).not.toHaveBeenCalledWith('core', 'main', WRITE_PATH, 'edited content');
   });
 
   it('surfaces a failed lens fetch and clears factSource so no stale source pairs with the new fact (m30)', async () => {

--- a/web/src/RightPanel.lens.test.tsx
+++ b/web/src/RightPanel.lens.test.tsx
@@ -189,4 +189,24 @@ describe('RightPanel — lens fact view', () => {
     await screen.findByTestId('fact-title');
     await waitFor(() => expect(dispatch).toHaveBeenCalledWith({ type: 'SET_FACT_SOURCE', source: readSource }));
   });
+
+  // Task 17 (fixes m36): VersionWalker is a HISTORY surface, not a write surface.
+  // It must read the open fact's versions through the fact's SOURCE MOUNT
+  // (openFactSource) with the RELATIVE path — not the write target with the raw
+  // kb:// address, which the mount's repo-scoped /commits endpoint can't resolve.
+  it('reads a read-mount fact history against the MOUNT repo/branch + relative path (m36)', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(readFact());
+    render(<RightPanel state={lensState(READ_PATH, readSource)} dispatch={vi.fn()} />);
+    await screen.findByTestId('fact-title');
+    await waitFor(() => expect(api.factCommits).toHaveBeenCalledWith('docs', 'main', 'kb/api/auth.md'));
+    // Never the write target paired with the raw kb:// path (the m36 no-op).
+    expect(api.factCommits).not.toHaveBeenCalledWith('core', 'agent/main', READ_PATH);
+  });
+
+  it('reads a write-repo fact history against the write mount + bare path', async () => {
+    (api.getLensFact as ReturnType<typeof vi.fn>).mockResolvedValue(writeFact());
+    render(<RightPanel state={lensState(WRITE_PATH, writeSource)} dispatch={vi.fn()} />);
+    await screen.findByTestId('fact-title');
+    await waitFor(() => expect(api.factCommits).toHaveBeenCalledWith('core', 'agent/main', WRITE_PATH));
+  });
 });

--- a/web/src/RightPanel.lensstats.test.tsx
+++ b/web/src/RightPanel.lensstats.test.tsx
@@ -1,0 +1,131 @@
+// Tests for the RightPanel SUMMARY view (no fact open) in lens vs repo
+// context: a lens context fetches ONE union stats call through the lens
+// endpoint (getLensStats) and renders the roll-up header + per-repo rows; a
+// repo context keeps the existing api.stats/api.activity pair and rendering.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { RightPanel } from './RightPanel';
+import { init } from './state';
+import type { AppState } from './state';
+import type { Lens, LensStats } from './api';
+
+vi.mock('./api', () => ({
+  api: {
+    fact: vi.fn(),
+    getLensFact: vi.fn(),
+    getLensStats: vi.fn(),
+    getAgentBranch: vi.fn().mockResolvedValue('agent/main'),
+    stats: vi.fn().mockResolvedValue(null),
+    activity: vi.fn().mockResolvedValue(null),
+    updateFact: vi.fn(),
+    retractFact: vi.fn(),
+    factDiff: vi.fn().mockResolvedValue({ from: null, to: null }),
+    commitDetail: vi.fn().mockResolvedValue(null),
+    factCommits: vi.fn().mockResolvedValue({ entries: [] }),
+  },
+}));
+
+import { api } from './api';
+
+const lens: Lens = { name: 'eng', write: 'core', reads: [{ repo: 'core' }, { repo: 'docs' }] };
+
+const unionStats: LensStats = {
+  total: 250, repo_count: 2, last_commit: '2026-07-20T10:00:00Z', avg_confidence: 0.82,
+  domains: { go: 7, ai: 10 }, entities: { chi: 3 },
+  repos: [
+    { id: 'coreid123456', name: 'core', source: '', branch: 'agent/main', is_write: true,
+      total: 200, avg_confidence: 0.9, domains: { go: 5, ai: 10 }, entities: { chi: 3 },
+      last_commit: '2026-07-19T09:00:00Z', changes_7d: 1, changes_30d: 2, changes_90d: 3 },
+    { id: 'docsid123456', name: 'docs', source: 'src://docs', branch: 'main', is_write: false,
+      total: 50, avg_confidence: 0.5, domains: { go: 2 }, entities: {},
+      last_commit: '2026-07-20T10:00:00Z', changes_7d: 4, changes_30d: 5, changes_90d: 6 },
+  ],
+};
+
+function lensSummaryState(): AppState {
+  return {
+    ...init,
+    repo: 'core',
+    branch: 'agent/main',
+    headCommit: 'aaaaaaa',
+    context: { kind: 'lens', name: 'eng' },
+    lens,
+    factPath: null,
+  };
+}
+
+function repoSummaryState(): AppState {
+  return { ...init, repo: 'core', branch: 'agent/main', headCommit: 'aaaaaaa', factPath: null };
+}
+
+describe('RightPanel — summary view stats routing', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('lens context fetches union stats through the lens endpoint, never the repo pair', async () => {
+    (api.getLensStats as ReturnType<typeof vi.fn>).mockResolvedValue(unionStats);
+    render(<RightPanel state={lensSummaryState()} dispatch={vi.fn()} />);
+    await screen.findByTestId('lens-stats-header');
+    expect(api.getLensStats).toHaveBeenCalledWith('eng', 'kb');
+    expect(api.stats).not.toHaveBeenCalled();
+    expect(api.activity).not.toHaveBeenCalled();
+  });
+
+  it('renders the union header and merged stat boxes', async () => {
+    (api.getLensStats as ReturnType<typeof vi.fn>).mockResolvedValue(unionStats);
+    const { container } = render(<RightPanel state={lensSummaryState()} dispatch={vi.fn()} />);
+    const header = await screen.findByTestId('lens-stats-header');
+    expect(header.textContent).toContain('250 facts');
+    expect(header.textContent).toContain('2 repos');
+    expect(header.textContent).toContain('updated');
+    expect(container.textContent).toContain('0.82'); // weighted union confidence
+  });
+
+  it('renders one row per mount with the write marker on the write repo only', async () => {
+    (api.getLensStats as ReturnType<typeof vi.fn>).mockResolvedValue(unionStats);
+    render(<RightPanel state={lensSummaryState()} dispatch={vi.fn()} />);
+    await screen.findByTestId('lens-stats-header');
+    const rows = screen.getAllByTestId('lens-repo-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute('data-repo')).toBe('core');
+    expect(rows[1].getAttribute('data-repo')).toBe('docs');
+    const markers = screen.getAllByTestId('write-marker');
+    expect(markers).toHaveLength(1);
+    expect(rows[0].contains(markers[0])).toBe(true);
+    expect(rows[1].textContent).toContain('50 facts');
+    expect(rows[1].textContent).toContain('0.50');
+  });
+
+  it('merged histogram tags dispatch ADD_FILTER on click', async () => {
+    (api.getLensStats as ReturnType<typeof vi.fn>).mockResolvedValue(unionStats);
+    const dispatch = vi.fn();
+    render(<RightPanel state={lensSummaryState()} dispatch={dispatch} />);
+    await screen.findByTestId('lens-stats-header');
+    const tag = screen.getAllByTestId('tag-item').find(el => el.getAttribute('data-value') === 'ai')!;
+    fireEvent.click(tag);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'ADD_FILTER', chip: { category: 'domain', value: 'ai' } });
+  });
+
+  it('a failed union fetch surfaces an error, never the false "no facts" empty state', async () => {
+    // The backend fails the WHOLE request on any mount error (RFC §9.1), so a
+    // rejection means "a mount failed", NOT "the lens is empty".
+    (api.getLensStats as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('mount 500'));
+    render(<RightPanel state={lensSummaryState()} dispatch={vi.fn()} />);
+    await screen.findByTestId('lens-stats-error');
+    expect(screen.queryByTestId('lens-stats-header')).toBeNull();
+    expect(screen.queryByText(/no facts indexed/i)).toBeNull();
+  });
+
+  it('repo context keeps the repo stats/activity pair and never calls getLensStats', async () => {
+    (api.stats as ReturnType<typeof vi.fn>).mockResolvedValue(
+      { total: 42, avg_confidence: 0.85, domains: { ai: 10 }, entities: {} });
+    (api.activity as ReturnType<typeof vi.fn>).mockResolvedValue(
+      { last_commit: '2026-07-20T10:00:00Z', total: 9, changes_7d: 1, changes_30d: 2, changes_90d: 3 });
+    render(<RightPanel state={repoSummaryState()} dispatch={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('stats-view').textContent).toContain('42 facts'));
+    expect(api.stats).toHaveBeenCalledWith('core', 'agent/main', 'kb');
+    expect(api.activity).toHaveBeenCalledWith('core', 'agent/main', 'kb');
+    expect(api.getLensStats).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('lens-stats-header')).toBeNull();
+  });
+});

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -4,7 +4,7 @@ import { useAsync } from './hooks';
 import { api } from './api';
 import type { Fact, Stats, ActivityStats } from './api';
 import type { AppState, Action } from './state';
-import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, openFactSource } from './state';
+import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, factHistoryAnchor } from './state';
 import { relativeTime, displayLensPath, repoHue, repoHueBg, repoHueBorder } from './utils';
 import { RetractIcon, GitBranchIcon } from './icons';
 import { FactDiffView } from './FactDiffView';
@@ -41,12 +41,11 @@ function LensMeta({ repo, branch }: { repo: string; branch: string }) {
 
 function renderFact(
   fact: Fact,
-  // The fact's HISTORY source: its own source mount (openFactSource) + the
+  // The fact's HISTORY anchor (factHistoryAnchor): its own source mount + the
   // RELATIVE path. VersionWalker reads versions through the mount's repo-scoped
   // /commits endpoint, so it must NOT use the write target or the raw kb:// path
   // (that pairing was the m36 no-op on read-mount facts).
-  histRepo: string,
-  histBranch: string,
+  histAnchor: { repo: string; branch: string; path: string },
   dispatch: Dispatch<Action>,
   onRetract?: () => void,
   onScrub?: (commit: string) => void,
@@ -83,9 +82,9 @@ function renderFact(
             )}
             {fact.commit_hash && (
               <VersionWalker
-                repo={histRepo}
-                branch={histBranch}
-                factPath={displayLensPath(fact.path)}
+                repo={histAnchor.repo}
+                branch={histAnchor.branch}
+                factPath={histAnchor.path}
                 currentCommit={fact.commit_hash}
                 onScrub={onScrub ?? (() => {})}
               />
@@ -350,11 +349,6 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
   const writeTarget = (lensCtx && lensWrite)
     ? { repo: lensWrite, branch: writeBranch ?? state.branch }
     : { repo: state.repo, branch: state.branch };
-  // The HISTORY read anchor for the open fact (VersionWalker): its own source
-  // mount. Distinct from writeTarget — history reads route to where the fact
-  // LIVES (any read mount), writes to the lens's write repo. Repo context:
-  // both collapse to {state.repo, state.branch}.
-  const histSource = openFactSource(state);
   // A lens fact is writable only when it lives in the lens's WRITE repo; read-mount
   // facts render fully read-only. Repo context keeps its prior gate (isReadOnly).
   const isWriteFact = !lensCtx || state.factSource?.repo === lensWrite;
@@ -469,10 +463,9 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
       <div style={{ flex: 1, overflow: 'auto' }}>
         {renderFact(
           fact,
-          // History anchor (VersionWalker) — the fact's own source mount, NOT the
-          // write target. In a repo context this equals {state.repo, state.branch}.
-          histSource.repo,
-          histSource.branch,
+          // History anchor (VersionWalker) — the fact's own source mount + relative
+          // path, NOT the write target. Repo context: {state.repo, state.branch, path}.
+          factHistoryAnchor(state, fact.path),
           dispatch,
           () => { if (!readOnly) setConfirmRetract(true); },
           onScrub,

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 import type { Dispatch } from 'react';
 import { useAsync } from './hooks';
 import { api } from './api';
-import type { Fact, Stats, ActivityStats } from './api';
+import type { Fact, Stats, ActivityStats, LensStats, LensRepoStats } from './api';
 import type { AppState, Action } from './state';
-import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, factHistoryAnchor } from './state';
+import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, factHistoryAnchor, factTitleKey } from './state';
 import { relativeTime, displayLensPath, repoHue, repoHueBg, repoHueBorder } from './utils';
 import { RetractIcon, GitBranchIcon } from './icons';
 import { FactDiffView } from './FactDiffView';
@@ -245,6 +245,102 @@ function ConfirmModal({ message, onConfirm, onCancel }: {
   );
 }
 
+// ─── Summary-view components ─────────────────────────────────────────────────
+
+// StatsHistograms renders the top-10 domain + entity tag clouds. One
+// implementation shared by the repo summary and the lens union header, so the
+// two views cannot drift.
+function StatsHistograms({ domains, entities, dispatch }: {
+  domains: Record<string, number>;
+  entities: Record<string, number>;
+  dispatch: Dispatch<Action>;
+}) {
+  const domainEntries = Object.entries(domains).sort((a, b) => b[1] - a[1]).slice(0, 10);
+  const entityEntries = Object.entries(entities).sort((a, b) => b[1] - a[1]).slice(0, 10);
+  return (
+    <>
+      <TagCloud label="Domains" entries={domainEntries} color="119,204,153"
+        onTagClick={d => dispatch({ type: 'ADD_FILTER', chip: { category: 'domain', value: d } })} />
+      <TagCloud label="Entities" entries={entityEntries} color="136,170,255"
+        onTagClick={e => dispatch({ type: 'ADD_FILTER', chip: { category: 'entity', value: e } })} />
+    </>
+  );
+}
+
+// LensRepoRow is one compact per-mount row under the union header: source
+// badge in the repo's deterministic hue (matching Library union rows and
+// LensMeta), a write marker on the lens's write repo, facts count, confidence,
+// 1–2 top domains, and last-commit recency.
+function LensRepoRow({ repo }: { repo: LensRepoStats }) {
+  const c = repoHue(repo.name);
+  const topDomains = Object.entries(repo.domains)
+    .sort((a, b) => b[1] - a[1]).slice(0, 2).map(([d]) => d);
+  return (
+    <div data-testid="lens-repo-row" data-repo={repo.name}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px',
+        background: '#15151f', border: '1px solid #22222f', borderRadius: 6,
+        marginBottom: 8, flexWrap: 'wrap',
+      }}>
+      <span style={{
+        display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 11,
+        color: c, background: repoHueBg(repo.name), border: `1px solid ${repoHueBorder(repo.name)}`,
+        borderRadius: 3, padding: '0 6px', fontFamily: 'var(--k-font-mono)', lineHeight: 1.8,
+      }}>
+        <span style={{ width: 5, height: 5, borderRadius: '50%', background: c }} />
+        {repo.name}
+      </span>
+      {repo.is_write && (
+        <span data-testid="write-marker" title="Lens write repo"
+          style={{ fontSize: 10, color: '#7c9', border: '1px solid rgba(119,204,153,0.35)', borderRadius: 3, padding: '0 5px', lineHeight: 1.8 }}>
+          write
+        </span>
+      )}
+      <span style={{ fontSize: 11, color: '#999' }}>{repo.total} facts</span>
+      <span style={{ fontSize: 11, color: '#8af' }}>conf {repo.avg_confidence.toFixed(2)}</span>
+      {topDomains.length > 0 && (
+        <span style={{ fontSize: 11, color: '#7c9' }}>{topDomains.join(' · ')}</span>
+      )}
+      <span style={{ marginLeft: 'auto', fontSize: 11, color: '#555' }}
+        title={repo.last_commit ? new Date(repo.last_commit).toLocaleString() : undefined}>
+        {repo.last_commit ? relativeTime(repo.last_commit) : '—'}
+      </span>
+    </div>
+  );
+}
+
+// LensStatsView is the lens-context summary: a union roll-up header (exact
+// sums, total-weighted confidence, max last_commit — computed server-side by
+// GET /lenses/{lens}/stats) over the merged histograms, then one compact row
+// per mount.
+function LensStatsView({ stats, dispatch }: { stats: LensStats; dispatch: Dispatch<Action> }) {
+  const domainCount = Object.keys(stats.domains).length;
+  const entityCount = Object.keys(stats.entities).length;
+  return (
+    <>
+      <div data-testid="lens-stats-header"
+        style={{ fontSize: 12, color: '#555', marginBottom: 20, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span>{stats.total} facts {'·'} {stats.repo_count} repos</span>
+        {stats.last_commit && (
+          <span title={new Date(stats.last_commit).toLocaleString()} style={{ color: '#555', fontSize: 11 }}>
+            updated {relativeTime(stats.last_commit)}
+          </span>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: 10, marginBottom: 28, flexWrap: 'wrap' }}>
+        <StatBox label="Facts"      value={stats.total}                     color="#7c9" />
+        <StatBox label="Confidence" value={stats.avg_confidence.toFixed(2)} color="#8af" />
+        <StatBox label="Domains"    value={domainCount}                     color="#fa8" />
+        <StatBox label="Entities"   value={entityCount}                     color="#8af" />
+        <StatBox label="Repos"      value={stats.repo_count}                color="#555" />
+      </div>
+      <StatsHistograms domains={stats.domains} entities={stats.entities} dispatch={dispatch} />
+      <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: 1.5, color: '#555', margin: '4px 0 10px' }}>Repos</div>
+      {stats.repos.map(r => <LensRepoRow key={r.id || r.name} repo={r} />)}
+    </>
+  );
+}
+
 // ─── Main RightPanel ─────────────────────────────────────────────────────────
 
 export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
@@ -256,6 +352,8 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
   const [fact, setFact] = useState<Fact | null>(null);
   const [stats, setStats] = useState<Stats | null>(null);
   const [activity, setActivity] = useState<ActivityStats | null>(null);
+  const [lensStats, setLensStats] = useState<LensStats | null>(null);
+  const [lensStatsError, setLensStatsError] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [retracting, setRetracting] = useState(false);
   const [confirmRetract, setConfirmRetract] = useState(false);
@@ -278,6 +376,12 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
   const lensCtx = isLensContext(state);
   const lensName = state.lens?.name;
   const lensWrite = state.lens?.write;
+  // Read-set fingerprint: an edit that adds/removes a mount keeps the lens NAME
+  // but changes the reads, so the stats effect must re-fetch on it (a same-name
+  // SET_LENS does not touch state.repo/headCommit).
+  const lensReadSig = state.lens
+    ? state.lens.reads.map(r => `${r.repo}@${r.branch ?? ''}`).join(',')
+    : '';
 
   // Resolve the write repo's AGENT branch for lens writes. The open fact's
   // factSource.branch is the WRITE MOUNT's READ branch (WriteMountBranch) — which
@@ -347,8 +451,35 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
       .catch(e => { if (!stale()) setError(String(e)); });
   }, [factPath, anchorCommit, state.repo, useFallback, inDiff, lensCtx, lensName]);
 
+  // Cache the loaded fact's title so the breadcrumb labels this crumb with the
+  // title we already read — instead of a separate fetch that 404s for a
+  // retracted fact. Keyed identically to the breadcrumb's crumb key.
+  useEffect(() => {
+    if (fact?.title && factPath) {
+      dispatch({ type: 'CACHE_FACT_TITLE', key: factTitleKey(factPath, anchorCommit ?? undefined), title: fact.title });
+    }
+  }, [fact, factPath, anchorCommit, dispatch]);
+
   useAsync((stale) => {
     if (factPath) return;
+    if (lensCtx) {
+      // Lens context: ONE union stats call through the lens endpoint. The
+      // repo-scoped stats/activity pair would describe the WRITE mount only —
+      // silently misleading while browsing a union (design 2026-07-20). Clear
+      // prior state so a lens switch never flashes the old lens's rows, and a
+      // failed fetch (the backend fails the WHOLE request on any mount error —
+      // RFC §9.1) surfaces as an error, NOT a false "no facts" empty state.
+      setLensStats(null);
+      setLensStatsError(false);
+      // Lens named but not yet resolved (state.lens still stale/null): wait for
+      // the resolution effect rather than fetching the wrong lens or falling
+      // through to a pointless repo-scoped fetch.
+      if (!lensName) return;
+      api.getLensStats(lensName, path)
+        .then(s => { if (!stale()) setLensStats(s); })
+        .catch(() => { if (!stale()) setLensStatsError(true); });
+      return;
+    }
     Promise.all([
       api.stats(state.repo, state.branch, path).catch(() => null),
       api.activity(state.repo, state.branch, path).catch(() => null),
@@ -357,7 +488,7 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
       setStats(s);
       setActivity(a);
     });
-  }, [factPath, state.repo, path, state.headCommit]);
+  }, [factPath, state.repo, path, state.headCommit, lensCtx, lensName, lensReadSig]);
 
   // The repo-scoped write target for edits/retracts: {state.repo, state.branch} in
   // a repo context (unchanged); {lens.write, write-agent-branch} in a lens context.
@@ -426,8 +557,19 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
 
   // Summary view: no fact selected
   if (!factPath) {
-    const domainEntries = stats ? Object.entries(stats.domains).sort((a, b) => b[1] - a[1]).slice(0, 10) : [];
-    const entityEntries = stats ? Object.entries(stats.entities).sort((a, b) => b[1] - a[1]).slice(0, 10) : [];
+    if (lensCtx) {
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+          <div data-testid="stats-view" style={{ flex: 1, padding: '24px 28px', overflowY: 'auto', boxSizing: 'border-box' }}>
+            {lensStatsError
+              ? <div data-testid="lens-stats-error" style={{ color: '#f88' }}>Couldn’t load lens stats — a mount failed to respond.</div>
+              : lensStats
+                ? <LensStatsView stats={lensStats} dispatch={dispatch} />
+                : <div style={{ color: '#666' }}>Loading lens stats…</div>}
+          </div>
+        </div>
+      );
+    }
     const domainCount = stats ? Object.keys(stats.domains).length : 0;
     const entityCount = stats ? Object.keys(stats.entities).length : 0;
     const totalCommits = activity ? String(activity.total) : '\u2014';
@@ -452,10 +594,7 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
                 <StatBox label="Entities"   value={entityCount}                        color="#8af" />
                 <StatBox label="Commits"    value={totalCommits}                       color="#555" />
               </div>
-              <TagCloud label="Domains" entries={domainEntries} color="119,204,153"
-                onTagClick={d => dispatch({ type: 'ADD_FILTER', chip: { category: 'domain', value: d } })} />
-              <TagCloud label="Entities" entries={entityEntries} color="136,170,255"
-                onTagClick={e => dispatch({ type: 'ADD_FILTER', chip: { category: 'entity', value: e } })} />
+              <StatsHistograms domains={stats.domains} entities={stats.entities} dispatch={dispatch} />
             </>
           ) : <div style={{ color: '#666' }}>No facts indexed in this path.</div>}
         </div>

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -302,6 +302,25 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
     setError(null);
     setFact(null);
     if (lensCtx && lensName) {
+      // Anchored lens read (C1): a scrub/diff entered from an open fact carries
+      // an anchorCommit drawn from the fact's OWN mount timeline (VersionWalker),
+      // and factSource is already set to that mount. getLensFact ignores the
+      // anchor (always live), which would show the live body while the retracted-
+      // badge/scrub UI thinks it's off-live. Read the anchored version through the
+      // mount's repo-scoped commit endpoint instead — exactly as the repo-context
+      // branch does — via factHistoryAnchor (mount repo/branch + RELATIVE path).
+      // factSource is unchanged (same fact, same mount) so we don't re-dispatch it.
+      if (anchorCommit && state.factSource) {
+        const a = factHistoryAnchor(state);
+        api.fact(
+          a.repo, a.branch, a.path,
+          anchorCommit,
+          useFallback ? { fallback: 'before' } : undefined,
+        )
+          .then(f => { if (!stale()) setFact(f); })
+          .catch(e => { if (!stale()) setError(String(e)); });
+        return;
+      }
       api.getLensFact(lensName, factPath)
         .then(f => {
           if (stale()) return;

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -4,12 +4,40 @@ import { useAsync } from './hooks';
 import { api } from './api';
 import type { Fact, Stats, ActivityStats } from './api';
 import type { AppState, Action } from './state';
-import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE } from './state';
-import { relativeTime } from './utils';
-import { RetractIcon } from './icons';
+import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, openFactSource } from './state';
+import { relativeTime, displayLensPath, repoHue, repoHueBg, repoHueBorder } from './utils';
+import { RetractIcon, GitBranchIcon } from './icons';
 import { FactDiffView } from './FactDiffView';
 import { FactBody, StatBox, TagCloud } from './FactBody';
 import { VersionWalker } from './VersionWalker';
+
+// LensMeta prefixes a lens fact's breadcrumb with its source mount: a mono pill
+// in the repo's deterministic hue (dot + repo name) and a blue branch chip.
+// Mirrors the Library union-row badge (utils.repoHue*) so a fact reads the same
+// wherever it appears. Repo-context facts render no LensMeta (lensMeta absent).
+function LensMeta({ repo, branch }: { repo: string; branch: string }) {
+  const c = repoHue(repo);
+  return (
+    <>
+      <span
+        data-testid="source-badge"
+        data-repo={repo}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 10,
+          color: c, background: repoHueBg(repo), border: `1px solid ${repoHueBorder(repo)}`,
+          borderRadius: 3, padding: '0 5px', fontFamily: 'var(--k-font-mono)', lineHeight: 1.6, flexShrink: 0,
+        }}
+      >
+        <span style={{ width: 5, height: 5, borderRadius: '50%', background: c, flexShrink: 0 }} />
+        {repo}
+      </span>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, color: '#8af', flexShrink: 0 }}>
+        <GitBranchIcon color="#8af" size={12} />
+        <span style={{ fontFamily: 'var(--k-font-mono)', fontSize: 11 }}>{branch}</span>
+      </span>
+    </>
+  );
+}
 
 function renderFact(
   fact: Fact,
@@ -21,9 +49,11 @@ function renderFact(
   onHopRef?: (path: string, pinnedCommit: string) => void,
   readOnly = false,
   anchorCommit?: string | null,
+  lensMeta?: { repo: string; branch: string },
+  readOnlyTitle: string = READ_ONLY_TITLE,
 ) {
   const retractDisabled = readOnly;
-  const retractTitle = retractDisabled ? READ_ONLY_TITLE : 'Retract fact';
+  const retractTitle = retractDisabled ? readOnlyTitle : 'Retract fact';
   const retractColor = retractDisabled ? '#444' : '#f66';
   // Retracted-version badge: only when anchorCommit is set (history+history)
   // and fact.commit_hash is a different commit (the backend's ?fallback=before
@@ -83,8 +113,11 @@ function renderFact(
             )}
           </span>
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4 }}>
-          <span style={{ fontSize: 12, color: '#555', fontFamily: 'var(--k-font-mono)' }}>{fact.path}</span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4, flexWrap: 'wrap' }}>
+          {lensMeta && <LensMeta repo={lensMeta.repo} branch={lensMeta.branch} />}
+          <span style={{ fontSize: 12, color: '#555', fontFamily: 'var(--k-font-mono)' }}>
+            {lensMeta ? displayLensPath(fact.path) : fact.path}
+          </span>
         </div>
       </div>
 
@@ -103,7 +136,7 @@ function renderFact(
   );
 }
 
-function FactEditor({ fact, repo, branch, readOnly, onSaved }: { fact: Fact; repo: string; branch: string; readOnly: boolean; onSaved: (updated: Fact) => void }) {
+function FactEditor({ fact, repo, branch, readOnly, onSaved, readOnlyTitle = READ_ONLY_TITLE }: { fact: Fact; repo: string; branch: string; readOnly: boolean; onSaved: (updated: Fact) => void; readOnlyTitle?: string }) {
   const [raw, setRaw] = useState(fact.body);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -140,7 +173,7 @@ function FactEditor({ fact, repo, branch, readOnly, onSaved }: { fact: Fact; rep
           data-testid="fact-save-btn"
           onClick={save}
           disabled={saving || readOnly}
-          title={readOnly ? READ_ONLY_TITLE : undefined}
+          title={readOnly ? readOnlyTitle : undefined}
           style={{
             background: '#1a2e1a', border: '1px solid rgba(119,204,153,0.35)', color: '#7c9',
             padding: '6px 16px', borderRadius: 4,
@@ -233,6 +266,15 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
   // clicking a retracted file shows the pre-retraction content instead of a 404.
   const useFallback = state.asOf.mode === 'history' && !!anchorCommit;
 
+  // In a lens context the open fact must be read THROUGH the lens: factPath is
+  // the RAW canonical address (bare for the write repo, kb://<id12>/… for a read
+  // mount), which the repo-scoped api.fact endpoint can't resolve. getLensFact
+  // resolves it and returns the source mount, which RightPanel re-dispatches
+  // (coherent with Library's row-click open) so a failed/racing open can't strand
+  // a stale factSource on the new factPath (the m30 regression).
+  const lensCtx = isLensContext(state);
+  const lensName = state.lens?.name;
+
   useAsync((stale) => {
     // In diff mode, FactDiffView owns the fact fetching via api.factDiff.
     // Skip this effect's fetch entirely so we don't issue a single-sided
@@ -241,6 +283,21 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
     if (!factPath) { setFact(null); setError(null); return; }
     setError(null);
     setFact(null);
+    if (lensCtx && lensName) {
+      api.getLensFact(lensName, factPath)
+        .then(f => {
+          if (stale()) return;
+          setFact(f);
+          dispatch({ type: 'SET_FACT_SOURCE', source: f.source });
+        })
+        .catch(e => {
+          if (stale()) return;
+          setError(String(e));
+          // m30: never leave a stale source paired with the new (failed) fact.
+          dispatch({ type: 'SET_FACT_SOURCE', source: null });
+        });
+      return;
+    }
     api.fact(
       state.repo, state.branch, factPath,
       anchorCommit ?? undefined,
@@ -251,7 +308,7 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
         setFact(f);
       })
       .catch(e => { if (!stale()) setError(String(e)); });
-  }, [factPath, anchorCommit, state.repo, useFallback, inDiff]);
+  }, [factPath, anchorCommit, state.repo, useFallback, inDiff, lensCtx, lensName]);
 
   useAsync((stale) => {
     if (factPath) return;
@@ -265,11 +322,28 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
     });
   }, [factPath, state.repo, path, state.headCommit]);
 
+  // openFactSource is the blessed write/temporal anchor: {state.repo, state.branch}
+  // in a repo context (unchanged), and the open fact's SOURCE mount in a lens
+  // context — which for a write-repo fact is {lens.write, write-agent-branch}, the
+  // exact repo-scoped target edits/retracts must hit. The bare fact path is already
+  // write-repo-relative, so the existing api.updateFact/retractFact reach the fact.
+  const writeTarget = openFactSource(state);
+  // A lens fact is writable only when it lives in the lens's WRITE repo; read-mount
+  // facts render fully read-only. Repo context keeps its prior gate (isReadOnly).
+  const isWriteFact = !lensCtx || state.factSource?.repo === state.lens?.write;
+  const factReadOnly = isReadOnly(state) || !isWriteFact;
+  const factReadOnlyTitle = (!isWriteFact && state.lens?.write)
+    ? `Read-only mount — edits go to ${state.lens.write}`
+    : READ_ONLY_TITLE;
+  const lensMeta = lensCtx && state.factSource
+    ? { repo: state.factSource.repo, branch: state.factSource.branch }
+    : undefined;
+
   const doRetract = useCallback(() => {
-    if (!fact || retracting || isReadOnly(state)) return;
+    if (!fact || retracting || factReadOnly) return;
     setConfirmRetract(false);
     setRetracting(true);
-    api.retractFact(state.repo, state.branch, fact.path)
+    api.retractFact(writeTarget.repo, writeTarget.branch, fact.path)
       .then(() => {
         setRetracting(false);
         // Clear the fact without touching headCommit. The git observer will
@@ -279,7 +353,7 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
         dispatch({ type: 'AMEND_NAV', factPath: null });
       })
       .catch(e => { setRetracting(false); setError(String(e)); });
-  }, [fact, retracting, state, dispatch]);
+  }, [fact, retracting, factReadOnly, writeTarget.repo, writeTarget.branch, dispatch]);
 
   // Keyboard: ArrowLeft blurs right panel
   useEffect(() => {
@@ -352,9 +426,9 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
   // Fact view (normal or time-travel)
   if (!fact) return <div style={{ padding: 24, color: '#666' }}>Loading...</div>;
 
-  if (fact.parse_error) return <FactEditor fact={fact} repo={state.repo} branch={state.branch} readOnly={isReadOnly(state)} onSaved={setFact} />;
+  if (fact.parse_error) return <FactEditor fact={fact} repo={writeTarget.repo} branch={writeTarget.branch} readOnly={factReadOnly} readOnlyTitle={factReadOnlyTitle} onSaved={setFact} />;
 
-  const readOnly = isReadOnly(state);
+  const readOnly = factReadOnly;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
@@ -368,8 +442,8 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
       <div style={{ flex: 1, overflow: 'auto' }}>
         {renderFact(
           fact,
-          state.repo,
-          state.branch,
+          writeTarget.repo,
+          writeTarget.branch,
           dispatch,
           () => { if (!readOnly) setConfirmRetract(true); },
           onScrub,
@@ -380,6 +454,8 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
           // anchor either matches the fact's commit_hash (no badge) or is
           // null (badge suppressed).
           useFallback ? anchorCommit : null,
+          lensMeta,
+          factReadOnlyTitle,
         )}
       </div>
     </div>

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -4,7 +4,7 @@ import { useAsync } from './hooks';
 import { api } from './api';
 import type { Fact, Stats, ActivityStats } from './api';
 import type { AppState, Action } from './state';
-import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, openFactSource } from './state';
+import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext } from './state';
 import { relativeTime, displayLensPath, repoHue, repoHueBg, repoHueBorder } from './utils';
 import { RetractIcon, GitBranchIcon } from './icons';
 import { FactDiffView } from './FactDiffView';
@@ -274,6 +274,21 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
   // a stale factSource on the new factPath (the m30 regression).
   const lensCtx = isLensContext(state);
   const lensName = state.lens?.name;
+  const lensWrite = state.lens?.write;
+
+  // Resolve the write repo's AGENT branch for lens writes. The open fact's
+  // factSource.branch is the WRITE MOUNT's READ branch (WriteMountBranch) — which
+  // Lens.normalize preserves when the write repo is pinned (e.g. core@main), a
+  // NON-agent branch. Writes must land on the agent branch (the only branch the
+  // repo write handlers accept as WritableBranch), so resolve it explicitly and
+  // cache it; the read-mount branch stays purely a display concern (meta line).
+  const [writeBranch, setWriteBranch] = useState<string | null>(null);
+  useAsync((stale) => {
+    if (!lensCtx || !lensWrite) { setWriteBranch(null); return; }
+    api.getAgentBranch(lensWrite)
+      .then(b => { if (!stale()) setWriteBranch(b); })
+      .catch(() => { /* fall back to state.branch (already the write agent branch) */ });
+  }, [lensCtx, lensWrite]);
 
   useAsync((stale) => {
     // In diff mode, FactDiffView owns the fact fetching via api.factDiff.
@@ -322,18 +337,21 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
     });
   }, [factPath, state.repo, path, state.headCommit]);
 
-  // openFactSource is the blessed write/temporal anchor: {state.repo, state.branch}
-  // in a repo context (unchanged), and the open fact's SOURCE mount in a lens
-  // context — which for a write-repo fact is {lens.write, write-agent-branch}, the
-  // exact repo-scoped target edits/retracts must hit. The bare fact path is already
-  // write-repo-relative, so the existing api.updateFact/retractFact reach the fact.
-  const writeTarget = openFactSource(state);
+  // The repo-scoped write target for edits/retracts: {state.repo, state.branch} in
+  // a repo context (unchanged); {lens.write, write-agent-branch} in a lens context.
+  // The bare fact path is already write-repo-relative, so the existing
+  // api.updateFact/retractFact reach the fact. Until getAgentBranch resolves we
+  // fall back to state.branch, which in a lens context IS the write repo's agent
+  // branch (App's status bootstrap resolved it the same way).
+  const writeTarget = (lensCtx && lensWrite)
+    ? { repo: lensWrite, branch: writeBranch ?? state.branch }
+    : { repo: state.repo, branch: state.branch };
   // A lens fact is writable only when it lives in the lens's WRITE repo; read-mount
   // facts render fully read-only. Repo context keeps its prior gate (isReadOnly).
-  const isWriteFact = !lensCtx || state.factSource?.repo === state.lens?.write;
+  const isWriteFact = !lensCtx || state.factSource?.repo === lensWrite;
   const factReadOnly = isReadOnly(state) || !isWriteFact;
-  const factReadOnlyTitle = (!isWriteFact && state.lens?.write)
-    ? `Read-only mount — edits go to ${state.lens.write}`
+  const factReadOnlyTitle = (!isWriteFact && lensWrite)
+    ? `Read-only mount — edits go to ${lensWrite}`
     : READ_ONLY_TITLE;
   const lensMeta = lensCtx && state.factSource
     ? { repo: state.factSource.repo, branch: state.factSource.branch }

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -4,7 +4,7 @@ import { useAsync } from './hooks';
 import { api } from './api';
 import type { Fact, Stats, ActivityStats } from './api';
 import type { AppState, Action } from './state';
-import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext } from './state';
+import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, openFactSource } from './state';
 import { relativeTime, displayLensPath, repoHue, repoHueBg, repoHueBorder } from './utils';
 import { RetractIcon, GitBranchIcon } from './icons';
 import { FactDiffView } from './FactDiffView';
@@ -41,8 +41,12 @@ function LensMeta({ repo, branch }: { repo: string; branch: string }) {
 
 function renderFact(
   fact: Fact,
-  repo: string,
-  branch: string,
+  // The fact's HISTORY source: its own source mount (openFactSource) + the
+  // RELATIVE path. VersionWalker reads versions through the mount's repo-scoped
+  // /commits endpoint, so it must NOT use the write target or the raw kb:// path
+  // (that pairing was the m36 no-op on read-mount facts).
+  histRepo: string,
+  histBranch: string,
   dispatch: Dispatch<Action>,
   onRetract?: () => void,
   onScrub?: (commit: string) => void,
@@ -79,9 +83,9 @@ function renderFact(
             )}
             {fact.commit_hash && (
               <VersionWalker
-                repo={repo}
-                branch={branch}
-                factPath={fact.path}
+                repo={histRepo}
+                branch={histBranch}
+                factPath={displayLensPath(fact.path)}
                 currentCommit={fact.commit_hash}
                 onScrub={onScrub ?? (() => {})}
               />
@@ -346,6 +350,11 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
   const writeTarget = (lensCtx && lensWrite)
     ? { repo: lensWrite, branch: writeBranch ?? state.branch }
     : { repo: state.repo, branch: state.branch };
+  // The HISTORY read anchor for the open fact (VersionWalker): its own source
+  // mount. Distinct from writeTarget — history reads route to where the fact
+  // LIVES (any read mount), writes to the lens's write repo. Repo context:
+  // both collapse to {state.repo, state.branch}.
+  const histSource = openFactSource(state);
   // A lens fact is writable only when it lives in the lens's WRITE repo; read-mount
   // facts render fully read-only. Repo context keeps its prior gate (isReadOnly).
   const isWriteFact = !lensCtx || state.factSource?.repo === lensWrite;
@@ -460,8 +469,10 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
       <div style={{ flex: 1, overflow: 'auto' }}>
         {renderFact(
           fact,
-          writeTarget.repo,
-          writeTarget.branch,
+          // History anchor (VersionWalker) — the fact's own source mount, NOT the
+          // write target. In a repo context this equals {state.repo, state.branch}.
+          histSource.repo,
+          histSource.branch,
           dispatch,
           () => { if (!readOnly) setConfirmRetract(true); },
           onScrub,

--- a/web/src/SourcesDropdown.tsx
+++ b/web/src/SourcesDropdown.tsx
@@ -1,0 +1,118 @@
+import { useRef, useState } from 'react';
+import type { Dispatch } from 'react';
+import type { Action } from './state';
+import type { Lens } from './api';
+import { useDismiss } from './hooks';
+import { repoHue, LENS } from './utils';
+import { LayersIcon, ChevronDownIcon } from './icons';
+
+interface Props {
+  lens: Lens;
+  // Current sources-dropdown selection: null = all mounts, else the explicit
+  // subset of read-mount repo names that are checked ([] = none selected).
+  selection: string[] | null;
+  dispatch: Dispatch<Action>;
+}
+
+// SourcesDropdown lets a lens reader narrow the union down to a subset of its
+// read mounts. It lives in the left panel above the sort tabs and renders ONLY
+// in lens context. Toggling a mount dispatches SET_LENS_SOURCES; a full set
+// collapses back to null ("all mounts"), which drops the repos param so the
+// server fans out to every mount.
+export function SourcesDropdown({ lens, selection, dispatch }: Props) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  useDismiss(open, () => setOpen(false), [triggerRef, menuRef]);
+
+  const mounts = lens.reads.map(r => r.repo);
+  const total = mounts.length;
+  // null selection means every mount is on; an explicit array means only those.
+  const selected = new Set(selection === null ? mounts : selection);
+  const filtered = selection !== null;
+  const n = selection === null ? total : selection.length;
+
+  const toggle = (repo: string) => {
+    const next = new Set(selected);
+    if (next.has(repo)) next.delete(repo); else next.add(repo);
+    // Preserve server (reads) order and de-dupe by filtering the mount list.
+    const arr = mounts.filter(m => next.has(m));
+    // A full selection is semantically "all mounts" → collapse to null so the
+    // repos param is dropped; an empty selection stays [] ("none selected").
+    dispatch({ type: 'SET_LENS_SOURCES', repos: arr.length === total ? null : arr });
+  };
+
+  return (
+    <div style={{ padding: '8px 12px', borderBottom: '1px solid #1a1a1a', background: '#0f0f0f' }}>
+      <div style={{ fontSize: 10, letterSpacing: '.09em', textTransform: 'uppercase', color: '#555', marginBottom: 6 }}>
+        Sources
+      </div>
+      <div
+        data-testid="sources-dropdown"
+        ref={triggerRef}
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+        style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          background: '#161616', border: '1px solid #333', borderRadius: 5,
+          padding: '5px 9px', fontSize: 12, color: '#bbb', cursor: 'pointer',
+        }}
+      >
+        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <LayersIcon color={LENS.accent} size={12} />
+          {filtered ? (
+            <span data-testid="sources-label">{n} of {total} mounts</span>
+          ) : (
+            <span data-testid="sources-label">All mounts <span style={{ color: '#666' }}>· {total}</span></span>
+          )}
+        </span>
+        <ChevronDownIcon color="#888" size={11} />
+      </div>
+      {open && (
+        <div
+          data-testid="sources-menu"
+          ref={menuRef}
+          style={{
+            marginTop: 4, background: '#1a1a1a', border: '1px solid #333', borderRadius: 5,
+            padding: '4px 0', boxShadow: '0 6px 18px rgba(0,0,0,.45)',
+          }}
+        >
+          {lens.reads.map(r => {
+            const on = selected.has(r.repo);
+            const c = repoHue(r.repo);
+            return (
+              <div
+                key={r.repo}
+                data-testid="source-option"
+                data-repo={r.repo}
+                data-on={String(on)}
+                onClick={() => toggle(r.repo)}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: 8, padding: '5px 10px',
+                  fontSize: 12.5, color: on ? '#ddd' : '#888', cursor: 'pointer',
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    width: 14, height: 14, borderRadius: 3,
+                    border: `1.5px solid ${on ? c : '#3a3a3a'}`,
+                    background: on ? c : 'transparent',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    flexShrink: 0, color: '#0c0c0c', fontSize: 10, lineHeight: 1,
+                  }}
+                >
+                  {on ? '✓' : ''}
+                </span>
+                <span style={{ width: 7, height: 7, borderRadius: '50%', background: c, flexShrink: 0 }} />
+                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.repo}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/TopBar.test.tsx
+++ b/web/src/TopBar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { TopBar } from './TopBar';
 import { init } from './state';
 import type { AppState } from './state';
-import type { RepoInfo } from './api';
+import type { RepoInfo, Lens } from './api';
 
 describe('TopBar commit chip', () => {
   it('shows a borderless amber commit chip (clock + hash, no "as of") when history', () => {
@@ -39,6 +39,27 @@ const repos: RepoInfo[] = [
   { name: 'beta' } as RepoInfo,
   { name: 'gamma' } as RepoInfo,
 ];
+
+const engLens: Lens = {
+  name: 'eng',
+  write: 'core',
+  reads: [{ repo: 'core' }, { repo: 'docs' }, { repo: 'infra' }],
+};
+const researchLens: Lens = {
+  name: 'research',
+  write: 'scratch',
+  reads: [{ repo: 'papers' }, { repo: 'notes' }],
+};
+const lenses: Lens[] = [engLens, researchLens];
+
+// A lens-context state: browsing the "eng" lens (write mount core / agent/main).
+const lensState: AppState = {
+  ...init,
+  repo: 'core',
+  branch: 'agent/main',
+  context: { kind: 'lens', name: 'eng' },
+  lens: engLens,
+};
 
 describe('TopBar repo selector', () => {
   it('renders a button trigger (not a native select) when multiple repos exist', () => {
@@ -142,5 +163,104 @@ describe('TopBar desktop window drag', () => {
     render(<TopBar state={baseState} repos={repos} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
     fireEvent.mouseDown(screen.getByTestId('toknomitr-branch'));
     expect(post).not.toHaveBeenCalled();
+  });
+});
+
+describe('TopBar two-group context switcher', () => {
+  it('opens a dropdown with Repositories and Lenses groups listing both', () => {
+    render(<TopBar state={baseState} repos={repos} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    fireEvent.click(screen.getByTestId('toknomitr-repo-select'));
+
+    // Group headers.
+    expect(screen.getByTestId('toknomitr-group-repos')).toHaveTextContent('Repositories');
+    expect(screen.getByTestId('toknomitr-group-lenses')).toHaveTextContent('Lenses');
+
+    // Repo rows (unchanged testids) still present.
+    expect(screen.getByTestId('toknomitr-repo-option-alpha')).toBeInTheDocument();
+    expect(screen.getByTestId('toknomitr-repo-option-gamma')).toBeInTheDocument();
+
+    // Lens rows with two-line label (name + `N mounts · → <write>`).
+    expect(screen.getByTestId('toknomitr-lens-option-eng')).toBeInTheDocument();
+    expect(screen.getByTestId('toknomitr-lens-option-research')).toBeInTheDocument();
+    expect(screen.getByTestId('toknomitr-lens-option-eng')).toHaveTextContent('3 mounts · → core');
+    expect(screen.getByTestId('toknomitr-lens-option-research')).toHaveTextContent('2 mounts · → scratch');
+  });
+
+  it('omits the Lenses group when there are no lenses', () => {
+    render(<TopBar state={baseState} repos={repos} lenses={[]} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    fireEvent.click(screen.getByTestId('toknomitr-repo-select'));
+    expect(screen.getByTestId('toknomitr-group-repos')).toBeInTheDocument();
+    expect(screen.queryByTestId('toknomitr-group-lenses')).toBeNull();
+  });
+
+  it('offers the switcher with a single repo when lenses exist', () => {
+    render(<TopBar state={baseState} repos={[repos[0]]} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    expect(screen.getByTestId('toknomitr-repo-select')).toBeInTheDocument();
+    expect(screen.queryByTestId('toknomitr-repo-name')).toBeNull();
+  });
+
+  it('selecting a lens dispatches SET_CONTEXT {kind:lens,name} and closes', () => {
+    const dispatch = vi.fn();
+    render(<TopBar state={baseState} repos={repos} lenses={lenses} dispatch={dispatch} onManageRepos={() => {}} leftWidth={300} />);
+    fireEvent.click(screen.getByTestId('toknomitr-repo-select'));
+    fireEvent.click(screen.getByTestId('toknomitr-lens-option-eng'));
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_CONTEXT', context: { kind: 'lens', name: 'eng' } });
+    expect(screen.queryByTestId('toknomitr-repo-menu')).toBeNull();
+  });
+
+  it('selecting a repo still dispatches SET_REPO (repo rows unchanged)', () => {
+    const dispatch = vi.fn();
+    render(<TopBar state={baseState} repos={repos} lenses={lenses} dispatch={dispatch} onManageRepos={() => {}} leftWidth={300} />);
+    fireEvent.click(screen.getByTestId('toknomitr-repo-select'));
+    fireEvent.click(screen.getByTestId('toknomitr-repo-option-beta'));
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_REPO', repo: 'beta' });
+  });
+});
+
+describe('TopBar lens-context chips', () => {
+  it('shows a lens chip (name) instead of the repo book chip', () => {
+    render(<TopBar state={lensState} repos={repos} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    const trigger = screen.getByTestId('toknomitr-lens-select');
+    expect(trigger.tagName.toLowerCase()).toBe('button');
+    expect(trigger).toHaveTextContent('eng');
+    // The repo book chip / branch chip are not rendered in a lens context.
+    expect(screen.queryByTestId('toknomitr-repo-select')).toBeNull();
+    expect(screen.queryByTestId('toknomitr-branch')).toBeNull();
+  });
+
+  it('replaces the branch chip with an N-mounts summary', () => {
+    render(<TopBar state={lensState} repos={repos} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    expect(screen.getByTestId('toknomitr-mounts')).toHaveTextContent('3 mounts');
+  });
+
+  it('shows a writes-→ pill with the lens write target', () => {
+    render(<TopBar state={lensState} repos={repos} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    expect(screen.getByTestId('toknomitr-writes')).toHaveTextContent('writes → core');
+  });
+
+  it('clicking the lens chip opens the two-group switcher with eng active', () => {
+    render(<TopBar state={lensState} repos={repos} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    fireEvent.click(screen.getByTestId('toknomitr-lens-select'));
+    const active = screen.getByTestId('toknomitr-lens-option-eng');
+    expect(active).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('hides the commit chip when live even with a fact open', () => {
+    const state: AppState = { ...lensState, factPath: 'kb/a/b.md', asOf: { mode: 'live' } };
+    render(<TopBar state={state} repos={repos} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    expect(screen.queryByTestId('toknomitr-commit')).toBeNull();
+  });
+
+  it('shows the open fact anchor commit when a fact is open in history', () => {
+    const state: AppState = { ...lensState, factPath: 'kb/a/b.md', asOf: { mode: 'history', commit: 'abc1234def5' } };
+    render(<TopBar state={state} repos={repos} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    expect(screen.getByTestId('toknomitr-commit')).toHaveTextContent('abc1234');
+  });
+
+  it('hides the commit chip in a lens context when no fact is open', () => {
+    const state: AppState = { ...lensState, factPath: null, asOf: { mode: 'history', commit: 'abc1234def5' } };
+    render(<TopBar state={state} repos={repos} lenses={lenses} dispatch={vi.fn()} onManageRepos={() => {}} leftWidth={300} />);
+    expect(screen.queryByTestId('toknomitr-commit')).toBeNull();
   });
 });

--- a/web/src/TopBar.test.tsx
+++ b/web/src/TopBar.test.tsx
@@ -32,7 +32,9 @@ describe('TopBar commit chip', () => {
   });
 });
 
-const baseState: AppState = { ...init, repo: 'alpha', branch: 'agent/test' };
+// A realistic repo context: SET_CONTEXT sets repo and context.repo atomically,
+// so the fixture pins both (production state can never diverge here).
+const baseState: AppState = { ...init, repo: 'alpha', branch: 'agent/test', context: { kind: 'repo', repo: 'alpha' } };
 
 const repos: RepoInfo[] = [
   { name: 'alpha' } as RepoInfo,

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -2,13 +2,18 @@ import { useState, useRef } from 'react';
 import type { Dispatch, CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { AppState, Action } from './state';
-import type { RepoInfo } from './api';
+import { isLensContext, selectAnchorCommit } from './state';
+import type { RepoInfo, Lens } from './api';
 import { useDismiss } from './hooks';
-import { BookIcon, GitBranchIcon, ChevronDownIcon, GearIcon } from './icons';
+import { BookIcon, GitBranchIcon, ChevronDownIcon, GearIcon, LayersIcon, PencilIcon } from './icons';
+import { LENS, repoHue } from './utils';
 
 interface Props {
   state: AppState;
   repos: RepoInfo[];
+  /** All lenses (for the switcher's Lenses group). Defaults to [] when the
+   *  caller hasn't loaded them yet, so the repo group still renders. */
+  lenses?: Lens[];
   dispatch: Dispatch<Action>;
   onManageRepos: () => void;
   /** Live width of the Library panel; the title-bar identity zone matches it
@@ -16,25 +21,40 @@ interface Props {
   leftWidth: number;
 }
 
-export function TopBar({ state, repos, dispatch, onManageRepos, leftWidth }: Props) {
-  const [repoOpen, setRepoOpen] = useState(false);
-  const repoBtnRef = useRef<HTMLButtonElement>(null);
-  const repoMenuRef = useRef<HTMLDivElement>(null);
-  const [repoPos, setRepoPos] = useState({ top: 0, left: 0, minWidth: 0 });
+export function TopBar({ state, repos, lenses = [], dispatch, onManageRepos, leftWidth }: Props) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuBtnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuPos, setMenuPos] = useState({ top: 0, left: 0, minWidth: 0 });
 
-  useDismiss(repoOpen, () => setRepoOpen(false), [repoBtnRef, repoMenuRef]);
+  const lensCtx = isLensContext(state);
+  // The switcher trigger appears when there's more than one surface to pick:
+  // multiple repos, any lens (even with a single repo), or a lens context.
+  const showTrigger = repos.length > 1 || lenses.length > 0 || lensCtx;
 
-  const toggleRepoMenu = () => {
-    if (!repoOpen && repoBtnRef.current) {
-      const rect = repoBtnRef.current.getBoundingClientRect();
-      setRepoPos({ top: rect.bottom + 4, left: rect.left, minWidth: rect.width });
+  useDismiss(menuOpen, () => setMenuOpen(false), [menuBtnRef, menuRef]);
+
+  const toggleMenu = () => {
+    if (!menuOpen && menuBtnRef.current) {
+      const rect = menuBtnRef.current.getBoundingClientRect();
+      setMenuPos({ top: rect.bottom + 4, left: rect.left, minWidth: rect.width });
     }
-    setRepoOpen(o => !o);
+    setMenuOpen(o => !o);
   };
 
   const pickRepo = (name: string) => {
-    setRepoOpen(false);
-    if (name !== state.repo) dispatch({ type: 'SET_REPO', repo: name });
+    setMenuOpen(false);
+    // No-op only when already in this repo context. In a lens context
+    // (context.kind !== 'repo') a repo pick always switches surface, even if the
+    // name matches the lens's write mount (state.repo).
+    if (state.context.kind === 'repo' && name === state.repo) return;
+    dispatch({ type: 'SET_REPO', repo: name });
+  };
+
+  const pickLens = (name: string) => {
+    setMenuOpen(false);
+    if (state.context.kind === 'lens' && name === state.context.name) return;
+    dispatch({ type: 'SET_CONTEXT', context: { kind: 'lens', name } });
   };
 
   // In the desktop app the native title bar is hidden, so the macOS traffic
@@ -102,6 +122,13 @@ export function TopBar({ state, repos, dispatch, onManageRepos, leftWidth }: Pro
     padding: '0 14px',
   };
 
+  // Dropdown group header: small uppercase label with an icon (Repositories /
+  // Lenses). Verbatim spec from the design handoff (Part 2 §switcher).
+  const groupHeaderStyle: CSSProperties = {
+    fontSize: 10, letterSpacing: '.1em', textTransform: 'uppercase', color: '#555',
+    padding: '5px 12px 3px', display: 'flex', alignItems: 'center', gap: 6,
+  };
+
   return (
     <div style={outerStyle} onMouseDown={startWindowDrag}>
       {/* ── OS-chrome strip: native traffic lights float here ── */}
@@ -127,53 +154,101 @@ export function TopBar({ state, repos, dispatch, onManageRepos, leftWidth }: Pro
         </span>
       </div>
 
-      {/* ── Right zone: repo · branch · commit ········ gear ── */}
+      {/* ── Right zone: context · (branch|mounts) · commit ········ gear ── */}
       <div style={rightZoneStyle}>
-        <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: '#7c9', fontSize: 12 }}>
-          <BookIcon color="currentColor" size={13} />
-          {repos.length > 1 ? (
-            <button
-              data-testid="toknomitr-repo-select"
-              data-nodrag
-              ref={repoBtnRef}
-              onClick={toggleRepoMenu}
-              aria-haspopup="listbox"
-              aria-expanded={repoOpen}
-              style={{
-                background: '#1a1a2a', color: '#7c9', border: '1px solid #333',
-                borderRadius: 3, fontSize: 12, padding: '1px 4px 1px 6px', cursor: 'pointer',
-                display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: 'inherit',
-                lineHeight: 1.5, ...noDrag,
-              }}
-            >
-              <span>{state.repo}</span>
-              <ChevronDownIcon color="currentColor" size={11} />
-            </button>
-          ) : (
-            <span data-testid="toknomitr-repo-name">{state.repo}</span>
-          )}
-        </span>
-        {state.branch && (
-          <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: '#8af', fontSize: 12, minWidth: 0 }}>
-            <GitBranchIcon color="currentColor" size={13} />
-            <span data-testid="toknomitr-branch" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{state.branch}</span>
-          </span>
-        )}
-        {/* line-height 1 collapses the monospace block to its glyph extent so
-            the digit caps align with the surrounding sans-serif text. */}
-        {/* Commit chip — borderless icon + hash in the mode color (amber = past,
-            green = now), so live and history read as the same shape. */}
-        {state.asOf.mode === 'history' ? (
-          <span data-testid="toknomitr-commit" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: 'var(--k-font-mono)', fontSize: 11, lineHeight: 1, flexShrink: 0, color: '#e5a23c' }}>
-            <span aria-hidden="true">⏱</span>{state.asOf.commit.slice(0, 7)}
-          </span>
-        ) : (
-          state.headCommit && (
-            <span data-testid="toknomitr-commit" style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: 'var(--k-font-mono)', fontSize: 11, lineHeight: 1, flexShrink: 0, color: '#7c9' }}>
-              <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: '50%', background: '#7c9', boxShadow: '0 0 6px #7c9' }} />
-              {state.headCommit.slice(0, 7)}
+        {lensCtx ? (
+          /* ── LENS context: lens chip · N mounts · writes-→ pill · commit ── */
+          <>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: LENS.accent, fontSize: 12 }}>
+              <LayersIcon color="currentColor" size={13} />
+              <button
+                data-testid="toknomitr-lens-select"
+                data-nodrag
+                ref={menuBtnRef}
+                onClick={toggleMenu}
+                aria-haspopup="listbox"
+                aria-expanded={menuOpen}
+                style={{
+                  background: LENS.bg, color: LENS.accent, border: `1px solid ${LENS.border}`,
+                  borderRadius: 3, fontSize: 12, padding: '1px 4px 1px 6px', cursor: 'pointer',
+                  display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: 'inherit',
+                  lineHeight: 1.5, ...noDrag,
+                }}
+              >
+                <span>{state.context.kind === 'lens' ? state.context.name : ''}</span>
+                <ChevronDownIcon color="currentColor" size={11} />
+              </button>
             </span>
-          )
+            {state.lens && (
+              <span data-testid="toknomitr-mounts" style={{ display: 'flex', alignItems: 'center', gap: 5, color: '#8af', fontSize: 12 }}>
+                <GitBranchIcon color="currentColor" size={13} />
+                {state.lens.reads.length} mounts
+              </span>
+            )}
+            {state.lens && (
+              <span data-testid="toknomitr-writes" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 11, color: '#7c9', background: '#1a2e1a', border: '1px solid #2a4a2a', borderRadius: 3, padding: '1px 7px' }}>
+                <PencilIcon color="currentColor" size={11} /> writes → {state.lens.write}
+              </span>
+            )}
+            {/* Commit chip reflects the open fact's mount commit. v1: shown only
+                when a fact is open AND the view is anchored (history/diff); the
+                anchor commit stands in for the mount commit. Hidden when live. */}
+            {state.factPath && selectAnchorCommit(state) && (
+              <span data-testid="toknomitr-commit" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: 'var(--k-font-mono)', fontSize: 11, lineHeight: 1, flexShrink: 0, color: '#e5a23c' }}>
+                <span aria-hidden="true">⏱</span>{selectAnchorCommit(state)!.slice(0, 7)}
+              </span>
+            )}
+          </>
+        ) : (
+          /* ── REPO context (unchanged): book chip · branch · commit ── */
+          <>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: '#7c9', fontSize: 12 }}>
+              <BookIcon color="currentColor" size={13} />
+              {showTrigger ? (
+                <button
+                  data-testid="toknomitr-repo-select"
+                  data-nodrag
+                  ref={menuBtnRef}
+                  onClick={toggleMenu}
+                  aria-haspopup="listbox"
+                  aria-expanded={menuOpen}
+                  style={{
+                    background: '#1a1a2a', color: '#7c9', border: '1px solid #333',
+                    borderRadius: 3, fontSize: 12, padding: '1px 4px 1px 6px', cursor: 'pointer',
+                    display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: 'inherit',
+                    lineHeight: 1.5, ...noDrag,
+                  }}
+                >
+                  <span>{state.repo}</span>
+                  <ChevronDownIcon color="currentColor" size={11} />
+                </button>
+              ) : (
+                <span data-testid="toknomitr-repo-name">{state.repo}</span>
+              )}
+            </span>
+            {state.branch && (
+              <span style={{ display: 'flex', alignItems: 'center', gap: 5, color: '#8af', fontSize: 12, minWidth: 0 }}>
+                <GitBranchIcon color="currentColor" size={13} />
+                <span data-testid="toknomitr-branch" style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{state.branch}</span>
+              </span>
+            )}
+            {/* line-height 1 collapses the monospace block to its glyph extent so
+                the digit caps align with the surrounding sans-serif text. */}
+            {/* Commit chip — borderless icon + hash in the mode color (amber = past,
+                green = now), so live and history read as the same shape. */}
+            {state.asOf.mode === 'history' ? (
+              <span data-testid="toknomitr-commit" style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontFamily: 'var(--k-font-mono)', fontSize: 11, lineHeight: 1, flexShrink: 0, color: '#e5a23c' }}>
+                <span aria-hidden="true">⏱</span>{state.asOf.commit.slice(0, 7)}
+              </span>
+            ) : (
+              state.headCommit && (
+                <span data-testid="toknomitr-commit" style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: 'var(--k-font-mono)', fontSize: 11, lineHeight: 1, flexShrink: 0, color: '#7c9' }}>
+                  <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: '50%', background: '#7c9', boxShadow: '0 0 6px #7c9' }} />
+                  {state.headCommit.slice(0, 7)}
+                </span>
+              )
+            )}
+          </>
         )}
         <div style={{ flex: 1 }} />
         <button
@@ -193,23 +268,27 @@ export function TopBar({ state, repos, dispatch, onManageRepos, leftWidth }: Pro
       </div>
       </div>
 
-      {repoOpen && createPortal(
-        <div ref={repoMenuRef} role="listbox" data-testid="toknomitr-repo-menu" style={{
+      {menuOpen && createPortal(
+        <div ref={menuRef} role="listbox" data-testid="toknomitr-repo-menu" style={{
           position: 'fixed',
-          top: repoPos.top,
-          left: repoPos.left,
-          minWidth: Math.max(repoPos.minWidth, 140),
+          top: menuPos.top,
+          left: menuPos.left,
+          minWidth: Math.max(menuPos.minWidth, 200),
           background: '#1a1a1a',
           border: '1px solid #333',
-          borderRadius: 4,
+          borderRadius: 6,
           zIndex: 10000,
           boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
-          padding: '4px 0',
-          maxHeight: 300,
+          padding: '5px 0',
+          maxHeight: 340,
           overflowY: 'auto',
         }}>
+          {/* ── Repositories group ── */}
+          <div data-testid="toknomitr-group-repos" style={groupHeaderStyle}>
+            <BookIcon color="#6a8" size={11} /> Repositories
+          </div>
           {repos.map(r => {
-            const active = r.name === state.repo;
+            const active = state.context.kind === 'repo' && r.name === state.repo;
             return (
               <div
                 key={r.name}
@@ -227,10 +306,48 @@ export function TopBar({ state, repos, dispatch, onManageRepos, leftWidth }: Pro
                 onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = active ? '#7c9' : '#aaa'; }}
               >
                 <span style={{ width: 10, color: '#7c9' }}>{active ? '✓' : ''}</span>
+                <span aria-hidden="true" style={{ width: 7, height: 7, borderRadius: '50%', background: repoHue(r.name), flexShrink: 0 }} />
                 <span>{r.name}</span>
               </div>
             );
           })}
+
+          {/* ── Lenses group (omitted when there are no lenses) ── */}
+          {lenses.length > 0 && (
+            <>
+              <div style={{ borderTop: '1px solid #2a2a2a', margin: '5px 0' }} />
+              <div data-testid="toknomitr-group-lenses" style={groupHeaderStyle}>
+                <LayersIcon color={LENS.accent} size={11} /> Lenses
+              </div>
+              {lenses.map(l => {
+                const active = state.context.kind === 'lens' && l.name === state.context.name;
+                return (
+                  <div
+                    key={l.name}
+                    role="option"
+                    aria-selected={active}
+                    data-testid={`toknomitr-lens-option-${l.name}`}
+                    onClick={() => pickLens(l.name)}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: 8,
+                      padding: '6px 12px',
+                      cursor: 'pointer',
+                      background: active ? LENS.soft : 'transparent',
+                    }}
+                    onMouseEnter={e => { if (!active) e.currentTarget.style.background = '#26243a'; }}
+                    onMouseLeave={e => { e.currentTarget.style.background = active ? LENS.soft : 'transparent'; }}
+                  >
+                    <span style={{ width: 10, color: LENS.accent }}>{active ? '✓' : ''}</span>
+                    <LayersIcon color={LENS.accent} size={13} />
+                    <span style={{ display: 'flex', flexDirection: 'column' }}>
+                      <span style={{ fontSize: 12, color: active ? LENS.accent : '#ccc' }}>{l.name}</span>
+                      <span style={{ fontSize: 10.5, color: '#888' }}>{l.reads.length} mounts · → {l.write}</span>
+                    </span>
+                  </div>
+                );
+              })}
+            </>
+          )}
         </div>,
         document.body
       )}

--- a/web/src/TrailBreadcrumb.test.tsx
+++ b/web/src/TrailBreadcrumb.test.tsx
@@ -5,14 +5,21 @@ import { api } from './api';
 
 vi.mock('./api', async (orig) => {
   const mod = await orig<typeof import('./api')>();
-  return { ...mod, api: { ...mod.api, fact: vi.fn() } };
+  return { ...mod, api: { ...mod.api, fact: vi.fn(), getLensFact: vi.fn() } };
 });
 
 beforeEach(() => {
+  (api.fact as any).mockClear();
   // Title = "T <path>" so each crumb is individually identifiable.
   (api.fact as any).mockImplementation(async (_r: string, _b: string, path: string) => ({
     path, title: `T ${path}`,
     body: '', domain: [], confidence: 0, sources: 0, entities: [], refs: [],
+  }));
+  (api.getLensFact as any).mockReset();
+  (api.getLensFact as any).mockImplementation(async (_lens: string, path: string) => ({
+    path, title: `L ${path}`,
+    body: '', domain: [], confidence: 0, sources: 0, entities: [], refs: [],
+    source: { repo: 'docs', id: 'aaabbbcccddd', branch: 'main' },
   }));
 });
 
@@ -88,4 +95,28 @@ it('renders all crumbs without an ellipsis for a short (<=4) trail', async () =>
   expect(screen.getByText('T kb/c.md')).toBeTruthy();
   expect(screen.getByText('T kb/d.md')).toBeTruthy();
   expect(screen.queryByTestId('crumb-overflow')).toBeNull();
+});
+
+// Regression: in a lens context, crumbs carry canonical paths (kb://<id12>/…
+// for read mounts) that the repo-scoped fact endpoint cannot resolve — a
+// commit-anchored api.fact(state.repo, …, "kb://…") 404s server-side. With
+// lensName set, titles come from the lens endpoint (which routes canonical
+// paths to their mount) and the repo endpoint is never called.
+it('lens context: titles fetched via getLensFact with the RAW canonical path, never api.fact', async () => {
+  const lensTrail = [
+    { factPath: 'kb/a.md', asOf: live },                                    // write-repo fact (bare)
+    { factPath: 'kb://aaabbbcccddd/kb/b.md', asOf: hist('bbb1111') },       // read-mount fact (qualified)
+  ];
+  render(<TrailBreadcrumb repo="core" branch="agent/x" lensName="dev" trail={lensTrail} onJump={vi.fn()} />);
+  await waitFor(() => screen.getByText('L kb://aaabbbcccddd/kb/b.md'));
+  expect(api.getLensFact).toHaveBeenCalledWith('dev', 'kb/a.md');
+  expect(api.getLensFact).toHaveBeenCalledWith('dev', 'kb://aaabbbcccddd/kb/b.md');
+  expect(api.fact).not.toHaveBeenCalled();
+});
+
+it('lens context: a failed title fetch still falls back to the basename', async () => {
+  (api.getLensFact as any).mockRejectedValue(new Error('404'));
+  const lensTrail = [{ factPath: 'kb://aaabbbcccddd/kb/deep/fail.md', asOf: hist('ccc2222') }];
+  render(<TrailBreadcrumb repo="core" branch="agent/x" lensName="dev" trail={lensTrail} onJump={vi.fn()} />);
+  await waitFor(() => screen.getByText('fail')); // basename strips .md
 });

--- a/web/src/TrailBreadcrumb.test.tsx
+++ b/web/src/TrailBreadcrumb.test.tsx
@@ -120,3 +120,25 @@ it('lens context: a failed title fetch still falls back to the basename', async 
   render(<TrailBreadcrumb repo="core" branch="agent/x" lensName="dev" trail={lensTrail} onJump={vi.fn()} />);
   await waitFor(() => screen.getByText('fail')); // basename strips .md
 });
+
+// Regression (retracted-crumb breadcrumb bug): the RightPanel already read the
+// fact when we navigated to it, so its title is in the shared cache. The
+// breadcrumb must use that — never re-fetch — because a retracted fact 404s on
+// the live lens single-fact endpoint (which would strand the basename hash).
+it('lens context: labels a cached (retracted) crumb from the cache without fetching', async () => {
+  (api.getLensFact as any).mockRejectedValue(new Error('404')); // retracted → live endpoint 404s
+  const lensTrail = [
+    { factPath: 'kb/a.md', asOf: live },
+    { factPath: 'kb://aaabbbcccddd/kb/6cf51b30.md', asOf: hist('ddd3333') }, // retracted read-mount fact
+  ];
+  const titles = {
+    'kb/a.md@HEAD': 'Canonical fact',
+    'kb://aaabbbcccddd/kb/6cf51b30.md@ddd3333': 'AI agents are compromised via over-broad permissions',
+  };
+  render(<TrailBreadcrumb repo="core" branch="agent/x" lensName="dev" trail={lensTrail} titles={titles} onJump={vi.fn()} />);
+  // The cached title shows even though the live endpoint would 404 for this tombstone.
+  await screen.findByText('AI agents are compromised via over-broad permissions');
+  expect(screen.getByText('Canonical fact')).toBeTruthy();
+  expect(screen.queryByText('6cf51b30')).toBeNull(); // never the raw hash
+  expect(api.getLensFact).not.toHaveBeenCalled();     // reused, not re-fetched
+});

--- a/web/src/TrailBreadcrumb.tsx
+++ b/web/src/TrailBreadcrumb.tsx
@@ -48,11 +48,15 @@ function layoutItems(count: number): Item[] {
 interface TrailBreadcrumbProps {
   repo: string;
   branch: string;
+  // In a lens context crumbs carry canonical paths (bare = write repo,
+  // kb://<id12>/… = a read mount) that the repo-scoped fact endpoint cannot
+  // resolve; the lens single-fact endpoint routes them to the right mount.
+  lensName?: string;
   trail: TrailCrumb[];
   onJump: (index: number) => void;
 }
 
-export function TrailBreadcrumb({ repo, branch, trail, onJump }: TrailBreadcrumbProps) {
+export function TrailBreadcrumb({ repo, branch, lensName, trail, onJump }: TrailBreadcrumbProps) {
   // Crumbs carry only path + anchor; fetch each fact's human title (cached by
   // path@commit) so the breadcrumb reads "Alpha fact…", not the hash filename.
   const [titles, setTitles] = useState<Record<string, string>>({});
@@ -63,7 +67,14 @@ export function TrailBreadcrumb({ repo, branch, trail, onJump }: TrailBreadcrumb
       const key = crumbKey(crumb);
       if (titles[key] !== undefined) continue;
       const commit = crumbCommit(crumb.asOf);
-      api.fact(repo, branch, crumb.factPath, commit, commit ? { fallback: 'before' } : undefined)
+      // Lens context: fetch the LIVE title through the lens endpoint. Anchoring
+      // the title at the crumb's commit would need an id12→mount mapping the
+      // client doesn't keep; titles are stable enough for breadcrumb chrome and
+      // a failure already falls back to the basename.
+      const fetchTitle = lensName
+        ? api.getLensFact(lensName, crumb.factPath)
+        : api.fact(repo, branch, crumb.factPath, commit, commit ? { fallback: 'before' } : undefined);
+      fetchTitle
         .then(f => {
           if (!cancelled && f?.title) setTitles(prev => ({ ...prev, [key]: f.title }));
         })
@@ -71,7 +82,7 @@ export function TrailBreadcrumb({ repo, branch, trail, onJump }: TrailBreadcrumb
     }
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [repo, branch, trail]);
+  }, [repo, branch, lensName, trail]);
 
   const label = (index: number) => titles[crumbKey(trail[index])] ?? basename(trail[index].factPath);
   const items = layoutItems(trail.length);

--- a/web/src/TrailBreadcrumb.tsx
+++ b/web/src/TrailBreadcrumb.tsx
@@ -53,38 +53,46 @@ interface TrailBreadcrumbProps {
   // resolve; the lens single-fact endpoint routes them to the right mount.
   lensName?: string;
   trail: TrailCrumb[];
+  // Shared title cache (state.factTitles) — the RightPanel writes the title of
+  // every fact it loads here, so a crumb we've navigated to is already labelled
+  // WITHOUT re-fetching. This is the authoritative source; the local fetch below
+  // is only a fallback for a crumb not (yet) in the cache.
+  titles?: Record<string, string>;
   onJump: (index: number) => void;
 }
 
-export function TrailBreadcrumb({ repo, branch, lensName, trail, onJump }: TrailBreadcrumbProps) {
-  // Crumbs carry only path + anchor; fetch each fact's human title (cached by
-  // path@commit) so the breadcrumb reads "Alpha fact…", not the hash filename.
-  const [titles, setTitles] = useState<Record<string, string>>({});
+export function TrailBreadcrumb({ repo, branch, lensName, trail, titles, onJump }: TrailBreadcrumbProps) {
+  // Fallback fetch cache: for crumbs the shared cache doesn't cover. Crumbs
+  // carry only path + anchor; fetch each fact's human title so the breadcrumb
+  // reads "Alpha fact…", not the hash filename.
+  const [fetched, setFetched] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let cancelled = false;
     for (const crumb of trail) {
       const key = crumbKey(crumb);
-      if (titles[key] !== undefined) continue;
+      // Already labelled — the RightPanel cached this fact's title when we
+      // navigated to it (the common case, and the only one that resolves a
+      // retracted fact, whose live single-fact endpoint 404s a tombstone).
+      if (titles?.[key] !== undefined || fetched[key] !== undefined) continue;
       const commit = crumbCommit(crumb.asOf);
-      // Lens context: fetch the LIVE title through the lens endpoint. Anchoring
-      // the title at the crumb's commit would need an id12→mount mapping the
-      // client doesn't keep; titles are stable enough for breadcrumb chrome and
-      // a failure already falls back to the basename.
       const fetchTitle = lensName
         ? api.getLensFact(lensName, crumb.factPath)
         : api.fact(repo, branch, crumb.factPath, commit, commit ? { fallback: 'before' } : undefined);
       fetchTitle
         .then(f => {
-          if (!cancelled && f?.title) setTitles(prev => ({ ...prev, [key]: f.title }));
+          if (!cancelled && f?.title) setFetched(prev => ({ ...prev, [key]: f.title }));
         })
         .catch(() => { /* leave fallback to basename */ });
     }
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [repo, branch, lensName, trail]);
+  }, [repo, branch, lensName, trail, titles]);
 
-  const label = (index: number) => titles[crumbKey(trail[index])] ?? basename(trail[index].factPath);
+  const label = (index: number) => {
+    const key = crumbKey(trail[index]);
+    return titles?.[key] ?? fetched[key] ?? basename(trail[index].factPath);
+  };
   const items = layoutItems(trail.length);
 
   return (

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -496,6 +496,119 @@ describe('api lens client', () => {
   });
 });
 
+describe('api lens read surface', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  function mockJSON(body: unknown): string[] {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+      calls.push(url);
+      return { ok: true, status: 200, json: async () => body };
+    });
+    return calls;
+  }
+
+  it('listLensFacts builds the union facts URL with path, query, paging, and repeated repo=', async () => {
+    const calls = mockJSON({
+      facts: [{ path: 'kb/a.md', title: 'A', committed_at: 10, score: 0.5,
+        source: { repo: 'core', id: 'abc123def456', branch: 'main' } }],
+      total: 1,
+    });
+    const res = await api.listLensFacts('dev', {
+      path: 'kb/tech', query: 'goroutine', limit: 20, offset: 40, repos: ['core', 'beta'],
+    });
+    expect(calls[0]).toBe(
+      '/api/v1/lenses/dev/facts?path=kb%2Ftech&query=goroutine&limit=20&offset=40&repo=core&repo=beta');
+    expect(res.total).toBe(1);
+    expect(res.facts[0].source).toEqual({ repo: 'core', id: 'abc123def456', branch: 'main' });
+  });
+
+  it('listLensFacts emits a bare /facts URL when no options are given', async () => {
+    const calls = mockJSON({ facts: [], total: 0 });
+    await api.listLensFacts('dev', {});
+    expect(calls[0]).toBe('/api/v1/lenses/dev/facts');
+  });
+
+  it('lensSearch builds ?q= with repeated repo= and unwraps the flat results array', async () => {
+    const calls = mockJSON({
+      results: [{ path: 'kb://abc123def456/kb/b.md', title: 'B', body: '', score: 0.9,
+        source: { repo: 'beta', id: 'abc123def456', branch: 'main' } }],
+      total: 1,
+    });
+    const res = await api.lensSearch('dev', 'query text', ['core', 'beta']);
+    expect(calls[0]).toBe('/api/v1/lenses/dev/search?q=query+text&repo=core&repo=beta');
+    expect(res).toHaveLength(1);
+    expect(res[0].source).toEqual({ repo: 'beta', id: 'abc123def456', branch: 'main' });
+  });
+
+  it('lensSearch omits repo= when no repos are passed', async () => {
+    const calls = mockJSON({ results: [], total: 0 });
+    await api.lensSearch('dev', 'x');
+    expect(calls[0]).toBe('/api/v1/lenses/dev/search?q=x');
+  });
+
+  it('lensCompletions builds the category+prefix URL', async () => {
+    const calls = mockJSON({ values: ['core', 'beta'] });
+    const res = await api.lensCompletions('dev', 'repo', 'co');
+    expect(calls[0]).toBe('/api/v1/lenses/dev/completions?category=repo&prefix=co');
+    expect(res.values).toEqual(['core', 'beta']);
+  });
+
+  it('lensCompletions defaults prefix to empty', async () => {
+    const calls = mockJSON({ values: [] });
+    await api.lensCompletions('dev', 'domain');
+    expect(calls[0]).toBe('/api/v1/lenses/dev/completions?category=domain&prefix=');
+  });
+
+  it('getLensFact URL-encodes an entire kb:// qualified path as one segment', async () => {
+    const calls = mockJSON({
+      path: 'kb://abc123def456/kb/foo.md', title: 'Foo', body: 'hi',
+      as_of: { commit: 'deadbee' },
+      source: { repo: 'beta', id: 'abc123def456', branch: 'main' },
+    });
+    const f = await api.getLensFact('dev', 'kb://abc123def456/kb/foo.md');
+    expect(calls[0]).toBe(
+      '/api/v1/lenses/dev/facts/kb%3A%2F%2Fabc123def456%2Fkb%2Ffoo.md');
+    // normalized fact body preserved, as_of.commit hoisted, source attached
+    expect(f.body).toBe('hi');
+    expect(f.commit_hash).toBe('deadbee');
+    expect(f.source).toEqual({ repo: 'beta', id: 'abc123def456', branch: 'main' });
+  });
+
+  it('getLensFact encodes a bare write-repo path', async () => {
+    const calls = mockJSON({
+      path: 'kb/x.md', title: 'X', body: '',
+      source: { repo: 'core', id: 'abc123def456', branch: 'main' },
+    });
+    await api.getLensFact('dev', 'kb/x.md');
+    expect(calls[0]).toBe('/api/v1/lenses/dev/facts/kb%2Fx.md');
+  });
+
+  it('updateLens PATCHes the body and returns the updated lens with description', async () => {
+    const calls: Array<[string, RequestInit]> = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {
+      calls.push([url, init]);
+      return { ok: true, status: 200, json: async () => ({
+        name: 'dev', write: 'work', description: 'my lens', reads: [{ repo: 'core' }],
+      }) };
+    });
+    const body = { write: 'work', description: 'my lens', reads: [{ repo: 'core' }] };
+    const lens = await api.updateLens('dev', body);
+    expect(calls[0][0]).toBe('/api/v1/lenses/dev');
+    expect(calls[0][1].method).toBe('PATCH');
+    expect(JSON.parse(calls[0][1].body as string)).toEqual(body);
+    expect(lens.description).toBe('my lens');
+  });
+
+  it('updateLens surfaces the problem+json detail on non-2xx', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false, status: 422, statusText: 'Unprocessable Entity',
+      json: async () => ({ detail: 'unknown repo "ghost"' }),
+    });
+    await expect(api.updateLens('dev', { write: 'ghost' })).rejects.toThrow('unknown repo "ghost"');
+  });
+});
+
 describe('parseNDJSONLine', () => {
   it('parses a progress line', () => {
     const e = parseNDJSONLine('{"type":"progress","step":"clone","message":"x","pct":40}');

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -584,6 +584,53 @@ describe('api lens read surface', () => {
     expect(calls[0]).toBe('/api/v1/lenses/dev/facts/kb%2Fx.md');
   });
 
+  it('getLensStats builds the lens stats URL with the encoded path and returns the flat envelope', async () => {
+    const calls = mockJSON({
+      total: 250, repo_count: 2, last_commit: '2026-07-20T10:00:00Z', avg_confidence: 0.82,
+      domains: { go: 7 }, entities: {},
+      repos: [{ id: 'abc123def456', name: 'core', source: '', branch: 'agent/main', is_write: true,
+        total: 200, avg_confidence: 0.9, domains: { go: 5 }, entities: {},
+        last_commit: '2026-07-19T09:00:00Z', changes_7d: 1, changes_30d: 2, changes_90d: 3 }],
+    });
+    const res = await api.getLensStats('dev', 'kb/tech');
+    expect(calls[0]).toBe('/api/v1/lenses/dev/stats?path=kb%2Ftech');
+    expect(res.total).toBe(250);
+    expect(res.repo_count).toBe(2);
+    expect(res.repos[0].is_write).toBe(true);
+  });
+
+  it('lensBrowse strips the ontology root and emits the bare /topics URL at the root', async () => {
+    const calls = mockJSON({ path: 'kb', children: [] });
+    const res = await api.lensBrowse('dev', 'kb', 'kb');
+    expect(calls[0]).toBe('/api/v1/lenses/dev/topics');
+    expect(res.path).toBe('kb');
+    expect(res.children).toEqual([]);
+  });
+
+  it('lensBrowse builds the node URL with repeated repo= and surfaces leaf path/source', async () => {
+    const calls = mockJSON({
+      path: 'kb/decisions',
+      children: [
+        { name: 'lens', is_dir: true },
+        { name: 'a.md', is_dir: false, type: 'decision', title: 'A',
+          path: 'kb://abc123def456/kb/decisions/a.md', source: { repo: 'docs', id: 'abc123def456' } },
+      ],
+    });
+    const res = await api.lensBrowse('dev', 'kb/decisions', 'kb', ['core', 'docs']);
+    expect(calls[0]).toBe('/api/v1/lenses/dev/topics/decisions?repo=core&repo=docs');
+    expect(res.children).toHaveLength(2);
+    expect(res.children[0]).toEqual({ name: 'lens', is_dir: true });
+    expect(res.children[1].path).toBe('kb://abc123def456/kb/decisions/a.md');
+    expect(res.children[1].source).toEqual({ repo: 'docs', id: 'abc123def456' });
+  });
+
+  it('lensBrowse tolerates a missing children array', async () => {
+    const calls = mockJSON({ path: 'kb' });
+    const res = await api.lensBrowse('dev', 'kb', 'kb');
+    expect(calls[0]).toBe('/api/v1/lenses/dev/topics');
+    expect(res.children).toEqual([]);
+  });
+
   it('updateLens PATCHes the body and returns the updated lens with description', async () => {
     const calls: Array<[string, RequestInit]> = [];
     globalThis.fetch = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -80,8 +80,16 @@ export interface LensRead { repo: string; branch?: string; source?: string }
 // created_at/updated_at are unix seconds, present on server responses.
 export interface Lens {
   name: string; write: string; reads: LensRead[];
+  description?: string;
   created_at?: number; updated_at?: number;
 }
+// LensSource identifies which mount a lens union row came from: the source
+// repo, its 12-char id, and the branch the row was read at (RFC §6.2).
+export interface LensSource { repo: string; id: string; branch: string }
+// LensFactEntry is one row of a lens union facts collection — a RecentFactEntry
+// (path canonical: bare for the write repo, kb://<id12>/… for a read mount) plus
+// its source mount.
+export interface LensFactEntry extends RecentFactEntry { source: LensSource }
 
 export interface DirChild { name: string; is_dir: boolean; type?: string; title?: string; fullPath?: string }
 export interface BrowseResponse { path: string; children: DirChild[] }
@@ -507,9 +515,66 @@ async function getLens(name: string): Promise<Lens> {
 
 // createLens POSTs a new lens. fetchJSON throws on non-2xx surfacing the
 // problem+json `detail`, so the UI shows the server's validation message.
-async function createLens(body: { name: string; write: string; reads: LensRead[] }): Promise<Lens> {
+async function createLens(body: { name: string; write: string; reads: LensRead[]; description?: string }): Promise<Lens> {
   return fetchJSON<Lens>(apiUrl('/api/v1/lenses'), {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// lensBase builds the base URL for a single lens's sub-resources.
+function lensBase(name: string): string {
+  return apiUrl(`/api/v1/lenses/${name}`);
+}
+
+// listLensFacts GETs /api/v1/lenses/{lens}/facts — the recency-ordered, deduped
+// union of the lens's write repo + read mounts. Flat envelope ({facts,total});
+// each row carries a canonical `path` and its `source` mount. `repos` maps to
+// repeated `repo=` params (narrows the fan-out); omitted params are dropped.
+async function listLensFacts(lens: string, opts: { path?: string; query?: string; limit?: number; offset?: number; repos?: string[] }): Promise<{ facts: LensFactEntry[]; total: number }> {
+  const p = new URLSearchParams();
+  if (opts.path) p.set('path', opts.path);
+  if (opts.query) p.set('query', opts.query);
+  if (opts.limit !== undefined) p.set('limit', String(opts.limit));
+  if (opts.offset !== undefined) p.set('offset', String(opts.offset));
+  for (const repo of opts.repos ?? []) p.append('repo', repo);
+  const qs = p.toString();
+  return fetchJSON<{ facts: LensFactEntry[]; total: number }>(`${lensBase(lens)}/facts${qs ? `?${qs}` : ''}`);
+}
+
+// lensSearch GETs /api/v1/lenses/{lens}/search — the RRF-fused union relevance
+// search. The envelope is flat ({results,total}); this returns just the results
+// array (each row canonical path + source). `repos` → repeated `repo=` params.
+async function lensSearch(lens: string, q: string, repos?: string[]): Promise<(SearchResult & { source: LensSource })[]> {
+  const p = new URLSearchParams({ q });
+  for (const repo of repos ?? []) p.append('repo', repo);
+  const data = await fetchJSON<{ results?: (SearchResult & { source: LensSource })[] }>(`${lensBase(lens)}/search?${p}`);
+  return data.results ?? [];
+}
+
+// lensCompletions GETs /api/v1/lenses/{lens}/completions — the union of per-mount
+// completion values, plus the lens-only category=repo that lists mount names.
+async function lensCompletions(lens: string, category: string, prefix = ''): Promise<{ values: string[] }> {
+  return fetchJSON<{ values: string[] }>(`${lensBase(lens)}/completions?category=${encodeURIComponent(category)}&prefix=${encodeURIComponent(prefix)}`);
+}
+
+// getLensFact GETs /api/v1/lenses/{lens}/facts/{path} — a single fact read
+// through a lens. The whole path is encodeURIComponent'd as one segment so a
+// kb://<id12>/kb/… qualified address survives to the server, which PathUnescapes
+// it (a bare kb/… path round-trips too). Response is the repo FactView body
+// (normalized) plus a `source` mount.
+async function getLensFact(lens: string, path: string): Promise<Fact & { source: LensSource }> {
+  const data = await fetchJSON<any>(`${lensBase(lens)}/facts/${encodeURIComponent(path)}`);
+  return { ...normalizeFactResponse(data), source: data.source as LensSource };
+}
+
+// updateLens PATCHes /api/v1/lenses/{name} — omitted fields keep their current
+// value, provided fields replace wholesale (reads replace as a set). Returns the
+// updated lens view. fetchJSON surfaces the problem+json detail on non-2xx.
+async function updateLens(name: string, body: { write?: string; reads?: LensRead[]; description?: string }): Promise<Lens> {
+  return fetchJSON<Lens>(lensBase(name), {
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
@@ -549,7 +614,12 @@ export const api = {
   listLenses,
   getLens,
   createLens,
+  updateLens,
   deleteLens,
+  listLensFacts,
+  lensSearch,
+  lensCompletions,
+  getLensFact,
 
   browse: (repo: string, branch: string, path: string, ontologyRoot: string): Promise<BrowseResponse> => {
     const relative = stripOntologyRoot(ontologyRoot, path);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -221,7 +221,12 @@ function parseAnchorToken(prefix: 'at' | 'vs', value: string, lookupHead?: () =>
   return undefined;
 }
 
-export function parseFilterQuery(raw: string, lookupHead?: () => string): { chips: FilterChip[]; text: string; asOf?: AsOf; warnings: string[] } {
+// parseFilterQuery is context-aware via opts.allowRepo. `repo:` is a lens-only
+// facet: it is recognised as a chip category ONLY when allowRepo is set (lens
+// context). In a repo context (the default) `repo:foo` stays free text — the
+// repo-context parse output is byte-for-byte what it was before this facet
+// existed, so no new chip category can leak onto a repo surface.
+export function parseFilterQuery(raw: string, lookupHead?: () => string, opts?: { allowRepo?: boolean }): { chips: FilterChip[]; text: string; asOf?: AsOf; warnings: string[] } {
   const chips: FilterChip[] = [];
   let asOf: AsOf | undefined;
   const warnings: string[] = [];
@@ -240,13 +245,20 @@ export function parseFilterQuery(raw: string, lookupHead?: () => string): { chip
     return '';
   });
 
+  // The recognised chip categories. `repo` is appended only in lens context.
+  const cats = opts?.allowRepo
+    ? 'domain|entity|type|kind|origin|ep|path|repo'
+    : 'domain|entity|type|kind|origin|ep|path';
+  const quotedRe = new RegExp(`(${cats}):"([^"]+)"`, 'g');
+  const bareRe = new RegExp(`(${cats}):(\\S+)`, 'g');
+
   // Extract prefix:"quoted value" patterns first
-  remaining = remaining.replace(/(domain|entity|type|kind|origin|ep|path):"([^"]+)"/g, (_m, prefix, value) => {
+  remaining = remaining.replace(quotedRe, (_m, prefix, value) => {
     chips.push({ category: prefix as FilterChip['category'], value });
     return '';
   });
   // Extract prefix:value patterns (no quotes, no spaces)
-  remaining = remaining.replace(/(domain|entity|type|kind|origin|ep|path):(\S+)/g, (_m, prefix, value) => {
+  remaining = remaining.replace(bareRe, (_m, prefix, value) => {
     chips.push({ category: prefix as FilterChip['category'], value });
     return '';
   });
@@ -546,8 +558,23 @@ async function listLensFacts(lens: string, opts: { path?: string; query?: string
 // lensSearch GETs /api/v1/lenses/{lens}/search — the RRF-fused union relevance
 // search. The envelope is flat ({results,total}); this returns just the results
 // array (each row canonical path + source). `repos` → repeated `repo=` params.
-async function lensSearch(lens: string, q: string, repos?: string[]): Promise<(SearchResult & { source: LensSource })[]> {
-  const p = new URLSearchParams({ q });
+// `opts` forwards the same content filters the repo /search sends — the lens
+// search handler accepts the full set (path/type/kind/origin/ep/domain/entities);
+// the lens FACTS handler does NOT, which is why the Library routes filter-bearing
+// reads through this search path.
+async function lensSearch(
+  lens: string, q: string, repos?: string[],
+  opts?: { path?: string; types?: string[]; kinds?: string[]; origins?: string[]; eps?: string[]; domains?: string[]; entities?: string[] },
+): Promise<(SearchResult & { source: LensSource })[]> {
+  const p = new URLSearchParams();
+  if (q) p.set('q', q);
+  if (opts?.path) p.set('path', opts.path);
+  if (opts?.types?.length) p.set('type', opts.types.join(','));
+  if (opts?.kinds?.length) p.set('kind', opts.kinds.join(','));
+  if (opts?.origins?.length) p.set('origin', opts.origins.join(','));
+  if (opts?.eps?.length) p.set('ep', opts.eps.join(','));
+  if (opts?.domains?.length) p.set('domain', opts.domains.join(','));
+  if (opts?.entities?.length) p.set('entities', opts.entities.join(','));
   for (const repo of repos ?? []) p.append('repo', repo);
   const data = await fetchJSON<{ results?: (SearchResult & { source: LensSource })[] }>(`${lensBase(lens)}/search?${p}`);
   return data.results ?? [];

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -91,8 +91,32 @@ export interface LensSource { repo: string; id: string; branch: string }
 // its source mount.
 export interface LensFactEntry extends RecentFactEntry { source: LensSource }
 
+// LensRepoStats is one per-mount row of the lens union stats: the mount's
+// identity plus its own aggregate stats and commit activity.
+export interface LensRepoStats {
+  id: string; name: string; source: string; branch: string; is_write: boolean;
+  total: number; avg_confidence: number;
+  domains: Record<string, number>; entities: Record<string, number>;
+  last_commit: string; changes_7d: number; changes_30d: number; changes_90d: number;
+}
+// LensStats is the flat union stats envelope: exact-sum roll-up (weighted
+// avg_confidence, max last_commit) plus one LensRepoStats row per mount.
+export interface LensStats {
+  total: number; repo_count: number; last_commit: string; avg_confidence: number;
+  domains: Record<string, number>; entities: Record<string, number>;
+  repos: LensRepoStats[];
+}
+
 export interface DirChild { name: string; is_dir: boolean; type?: string; title?: string; fullPath?: string }
 export interface BrowseResponse { path: string; children: DirChild[] }
+
+// LensDirChild is one child of a unified lens tree level: a DirChild plus —
+// on fact leaves only — the canonical qualified wire `path` (bare for the
+// write mount, kb://<id12>/… for a read mount; what openFact needs) and the
+// owning mount's `source` tag. Directories are merged across mounts and carry
+// neither.
+export interface LensDirChild extends DirChild { path?: string; source?: { repo: string; id: string } }
+export interface LensBrowseResponse { path: string; children: LensDirChild[] }
 export interface Fact { path: string; title: string; kind?: string; type?: string; origin?: string; body: string; domain: string[]; confidence: number; sources: number; entities: string[]; refs: string[]; parse_error?: string; from_commit?: string; commit_hash?: string; commit_date?: string }
 
 // normalizeFactResponse maps the new HAL FactView shape to the Fact interface.
@@ -596,6 +620,30 @@ async function getLensFact(lens: string, path: string): Promise<Fact & { source:
   return { ...normalizeFactResponse(data), source: data.source as LensSource };
 }
 
+// getLensStats GETs /api/v1/lenses/{lens}/stats — the union stats/activity
+// roll-up of the lens's write repo + read mounts (exact sums, total-weighted
+// avg_confidence, max last_commit) with one row per mount. Flat envelope,
+// mirroring the other lens reads.
+async function getLensStats(lens: string, path: string): Promise<LensStats> {
+  return fetchJSON<LensStats>(`${lensBase(lens)}/stats?path=${encodeURIComponent(path)}`);
+}
+
+// lensBrowse GETs /api/v1/lenses/{lens}/topics[/{segments}] — ONE level of the
+// unified, merged-by-topic ontology tree across the lens's mounts. Strips the
+// ontology root from `path` like api.browse does; `repos` maps to repeated
+// `repo=` params like listLensFacts (omitted → all mounts). The envelope is
+// flat ({path, children}) — no HAL _embedded — and the returned `path` echoes
+// the caller's full path, mirroring api.browse.
+async function lensBrowse(lens: string, path: string, ontologyRoot: string, repos?: string[]): Promise<LensBrowseResponse> {
+  const relative = stripOntologyRoot(ontologyRoot, path);
+  const p = new URLSearchParams();
+  for (const repo of repos ?? []) p.append('repo', repo);
+  const qs = p.toString();
+  const url = `${lensBase(lens)}/topics${relative ? `/${relative}` : ''}${qs ? `?${qs}` : ''}`;
+  const data = await fetchJSON<{ path: string; children?: LensDirChild[] }>(url);
+  return { path, children: data.children ?? [] };
+}
+
 // updateLens PATCHes /api/v1/lenses/{name} — omitted fields keep their current
 // value, provided fields replace wholesale (reads replace as a set). Returns the
 // updated lens view. fetchJSON surfaces the problem+json detail on non-2xx.
@@ -647,6 +695,8 @@ export const api = {
   lensSearch,
   lensCompletions,
   getLensFact,
+  getLensStats,
+  lensBrowse,
 
   browse: (repo: string, branch: string, path: string, ontologyRoot: string): Promise<BrowseResponse> => {
     const relative = stripOntologyRoot(ontologyRoot, path);

--- a/web/src/icons.test.tsx
+++ b/web/src/icons.test.tsx
@@ -1,0 +1,21 @@
+import { it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LayersIcon } from './icons';
+
+it('LayersIcon renders the Feather "layers" polygon and two polylines', () => {
+  const { container } = render(<LayersIcon color="#a8a4f0" />);
+  const polygon = container.querySelector('polygon');
+  const polylines = container.querySelectorAll('polyline');
+  expect(polygon?.getAttribute('points')).toBe('12 2 2 7 12 12 22 7 12 2');
+  expect(polylines).toHaveLength(2);
+  expect(polylines[0].getAttribute('points')).toBe('2 12 12 17 22 12');
+  expect(polylines[1].getAttribute('points')).toBe('2 17 12 22 22 17');
+});
+
+it('LayersIcon applies color and size props like sibling icons', () => {
+  const { container } = render(<LayersIcon color="#a8a4f0" size={20} />);
+  const svg = container.querySelector('svg');
+  expect(svg?.getAttribute('stroke')).toBe('#a8a4f0');
+  expect(svg?.getAttribute('width')).toBe('20');
+  expect(svg?.getAttribute('height')).toBe('20');
+});

--- a/web/src/icons.tsx
+++ b/web/src/icons.tsx
@@ -96,6 +96,32 @@ export const LayersIcon = ({ color, size = 14 }: IconProps) => (
   </svg>
 );
 
+// Pencil — the "Edit mounts" affordance (Feather "edit-3").
+export const PencilIcon = ({ color, size = 14 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 20h9"/>
+    <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>
+  </svg>
+);
+
+// Trash — the delete affordance (Feather "trash-2").
+export const TrashIcon = ({ color, size = 14 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="3 6 5 6 21 6"/>
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+    <line x1="10" y1="11" x2="10" y2="17"/>
+    <line x1="14" y1="11" x2="14" y2="17"/>
+  </svg>
+);
+
+// Copy — the "copy to clipboard" affordance (Feather "copy").
+export const CopyIcon = ({ color, size = 14 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+  </svg>
+);
+
 // ---------- Library sort icons ----------
 
 // Nested-list tree — the directory hierarchy of the Path sort.

--- a/web/src/icons.tsx
+++ b/web/src/icons.tsx
@@ -87,6 +87,15 @@ export const FolderIcon = ({ color, size = 14 }: IconProps) => (
   </svg>
 );
 
+// Stacked planes — the lens/overlay metaphor (Feather "layers").
+export const LayersIcon = ({ color, size = 14 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polygon points="12 2 2 7 12 12 22 7 12 2"/>
+    <polyline points="2 12 12 17 22 12"/>
+    <polyline points="2 17 12 22 22 17"/>
+  </svg>
+);
+
 // ---------- Library sort icons ----------
 
 // Nested-list tree — the directory hierarchy of the Path sort.

--- a/web/src/repoSelection.test.ts
+++ b/web/src/repoSelection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
-import { pickRepo, loadLastRepo, saveLastRepo, REPO_STORAGE_KEY } from './repoSelection';
+import { pickRepo, loadLastRepo, saveLastRepo, loadLastContext, saveLastContext, REPO_STORAGE_KEY, CONTEXT_STORAGE_KEY } from './repoSelection';
 import type { RepoInfo } from './api';
 
 const repos = (...names: string[]): RepoInfo[] => names.map(name => ({ name }));
@@ -73,6 +73,61 @@ describe('loadLastRepo / saveLastRepo', () => {
       throw new Error('disabled');
     });
     expect(loadLastRepo()).toBeNull();
+    spy.mockRestore();
+  });
+});
+
+describe('loadLastContext / saveLastContext', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips a repo context', () => {
+    saveLastContext({ kind: 'repo', repo: 'work' });
+    expect(loadLastContext()).toEqual({ kind: 'repo', repo: 'work' });
+  });
+
+  it('round-trips a lens context', () => {
+    saveLastContext({ kind: 'lens', name: 'dev' });
+    expect(loadLastContext()).toEqual({ kind: 'lens', name: 'dev' });
+  });
+
+  it('migrates a legacy bare-repo value to {kind:"repo"}', () => {
+    // Old builds stored just the repo name under REPO_STORAGE_KEY.
+    localStorage.setItem(REPO_STORAGE_KEY, 'legacy-repo');
+    expect(loadLastContext()).toEqual({ kind: 'repo', repo: 'legacy-repo' });
+  });
+
+  it('prefers the JSON context key over the legacy bare-repo key', () => {
+    localStorage.setItem(REPO_STORAGE_KEY, 'legacy-repo');
+    saveLastContext({ kind: 'lens', name: 'dev' });
+    expect(loadLastContext()).toEqual({ kind: 'lens', name: 'dev' });
+  });
+
+  it('returns null when nothing has been saved', () => {
+    expect(loadLastContext()).toBeNull();
+  });
+
+  it('does not persist a repo context with an empty repo name', () => {
+    saveLastContext({ kind: 'repo', repo: '' });
+    expect(localStorage.getItem(CONTEXT_STORAGE_KEY)).toBeNull();
+  });
+
+  it('keeps the legacy repo key in sync for a repo context (downgrade safety)', () => {
+    saveLastContext({ kind: 'repo', repo: 'work' });
+    expect(localStorage.getItem(REPO_STORAGE_KEY)).toBe('work');
+    expect(loadLastRepo()).toBe('work');
+  });
+
+  it('falls back to the legacy key when the context JSON is corrupt', () => {
+    localStorage.setItem(CONTEXT_STORAGE_KEY, '{not valid json');
+    localStorage.setItem(REPO_STORAGE_KEY, 'legacy-repo');
+    expect(loadLastContext()).toEqual({ kind: 'repo', repo: 'legacy-repo' });
+  });
+
+  it('survives localStorage throwing', () => {
+    const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('disabled');
+    });
+    expect(loadLastContext()).toBeNull();
     spy.mockRestore();
   });
 });

--- a/web/src/repoSelection.ts
+++ b/web/src/repoSelection.ts
@@ -7,8 +7,13 @@
 // user's last explicit choice across reloads.
 
 import type { RepoInfo } from './api';
+import type { BrowseContext } from './state';
 
 export const REPO_STORAGE_KEY = 'knomit.repo';
+// The last browse context (repo | lens) is stored as a JSON tagged union under
+// its own key. The legacy REPO_STORAGE_KEY (a bare repo name string) is still
+// read as a migration fallback so an existing user lands back on their repo.
+export const CONTEXT_STORAGE_KEY = 'knomit.context';
 
 // pickRepo chooses which repo the UI should show, given the repos the server
 // currently knows about, the currently-selected repo, and the last repo the
@@ -42,5 +47,51 @@ export function saveLastRepo(repo: string): void {
     localStorage.setItem(REPO_STORAGE_KEY, repo);
   } catch {
     /* quota exceeded / storage disabled — last-repo memory is best-effort */
+  }
+}
+
+// loadLastContext returns the last browse context the user was in, or null.
+// Precedence:
+//   1. the JSON tagged union under CONTEXT_STORAGE_KEY (repo | lens)
+//   2. a legacy bare-repo name under REPO_STORAGE_KEY → {kind:'repo', repo}
+//   3. null (nothing usable stored)
+// Any parse/shape error is treated as "nothing stored" so a corrupt value can
+// never wedge bootstrap.
+export function loadLastContext(): BrowseContext | null {
+  try {
+    const raw = localStorage.getItem(CONTEXT_STORAGE_KEY);
+    if (raw) {
+      // A malformed value must not wedge bootstrap — swallow the parse error and
+      // fall through to the legacy migration below.
+      let parsed: Partial<BrowseContext> | null = null;
+      try { parsed = JSON.parse(raw) as Partial<BrowseContext>; } catch { parsed = null; }
+      if (parsed && parsed.kind === 'repo' && typeof parsed.repo === 'string' && parsed.repo) {
+        return { kind: 'repo', repo: parsed.repo };
+      }
+      if (parsed && parsed.kind === 'lens' && typeof parsed.name === 'string' && parsed.name) {
+        return { kind: 'lens', name: parsed.name };
+      }
+      // Unknown/corrupt shape: fall through to the legacy migration.
+    }
+    // Migration: an old bare-repo value loads as a {kind:'repo'} context.
+    const legacy = localStorage.getItem(REPO_STORAGE_KEY);
+    if (legacy) return { kind: 'repo', repo: legacy };
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// saveLastContext persists the browse context. An empty repo name (the initial
+// pre-selection state) is not persisted, matching saveLastRepo.
+export function saveLastContext(ctx: BrowseContext): void {
+  if (ctx.kind === 'repo' && !ctx.repo) return;
+  try {
+    localStorage.setItem(CONTEXT_STORAGE_KEY, JSON.stringify(ctx));
+    // Keep the legacy key in sync for a repo context so a downgrade still lands
+    // the user on the right repo; a lens context has no legacy representation.
+    if (ctx.kind === 'repo') localStorage.setItem(REPO_STORAGE_KEY, ctx.repo);
+  } catch {
+    /* quota exceeded / storage disabled — last-context memory is best-effort */
   }
 }

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { reducer, init, currentPath, selectAnchorCommit, selectTrail, isLive, isReadOnly } from './state';
+import { reducer, init, currentPath, selectAnchorCommit, selectTrail, isLive, isReadOnly, isLensContext, openFactSource } from './state';
 import type { AppState, FilterChip } from './state';
+import type { Lens, LensSource } from './api';
 
 describe('reducer — cycle-collapse on hop (APPLY_NAV hop:true)', () => {
   const histHop = (factPath: string, commit: string) =>
@@ -221,6 +222,123 @@ describe('reducer — SET_REPO', () => {
 
   it('init has no repo selected (repo is chosen from the server list on mount)', () => {
     expect(init.repo).toBe('');
+  });
+});
+
+describe('reducer — BrowseContext (SET_CONTEXT / SET_REPO wrapper)', () => {
+  const lens: Lens = { name: 'dev', write: 'work', reads: [{ repo: 'work' }, { repo: 'core' }] };
+  const source: LensSource = { repo: 'core', id: 'abc123def456', branch: 'main' };
+
+  it('init is a repo context matching init.repo', () => {
+    expect(init.context).toEqual({ kind: 'repo', repo: '' });
+    expect(isLensContext(init)).toBe(false);
+    expect(init.lens).toBeNull();
+    expect(init.lensSources).toBeNull();
+    expect(init.factSource).toBeNull();
+  });
+
+  it('SET_CONTEXT {kind:repo} resets asOf/fact/filters like a repo switch', () => {
+    let s: AppState = { ...init };
+    s = reducer(s, { type: 'ADD_FILTER', chip: { category: 'domain', value: 'tech' } });
+    s = reducer(s, { type: 'APPLY_NAV', view: 'library', factPath: 'kb/x.md', asOf: { mode: 'history', commit: 'abc1234' } });
+    s = reducer(s, { type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'work' } });
+    expect(s.context).toEqual({ kind: 'repo', repo: 'work' });
+    expect(s.repo).toBe('work');
+    expect(s.view).toBe('library');
+    expect(s.factPath).toBeNull();
+    expect(s.asOf).toEqual({ mode: 'live' });
+    expect(s.filters).toHaveLength(0);
+    expect(s.freeText).toBe('');
+    expect(s.navStack).toHaveLength(0);
+    expect(s.headCommit).toBe('');
+    expect(s.branch).toBe('');
+    expect(s.remoteError).toBe('');
+    expect(s.rightPanelFocused).toBe(false);
+    expect(s.lens).toBeNull();
+    expect(s.lensSources).toBeNull();
+  });
+
+  it('SET_REPO behaves byte-identically to SET_CONTEXT {kind:repo} on the shared fields', () => {
+    const start: AppState = { ...init, filters: [{ category: 'domain', value: 'go' }], factPath: 'kb/y.md', freeText: 'q' };
+    const viaRepo = reducer(start, { type: 'SET_REPO', repo: 'work' });
+    const viaContext = reducer(start, { type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'work' } });
+    expect(viaRepo).toEqual(viaContext);
+  });
+
+  it('SET_REPO still resets navigation state (regression: existing consumers)', () => {
+    let s = reducer(init, { type: 'ADD_FILTER', chip: { category: 'domain', value: 'tech' } });
+    s = reducer(s, { type: 'SET_REPO', repo: 'work' });
+    expect(s.repo).toBe('work');
+    expect(s.context).toEqual({ kind: 'repo', repo: 'work' });
+    expect(s.filters).toHaveLength(0);
+    expect(s.branch).toBe('');
+  });
+
+  it('SET_CONTEXT {kind:lens} enters a lens context and resets navigation', () => {
+    let s: AppState = { ...init, repo: 'work', branch: 'agent/x' };
+    s = reducer(s, { type: 'ADD_FILTER', chip: { category: 'domain', value: 'tech' } });
+    s = reducer(s, { type: 'SET_CONTEXT', context: { kind: 'lens', name: 'dev' } });
+    expect(s.context).toEqual({ kind: 'lens', name: 'dev' });
+    expect(isLensContext(s)).toBe(true);
+    expect(s.lens).toBeNull();
+    expect(s.filters).toHaveLength(0);
+    expect(s.asOf).toEqual({ mode: 'live' });
+    // repo/branch stay valid (previous values) until SET_LENS resolves the write mount.
+    expect(s.repo).toBe('work');
+    expect(s.branch).toBe('agent/x');
+  });
+
+  it('SET_LENS stores the lens doc and points repo at the write mount', () => {
+    let s = reducer(init, { type: 'SET_CONTEXT', context: { kind: 'lens', name: 'dev' } });
+    s = reducer(s, { type: 'SET_LENS', lens });
+    expect(s.lens).toEqual(lens);
+    expect(s.repo).toBe('work');
+    expect(s.branch).toBe(''); // cleared → status bootstrap resolves the agent branch
+  });
+
+  it('SET_LENS_SOURCES sets the sources selection (null = all mounts)', () => {
+    let s = reducer(init, { type: 'SET_LENS_SOURCES', repos: ['core', 'work'] });
+    expect(s.lensSources).toEqual(['core', 'work']);
+    s = reducer(s, { type: 'SET_LENS_SOURCES', repos: null });
+    expect(s.lensSources).toBeNull();
+  });
+
+  it('SET_FACT_SOURCE sets and clears the open fact source mount', () => {
+    let s = reducer(init, { type: 'SET_FACT_SOURCE', source });
+    expect(s.factSource).toEqual(source);
+    s = reducer(s, { type: 'SET_FACT_SOURCE', source: null });
+    expect(s.factSource).toBeNull();
+  });
+
+  it('factSource is cleared on context switch', () => {
+    let s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factSource: source, factPath: 'kb/x.md' };
+    s = reducer(s, { type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'work' } });
+    expect(s.factSource).toBeNull();
+  });
+});
+
+describe('openFactSource — the temporal/write anchor', () => {
+  const lens: Lens = { name: 'dev', write: 'work', reads: [{ repo: 'work' }, { repo: 'core' }] };
+  const source: LensSource = { repo: 'core', id: 'abc123def456', branch: 'main' };
+
+  it('repo context → {state.repo, state.branch}', () => {
+    const s: AppState = { ...init, context: { kind: 'repo', repo: 'work' }, repo: 'work', branch: 'agent/x' };
+    expect(openFactSource(s)).toEqual({ repo: 'work', branch: 'agent/x' });
+  });
+
+  it('lens context with an open fact → the fact source mount', () => {
+    const s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factPath: 'kb://abc123def456/kb/x.md', factSource: source };
+    expect(openFactSource(s)).toEqual({ repo: 'core', branch: 'main' });
+  });
+
+  it('lens context with no open fact → {lens.write, ""} (branch "" = resolve agent branch)', () => {
+    const s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factPath: null, factSource: null };
+    expect(openFactSource(s)).toEqual({ repo: 'work', branch: '' });
+  });
+
+  it('lens context falls back to lens.write once the fact is closed (stale factSource ignored)', () => {
+    const s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factPath: null, factSource: source };
+    expect(openFactSource(s)).toEqual({ repo: 'work', branch: '' });
   });
 });
 

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { reducer, init, currentPath, selectAnchorCommit, selectTrail, isLive, isReadOnly, isLensContext, openFactSource, factHistoryAnchor, edgeAnchorCommit } from './state';
+import { reducer, init, currentPath, selectAnchorCommit, selectTrail, isLive, isReadOnly, isLensContext, lensResolutionPending, openFactSource, factHistoryAnchor, edgeAnchorCommit } from './state';
 import type { AppState, FilterChip } from './state';
 import type { Lens, LensSource } from './api';
 
@@ -294,6 +294,21 @@ describe('reducer — BrowseContext (SET_CONTEXT / SET_REPO wrapper)', () => {
     expect(s.lens).toEqual(lens);
     expect(s.repo).toBe('work');
     expect(s.branch).toBe(''); // cleared → status bootstrap resolves the agent branch
+  });
+
+  it('lensResolutionPending flags an unresolved lens context from ANY entry surface', () => {
+    // Regression: entering a lens via the TopBar switcher only dispatches
+    // SET_CONTEXT — nothing else runs. App's resolution effect keys off this
+    // predicate; if it missed the unresolved state, RightPanel fell through to
+    // the repo-scoped fetch with a raw kb:// path (404).
+    let s = reducer(init, { type: 'SET_CONTEXT', context: { kind: 'lens', name: 'dev' } });
+    expect(lensResolutionPending(s)).toBe(true);       // entered, not resolved
+    s = reducer(s, { type: 'SET_LENS', lens });
+    expect(lensResolutionPending(s)).toBe(false);      // resolved
+    s = reducer(s, { type: 'SET_CONTEXT', context: { kind: 'lens', name: 'other' } });
+    expect(lensResolutionPending(s)).toBe(true);       // switched to another lens
+    s = reducer(s, { type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'work' } });
+    expect(lensResolutionPending(s)).toBe(false);      // repo context never pends
   });
 
   it('SET_LENS_SOURCES sets the sources selection (null = all mounts)', () => {

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { reducer, init, currentPath, selectAnchorCommit, selectTrail, isLive, isReadOnly, isLensContext, openFactSource } from './state';
+import { reducer, init, currentPath, selectAnchorCommit, selectTrail, isLive, isReadOnly, isLensContext, openFactSource, factHistoryAnchor, edgeAnchorCommit } from './state';
 import type { AppState, FilterChip } from './state';
 import type { Lens, LensSource } from './api';
 
@@ -385,6 +385,50 @@ describe('openFactSource — the temporal/write anchor', () => {
   it('lens context falls back to lens.write once the fact is closed (stale factSource ignored)', () => {
     const s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factPath: null, factSource: source };
     expect(openFactSource(s)).toEqual({ repo: 'work', branch: '' });
+  });
+});
+
+describe('factHistoryAnchor — mount + RELATIVE path, co-located', () => {
+  const lens: Lens = { name: 'dev', write: 'work', reads: [{ repo: 'work' }, { repo: 'core' }] };
+  const source: LensSource = { repo: 'core', id: 'abc123def456', branch: 'main' };
+
+  it('repo context → {state.repo, state.branch, bare path} (byte-identical)', () => {
+    const s: AppState = { ...init, context: { kind: 'repo', repo: 'work' }, repo: 'work', branch: 'agent/x', factPath: 'kb/a.md' };
+    expect(factHistoryAnchor(s)).toEqual({ repo: 'work', branch: 'agent/x', path: 'kb/a.md' });
+  });
+
+  it('lens read-mount fact → mount repo/branch + relative path (kb://<id12>/ stripped)', () => {
+    const s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factPath: 'kb://abc123def456/kb/x.md', factSource: source };
+    expect(factHistoryAnchor(s)).toEqual({ repo: 'core', branch: 'main', path: 'kb/x.md' });
+  });
+
+  it('honours an explicit path arg (e.g. an edge target), still stripping the qualifier', () => {
+    const s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factPath: 'kb://abc123def456/kb/x.md', factSource: source };
+    expect(factHistoryAnchor(s, 'kb://abc123def456/kb/y.md')).toEqual({ repo: 'core', branch: 'main', path: 'kb/y.md' });
+  });
+});
+
+describe('edgeAnchorCommit — mount-safe live edge anchor', () => {
+  const lens: Lens = { name: 'dev', write: 'work', reads: [{ repo: 'work' }, { repo: 'core' }] };
+  const source: LensSource = { repo: 'core', id: 'abc123def456', branch: 'main' };
+
+  it('repo context, live → state.headCommit (the repo\'s own head)', () => {
+    const s: AppState = { ...init, context: { kind: 'repo', repo: 'work' }, repo: 'work', branch: 'agent/x', headCommit: 'repohead', asOf: { mode: 'live' } };
+    expect(edgeAnchorCommit(s)).toBe('repohead');
+  });
+
+  it('lens context, live with an open read-mount fact → "" (never the WRITE repo head)', () => {
+    // state.headCommit here is the write repo\'s head — passing it against the read
+    // mount would 404. Live lens edges must resolve at the mount\'s live HEAD.
+    const s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, repo: 'work', branch: 'agent/x', headCommit: 'writehead', factPath: 'kb://abc123def456/kb/x.md', factSource: source, asOf: { mode: 'live' } };
+    expect(edgeAnchorCommit(s)).toBe('');
+  });
+
+  it('history/diff → the time-travel anchor (a commit from the fact\'s own mount timeline)', () => {
+    const hist: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factSource: source, factPath: 'kb://abc123def456/kb/x.md', asOf: { mode: 'history', commit: 'mountc1' } };
+    expect(edgeAnchorCommit(hist)).toBe('mountc1');
+    const diff: AppState = { ...init, asOf: { mode: 'diff', from: 'f1', to: 't1' } };
+    expect(edgeAnchorCommit(diff)).toBe('t1');
   });
 });
 

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -304,7 +304,9 @@ describe('reducer — BrowseContext (SET_CONTEXT / SET_REPO wrapper)', () => {
   });
 
   it('SET_FACT_SOURCE sets and clears the open fact source mount', () => {
-    let s = reducer(init, { type: 'SET_FACT_SOURCE', source });
+    // A source is only meaningful while a fact is open, so open one first.
+    let s = reducer(init, { type: 'APPLY_NAV', view: 'library', factPath: 'kb/x.md', asOf: { mode: 'live' } });
+    s = reducer(s, { type: 'SET_FACT_SOURCE', source });
     expect(s.factSource).toEqual(source);
     s = reducer(s, { type: 'SET_FACT_SOURCE', source: null });
     expect(s.factSource).toBeNull();
@@ -314,6 +316,50 @@ describe('reducer — BrowseContext (SET_CONTEXT / SET_REPO wrapper)', () => {
     let s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens, factSource: source, factPath: 'kb/x.md' };
     s = reducer(s, { type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'work' } });
     expect(s.factSource).toBeNull();
+  });
+
+  it('factSource is cleared when the open fact closes (factPath -> null)', () => {
+    // Open a lens fact and record its source mount, then navigate away (fact
+    // closes). The source must not linger for a direct reader.
+    let s: AppState = { ...init, context: { kind: 'lens', name: 'dev' }, lens };
+    s = reducer(s, { type: 'APPLY_NAV', view: 'library', factPath: 'kb/x.md', asOf: { mode: 'live' } });
+    s = reducer(s, { type: 'SET_FACT_SOURCE', source });
+    expect(s.factSource).toEqual(source);
+    // Close the fact via APPLY_NAV to null.
+    s = reducer(s, { type: 'APPLY_NAV', view: 'library', factPath: null, asOf: { mode: 'live' } });
+    expect(s.factPath).toBeNull();
+    expect(s.factSource).toBeNull();
+  });
+
+  it('SET_LENS is a no-op after switching back to a repo context (stale resolution)', () => {
+    // resolveLens(A) is in flight; user switches to a repo context; the late
+    // SET_LENS{A} must not repoint repo or set lens in a repo context.
+    let s = reducer(init, { type: 'SET_CONTEXT', context: { kind: 'lens', name: 'dev' } });
+    s = reducer(s, { type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'other' } });
+    const before = s;
+    s = reducer(s, { type: 'SET_LENS', lens });
+    expect(s).toBe(before);          // untouched
+    expect(s.lens).toBeNull();
+    expect(s.repo).toBe('other');    // not yanked to lens.write
+    expect(s.context).toEqual({ kind: 'repo', repo: 'other' });
+  });
+
+  it('SET_LENS is a no-op when a different lens is now active (out-of-order resolution)', () => {
+    // resolveLens(A) resolves after the user already switched to lens B.
+    let s = reducer(init, { type: 'SET_CONTEXT', context: { kind: 'lens', name: 'dev' } });
+    s = reducer(s, { type: 'SET_CONTEXT', context: { kind: 'lens', name: 'other' } });
+    const before = s;
+    s = reducer(s, { type: 'SET_LENS', lens }); // lens.name === 'dev', context is 'other'
+    expect(s).toBe(before);
+    expect(s.lens).toBeNull();
+    expect(s.context).toEqual({ kind: 'lens', name: 'other' });
+  });
+
+  it('SET_LENS applies when its name matches the active lens context', () => {
+    let s = reducer(init, { type: 'SET_CONTEXT', context: { kind: 'lens', name: 'dev' } });
+    s = reducer(s, { type: 'SET_LENS', lens });
+    expect(s.lens).toEqual(lens);
+    expect(s.repo).toBe('work');
   });
 });
 

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -12,7 +12,9 @@ export type BrowseContext =
   | { kind: 'lens'; name: string };
 
 export interface FilterChip {
-  category: 'domain' | 'entity' | 'type' | 'kind' | 'origin' | 'ep' | 'path';
+  // 'repo' is a lens-only facet (narrows the union fan-out); it never appears in
+  // a repo context. See parseFilterQuery(opts.allowRepo) and FilterBar.
+  category: 'domain' | 'entity' | 'type' | 'kind' | 'origin' | 'ep' | 'path' | 'repo';
   value: string;
 }
 

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -428,6 +428,17 @@ export function isLensContext(s: AppState): boolean {
   return s.context.kind === 'lens';
 }
 
+// lensResolutionPending is true when the context names a lens that state.lens
+// does not yet reflect — the signal for App's resolution effect. A lens context
+// can be entered from several surfaces (TopBar switcher, manager Browse,
+// bootstrap restore); they all just dispatch SET_CONTEXT, and App resolves
+// whenever this returns true. Same-name re-resolution after an edit is
+// deliberately NOT covered (state.lens.name already matches) — that path goes
+// through refreshContextAfterChange.
+export function lensResolutionPending(s: AppState): boolean {
+  return s.context.kind === 'lens' && s.lens?.name !== s.context.name;
+}
+
 // openFactSource is THE temporal/write anchor for the current view:
 //   - repo context      → {state.repo, state.branch} (authoritative)
 //   - lens context, fact open → the open fact's source mount (repo + the branch

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -168,7 +168,7 @@ function replacePathChip(filters: FilterChip[], value: string): FilterChip[] {
 }
 
 
-export function reducer(s: AppState, a: Action): AppState {
+function applyAction(s: AppState, a: Action): AppState {
   switch (a.type) {
     case 'NAVIGATE':
       return {
@@ -308,6 +308,13 @@ export function reducer(s: AppState, a: Action): AppState {
       return { ...base, lens: null, lensSources: null };
     }
     case 'SET_LENS':
+      // Guard against a stale, out-of-order resolution. resolveLens is
+      // fire-and-forget: a slow getLens(A) can resolve after the user already
+      // switched to lens B or back to a repo context. Applying it would repoint
+      // repo at A's write mount and set lens=A in the wrong context (violating
+      // "lens is null in a repo context"). Only accept a lens doc that still
+      // matches the active lens context.
+      if (s.context.kind !== 'lens' || s.context.name !== a.lens.name) return s;
       // The lens's write mount becomes the app's write/status target so
       // state.repo/state.branch stay valid in a lens context. When the write
       // repo actually changes, clear branch/headCommit to re-run the status
@@ -384,6 +391,21 @@ export function reducer(s: AppState, a: Action): AppState {
     default:
       return s;
   }
+}
+
+// reducer wraps applyAction with a cross-cutting invariant: factSource is
+// meaningful only while a fact is open. Whenever a fact closes (factPath -> null)
+// — via APPLY_NAV/AMEND_NAV to null, NAVIGATE, GO_UP, filter changes, sort
+// switch, context switch, etc. — drop the source mount so no direct reader can
+// observe stale data. Centralizing this here means new fact-close paths inherit
+// the guarantee for free. Referential identity is preserved for the common case
+// (already-null factSource), so no-op arms that `return s` stay ===.
+export function reducer(s: AppState, a: Action): AppState {
+  const next = applyAction(s, a);
+  if (next.factPath === null && next.factSource !== null) {
+    return { ...next, factSource: null };
+  }
+  return next;
 }
 
 export function selectAnchorCommit(s: AppState): string | null {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -78,6 +78,20 @@ export interface AppState {
   notice: string;
   searching: boolean;            // a relevance (free-text) search request is in flight
   serverReadOnly: boolean;       // instance-level read-only (demo mode)
+  // factTitles caches the human title of every fact the RightPanel has loaded,
+  // keyed by factTitleKey(path, commit). The breadcrumb reads from it so it can
+  // label a crumb with the title we ALREADY read when navigating there — rather
+  // than re-fetching, which fails for a retracted fact (the live single-fact
+  // endpoint 404s a tombstone). Session-only: the trail is session-only too, so
+  // every crumb was visited and is therefore cached.
+  factTitles: Record<string, string>;
+}
+
+// factTitleKey is the shared cache key for a fact's title: its path plus the
+// commit it was read at (undefined = live/HEAD). The breadcrumb's crumb key and
+// the RightPanel's cache write MUST agree, so both go through this.
+export function factTitleKey(path: string, commit?: string): string {
+  return `${path}@${commit ?? 'HEAD'}`;
 }
 
 export type Action =
@@ -96,6 +110,7 @@ export type Action =
   | { type: 'CONSOLE_SET_HEIGHT'; height: number }
   | { type: 'SET_REPO'; repo: string }
   | { type: 'SET_CONTEXT'; context: BrowseContext }
+  | { type: 'CACHE_FACT_TITLE'; key: string; title: string }
   | { type: 'SET_LENS'; lens: Lens }
   | { type: 'SET_LENS_SOURCES'; repos: string[] | null }
   | { type: 'SET_FACT_SOURCE'; source: LensSource | null }
@@ -144,6 +159,7 @@ export const init: AppState = {
   notice: '',
   searching: false,
   serverReadOnly: false,
+  factTitles: {},
 };
 
 function pushNav(s: AppState): NavEntry[] {
@@ -390,6 +406,11 @@ function applyAction(s: AppState, a: Action): AppState {
         factPath: a.factPath,
         ...(a.asOf !== undefined ? { asOf: a.asOf } : {}),
       };
+    }
+    case 'CACHE_FACT_TITLE': {
+      // No-op when nothing changes so a re-fire never triggers a needless render.
+      if (!a.title || s.factTitles[a.key] === a.title) return s;
+      return { ...s, factTitles: { ...s.factTitles, [a.key]: a.title } };
     }
     default:
       return s;

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -1,6 +1,15 @@
+import type { Lens, LensSource } from './api';
+
 export type View = 'library';
 
 export type LibrarySort = 'path' | 'recent' | 'relevance';
+
+// BrowseContext is the surface the app is currently browsing: a whole repo, or
+// a lens's read union. It is the single source of truth for "what am I looking
+// at" — SET_REPO is a thin wrapper that dispatches SET_CONTEXT {kind:'repo'}.
+export type BrowseContext =
+  | { kind: 'repo'; repo: string }
+  | { kind: 'lens'; name: string };
 
 export interface FilterChip {
   category: 'domain' | 'entity' | 'type' | 'kind' | 'origin' | 'ep' | 'path';
@@ -31,6 +40,17 @@ interface ConsoleEntry {
 
 export interface AppState {
   repo: string;
+  // context is the browse surface (repo | lens). In a repo context, repo/branch
+  // are authoritative for both reads and writes. In a lens context, reads come
+  // via the lens endpoints (Task 14); repo/branch are kept valid pointing at the
+  // lens's write mount + its agent branch so write routing never breaks.
+  context: BrowseContext;
+  lens: Lens | null;            // resolved lens doc; null in repo context
+  lensSources: string[] | null; // sources-dropdown selection; null = all mounts
+  // factSource is the source mount of the currently open lens fact — set by the
+  // fact-open path when a lens fact loads (Task 14/16), and cleared on context
+  // switch. It is the temporal/write anchor for the open fact in a lens context.
+  factSource: LensSource | null;
   view: View;
   factPath: string | null;       // right panel: fact to display (all modes)
   asOf: AsOf;                    // global "as of when" anchor (live | history | diff)
@@ -72,6 +92,10 @@ export type Action =
   | { type: 'CONSOLE_TOGGLE' }
   | { type: 'CONSOLE_SET_HEIGHT'; height: number }
   | { type: 'SET_REPO'; repo: string }
+  | { type: 'SET_CONTEXT'; context: BrowseContext }
+  | { type: 'SET_LENS'; lens: Lens }
+  | { type: 'SET_LENS_SOURCES'; repos: string[] | null }
+  | { type: 'SET_FACT_SOURCE'; source: LensSource | null }
   | { type: 'SET_REMOTE_ERROR'; error: string }
   | { type: 'FOCUS_RIGHT_PANEL' }
   | { type: 'BLUR_RIGHT_PANEL' }
@@ -89,6 +113,10 @@ export const init: AppState = {
   // assume a repo name exists (any repo, including the default, can be renamed
   // or deleted server-side). App picks the repo from /api/v1/repos on mount.
   repo: '',
+  context: { kind: 'repo', repo: '' },
+  lens: null,
+  lensSources: null,
+  factSource: null,
   view: 'library',
   factPath: null,
   asOf: { mode: 'live' },
@@ -247,20 +275,54 @@ export function reducer(s: AppState, a: Action): AppState {
     case 'CONSOLE_SET_HEIGHT':
       return { ...s, consoleHeight: Math.max(80, Math.min(a.height, 600)) };
     case 'SET_REPO':
-      return {
+      // Thin wrapper: switching to a repo is just entering a {kind:'repo'}
+      // context. Reducing through SET_CONTEXT keeps a single reset path so repo
+      // and lens switches can never drift apart.
+      return reducer(s, { type: 'SET_CONTEXT', context: { kind: 'repo', repo: a.repo } });
+    case 'SET_CONTEXT': {
+      // Entering any browse surface resets the navigation state exactly as a
+      // repo switch always did: asOf → live, open fact closed, filters/freeText
+      // cleared, nav trail dropped, remote error cleared, right panel blurred.
+      // factSource is dropped too — the open fact (and its source mount) is gone.
+      const base: AppState = {
         ...s,
-        repo: a.repo,
+        context: a.context,
         view: 'library',
         factPath: null,
         asOf: { mode: 'live' },
         filters: [],
         freeText: '',
-        headCommit: '',
-        branch: '',
         navStack: [],
         remoteError: '',
         rightPanelFocused: false,
+        factSource: null,
       };
+      if (a.context.kind === 'repo') {
+        // Repo context: repo/branch are authoritative. Clearing branch/headCommit
+        // re-triggers the status bootstrap. lens state is not applicable.
+        return { ...base, repo: a.context.repo, headCommit: '', branch: '', lens: null, lensSources: null };
+      }
+      // Lens context: the write mount isn't known until SET_LENS resolves the
+      // lens doc, so repo/branch stay at their previous (still valid) values
+      // until then. lens/lensSources reset; App re-fetches the lens.
+      return { ...base, lens: null, lensSources: null };
+    }
+    case 'SET_LENS':
+      // The lens's write mount becomes the app's write/status target so
+      // state.repo/state.branch stay valid in a lens context. When the write
+      // repo actually changes, clear branch/headCommit to re-run the status
+      // bootstrap (which resolves the write repo's agent branch).
+      return {
+        ...s,
+        lens: a.lens,
+        repo: a.lens.write,
+        branch: s.repo === a.lens.write ? s.branch : '',
+        headCommit: s.repo === a.lens.write ? s.headCommit : '',
+      };
+    case 'SET_LENS_SOURCES':
+      return { ...s, lensSources: a.repos };
+    case 'SET_FACT_SOURCE':
+      return { ...s, factSource: a.source };
     case 'SET_REMOTE_ERROR':
       return { ...s, remoteError: a.error };
     case 'FOCUS_RIGHT_PANEL':
@@ -334,6 +396,30 @@ export function selectAnchorCommit(s: AppState): string | null {
 
 export function isLive(s: AppState): boolean {
   return s.asOf.mode === 'live';
+}
+
+// isLensContext is true when the app is browsing a lens (rather than a repo).
+export function isLensContext(s: AppState): boolean {
+  return s.context.kind === 'lens';
+}
+
+// openFactSource is THE temporal/write anchor for the current view:
+//   - repo context      → {state.repo, state.branch} (authoritative)
+//   - lens context, fact open → the open fact's source mount (repo + the branch
+//     it was read at), so writes/history for that fact route to where it lives.
+//   - lens context, no fact   → the lens's write mount, {lens.write, ''}.
+// A branch of '' is the "resolve the agent branch" sentinel: callers translate
+// it (via api.getAgentBranch) before issuing a write. A closed fact (factPath
+// null) is treated as "no fact open" so a stale factSource can never leak past
+// a fact close — the fact-open path re-sets factSource for the next lens fact.
+export function openFactSource(s: AppState): { repo: string; branch: string } {
+  if (s.context.kind === 'lens') {
+    if (s.factPath && s.factSource) {
+      return { repo: s.factSource.repo, branch: s.factSource.branch };
+    }
+    if (s.lens) return { repo: s.lens.write, branch: '' };
+  }
+  return { repo: s.repo, branch: s.branch };
 }
 
 export function isReadOnly(s: AppState): boolean {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -1,4 +1,5 @@
 import type { Lens, LensSource } from './api';
+import { displayLensPath } from './utils';
 
 export type View = 'library';
 
@@ -444,6 +445,35 @@ export function openFactSource(s: AppState): { repo: string; branch: string } {
     if (s.lens) return { repo: s.lens.write, branch: '' };
   }
   return { repo: s.repo, branch: s.branch };
+}
+
+// factHistoryAnchor is the READ anchor for a fact's history/edges: the open
+// fact's source mount (openFactSource) paired with the RELATIVE path (the
+// kb://<id12>/ qualifier stripped via displayLensPath). Co-locating repo,
+// branch, AND path in one helper keeps the three dimensions from drifting apart
+// at the call sites (LeftPanel/App/RightPanel/useTimeTravel) — the drift that
+// let a browse-surface commit leak against a read mount. `path` defaults to the
+// open fact; pass the loaded fact's own canonical path where it differs. Repo
+// context: {state.repo, state.branch, <bare path>} — byte-identical to the old
+// inline pairing.
+export function factHistoryAnchor(
+  s: AppState,
+  path: string | null = s.factPath,
+): { repo: string; branch: string; path: string } {
+  const { repo, branch } = openFactSource(s);
+  return { repo, branch, path: displayLensPath(path ?? '') };
+}
+
+// edgeAnchorCommit is the commit EdgesRail anchors on. Time-travelling: the
+// history/diff anchor (selectAnchorCommit) — a commit drawn from the OPEN FACT's
+// own mount timeline, so it resolves against that mount. Live: the mount's live
+// HEAD — state.headCommit in a repo context (the repo's own head), but '' (no
+// commit → the non-anchored live-HEAD explain URL) in a lens context, where the
+// open fact's mount head isn't tracked in state and state.headCommit is the
+// WRITE repo's head (which doesn't exist in a read mount → an empty edge set in
+// the default live view). Repo context is byte-identical (always state.headCommit).
+export function edgeAnchorCommit(s: AppState): string {
+  return selectAnchorCommit(s) ?? (isLensContext(s) ? '' : s.headCommit);
 }
 
 export function isReadOnly(s: AppState): boolean {

--- a/web/src/useTimeTravel.test.ts
+++ b/web/src/useTimeTravel.test.ts
@@ -185,4 +185,38 @@ describe('useTimeTravel — per-fact anchor in a lens context', () => {
     await act(async () => { await result.current.returnToNow(); });
     expect(api.fact).toHaveBeenCalledWith('core', 'agent/main', 'kb/ops/rollback.md');
   });
+
+  // C2: an edge/in-body ref carries a MOUNT-RELATIVE bare path. In a lens context
+  // a bare path canonically addresses the WRITE repo, so a hop from a non-write
+  // read-mount fact must re-qualify the dispatched target to the SAME mount; a hop
+  // from a write-repo fact (and repo context) keeps the bare path. The relative
+  // path still drives the anchor read against the mount.
+  it('hopEdge from a read-mount fact qualifies the dispatched target with the source mount id (C2)', async () => {
+    (api.fact as any).mockResolvedValue(mkFact('head1'));
+    const dispatch = vi.fn();
+    const { result } = renderHook(() =>
+      useTimeTravel(lensState(READ_PATH, readSource, { mode: 'live' }), dispatch as any));
+    await act(async () => { await result.current.hopEdge('kb/other.md', 'pin1'); });
+    // Anchor read used the relative path against the mount…
+    expect(api.fact).toHaveBeenCalledWith('docs', 'main', 'kb/other.md');
+    // …but the dispatched fact identity is qualified to the same read mount.
+    expect(navFrom(dispatch)?.factPath).toBe('kb://docsid123456/kb/other.md');
+  });
+
+  it('hopEdge from a write-repo fact keeps the bare target (C2)', async () => {
+    (api.fact as any).mockResolvedValue(mkFact('head1'));
+    const dispatch = vi.fn();
+    const { result } = renderHook(() =>
+      useTimeTravel(lensState('kb/ops/rollback.md', writeSource, { mode: 'live' }), dispatch as any));
+    await act(async () => { await result.current.hopEdge('kb/other.md', 'pin1'); });
+    expect(navFrom(dispatch)?.factPath).toBe('kb/other.md');
+  });
+
+  it('openFileAt from a read-mount fact qualifies with the source mount id (C2)', () => {
+    const dispatch = vi.fn();
+    const { result } = renderHook(() =>
+      useTimeTravel(lensState(READ_PATH, readSource, { mode: 'live' }), dispatch as any));
+    act(() => { result.current.openFileAt('kb/other.md', 'c9'); });
+    expect(navFrom(dispatch)?.factPath).toBe('kb://docsid123456/kb/other.md');
+  });
 });

--- a/web/src/useTimeTravel.test.ts
+++ b/web/src/useTimeTravel.test.ts
@@ -138,3 +138,51 @@ describe('useTimeTravel stale-navigation guard', () => {
     expect(setAsOf).toEqual([{ type: 'SET_AS_OF', asOf: { mode: 'history', commit: 'commitX' } }]);
   });
 });
+
+// Task 17: in a lens context the temporal fetches must anchor on the OPEN
+// FACT's source mount (openFactSource) and read via the mount's repo-scoped
+// endpoints with the RELATIVE path (kb://<id12>/ stripped). In a repo context
+// this collapses to {state.repo, state.branch} + the bare path (unchanged).
+describe('useTimeTravel — per-fact anchor in a lens context', () => {
+  const lens = { name: 'eng', write: 'core', reads: [{ repo: 'core' }, { repo: 'docs' }] } as any;
+  const readSource = { repo: 'docs', id: 'docsid123456', branch: 'main' };
+  const writeSource = { repo: 'core', id: 'coreid123456', branch: 'agent/main' };
+  const READ_PATH = 'kb://docsid123456/kb/api/auth.md';
+
+  const lensState = (factPath: string, factSource: any, asOf: AppState['asOf']): AppState => ({
+    ...init, repo: 'core', branch: 'agent/main', headCommit: 'head1',
+    context: { kind: 'lens', name: 'eng' }, lens, factPath, factSource, asOf,
+  });
+
+  const navFrom = (dispatch: ReturnType<typeof vi.fn>) =>
+    dispatch.mock.calls.map(c => c[0]).find((a: any) => a.type === 'APPLY_NAV');
+
+  it('returnToNow reads the open fact against its MOUNT repo/branch with the RELATIVE path', async () => {
+    (api.fact as any).mockResolvedValue(mkFact('head1'));
+    const dispatch = vi.fn();
+    const { result } = renderHook(() =>
+      useTimeTravel(lensState(READ_PATH, readSource, { mode: 'history', commit: 'c1' }), dispatch as any));
+    await act(async () => { await result.current.returnToNow(); });
+    expect(api.fact).toHaveBeenCalledWith('docs', 'main', 'kb/api/auth.md');
+    // Navigates back to the RAW subject so RightPanel re-resolves through the lens.
+    expect(navFrom(dispatch)?.factPath).toBe(READ_PATH);
+  });
+
+  it('hopEdge (from live) classifies the target against the open fact MOUNT repo/branch', async () => {
+    (api.fact as any).mockResolvedValue(mkFact('head1'));
+    const dispatch = vi.fn();
+    const { result } = renderHook(() =>
+      useTimeTravel(lensState(READ_PATH, readSource, { mode: 'live' }), dispatch as any));
+    await act(async () => { await result.current.hopEdge('kb/other.md', 'pin1'); });
+    expect(api.fact).toHaveBeenCalledWith('docs', 'main', 'kb/other.md');
+  });
+
+  it('write-repo fact: returnToNow anchors on the write mount, bare path passes through', async () => {
+    (api.fact as any).mockResolvedValue(mkFact('head1'));
+    const dispatch = vi.fn();
+    const { result } = renderHook(() =>
+      useTimeTravel(lensState('kb/ops/rollback.md', writeSource, { mode: 'history', commit: 'c1' }), dispatch as any));
+    await act(async () => { await result.current.returnToNow(); });
+    expect(api.fact).toHaveBeenCalledWith('core', 'agent/main', 'kb/ops/rollback.md');
+  });
+});

--- a/web/src/useTimeTravel.ts
+++ b/web/src/useTimeTravel.ts
@@ -1,8 +1,7 @@
 import { useCallback, useRef, useEffect } from 'react';
 import type { Dispatch } from 'react';
 import { api } from './api';
-import { openFactSource } from './state';
-import { displayLensPath } from './utils';
+import { openFactSource, factHistoryAnchor } from './state';
 import type { AppState, Action, AsOf } from './state';
 
 export async function resolveHopAnchor(
@@ -104,8 +103,8 @@ export function useTimeTravel(state: AppState, dispatch: Dispatch<Action>) {
     // Read the subject against its source mount with the RELATIVE path; dispatch
     // still carries the RAW subject so a lens read-mount fact re-resolves through
     // getLensFact (the raw kb://<id12>/ address is the fact's canonical identity).
-    const src = openFactSource(s);
-    const r = await computeReturnToNow(src.repo, src.branch, displayLensPath(subject));
+    const a = factHistoryAnchor(s, subject);
+    const r = await computeReturnToNow(a.repo, a.branch, a.path);
     if (seq !== navSeq.current) return;       // superseded by a newer navigation
     if (r.kind === 'subject') {
       dispatch({ type: 'APPLY_NAV', view: 'library', factPath: subject, asOf: { mode: 'live' } });

--- a/web/src/useTimeTravel.ts
+++ b/web/src/useTimeTravel.ts
@@ -1,6 +1,8 @@
 import { useCallback, useRef, useEffect } from 'react';
 import type { Dispatch } from 'react';
 import { api } from './api';
+import { openFactSource } from './state';
+import { displayLensPath } from './utils';
 import type { AppState, Action, AsOf } from './state';
 
 export async function resolveHopAnchor(
@@ -54,7 +56,11 @@ export async function computeReturnToNow(
 export function useTimeTravel(state: AppState, dispatch: Dispatch<Action>) {
   const ref = useRef(state);
   useEffect(() => { ref.current = state; }, [state]);
-  const { repo, branch } = state;
+  // Temporal reads anchor on the OPEN FACT's source mount, not the browse
+  // surface: {state.repo, state.branch} in a repo context (unchanged), the read
+  // mount the open fact came from in a lens context. Same-mount edge/subject
+  // reads then resolve via that mount's repo-scoped endpoints.
+  const { repo, branch } = openFactSource(state);
 
   // Monotonic navigation generation. The async navigations (hopEdge,
   // returnToNow) resolve an anchor over the network before dispatching; a slow
@@ -95,10 +101,14 @@ export function useTimeTravel(state: AppState, dispatch: Dispatch<Action>) {
     const s = ref.current;
     const subject = s.factPath;
     if (!subject) { dispatch({ type: 'SET_AS_OF', asOf: { mode: 'live' } }); return; }
-    const r = await computeReturnToNow(s.repo, s.branch, subject);
+    // Read the subject against its source mount with the RELATIVE path; dispatch
+    // still carries the RAW subject so a lens read-mount fact re-resolves through
+    // getLensFact (the raw kb://<id12>/ address is the fact's canonical identity).
+    const src = openFactSource(s);
+    const r = await computeReturnToNow(src.repo, src.branch, displayLensPath(subject));
     if (seq !== navSeq.current) return;       // superseded by a newer navigation
     if (r.kind === 'subject') {
-      dispatch({ type: 'APPLY_NAV', view: 'library', factPath: r.factPath, asOf: { mode: 'live' } });
+      dispatch({ type: 'APPLY_NAV', view: 'library', factPath: subject, asOf: { mode: 'live' } });
     } else {
       dispatch({ type: 'APPLY_NAV', view: 'library', factPath: null,
         asOf: { mode: 'live' }, filters: [...s.filters.filter(f => f.category !== 'path'), { category: 'path', value: r.parentPath }] });

--- a/web/src/useTimeTravel.ts
+++ b/web/src/useTimeTravel.ts
@@ -29,6 +29,25 @@ export async function resolveHopAnchor(
   }
 }
 
+// qualifyHopTarget re-qualifies an edge/in-body ref target for the fact-open
+// dispatch in a lens context. EdgesRail groups and in-body refs carry
+// MOUNT-RELATIVE bare paths; a bare path is canonically the lens WRITE repo, so
+// dispatching it verbatim from a NON-write read-mount fact would 404 (or open the
+// write repo's shadow copy). When the open fact lives in a non-write mount,
+// re-qualify a bare target to that SAME mount (kb://<sourceId>/<relPath>) so a
+// same-mount hop lands where the referrer lives. Write-repo facts and repo
+// context keep the bare path; an already-qualified kb:// target (a cross-mount
+// ref naming another mount — the accepted pre-existing gap) passes through
+// untouched. The RELATIVE path is still what resolveHopAnchor reads against the
+// mount; only the dispatched fact identity is qualified.
+export function qualifyHopTarget(s: AppState, path: string): string {
+  if (s.context.kind !== 'lens') return path;
+  const src = s.factSource;
+  if (!src || src.repo === s.lens?.write) return path;
+  if (path.startsWith('kb://')) return path;
+  return `kb://${src.id}/${path}`;
+}
+
 export type ReturnToNowResult =
   | { kind: 'subject'; factPath: string }
   | { kind: 'parent'; parentPath: string; notice: string };
@@ -79,12 +98,15 @@ export function useTimeTravel(state: AppState, dispatch: Dispatch<Action>) {
     const fromAsOf = ref.current.asOf;
     const { asOf } = await resolveHopAnchor(repo, branch, path, pinnedCommit, fromAsOf);
     if (seq !== navSeq.current) return;       // superseded by a newer navigation
-    dispatch({ type: 'APPLY_NAV', view: 'library', factPath: path, asOf, hop: true });
+    // Qualify the dispatched fact identity to the referrer's mount (lens read
+    // mount) so RightPanel re-resolves it there; the relative `path` above still
+    // drove the same-mount anchor read.
+    dispatch({ type: 'APPLY_NAV', view: 'library', factPath: qualifyHopTarget(ref.current, path), asOf, hop: true });
   }, [repo, branch, dispatch]);
 
   const openFileAt = useCallback((path: string, commit: string) => {
     navSeq.current++;
-    dispatch({ type: 'APPLY_NAV', view: 'library', factPath: path, asOf: { mode: 'history', commit }, hop: true });
+    dispatch({ type: 'APPLY_NAV', view: 'library', factPath: qualifyHopTarget(ref.current, path), asOf: { mode: 'history', commit }, hop: true });
   }, [dispatch]);
 
   // Scrubbing always means "view this version in history". Selecting a version

--- a/web/src/utils.test.ts
+++ b/web/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { relativeTime, relativeTimeEpoch, opStyles, defaultOpStyle, typeStyles, defaultTypeStyle } from './utils';
+import { relativeTime, relativeTimeEpoch, opStyles, defaultOpStyle, typeStyles, defaultTypeStyle, LENS, repoHue, repoHueBg, repoHueBorder } from './utils';
 
 describe('relativeTime', () => {
   afterEach(() => { vi.useRealTimers(); });
@@ -94,5 +94,46 @@ describe('typeStyles', () => {
 
   it('defaultTypeStyle has unknown label', () => {
     expect(defaultTypeStyle.label).toBe('unknown');
+  });
+});
+
+describe('LENS tokens', () => {
+  it('carries the verbatim design-handoff hex values', () => {
+    expect(LENS.accent).toBe('#a8a4f0');
+    expect(LENS.bg).toBe('#1c1a2e');
+    expect(LENS.border).toBe('#38345c');
+    expect(LENS.soft).toBe('#231f38');
+    expect(LENS.text).toBe('#141230');
+  });
+});
+
+describe('repoHue', () => {
+  const sample = ['core', 'docs', 'infra', 'research', 'papers', 'scratch'];
+
+  it('is a #rrggbb hex string', () => {
+    for (const name of sample) {
+      expect(repoHue(name)).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it('is stable across calls (same in = same out)', () => {
+    for (const name of sample) {
+      expect(repoHue(name)).toBe(repoHue(name));
+    }
+  });
+
+  it('is pairwise distinct over the sample set', () => {
+    const hues = sample.map(repoHue);
+    expect(new Set(hues).size).toBe(sample.length);
+  });
+
+  it('exposes bg/border helpers as the hue plus 1f/44 alpha suffixes', () => {
+    for (const name of sample) {
+      const base = repoHue(name);
+      expect(repoHueBg(name)).toBe(base + '1f');
+      expect(repoHueBorder(name)).toBe(base + '44');
+      expect(repoHueBg(name)).toMatch(/^#[0-9a-f]{8}$/);
+      expect(repoHueBorder(name)).toMatch(/^#[0-9a-f]{8}$/);
+    }
   });
 });

--- a/web/src/utils.ts
+++ b/web/src/utils.ts
@@ -103,6 +103,14 @@ export function repoHueBorder(name: string): string {
   return repoHue(name) + '44';
 }
 
+/** displayLensPath strips the `kb://<id12>/` qualifier from a read-mount lens
+ *  path so the displayed breadcrumb never shows the opaque mount id — the
+ *  source badge already names the mount. Bare write-repo paths pass through
+ *  unchanged. Shared by the Library union list and the RightPanel meta line. */
+export function displayLensPath(path: string): string {
+  return path.replace(/^kb:\/\/[^/]+\//, '');
+}
+
 export const chipColors: Record<string, { bg: string; text: string; close: string }> = {
   domain: { bg: '#2a3a2a', text: '#7c9', close: '#5a7a5a' },
   entity: { bg: '#3a2a2a', text: '#f8a', close: '#8a5a5a' },

--- a/web/src/utils.ts
+++ b/web/src/utils.ts
@@ -49,6 +49,60 @@ export const typeStyles: Record<string, { color: string; bg: string; label: stri
 
 export const defaultTypeStyle = { color: '#666', bg: '#1a1a1a', label: 'unknown', icon: '·' };
 
+/** Lens design tokens (verbatim from the design handoff). Consumed by the
+ *  lens badges, dots, checkboxes and dropdown across the lens UI. */
+export const LENS = {
+  accent: '#a8a4f0',
+  bg: '#1c1a2e',
+  border: '#38345c',
+  soft: '#231f38',
+  text: '#141230',
+} as const;
+
+/** djb2 string hash → unsigned 32-bit. Stable and deterministic across
+ *  calls and sessions (pure function of the input). */
+function hashString(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  }
+  return h;
+}
+
+/** HSL (h in [0,360), s/l in [0,1]) → lowercase `#rrggbb`. */
+function hslToHex(h: number, s: number, l: number): string {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0, g = 0, b = 0;
+  if (h < 60) { r = c; g = x; }
+  else if (h < 120) { r = x; g = c; }
+  else if (h < 180) { g = c; b = x; }
+  else if (h < 240) { g = x; b = c; }
+  else if (h < 300) { r = x; b = c; }
+  else { r = c; b = x; }
+  const hex = (v: number) => Math.round((v + m) * 255).toString(16).padStart(2, '0');
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+/** Deterministic per-repo accent hue. Pure function of the repo name — stable
+ *  across calls and sessions. Fixed mid saturation / mid-high lightness keeps
+ *  the result a muted pastel that stays readable on the dark UI (#141414). */
+export function repoHue(name: string): string {
+  const hue = hashString(name) % 360;
+  return hslToHex(hue, 0.5, 0.66);
+}
+
+/** Repo hue as a translucent badge fill (hue + '1f' alpha, 8-digit hex). */
+export function repoHueBg(name: string): string {
+  return repoHue(name) + '1f';
+}
+
+/** Repo hue as a translucent badge border (hue + '44' alpha, 8-digit hex). */
+export function repoHueBorder(name: string): string {
+  return repoHue(name) + '44';
+}
+
 export const chipColors: Record<string, { bg: string; text: string; close: string }> = {
   domain: { bg: '#2a3a2a', text: '#7c9', close: '#5a7a5a' },
   entity: { bg: '#3a2a2a', text: '#f8a', close: '#8a5a5a' },


### PR DESCRIPTION
## Lens browsing UI + follow-on work

Merges the `lenses-ui` branch into `lenses`: the lens browsing UI (RFC #8 deferred item #1) plus a round of follow-on features and fixes. Everything reads through real lens REST endpoints — no client-side fan-out.

### Lens read REST (behind `LensMiddleware`, union machinery in `internal/federate`)
- `GET /lenses/{lens}/facts`, `/facts/*`, `/search`, `/completions` — the recency/RRF-fused union of a lens's write repo + N read mounts, with `repo=` narrowing and canonical `kb://<id12>/…` addressing.
- `GET /lenses/{lens}/stats` — union stats/activity: exact-sum roll-up (total-weighted `avg_confidence`, max `last_commit`, merged domains/entities) + a per-repo breakdown; RFC §9.1 fail-whole-request.
- `GET /lenses/{lens}/topics[/*]` — unified, merged-by-topic, lazy per-level ontology tree: directories dedup by name, fact leaves stay per-mount deduped write-first (`writeFirstWinners`, so the tree agrees with the flat facts union).
- `PATCH /lenses/{lens}` + lens descriptions (control.db).

### Web UI
- `BrowseContext` (repo | lens) state + persistence; TopBar two-group switcher with lens chips.
- Union Library with source badges, sources dropdown, and a `repo:` facet; write-repo-only editing routed to the write repo's agent branch.
- Per-fact history anchored on the open fact's own source mount.
- `RightPanel` `LensStatsView` (union header + merged histograms over per-repo rows, with an honest error/loading state); lens Path-sort browses the unified tree via `api.lensBrowse`.
- Repo/lens "Connect an agent" panel covering **both** client families: Claude Code (`knomit-bridge claude init --repo|--lens`) and Cowork/Desktop/other MCP clients (the `mcpServers` config); `RepoDetail` restyled to mirror `LensDetail`.

### Fixes in this round
- **graph:** match DERIVED_FROM in/out edges by the fact's `(path, blob_hash)` node instead of `source/target_commit`, so a fact brought into a branch via a merge commit still shows its connections at HEAD.
- **breadcrumb:** reuse the title RightPanel already loaded (`state.factTitles`) instead of re-fetching — the live lens single-fact endpoint 404s a retracted fact, which stranded the raw hash.

### Accepted v1 gaps (tracked)
SSE live-events + single-fact reads stay write-repo/live-scoped (no lens-wide temporal anchor); see `.claude/plans/lenses-backlog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
