### PR TITLE
fix(repos): refcounted store lifetime — drain in-flight users before close/swap

### DIFF
--- a/internal/mcp/explain.go
+++ b/internal/mcp/explain.go
@@ -130,7 +130,11 @@ func ExplainHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallT
 		// never fans out — the input fact fixes the mount, and the ENTIRE
 		// provenance walk lives inside that mount at its pinned branch (RFC §6.2).
 		b := repos.BindingFromContext(ctx)
-		sWrite := storeIndices(b.Write())
+		sWrite, releaseWrite, err := storeIndices(b.Write())
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		defer releaseWrite()
 
 		file := req.GetString("file", "")
 		commit := req.GetString("commit", "")
@@ -303,7 +307,11 @@ func explainFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, fi
 			return mcpgo.NewToolResultError(fmt.Sprintf("repo %s is not mounted in this binding", id)), nil
 		}
 	}
-	s := storeIndices(rt.RI)
+	s, release, serr := storeIndices(rt.RI)
+	if serr != nil {
+		return mcpgo.NewToolResultError(serr.Error()), nil
+	}
+	defer release()
 	branch := rt.Branch
 	rel = fact.NormalizePath(rt.RI.OntologyRoot(), rel)
 
@@ -467,6 +475,14 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 	// is routed the same way as query (RFC §7.3): unqualified → write mount,
 	// qualified → the mount its kb:// id names in the current binding.
 	stores := map[*repos.RepoInstance]mcpStore{b.Write(): sWrite}
+	// Non-write mounts are acquired on first use and released when the resume
+	// returns; the write mount's acquisition is owned by the calling handler.
+	var mountReleases []func()
+	defer func() {
+		for _, r := range mountReleases {
+			r()
+		}
+	}()
 
 	// Retry dequeue up to 3 times if all items in a batch fail.
 	for range 3 {
@@ -494,7 +510,15 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 			}
 			sm, ok := stores[rt.RI]
 			if !ok {
-				sm = storeIndices(rt.RI)
+				var release func()
+				var serr error
+				sm, release, serr = storeIndices(rt.RI)
+				if serr != nil {
+					// This item's mount is closing or replacing its store; the
+					// frozen view cannot be served consistently right now.
+					return mcpgo.NewToolResultError(serr.Error()), nil
+				}
+				mountReleases = append(mountReleases, release)
 				stores[rt.RI] = sm
 			}
 			// wire re-derives the item's own mount prefix (the walk never leaves the

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -1,12 +1,18 @@
 package mcp
 
 import (
+	"errors"
+
 	"knomit/internal/repos"
 	"knomit/internal/store"
 )
 
+// errStoreUnavailable is the caller-facing error for a mount whose store
+// cannot be acquired right now (repo closed, mid-SwapStore, or still opening).
+// The text is written for the LLM caller: actionable, no internal detail.
+var errStoreUnavailable = errors.New("knowledge base is unavailable (repo is closed, replacing its store, or still opening) — retry shortly")
+
 // mcpStore bundles the store indices used by MCP handlers.
-// Retrieved from a *repos.RepoInstance under a single read lock.
 type mcpStore struct {
 	facts       store.FactIndex
 	search      store.SearchIndex
@@ -15,19 +21,24 @@ type mcpStore struct {
 	branches    store.BranchIndex
 }
 
-// storeIndices extracts the indices a handler may need from ri under a single
-// read lock. Handlers use only the fields they need and ignore the rest.
-func storeIndices(ri *repos.RepoInstance) mcpStore {
-	var s mcpStore
-	ri.WithRead(func(svc *store.Service) {
-		if svc == nil {
-			return
-		}
-		s.facts = svc.Facts()
-		s.search = svc.Search()
-		s.toolSession = svc.ToolSession()
-		s.pipeline = svc.Pipeline()
-		s.branches = svc.Branches()
-	})
-	return s
+// storeIndices acquires the mount's store and returns its indices plus the
+// release func the caller MUST invoke when done with them (defer it, or — in
+// fan-out goroutines — call it before the goroutine exits). Holding the
+// acquisition, rather than copying pointers out of a lock, is what keeps a
+// concurrent SwapStore/Archive on this mount from closing the SQLite handle
+// mid-call: the repos layer drains acquirers before closing (RepoInstance
+// lifetime contract). On error the release is a no-op and the indices are
+// zero; callers surface errStoreUnavailable to the LLM.
+func storeIndices(ri *repos.RepoInstance) (mcpStore, func(), error) {
+	svc, release, err := ri.Acquire()
+	if err != nil {
+		return mcpStore{}, func() {}, errStoreUnavailable
+	}
+	return mcpStore{
+		facts:       svc.Facts(),
+		search:      svc.Search(),
+		toolSession: svc.ToolSession(),
+		pipeline:    svc.Pipeline(),
+		branches:    svc.Branches(),
+	}, release, nil
 }

--- a/internal/mcp/hypothesize.go
+++ b/internal/mcp/hypothesize.go
@@ -63,13 +63,16 @@ func HypothesizeHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.C
 				b.WriteMountBranch(), b.Write().AgentBranch())), nil
 		}
 		ri := b.Write()
-		s := storeIndices(ri)
+		s, release, err := storeIndices(ri)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		defer release()
 		agentBranch := ri.AgentBranch()
 		sessionID := req.GetString("session_id", "")
 		response := req.GetString("response", "")
 
 		var result *HypothesizeResult
-		var err error
 
 		if sessionID == "" {
 			effort, scope, perr := parseEffortAndScope(req, ri)

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -105,7 +105,11 @@ func LearnHandler(embedders ...store.BatchEmbedder) func(context.Context, mcpgo.
 				b.WriteMountBranch(), b.Write().AgentBranch())), nil
 		}
 		ri := b.Write()
-		s := storeIndices(ri)
+		s, release, err := storeIndices(ri)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		defer release()
 		agentBranch := ri.AgentBranch()
 		ontologyRoot := ri.OntologyRoot()
 		ontology := ri.Ontology()

--- a/internal/mcp/query.go
+++ b/internal/mcp/query.go
@@ -169,7 +169,11 @@ func QueryHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToo
 		// snapshots always live in the WRITE repo's store (sWrite); relevance
 		// reads fan out across every mount (queryFirstCall).
 		b := repos.BindingFromContext(ctx)
-		sWrite := storeIndices(b.Write())
+		sWrite, releaseWrite, err := storeIndices(b.Write())
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		defer releaseWrite()
 
 		includeBody := req.GetBool("include_body", false)
 		pageSize := pageSizeFor(req.GetInt("limit", 0), includeBody)
@@ -250,7 +254,12 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 			defer recoverFanout(mountLabel(t.RT), &errs[i])
 			mq := q
 			mq.Path = t.Path
-			sm := storeIndices(t.RT.RI)
+			sm, release, serr := storeIndices(t.RT.RI)
+			if serr != nil {
+				errs[i] = fmt.Errorf("mount %s: %w", mountLabel(t.RT), serr)
+				return
+			}
+			defer release()
 			lists[i], _, errs[i] = sm.search.RecentFacts(ctx, t.RT.Branch, mq)
 		}(i, t)
 	}
@@ -400,7 +409,12 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 			defer recoverFanout(mountLabel(t.RT), &errs[i])
 			mq := q
 			mq.Path = t.Path
