### PR TITLE
fix(web): in-body ref hops pin to the DERIVED_FROM target_commit

### DIFF
--- a/web/src/RightPanel.diff.test.tsx
+++ b/web/src/RightPanel.diff.test.tsx
@@ -11,6 +11,7 @@ vi.mock('./api', () => ({
     stats: vi.fn().mockResolvedValue(null),
     activity: vi.fn().mockResolvedValue(null),
     factCommits: vi.fn().mockResolvedValue({ entries: [] }),
+    explain: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }),
     commitDetail: vi.fn().mockResolvedValue({
       commit: 'bbb2222',
       date: '2026-05-01T00:00:00Z',

--- a/web/src/RightPanel.lens.test.tsx
+++ b/web/src/RightPanel.lens.test.tsx
@@ -25,6 +25,7 @@ vi.mock('./api', () => ({
     activity: vi.fn().mockResolvedValue(null),
     commitDetail: vi.fn().mockResolvedValue(null),
     factCommits: vi.fn().mockResolvedValue({ entries: [] }),
+    explain: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }),
   },
 }));
 

--- a/web/src/RightPanel.readonly.test.tsx
+++ b/web/src/RightPanel.readonly.test.tsx
@@ -24,6 +24,7 @@ vi.mock('./api', () => ({
     activity: vi.fn().mockResolvedValue(null),
     commitDetail: vi.fn().mockResolvedValue(null),
     factCommits: vi.fn().mockResolvedValue({ entries: [] }),
+    explain: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }),
   },
 }));
 

--- a/web/src/RightPanel.refclick.test.tsx
+++ b/web/src/RightPanel.refclick.test.tsx
@@ -29,6 +29,10 @@ vi.mock('./api', () => ({
     activity: vi.fn().mockResolvedValue(null),
     commitDetail: vi.fn().mockResolvedValue(null),
     factCommits: vi.fn().mockResolvedValue({ entries: [] }),
+    // No outgoing edge for REF_PATH → the hop uses the fallback (referrer
+    // commit). The edge-target_commit primary path is covered by
+    // RightPanel.refhop.test.tsx.
+    explain: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }),
   },
 }));
 
@@ -47,10 +51,12 @@ describe('RightPanel — ref click hops to referenced fact', () => {
     const refLink = await waitFor(() => screen.getByText(new RegExp(REF_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))));
     fireEvent.click(refLink);
 
-    // The hop must anchor to the REFERRER fact's own commit (the version the
-    // referrer reasoned over), not the current viewing anchor. Anchoring to the
-    // viewing anchor (repo HEAD when live) makes resolveHopAnchor misclassify
-    // the target as superseded and drops the UI into read-only history mode.
+    // Fallback path: with no outgoing DERIVED_FROM edge for this ref, the hop
+    // anchors to the REFERRER fact's own commit. (The primary path — pinning to
+    // the edge's target_commit — is covered by RightPanel.refhop.test.tsx.)
+    // Never the current viewing anchor: repo HEAD when live makes
+    // resolveHopAnchor misclassify the target as superseded and drops the UI
+    // into read-only history mode.
     expect(onHopRef).toHaveBeenCalledWith(REF_PATH, PARENT_COMMIT);
   });
 });