-			sm := storeIndices(t.RT.RI)
+			sm, release, serr := storeIndices(t.RT.RI)
+			if serr != nil {
+				errs[i] = fmt.Errorf("mount %s: %w", mountLabel(t.RT), serr)
+				return
+			}
+			defer release()
 			lists[i], errs[i] = sm.search.Search(ctx, t.RT.Branch, mq)
 		}(i, t)
 	}
@@ -550,8 +564,16 @@ func queryResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, cursor 
 		return mcpgo.NewToolResultError("session expired or not found — omit cursor to start a new query"), nil
 	}
 
-	// Per-mount store handles, resolved once per resume.
+	// Per-mount store handles, resolved once per resume. Non-write mounts are
+	// acquired on first use and released when the resume returns; the write
+	// mount's acquisition is owned by the calling handler.
 	stores := map[*repos.RepoInstance]mcpStore{b.Write(): sWrite}
+	var mountReleases []func()
+	defer func() {
+		for _, r := range mountReleases {
+			r()
+		}
+	}()
 	// Non-nil so a fully-unreadable resume still marshals facts:[] (never null).
 	page := []factOutput{}
 
@@ -590,7 +612,15 @@ func queryResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, cursor 
 			}
 			sm, ok := stores[rt.RI]
 			if !ok {
-				sm = storeIndices(rt.RI)
+				var release func()
+				var serr error
+				sm, release, serr = storeIndices(rt.RI)
+				if serr != nil {
+					// This row's mount is closing or replacing its store; the
+					// frozen view cannot be served consistently right now.
+					return mcpgo.NewToolResultError(serr.Error()), nil
+				}
+				mountReleases = append(mountReleases, release)
 				stores[rt.RI] = sm
 			}
 			// Re-read at the frozen commit on the mount's pinned branch; a row

--- a/internal/mcp/query_federation_test.go
+++ b/internal/mcp/query_federation_test.go
@@ -504,22 +504,21 @@ func TestQueryFederation_MountErrorFailsLoud(t *testing.T) {
 	require.Contains(t, text, "search error")
 }
 
-// TestQueryFederation_PanickingMountFailsLoud pins the fix for the fan-out
-// panic-recovery bug: a mount whose store is unavailable (svc == nil, e.g. an
-// archive/shutdown race) makes storeIndices return a zero mcpStore whose index
-// fields are nil interfaces, so the per-mount goroutine's sm.search.Search call
-// panics. A bare fan-out goroutine's panic is NOT recovered by net/http (only
-// the request goroutine is), so without recovery this crashes the whole process.
-// The recovery must instead route the panic into the mount's error slot so it
-// flows through the "any mount error fails the whole query" path (RFC §9.1) — a
-// lens must never silently shrink its read set — yielding a tool error, not a
-// crash. Covers the relevance (Search) fan-out site.
-func TestQueryFederation_PanickingMountFailsLoud(t *testing.T) {
+// TestQueryFederation_UnavailableMountFailsLoud pins the store-lifetime fix
+// for the fan-out on a mount whose store is unavailable (no service attached —
+// e.g. an archive/shutdown/SwapStore race). storeIndices now fails the Acquire
+// up front, so the per-mount goroutine routes a clean, mount-labelled
+// ErrStoreUnavailable into its error slot — no nil-interface panic ever fires —
+// and it flows through the "any mount error fails the whole query" path
+// (RFC §9.1): a lens must never silently shrink its read set. recoverFanout
+// remains as defense-in-depth for genuine panics. Covers the relevance
+// (Search) fan-out site.
+func TestQueryFederation_UnavailableMountFailsLoud(t *testing.T) {
 	repoA, ctxA := fedRepo(t)
 	seedFedFact(t, ctxA, "seed-a", "mission/store", "Alpha", "store", nil)
 
-	// A bare test instance with no Svc → WithRead passes svc == nil → storeIndices
-	// yields a zero mcpStore, so any index call on it panics.
+	// A bare test instance with no Svc → Acquire fails → storeIndices returns
+	// errStoreUnavailable without ever exposing nil index interfaces.
 	nosvc := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{Name: "nosvc", AgentBranch: "agent/test"})
 
 	b := repos.NewBindingForTest(repoA,
@@ -527,16 +526,16 @@ func TestQueryFederation_PanickingMountFailsLoud(t *testing.T) {
 		repos.ReadTarget{RI: nosvc, Branch: "agent/test"},
 	)
 	result, text := queryVia(t, b, map[string]any{"type": []any{"policy"}})
-	require.True(t, result.IsError, "a panicking mount must fail the whole query, not crash")
+	require.True(t, result.IsError, "an unavailable mount must fail the whole query, not crash")
 	require.Contains(t, text, "search error")
-	require.Contains(t, text, "panicked", "the panic must surface as an error, not be swallowed")
+	require.Contains(t, text, "unavailable", "the store-unavailable state must surface as a clean error")
 	require.Contains(t, text, "nosvc", "the error must name the offending mount")
 }
 
-// TestQueryFederation_RecentPanickingMountFailsLoud is the sort=recent twin of
-// TestQueryFederation_PanickingMountFailsLoud: the RecentFacts fan-out site must
-// recover a nil-svc mount's panic into its error slot rather than crashing.
-func TestQueryFederation_RecentPanickingMountFailsLoud(t *testing.T) {
+// TestQueryFederation_RecentUnavailableMountFailsLoud is the sort=recent twin
+// of TestQueryFederation_UnavailableMountFailsLoud: the RecentFacts fan-out
+// site must surface an unavailable mount as a clean, mount-labelled error.
+func TestQueryFederation_RecentUnavailableMountFailsLoud(t *testing.T) {
 	repoA, ctxA := fedRepo(t)
 	seedFedFact(t, ctxA, "seed-a", "mission/store", "Alpha", "store", nil)
 
@@ -547,9 +546,9 @@ func TestQueryFederation_RecentPanickingMountFailsLoud(t *testing.T) {
 		repos.ReadTarget{RI: nosvc, Branch: "agent/test"},
 	)
 	result, text := queryVia(t, b, map[string]any{"sort": "recent"})
-	require.True(t, result.IsError, "a panicking mount must fail the whole recent query, not crash")
+	require.True(t, result.IsError, "an unavailable mount must fail the whole recent query, not crash")
 	require.Contains(t, text, "recent error")
-	require.Contains(t, text, "panicked", "the panic must surface as an error, not be swallowed")
+	require.Contains(t, text, "unavailable", "the store-unavailable state must surface as a clean error")
 	require.Contains(t, text, "nosvc", "the error must name the offending mount")
 }
 

--- a/internal/mcp/retract.go
+++ b/internal/mcp/retract.go
@@ -41,7 +41,11 @@ func RetractHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallT
 				b.WriteMountBranch(), b.Write().AgentBranch())), nil
 		}
 		ri := b.Write()
-		s := storeIndices(ri)
+		s, release, err := storeIndices(ri)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		defer release()
 		agentBranch := ri.AgentBranch()
 		ontologyRoot := ri.OntologyRoot()
 
@@ -50,7 +54,7 @@ func RetractHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallT
 		if file == "" {
 			return mcpgo.NewToolResultError("file is required"), nil
 		}
-		file, err := federate.WriteRepoPath(b, file)
+		file, err = federate.WriteRepoPath(b, file)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/review.go
+++ b/internal/mcp/review.go
@@ -58,6 +58,17 @@ func ReviewHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 		}
 		ri := b.Write()
 
+		// Pin the write mount's store for the whole review call: the Reviewer
+		// resolves store indices from ri per operation and uses them across a
+		// long LLM-driven session step, so without the pin a concurrent
+		// SwapStore/Archive could close the SQLite handle mid-review. The pin
+		// makes those drains wait for this call instead.
+		unpin, err := ri.Pin()
+		if err != nil {
+			return mcpgo.NewToolResultError(errStoreUnavailable.Error()), nil
+		}
+		defer unpin()
+
 		effort, scope, err := parseEffortAndScope(req, ri)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil

--- a/internal/mcp/update.go
+++ b/internal/mcp/update.go
@@ -72,7 +72,11 @@ func UpdateHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 				b.WriteMountBranch(), b.Write().AgentBranch())), nil
 		}
 		ri := b.Write()
-		s := storeIndices(ri)
+		s, release, err := storeIndices(ri)
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		defer release()
 		agentBranch := ri.AgentBranch()
 		ontologyRoot := ri.OntologyRoot()
 		ontology := ri.Ontology()
@@ -82,7 +86,7 @@ func UpdateHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 		if file == "" {
 			return mcpgo.NewToolResultError("file is required"), nil
 		}