--- a/web/src/RightPanel.refhop.test.tsx
+++ b/web/src/RightPanel.refhop.test.tsx
@@ -1,0 +1,82 @@
+// Tests for in-body reference hops in the RightPanel fact view.
+//
+// Invariant (kb/principles/philosophy/historical-not-current): a ref resolves
+// at the commit-point of the referrer — following it opens the target as it was
+// WHEN it was referenced, not at the referrer's own current version. The
+// authoritative "version-as-referenced" is the outgoing DERIVED_FROM edge's
+// target_commit. Clicking a ref in the fact body must pin the hop to THAT
+// commit (matching the EdgesRail "OUT" rows), NOT to fact.commit_hash — which
+// 404s when the target was retracted before the referrer's displayed version.
+
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { RightPanel } from './RightPanel';
+import { init } from './state';
+import type { AppState } from './state';
+
+vi.mock('./api', () => ({
+  api: {
+    fact: vi.fn(),
+    factDiff: vi.fn().mockResolvedValue({ from: null, to: null }),
+    stats: vi.fn().mockResolvedValue(null),
+    activity: vi.fn().mockResolvedValue(null),
+    explain: vi.fn(),
+    factCommits: vi.fn().mockResolvedValue({ entries: [] }),
+  },
+}));
+
+import { api } from './api';
+
+const REFERRER_COMMIT = '3c50ca0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; // referrer's own version
+const EDGE_TARGET_COMMIT = 'f28d736bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'; // version-as-referenced
+const REF_PATH = 'kb/technology/security/ai-agents/6cf51b30.md';
+
+const liveState: AppState = {
+  ...init,
+  repo: 'core',
+  branch: 'agent/mindev.local-8ef0cd32',
+  view: 'library',
+  factPath: 'kb/technology/security/ai-agents/synthesis/agent-access-is-blast-radius.md',
+  asOf: { mode: 'live' },
+};
+
+beforeEach(() => {
+  (api.fact as ReturnType<typeof vi.fn>).mockResolvedValue({
+    path: liveState.factPath,
+    title: 'CANONICAL: an AI agent’s access is the attacker’s blast radius',
+    body: 'body',
+    type: 'synthesis',
+    confidence: 0.9,
+    sources: 1,
+    domain: [],
+    entities: [],
+    refs: [REF_PATH],
+    commit_hash: REFERRER_COMMIT,
+    commit_date: '2026-07-01T00:00:00Z',
+  });
+  // The referrer's outgoing edge pins the target to the version it reasoned
+  // over — retracted now (deleted:true), but resolvable at EDGE_TARGET_COMMIT.
+  (api.explain as ReturnType<typeof vi.fn>).mockResolvedValue({
+    incoming: [],
+    outgoing: [{
+      path: REF_PATH,
+      title: 'AI agents are compromised via over-broad permissions and injected instructions',
+      type: 'synthesis',
+      deleted: true,
+      versions: [{ commit: EDGE_TARGET_COMMIT, committed_at: 1783570610, deleted: true }],
+    }],
+  });
+});
+
+it('in-body ref hop pins to the edge target_commit, not the referrer commit', async () => {
+  const onHopRef = vi.fn();
+  render(<RightPanel state={liveState} dispatch={vi.fn()} onHopRef={onHopRef} />);
+
+  const link = await screen.findByText(
+    (_, el) => el?.tagName === 'SPAN' && el.childElementCount === 0 && !!el.textContent && el.textContent.includes(REF_PATH),
+  );
+  fireEvent.click(link);
+
+  await waitFor(() => expect(onHopRef).toHaveBeenCalled());
+  expect(onHopRef).toHaveBeenCalledWith(REF_PATH, EDGE_TARGET_COMMIT);
+});

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -4,7 +4,7 @@ import { useAsync } from './hooks';
 import { api } from './api';
 import type { Fact, Stats, ActivityStats, LensStats, LensRepoStats } from './api';
 import type { AppState, Action } from './state';
-import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, factHistoryAnchor, factTitleKey } from './state';
+import { currentPath, selectAnchorCommit, isReadOnly, READ_ONLY_TITLE, isLensContext, factHistoryAnchor, factTitleKey, edgeAnchorCommit, isLive } from './state';
 import { relativeTime, displayLensPath, repoHue, repoHueBg, repoHueBorder } from './utils';
 import { RetractIcon, GitBranchIcon } from './icons';
 import { FactDiffView } from './FactDiffView';