-		file, err := federate.WriteRepoPath(b, file)
+		file, err = federate.WriteRepoPath(b, file)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/write_path_test.go
+++ b/internal/mcp/write_path_test.go
@@ -56,7 +56,9 @@ func retractVia(t *testing.T, b *repos.Binding, args map[string]any) (*mcpgo.Cal
 // readFactAt reads and parses a fact from ri's agent branch.
 func readFactAt(t *testing.T, ri *repos.RepoInstance, path string) fact.Fact {
 	t.Helper()
-	s := storeIndices(ri)
+	s, release, err := storeIndices(ri)
+	require.NoError(t, err)
+	defer release()
 	res, err := s.facts.ReadFact(context.Background(), "agent/test", path, nil)
 	require.NoError(t, err)
 	f, err := fact.ParseFact(path, res.Content)
@@ -67,7 +69,9 @@ func readFactAt(t *testing.T, ri *repos.RepoInstance, path string) fact.Fact {
 // factExistsAt reports whether path exists on ri's agent branch.
 func factExistsAt(t *testing.T, ri *repos.RepoInstance, path string) bool {
 	t.Helper()
-	s := storeIndices(ri)
+	s, release, err := storeIndices(ri)
+	require.NoError(t, err)
+	defer release()
 	exists, err := s.facts.FactExists(context.Background(), "agent/test", path)
 	require.NoError(t, err)
 	return exists

--- a/internal/repos/builder.go
+++ b/internal/repos/builder.go
@@ -405,7 +405,7 @@ func (b *repoBuilder) build() *RepoInstance {
 		discoveryWCoh:                 b.cfg.Discovery.WCoh,
 		discoveryWGap:                 b.cfg.Discovery.WGap,
 		discoveryWSpec:                b.cfg.Discovery.WSpec,
-		svc:                           b.svc,
+		handle:                        newStoreHandle(b.svc),
 		hub:                           hub,
 	}
 
@@ -416,9 +416,16 @@ func (b *repoBuilder) build() *RepoInstance {
 	// serialize with that Rebuild and with inline writes. Bare Sync here would
 	// observe the heal's cleared watermark and race a full re-index.
 	obs := observe.New(time.Second, func(hash string) {
-		ri.mu.RLock()
-		currentSvc := ri.svc
-		ri.mu.RUnlock()
+		// Acquire (not a bare pointer snapshot) so a teardown/SwapStore that
+		// fires while this callback is mid-Sync waits for the release below
+		// instead of closing the SQLite handle under the running sync. Once
+		// teardown has begun the Acquire fails and the sync is skipped — the
+		// store is going away, so there is nothing left worth indexing.
+		currentSvc, release, err := ri.Acquire()
+		if err != nil {
+			return
+		}
+		defer release()
 		if err := currentSvc.IndexManager().SyncLocked(context.Background(), b.agentBranch); err != nil {
 			log.Warn().Err(err).Str("repo", b.name).Msg("observer sync failed")
 		}
@@ -466,9 +473,17 @@ func (b *repoBuilder) build() *RepoInstance {
 	agentBranch := b.agentBranch
 
 	ri.startSync = func(remoteURL string) error {
-		ri.mu.RLock()
-		currentSvc := ri.svc
-		ri.mu.RUnlock()
+		// Hold a store reference for the whole activation (remote read +
+		// synchronous reconcile) so a concurrent SwapStore/teardown drains this
+		// call rather than closing the service under it. The reconcile loop
+		// started at the end captures currentSvc beyond this scope; that is
+		// safe because every close/swap path cancels the loop and waits syncWg
+		// before touching the store.
+		currentSvc, release, err := ri.Acquire()
+		if err != nil {
+			return fmt.Errorf("ActivateSync: %w", err)
+		}
+		defer release()
 
 		remote, err := currentSvc.Remote().GetRemote("origin")
 		if err != nil || remote == nil {
@@ -537,14 +552,18 @@ func (b *repoBuilder) build() *RepoInstance {
 
 	ri.closeFn = func() {
 		obs.Stop()
-		// Acquire the WRITE lock to drain all in-flight readers (WithRead holds
-		// the RLock while calling fn(svc)) before closing the SQLite handle.
-		// Using RLock here would let a concurrent WithRead execute fn(svc)
-		// while Close runs → use-after-close.
-		ri.mu.Lock()
-		svc := ri.svc
-		ri.mu.Unlock()
-		svc.Close()
+		// Detach the handle (marking the instance closed so any later Acquire —
+		// e.g. an HTTP handler that resolved this ri before Archive removed it
+		// from the map, or an observer callback that fires after Stop's flush —
+		// fails with ErrRepoClosed), then drain every in-flight user before
+		// closing the SQLite handle. Draining on the refcount, not the lock, is
+		// what covers users that acquired earlier and are still mid-operation.
+		h := ri.detachStore(true)
+		if h == nil {
+			return
+		}
+		h.wg.Wait()
+		h.svc.Close()
 	}
 
 	return ri

--- a/internal/repos/builder_ontology_test.go
+++ b/internal/repos/builder_ontology_test.go
@@ -42,7 +42,7 @@ func bootKnomitWithStaleOntology(t *testing.T, staleYAML string) (dir, agentBran
 	require.NotNil(t, ri)
 
 	// Overwrite the seeded ontology with the stale version on the agent branch.
-	_, err := ri.svc.Facts().WriteFact(
+	_, err := testService(t, ri).Facts().WriteFact(
 		context.Background(),
 		agentBranch,
 		"domains/ontology.yaml",
@@ -92,7 +92,7 @@ topics:
 		"refreshed ontology must include the principles topic from the latest preset")
 
 	// The on-branch file must match CodeOntology().Serialize().
-	result, err := ri.svc.Facts().ReadFact(context.Background(), agentBranch, "domains/ontology.yaml", nil)
+	result, err := testService(t, ri).Facts().ReadFact(context.Background(), agentBranch, "domains/ontology.yaml", nil)
 	require.NoError(t, err)
 
 	expectedY, err := fact.CodeOntology().Serialize()
@@ -139,7 +139,7 @@ topics:
 		"diverged ontology must NOT be refreshed; preset-only topics must NOT appear")
 
 	// The on-branch file must still match the diverged YAML.
-	result, err := ri.svc.Facts().ReadFact(context.Background(), agentBranch, "domains/ontology.yaml", nil)
+	result, err := testService(t, ri).Facts().ReadFact(context.Background(), agentBranch, "domains/ontology.yaml", nil)
 	require.NoError(t, err)
 	require.Equal(t, divergedYAML, result.Content,
 		"domains/ontology.yaml on the agent branch must NOT be rewritten when the stored ontology has diverged from the preset")

--- a/internal/repos/init_ontology_test.go
+++ b/internal/repos/init_ontology_test.go
@@ -25,7 +25,7 @@ func TestBoot_firstRunWritesOntologyToAgentBranch(t *testing.T) {
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
 
-	result, err := ri.svc.Facts().ReadFact(context.Background(), "agent/test-abc", "domains/ontology.yaml", nil)
+	result, err := testService(t, ri).Facts().ReadFact(context.Background(), "agent/test-abc", "domains/ontology.yaml", nil)
 	require.NoError(t, err, "ontology must be readable from agent branch after init")
 	require.NotEmpty(t, result.Content, "ontology file must have content on agent branch")
 }
@@ -54,7 +54,7 @@ func TestBoot_firstRunWithEmptyRemoteWritesOntology(t *testing.T) {
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
 
-	result, err := ri.svc.Facts().ReadFact(context.Background(), "agent/test-abc", "domains/ontology.yaml", nil)
+	result, err := testService(t, ri).Facts().ReadFact(context.Background(), "agent/test-abc", "domains/ontology.yaml", nil)
 	require.NoError(t, err, "ontology must be readable from agent branch after init from empty remote")
 	require.NotEmpty(t, result.Content, "ontology file must have content on agent branch")
 }

--- a/internal/repos/instance.go
+++ b/internal/repos/instance.go
@@ -2,6 +2,7 @@ package repos
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 
@@ -10,6 +11,42 @@ import (
 	"knomit/internal/fact"
 	"knomit/internal/store"
 )
+
+var (
+	// ErrRepoClosed is returned by Acquire/WithRead after the instance began
+	// teardown (Archive, Manager.Close). The store is gone for good; callers
+	// should treat the repo as unregistered.
+	ErrRepoClosed = errors.New("repo is closed")
+	// ErrStoreUnavailable is returned by Acquire/WithRead while no store is
+	// attached — the on-disk database is being replaced (SwapStore) or a test
+	// instance carries no service. Transient; callers may retry.
+	ErrStoreUnavailable = errors.New("repo store is unavailable")
+)
+
+// storeHandle pairs one generation of the store service with a refcount of
+// in-flight users. Teardown (closeFn) and replacement (SwapStore) detach the
+// handle under the write lock — making it unreachable for new Acquires — then
+// wait for wg to drain before closing svc. This is the single mechanism that
+// makes "snapshot the service, use it after releasing the lock" safe: a caller
+// that went through Acquire keeps its generation alive until it releases.
+//
+// WaitGroup discipline: every wg.Add(1) happens under ri.mu.RLock while the
+// handle is still attached. Detaching requires ri.mu.Lock, which drains all
+// RLock holders first — so by the time a detacher calls wg.Wait, no new Add
+// can race it (the counter only decreases).
+type storeHandle struct {
+	svc *store.Service
+	wg  sync.WaitGroup
+}
+
+// newStoreHandle wraps svc in a handle; nil svc yields a nil handle so
+// Acquire reports ErrStoreUnavailable rather than handing out a nil service.
+func newStoreHandle(svc *store.Service) *storeHandle {
+	if svc == nil {
+		return nil
+	}
+	return &storeHandle{svc: svc}
+}
 
 // Index readiness states for a RepoInstance. The store is live for reads in
 // every state; "indexing" means a background (re)build is populating the
@@ -52,10 +89,16 @@ type RepoInstance struct {
 	discoveryWGap         float64
 	discoveryWSpec        float64
 	onCommit              func(string, string) // re-applied to new svc after SwapStore
-	svc                   *store.Service
-	hub                   *TaskHub
-	syncCancel            context.CancelFunc
-	syncWg                *sync.WaitGroup
+	// handle is the current store generation; nil while no store is attached
+	// (mid-SwapStore, or a test instance without a service). closed marks the
+	// beginning of permanent teardown. Both are guarded by mu; all store access
+	// goes through Acquire so close/swap can drain in-flight users before
+	// closing the underlying service.
+	handle     *storeHandle
+	closed     bool
+	hub        *TaskHub
+	syncCancel context.CancelFunc
+	syncWg     *sync.WaitGroup
 	// indexCancel/indexWg own the background index-heal lifecycle, SEPARATE from
 	// syncCancel/syncWg (the reconcile loop). Only real teardown cancels/waits
 	// these; startSync's loop-restart must not touch them. See repoBuilder.build.
@@ -99,20 +142,86 @@ func (ri *RepoInstance) setIndexProgress(done, total int) {
 func (ri *RepoInstance) markIndexReady()  { ri.indexState.Store(indexReady) }
 func (ri *RepoInstance) markIndexFailed() { ri.indexState.Store(indexFailed) }
 
-// WithRead calls fn with the store service under a read lock.
-// This is the only way external code may access svc.
-func (ri *RepoInstance) WithRead(fn func(*store.Service)) {
+// Acquire returns the current store service together with a release func the
+// caller MUST invoke when it is done with the service (idempotent). Between
+// Acquire and release the service is guaranteed to stay open: teardown
+// (Archive/Close) and replacement (SwapStore) wait for every outstanding
+// release before closing the underlying handle. This — not lock scope — is
+// what makes it safe to keep using the service after Acquire returns, so
+// long-running operations (MCP tool calls, SSE flows, background rebuilds,
+// synthesis sessions) hold one Acquire for their full duration instead of
+// snapshotting the pointer out of a lock.
+//
+// Returns ErrRepoClosed once teardown has begun, or ErrStoreUnavailable while
+// no store is attached (mid-swap / test instance without a service).
+//
+// Do NOT hold an Acquire across a call that replaces or closes this repo's
+// store (Manager.SwapStore, Manager.Archive) — the drain would wait on the
+// caller's own reference and deadlock.
+func (ri *RepoInstance) Acquire() (*store.Service, func(), error) {
 	ri.mu.RLock()
 	defer ri.mu.RUnlock()
-	fn(ri.svc)
+	if ri.closed {
+		return nil, nil, ErrRepoClosed
+	}
+	h := ri.handle
+	if h == nil {
+		return nil, nil, ErrStoreUnavailable
+	}
+	h.wg.Add(1)
+	var once sync.Once
+	return h.svc, func() { once.Do(h.wg.Done) }, nil
 }
 
-// withWrite calls fn under a write lock. Only used within the repos package
-// (SwapStore, StartSync closure).
-func (ri *RepoInstance) withWrite(fn func()) {
+// Pin holds the current store generation open without exposing the service —
+// for callers that delegate store access to a component taking the whole
+// RepoInstance (e.g. a synthesize.Reviewer) but must guarantee the store is
+// not closed out from under it. Release with the returned func (idempotent).
+func (ri *RepoInstance) Pin() (func(), error) {
+	_, release, err := ri.Acquire()
+	return release, err
+}
+
+// WithRead calls fn with the store service, holding a store reference (via
+// Acquire) for the duration of fn. This is the scoped convenience form; fn is
+// NOT called when no service is available — the error reports why
+// (ErrRepoClosed / ErrStoreUnavailable). Callers that need the service beyond
+// fn's scope must use Acquire directly instead of copying the pointer out.
+func (ri *RepoInstance) WithRead(fn func(*store.Service)) error {
+	svc, release, err := ri.Acquire()
+	if err != nil {
+		return err
+	}
+	defer release()
+	fn(svc)
+	return nil
+}
+
+// detachStore atomically takes the current handle out of the instance so no
+// new Acquire can reach it, optionally marking the instance permanently
+// closed. The caller owns the returned handle and must drain it
+// (h.wg.Wait()) before closing h.svc. Returns nil when no store was attached.
+func (ri *RepoInstance) detachStore(markClosed bool) *storeHandle {
 	ri.mu.Lock()
 	defer ri.mu.Unlock()
-	fn()
+	if markClosed {
+		ri.closed = true
+	}
+	h := ri.handle
+	ri.handle = nil
+	return h
+}
+
+// attachStore installs a new store generation. No-op (returns false) when the
+// instance is already closed — the caller must close svc itself in that case.
+func (ri *RepoInstance) attachStore(svc *store.Service) bool {
+	ri.mu.Lock()
+	defer ri.mu.Unlock()
+	if ri.closed {
+		return false
+	}
+	ri.handle = newStoreHandle(svc)
+	return true
 }
 
 // Name returns the repository name.
@@ -328,13 +437,16 @@ func (ri *RepoInstance) shutdown() {
 	}
 }
 
-// Verify runs the integrity check against the current store under the read
-// lock so that a concurrent SwapStore cannot move the rug. Delegates to
-// store.Service.Verify and stamps the report with this repo's name.
+// Verify runs the integrity check against the current store while holding a
+// store reference (Acquire), so a concurrent SwapStore/Archive drains this
+// call before closing the service instead of closing it mid-check. Delegates
+// to store.Service.Verify and stamps the report with this repo's name.
 func (ri *RepoInstance) Verify(ctx context.Context, opts store.VerifyOpts) (store.IntegrityReport, error) {
-	ri.mu.RLock()
-	svc := ri.svc
-	ri.mu.RUnlock()
+	svc, release, err := ri.Acquire()
+	if err != nil {
+		return store.IntegrityReport{Repo: ri.name}, err
+	}
+	defer release()
 	report, err := svc.Verify(ctx, opts)
 	report.Repo = ri.name
 	return report, err
@@ -374,7 +486,7 @@ func NewTestInstanceWithDeps(cfg TestInstanceConfig) *RepoInstance {
 	return &RepoInstance{
 		name:                cfg.Name,
 		agentBranch:         cfg.AgentBranch,
-		svc:                 cfg.Svc,
+		handle:              newStoreHandle(cfg.Svc),
 		ontology:            cfg.Ontology,
 		embedder:            cfg.Embedder,
 		ontologyRoot:        cfg.OntologyRoot,

--- a/internal/repos/instance_lifetime_test.go
+++ b/internal/repos/instance_lifetime_test.go
@@ -1,0 +1,208 @@
+package repos
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/config"
+	"knomit/internal/store"
+)
+
+// newLifetimeTestManager boots a Manager with a real default repo in a temp
+// home. DisableBackgroundSync keeps construction synchronous and free of
+// network activity.
+func newLifetimeTestManager(t *testing.T) *Manager {
+	t.Helper()
+	m := New(context.Background(), Deps{
+		Cfg:                   config.Config{Home: t.TempDir()},
+		AgentBranch:           "agent/test",
+		DisableBackgroundSync: true,
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+	return m
+}
+
+// TestAcquire_AfterClose_ReturnsErrRepoClosed: once teardown ran, Acquire and
+// WithRead must fail with ErrRepoClosed instead of handing out a closed store.
+func TestAcquire_AfterClose_ReturnsErrRepoClosed(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	ri.shutdown()
+
+	_, _, err := ri.Acquire()
+	require.ErrorIs(t, err, ErrRepoClosed)
+
+	called := false
+	err = ri.WithRead(func(*store.Service) { called = true })
+	require.ErrorIs(t, err, ErrRepoClosed)
+	require.False(t, called, "WithRead must not invoke fn on a closed instance")
+
+	_, err = ri.Verify(context.Background(), store.VerifyOpts{})
+	require.ErrorIs(t, err, ErrRepoClosed)
+}
+
+// TestClose_WaitsForInFlightAcquire: teardown must drain an outstanding
+// Acquire before closing the store — the in-flight user finishes its store
+// call on an open service, never observing "database is closed".
+func TestClose_WaitsForInFlightAcquire(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	svc, release, err := ri.Acquire()
+	require.NoError(t, err)
+
+	closed := make(chan struct{})
+	go func() {
+		ri.shutdown()
+		close(closed)
+	}()
+
+	// The close must not complete while we hold the acquisition.
+	select {
+	case <-closed:
+		t.Fatal("shutdown completed while an Acquire was outstanding")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The store must still be fully usable while held.
+	_, err = svc.Branches().HeadCommit(context.Background(), "agent/test")
+	require.NoError(t, err, "store must stay open while acquired")
+
+	release()
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shutdown did not complete after release")
+	}
+}
+
+// TestWithRead_ConcurrentWithClose_NeverSeesClosedStore hammers WithRead from
+// multiple goroutines while teardown runs. Every fn invocation must see a
+// working store; once closed, callers must get ErrRepoClosed — never a
+// "database is closed" SQL error or a panic. Run with -race.
+func TestWithRead_ConcurrentWithClose_NeverSeesClosedStore(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	var sqlErrs atomic.Int64
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				err := ri.WithRead(func(svc *store.Service) {
+					if _, herr := svc.Branches().HeadCommit(context.Background(), "agent/test"); herr != nil {
+						sqlErrs.Add(1)
+					}
+				})
+				if err != nil {
+					require.ErrorIs(t, err, ErrRepoClosed)
+					return
+				}
+			}
+		}()
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	ri.shutdown()
+	close(stop)
+	wg.Wait()
+	require.Zero(t, sqlErrs.Load(), "no acquired reader may ever observe a closed/failed store")
+}
+
+// TestSwapStore_DrainsInFlightUsers: an in-memory SwapStore must wait for
+// outstanding acquisitions of the old generation before closing it, and new
+// acquisitions after the swap must see the new service.
+func TestSwapStore_DrainsInFlightUsers(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+	// Force the in-memory (pointer-swap) path.
+	ri.dbPath = ""
+
+	oldSvc, release, err := ri.Acquire()
+	require.NoError(t, err)
+
+	// Build a second store to swap in.
+	tempDB := filepath.Join(t.TempDir(), "swap.db")
+	seed, err := store.Open(tempDB)
+	require.NoError(t, err)
+	require.NoError(t, seed.InitRepo(map[string]string{}, "agent/test"))
+	seed.Close()
+
+	swapped := make(chan error, 1)
+	go func() { swapped <- m.SwapStore(ri, tempDB) }()
+
+	// The swap must not finish while the old generation is held.
+	select {
+	case <-swapped:
+		t.Fatal("SwapStore completed while an Acquire on the old store was outstanding")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Old service must still work while held.
+	_, err = oldSvc.Branches().HeadCommit(context.Background(), "agent/test")
+	require.NoError(t, err, "old store must stay open until released")
+
+	release()
+	select {
+	case err := <-swapped:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("SwapStore did not complete after release")
+	}
+
+	// New acquisitions see the swapped-in service, and it works.
+	newSvc, release2, err := ri.Acquire()
+	require.NoError(t, err)
+	defer release2()
+	require.NotSame(t, oldSvc, newSvc, "post-swap Acquire must return the new service")
+	_, err = newSvc.Branches().HeadCommit(context.Background(), "agent/test")
+	require.NoError(t, err)
+}
+
+// TestRescan_SkipsInFlightCreate: a .db that belongs to an in-flight
+// Create/Restore (name reserved, not yet registered) must not be opened by a
+// concurrent Rescan — that double-open orphaned a store handle and its
+// goroutines.
+func TestRescan_SkipsInFlightCreate(t *testing.T) {
+	m := newLifetimeTestManager(t)
+
+	// Simulate the mid-Create window: the reservation is held and the .db is
+	// already on disk, but the name is not yet in the active map.
+	releaseReservation, err := m.reserveNameAndOrigin("pending", "")
+	require.NoError(t, err)
+	defer releaseReservation()
+
+	dbPath := filepath.Join(m.deps.Cfg.Home, "repos", "pending.db")
+	svc, err := store.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+	svc.Close()
+	defer os.Remove(dbPath)
+
+	result, err := m.Rescan()
+	require.NoError(t, err)
+	require.NotContains(t, result.Added, "pending", "Rescan must not open a db reserved by an in-flight Create")
+	require.Contains(t, result.Skipped, "pending")
+	require.Nil(t, m.Get("pending"), "in-flight repo must not be registered by Rescan")
+}

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -609,6 +609,17 @@ func (m *Manager) Rescan() (RescanResult, error) {
 		if !isValidRepoName(name) {
 			continue
 		}
+		// A Create/Restore in flight has already put the .db on disk but not yet
+		// registered the name (the whole clone happens in that window). Opening
+		// the file here would double-open the same database and orphan one
+		// instance's handle and goroutines when the create's Add overwrites the
+		// map entry — so honour the same reservation gate Create/Restore hold.
+		// Check the reservation BEFORE the map: the reservation is released only
+		// after Add, so a name missing from both really is unowned.
+		if m.isCreateInFlight(name) {
+			result.Skipped = append(result.Skipped, name)
+			continue
+		}
 		if m.Get(name) != nil {
 			result.Skipped = append(result.Skipped, name)
 			continue
@@ -622,6 +633,15 @@ func (m *Manager) Rescan() (RescanResult, error) {
 		log.Info().Str("repo", name).Msg("rescan: opened")
 	}
 	return result, nil
+}
+
+// isCreateInFlight reports whether a Create/Restore currently holds the
+// reservation for name (see reserveNameAndOrigin).
+func (m *Manager) isCreateInFlight(name string) bool {
+	m.inflightMu.Lock()
+	defer m.inflightMu.Unlock()
+	_, ok := m.creating[name]
+	return ok
 }
 
 // ---------- private helpers ----------

--- a/internal/repos/swapstore.go
+++ b/internal/repos/swapstore.go
@@ -70,37 +70,73 @@ func (m *Manager) SwapStore(ri *RepoInstance, tempDBPath string) error {
 			return nil
 		}
 		m.rewireStore(svc, ri.name)
-		// Swap under the write lock, then close the old Service. The write lock
-		// is a barrier: any reader (notably the background session reaper, which
-		// touches svc.sessionDB under WithRead's RLock) has released before the
-		// swap, and readers after it see the new svc — so the old Service has no
-		// in-flight users and is safe to Close. Closing it (rather than dropping
-		// it) also releases its ephemeral session DB handle and file, which would
-		// otherwise leak on every swap.
-		var old *store.Service
-		ri.withWrite(func() {
-			old = ri.svc
-			ri.svc = svc
-		})
-		if old != nil {
-			old.Close()
-		}
 		if ri.onCommit != nil {
 			svc.SetOnCommit(ri.onCommit)
+		}
+		// Detach the old generation and install the new one, then drain the old
+		// handle's in-flight users (Acquire holders: MCP tool calls, SSE flows,
+		// the session reaper, background rebuilds) before closing it. Detaching
+		// under the write lock guarantees no NEW user can reach the old service;
+		// the refcount drain covers users that acquired earlier and are still
+		// mid-operation — the case a bare lock barrier cannot cover. Closing the
+		// old Service (rather than dropping it) also releases its ephemeral
+		// session DB handle and file, which would otherwise leak on every swap.
+		old := ri.detachStore(false)
+		if !ri.attachStore(svc) {
+			// Instance was closed concurrently — the new service has no owner.
+			svc.Close()
+		}
+		if old != nil {
+			old.wg.Wait()
+			old.svc.Close()
 		}
 		broadcastHead(svc, ri.agentBranch, ri.hub)
 		return nil
 	}
 
-	// File-backed swap: close the old DB, copy the temp file over the real one,
-	// and reopen — all under the write lock so the old Service is never closed
-	// (which closes and removes its ephemeral session DB) while a reader, notably
-	// the background session reaper, holds it under WithRead.
-	ri.mu.Lock()
-	defer ri.mu.Unlock()
+	// File-backed swap: detach the current handle so new Acquires fail fast
+	// with ErrStoreUnavailable while the on-disk file is being replaced, drain
+	// the in-flight users (Acquire holders — MCP tool calls, SSE flows, the
+	// session reaper — that a lock barrier alone could not cover), close the
+	// old DB, copy the temp file over the real one, and reopen.
+	old := ri.detachStore(false)
+	if old != nil {
+		old.wg.Wait()
+		old.svc.Close()
+	}
 
-	if ri.svc != nil {
-		ri.svc.Close()
+	// reattach installs svc as the new generation on success paths; on failure
+	// paths it is called with the service reopened from the restored backup so
+	// the repo does not stay unavailable after a failed swap. A nil svc (the
+	// recovery reopen itself failed) leaves the handle detached — Acquire keeps
+	// returning ErrStoreUnavailable, which is the truthful state.
+	reattach := func(svc *store.Service) {
+		if svc == nil {
+			return
+		}
+		m.rewireStore(svc, ri.name)
+		if ri.onCommit != nil {
+			svc.SetOnCommit(ri.onCommit)
+		}
+		if !ri.attachStore(svc) {
+			svc.Close() // instance closed concurrently; nothing may own svc now
+			return
+		}
+		broadcastHead(svc, ri.agentBranch, ri.hub)
+	}
+	// reopenLocal reopens from ri.dbPath after the backup restore; best-effort.
+	reopenLocal := func() *store.Service {
+		svc, err := store.Open(ri.dbPath)
+		if err != nil {
+			log.Error().Err(err).Str("repo", ri.name).Msg("SwapStore: recovery reopen failed; repo store unavailable")
+			return nil
+		}
+		if err := svc.OpenRepo(); err != nil {
+			svc.Close()
+			log.Error().Err(err).Str("repo", ri.name).Msg("SwapStore: recovery git reopen failed; repo store unavailable")
+			return nil
+		}
+		return svc
 	}
 
 	// Copy temp DB over the real one (backup first).
@@ -110,31 +146,28 @@ func (m *Manager) SwapStore(ri *RepoInstance, tempDBPath string) error {
 		log.Warn().Err(err).Msg("SwapStore: backup failed")
 	}
 	if err := copyFile(tempDBPath, ri.dbPath); err != nil {
-		// Restore from backup.
+		// Restore from backup and reopen so the repo stays usable.
 		_ = copyFile(backupPath, ri.dbPath)
+		reattach(reopenLocal())
 		return fmt.Errorf("SwapStore: copy temp DB: %w", err)
 	}
 
 	// Reopen from the real path.
 	svc, err := store.Open(ri.dbPath)
 	if err != nil {
-		// Restore from backup.
 		_ = copyFile(backupPath, ri.dbPath)
+		reattach(reopenLocal())
 		return fmt.Errorf("SwapStore: reopen store: %w", err)
 	}
 
 	if err := svc.OpenRepo(); err != nil {
 		svc.Close()
 		_ = copyFile(backupPath, ri.dbPath)
+		reattach(reopenLocal())
 		return fmt.Errorf("SwapStore: reopen git: %w", err)
 	}
 
-	m.rewireStore(svc, ri.name)
-	ri.svc = svc
-	if ri.onCommit != nil {
-		svc.SetOnCommit(ri.onCommit)
-	}
-	broadcastHead(svc, ri.agentBranch, ri.hub)
+	reattach(svc)
 
 	// Clean up backup — swap succeeded.
 	os.Remove(backupPath)

--- a/internal/repos/testhelpers_test.go
+++ b/internal/repos/testhelpers_test.go
@@ -1,0 +1,23 @@
+package repos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// testService resolves the instance's current store via the production
+// Acquire path, failing the test if no store is attached. The acquisition is
+// released before returning: several tests close and reopen the manager
+// mid-test, and an acquisition held until t.Cleanup would deadlock that close
+// (it drains acquirers). Tests are single-goroutine, so the returned service
+// stays valid until the test itself tears the repo down.
+func testService(t *testing.T, ri *RepoInstance) *store.Service {
+	t.Helper()
+	svc, release, err := ri.Acquire()
+	require.NoError(t, err)
+	release()
+	return svc
+}

--- a/internal/web/gitremote.go
+++ b/internal/web/gitremote.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"knomit/internal/repos"
-	"knomit/internal/store"
 )
 
 // gitHTTPProvider is the narrow interface GitRemoteHandler needs — just the
@@ -41,12 +40,15 @@ func GitRemoteHandler(rm *repos.Manager) http.Handler {
 			return
 		}
 
-		var svc *store.Service
-		ri.WithRead(func(s *store.Service) { svc = s })
-		if svc == nil {
-			http.Error(w, "git serving not supported for this repo", http.StatusInternalServerError)
+		// Hold the acquisition for the whole git-protocol exchange (packfile
+		// streaming can be long-lived); a concurrent Archive/SwapStore drains
+		// this request before closing the store instead of closing it mid-fetch.
+		svc, release, err := ri.Acquire()
+		if err != nil {
+			http.Error(w, "repo store unavailable", http.StatusServiceUnavailable)
 			return
 		}
+		defer release()
 		provider, ok := (interface{})(svc).(gitHTTPProvider)
 		if !ok {
 			http.Error(w, "git serving not supported for this repo", http.StatusInternalServerError)

--- a/internal/web/handlers_jobs.go
+++ b/internal/web/handlers_jobs.go
@@ -14,7 +14,6 @@ import (
 
 	"knomit/internal/llm"
 	"knomit/internal/repos"
-	"knomit/internal/store"
 	"knomit/internal/synthesize"
 	"knomit/internal/web/hal"
 )
@@ -71,10 +70,24 @@ func handleStartSynthesis(m *repos.Manager, llmAdapter llm.LLMAdapter) http.Hand
 			return
 		}
 
+		// Pin the store for the task's lifetime: the Reviewer resolves store
+		// indices from ri per operation and the task outlives this request, so
+		// without the pin an Archive/SwapStore could close the SQLite handle
+		// mid-review. Teardown cancels hub tasks first (shutdown → hub.Shutdown
+		// precedes closeFn), so the drain does not wait on a task that will
+		// never be told to stop.
+		unpin, err := ri.Pin()
+		if err != nil {
+			hal.WriteProblem(w, http.StatusServiceUnavailable, "Store unavailable",
+				"store not available for this repo", r.URL.Path)
+			return
+		}
+
 		reviewer := synthesize.NewReviewer(ri, nil)
 		repo := ri.Name()
 
 		id, err := hub.Start("synth", func(ctx context.Context, emit func(repos.TaskEvent)) {
+			defer unpin()
 			emit(repos.TaskEvent{Status: "running", Phase: "start", Message: "review starting", Repo: repo})
 			if err := reviewer.RunAll(ctx, llmAdapter); err != nil {
 				emit(repos.TaskEvent{Status: "error", Message: err.Error(), Repo: repo})
@@ -83,6 +96,7 @@ func handleStartSynthesis(m *repos.Manager, llmAdapter llm.LLMAdapter) http.Hand
 			emit(repos.TaskEvent{Status: "done", Message: "review complete", Repo: repo})
 		})
 		if err != nil {
+			unpin()
 			hal.WriteProblem(w, http.StatusConflict, "Job already running",
 				err.Error(), r.URL.Path)
 			return
@@ -111,9 +125,13 @@ func handleStartRebuild(m *repos.Manager) http.HandlerFunc {
 
 		branch := BranchFromContext(r.Context())
 
-		var svc *store.Service
-		ri.WithRead(func(s *store.Service) { svc = s })
-		if svc == nil {
+		// Acquire (not a lock-scoped snapshot) because the rebuild task below
+		// outlives this request; the release runs when the task finishes, so a
+		// concurrent Archive/SwapStore drains the running rebuild instead of
+		// closing the SQLite handle under it. Teardown cancels hub tasks before
+		// draining, so the wait terminates.
+		svc, release, err := ri.Acquire()
+		if err != nil {
 			hal.WriteProblem(w, http.StatusServiceUnavailable, "Index unavailable",
 				"store not yet available for this repo", r.URL.Path)
 			return
@@ -121,6 +139,7 @@ func handleStartRebuild(m *repos.Manager) http.HandlerFunc {
 
 		hub := ri.TaskHub()
 		if hub == nil {
+			release()
 			hal.WriteProblem(w, http.StatusServiceUnavailable, "Task hub unavailable",
 				"task hub not initialised for this repo", r.URL.Path)
 			return
@@ -129,6 +148,7 @@ func handleStartRebuild(m *repos.Manager) http.HandlerFunc {
 		repo := ri.Name()
 
 		id, err := hub.Start("rebuild", func(ctx context.Context, emit func(repos.TaskEvent)) {
+			defer release()
 			emit(repos.TaskEvent{Status: "running", Phase: "start", Message: "rebuilding index", Repo: repo})
 			th := newProgressThrottle(250 * time.Millisecond)
 			progress := func(subPhase string, done, total int) {
@@ -143,6 +163,7 @@ func handleStartRebuild(m *repos.Manager) http.HandlerFunc {
 			emit(repos.TaskEvent{Status: "done", Message: "rebuild complete", Repo: repo})
 		})
 		if err != nil {
+			release() // task never ran; drop the acquisition or teardown would wait forever
 			hal.WriteProblem(w, http.StatusConflict, "Job already running",
 				err.Error(), r.URL.Path)
 			return

--- a/internal/web/handlers_origin_session.go
+++ b/internal/web/handlers_origin_session.go
@@ -140,8 +140,14 @@ func handleTestConnectivity(rm *repos.Manager, sm *SessionManager, agentBranch s
 		}
 
 		ri := repos.RepoFromContext(r.Context())
+		// Acquire pins the local store for this whole SSE flow so a concurrent
+		// SwapStore/Archive drains it instead of closing the service mid-use;
+		// on error localSvc stays nil, which the flow already tolerates.
 		var localSvc *store.Service
-		ri.WithRead(func(s *store.Service) { localSvc = s })
+		if s, release, err := ri.Acquire(); err == nil {
+			localSvc = s
+			defer release()
+		}
 
 		sendEvent, ok := beginSSE(w)
 		if !ok {
@@ -302,8 +308,13 @@ func handlePreview(rm *repos.Manager, sm *SessionManager, agentBranch string) ht
 		}
 
 		ri := repos.RepoFromContext(r.Context())
+		// Acquire pins the local store for this whole SSE flow (see
+		// handleTestConnectivity); nil svc is tolerated below.
 		var svc *store.Service
-		ri.WithRead(func(s *store.Service) { svc = s })
+		if s, release, err := ri.Acquire(); err == nil {
+			svc = s
+			defer release()
+		}
 
 		sendEvent, ok := beginSSE(w)
 		if !ok {
@@ -484,8 +495,13 @@ func handleApply(rm *repos.Manager, sm *SessionManager, agentBranch string) http
 		}
 
 		ri := repos.RepoFromContext(r.Context())
+		// Acquire pins the local store for the whole replay (see
+		// handleTestConnectivity); nil svc is rejected below before use.
 		var svc *store.Service
-		ri.WithRead(func(s *store.Service) { svc = s })
+		if s, release, err := ri.Acquire(); err == nil {
+			svc = s
+			defer release()
+		}
 
 		sendEvent, ok := beginSSE(w)
 		if !ok {
@@ -747,12 +763,18 @@ func (s *Server) handleCommit(rm *repos.Manager, sm *SessionManager, agentBranch
 			return
 		}
 
-		// MCP handlers are stateless — they read the current svc via ri.WithRead
-		// on each request, so no rebind is needed after SwapStore.
+		// MCP handlers are stateless — they acquire the current svc from ri on
+		// each request, so no rebind is needed after SwapStore.
 
-		// Snapshot after swap — protect against concurrent SwapStore.
+		// Acquire AFTER the swap (never before: SwapStore drains acquirers, so
+		// holding one across it would deadlock on our own reference). The pin
+		// keeps the freshly swapped-in store open for the config/rebuild steps
+		// below; nil svc is tolerated by the guards on each step.
 		var svc *store.Service
-		ri.WithRead(func(s *store.Service) { svc = s })
+		if s, release, err := ri.Acquire(); err == nil {
+			svc = s
+			defer release()
+		}
 
 		// Phase: configuring — save remote config and start sync.
 		sendEvent(map[string]string{"phase": "configuring"})
@@ -876,12 +898,15 @@ func (s *Server) commitSharedHistory(
 	sess.RemoteStore = nil
 	sess.mu.Unlock()
 
-	var svc *store.Service
-	ri.WithRead(func(c *store.Service) { svc = c })
-	if svc == nil {
+	// Acquire pins the local store for the config/sync steps below; a
+	// concurrent SwapStore/Archive drains this flow instead of closing the
+	// service under it.
+	svc, release, err := ri.Acquire()
+	if err != nil {
 		sendEvent(map[string]string{"phase": "error", "message": "local store unavailable"})
 		return
 	}
+	defer release()
 
 	upstreamMain := appliedRemoteBranch
 	if upstreamMain == "" {


### PR DESCRIPTION
## Problem

Store access leaned on lock scope alone: `WithRead` handed out `ri.svc` under an RLock, callers copied the pointer out, and close paths assumed the write lock was a barrier. Four unguarded races followed (P0.1 of the 2026-07-20 code review, re-verified against current dev):

- **MCP handlers used store indices after releasing the lock** (`storeIndices` snapshot-then-release), so a concurrent `SwapStore`/`Archive` could close the SQLite handle mid-call. The lens fan-out multiplied this per mount — upstream's `recoverFanout` absorbs the nil-svc panic symptom but misses the closed-store case entirely (a closed service is non-nil).
- **`Archive` closed the store under in-flight requests** that had already resolved the instance from middleware; no closed tombstone existed, so `WithRead` after the map-delete ran `fn` on a closed service.
- **`Rescan` raced `Create`/`Restore`** on the same `.db` during the clone window (it never consulted the `creating` reservation set), double-opening the database and orphaning one instance's handle and goroutines.
- **The commit observer's `SyncLocked` callback wasn't drained before close** (`Observer.Stop` doesn't wait for a running callback), racing `svc.Close()` within the debounce window.

## Mechanism

Each store generation is a refcounted `storeHandle`. `Acquire()` returns the service plus an idempotent release func; `WithRead`, `Verify`, and `Pin` build on it, and `WithRead` now reports `ErrRepoClosed`/`ErrStoreUnavailable` instead of invoking `fn` without a store. `closeFn` and `SwapStore` detach the handle under the write lock (teardown also sets the closed tombstone), then **wait for the refcount to drain before closing the service** — so no acquirer ever observes a closed store, and new acquirers fail fast with a typed error. The WaitGroup discipline is sound because every `Add` happens under `RLock` while the handle is attached, and detaching requires the write lock.

Also: `Rescan` honours the Create/Restore reservation gate before opening a discovered `.db`, and the file-backed `SwapStore` failure path reopens from the restored backup instead of leaving a closed service installed.

## Coverage

- **MCP:** `storeIndices` returns a release; every handler holds its acquisition for the full call — including the federated per-mount fan-out goroutines and the cursor-resume per-mount `stores` maps (each non-write mount acquired on first use, released at resume end). `knomit_review` pins the write mount across the LLM session step. An unavailable mount now fails a federated query with a clean, mount-labelled error instead of a recovered nil-interface panic.
- **Web:** `gitremote`, index-rebuild, synthesis-run, and all five origin-session flows acquire instead of copying `svc` out of the lock; background hub tasks release when the task finishes; the commit flow acquires only *after* `SwapStore` (holding one across it would deadlock on its own reference — documented on `Acquire`).
- **Repos:** observer callback, `startSync`, and `ActiveRepoWithOrigin` all go through the acquire path.

## Tests

Five new regression tests in `internal/repos/instance_lifetime_test.go` (close-waits-for-acquire, no-closed-store-under-concurrent-close with `-race`, swap-drains-in-flight-users, rescan-skips-inflight-create, closed-returns-typed-error), two federation tests updated to pin the new panic-free failure mode, and the full module suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YFKt9NwjbMm5NHDbNbTpx