@@ -54,6 +54,9 @@ function renderFact(
   anchorCommit?: string | null,
   lensMeta?: { repo: string; branch: string },
   readOnlyTitle: string = READ_ONLY_TITLE,
+  // path → the outgoing DERIVED_FROM edge's target_commit (the version the
+  // referrer reasoned over). Sourced from the open fact's own outgoing edges.
+  refCommits: Map<string, string> = new Map(),
 ) {
   const retractDisabled = readOnly;
   const retractTitle = retractDisabled ? readOnlyTitle : 'Retract fact';
@@ -128,12 +131,20 @@ function renderFact(
         fact={fact}
         dispatch={dispatch}
         readOnly={readOnly}
-        // Anchor the hop to THIS fact's own commit — the version of the edge
-        // the referrer reasoned over — not the current viewing anchor. Reusing
-        // the viewing anchor (repo HEAD when live) would make resolveHopAnchor
-        // misclassify nearly every target as superseded and drop the UI into
-        // read-only history mode. No commit_hash → no hop (matches old behavior).
-        onRefClick={onHopRef && refAnchor ? (refPath: string) => onHopRef(refPath, refAnchor) : undefined}
+        // Pin the hop to the ref's DERIVED_FROM edge target_commit — the exact
+        // version of the target the referrer reasoned over, recorded per
+        // ref-event at index time (resolveTargetCommit's first-parent walk from
+        // the ORIGINAL source commit). This is authoritative across PR merges:
+        // fact.commit_hash (the referrer's CURRENT version) + ?fallback=before
+        // walks first-parent from the tip, which cannot reach a target version
+        // that lives on a merge's second-parent line — yielding a 404 for refs
+        // to targets retracted before the referrer's displayed version. Matches
+        // what EdgesRail's "OUT" rows already hop to. Falls back to the
+        // referrer's own commit only when a ref has no matching edge.
+        onRefClick={onHopRef ? (refPath: string) => {
+          const pinned = refCommits.get(refPath) ?? refAnchor;
+          if (pinned) onHopRef(refPath, pinned);
+        } : undefined}
       />
     </div>
   );
@@ -357,6 +368,10 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
   const [error, setError] = useState<string | null>(null);
   const [retracting, setRetracting] = useState(false);
   const [confirmRetract, setConfirmRetract] = useState(false);
+  // path → target_commit for the open fact's outgoing DERIVED_FROM edges, so an
+  // in-body ref hop lands on the version the referrer reasoned over. See the
+  // FactBody onRefClick in renderFact for why this beats fact.commit_hash.
+  const [refCommits, setRefCommits] = useState<Map<string, string>>(new Map());
   const path = currentPath(state);
 
   const factPath = state.factPath;
@@ -450,6 +465,33 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
       })
       .catch(e => { if (!stale()) setError(String(e)); });
   }, [factPath, anchorCommit, state.repo, useFallback, inDiff, lensCtx, lensName]);
+
+  // Resolve each in-body ref's pinned commit from the open fact's OUTGOING
+  // DERIVED_FROM edges — anchored on the fact's own source mount + display
+  // anchor, exactly as EdgesRail fetches them (edgeAnchorCommit + isLive), so
+  // the in-body refs and the connections rail can never disagree. The edge's
+  // target_commit is the version-as-referenced; RightPanel owns this resolution
+  // rather than the referrer's fact.commit_hash (which 404s across PR merges).
+  useAsync((stale) => {
+    if (inDiff || !factPath) { setRefCommits(new Map()); return; }
+    // In a lens context openFactSource points at the WRITE repo until the open
+    // fact's mount resolves (SET_FACT_SOURCE after getLensFact). Fetching before
+    // then would read the wrong mount and leave the map empty — so wait for it,
+    // and re-run when it lands (factSource.repo/branch in the deps below).
+    if (lensCtx && !state.factSource) { setRefCommits(new Map()); return; }
+    const a = factHistoryAnchor(state);
+    api.explain(a.repo, a.branch, a.path, edgeAnchorCommit(state), isLive(state) ? undefined : { fallback: 'before' })
+      .then(e => {
+        if (stale()) return;
+        const m = new Map<string, string>();
+        for (const g of e.outgoing) {
+          const c = g.versions[0]?.commit;
+          if (c) m.set(g.path, c);
+        }
+        setRefCommits(m);
+      })
+      .catch(() => { if (!stale()) setRefCommits(new Map()); });
+  }, [factPath, anchorCommit, state.repo, useFallback, inDiff, lensCtx, lensName, state.factSource?.repo, state.factSource?.branch]);
 
   // Cache the loaded fact's title so the breadcrumb labels this crumb with the
   // title we already read — instead of a separate fetch that 404s for a
@@ -636,6 +678,7 @@ export function RightPanel({ state, dispatch, onScrub, onHopRef }: {
           useFallback ? anchorCommit : null,
           lensMeta,
           factReadOnlyTitle,
+          refCommits,
         )}
       </div>
     </div>


### PR DESCRIPTION
Follow-up fix that was committed locally on `lenses-ui-followups` but landed after PR #17 was auto-closed (its pushed commits were already contained in the PR #18 / #17 merge into `dev`, so GitHub marked it merged). This single commit was never in that merge.

## What
Clicking a fact's in-body reference navigated to the referrer's own current commit + `?fallback=before`, which 404s when the referenced target was retracted before the referrer's displayed version AND lives on a PR merge's second-parent line (`fallback=before` walks first-parent from the tip and never reaches the target version).

`RightPanel` now fetches the open fact's outgoing DERIVED_FROM edges and pins each in-body ref hop to the edge's `target_commit` (the version the referrer reasoned over), falling back to `fact.commit_hash` only when a ref has no matching edge.

Adds `RightPanel.refhop.test.tsx`.