### PR TITLE
refactor(store): decompose searchIndex god-object into cohesive sub-services (P1.3)

### DIFF
--- a/internal/mcp/explain.go
+++ b/internal/mcp/explain.go
@@ -181,7 +181,7 @@ func readNode(ctx context.Context, s mcpStore, branch, path, commit string) (par
 	if !ok {
 		return fact.Fact{}, false, false, false
 	}
-	headCommit, present := s.search.LastCommitForPath(ctx, branch, path)
+	headCommit, present := s.factQuery.LastCommitForPath(ctx, branch, path)
 	deleted = !present
 	superseded = present && headCommit != commit
 	return parsed, deleted, superseded, true
@@ -241,7 +241,7 @@ func revisionDelta(prev *fact.Fact, cur fact.Fact) *revisionDiff {
 // explainHistoryDisplay revisions in the ancestry of anchorCommit, each with
 // the diff from its immediately-older predecessor.
 func buildHistory(ctx context.Context, s mcpStore, branch, path, anchorCommit string) (*explainHistory, error) {
-	revs, err := s.search.RevisionsBefore(ctx, branch, path, anchorCommit, explainHistoryDisplay+1)
+	revs, err := s.history.RevisionsBefore(ctx, branch, path, anchorCommit, explainHistoryDisplay+1)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func explainFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, fi
 	// Enqueue children from the VERSIONED edges (each pinned at its target_commit).
 	// Queue items carry the WIRE path (uniform with query's snapshot contract);
 	// seen-keys stay repo-relative.
-	edges, err := s.search.OutgoingAtCommit(ctx, branch, rel, anchor)
+	edges, err := s.graph.OutgoingAtCommit(ctx, branch, rel, anchor)
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("outgoing error: %v", err)), nil
 	}
@@ -538,7 +538,7 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 			// Surface this node's children from the versioned edges. Seen-keys stay
 			// repo-relative; queued children carry the item's wire prefix.
 			if item.SortKey < explainMaxDepth {
-				edges, eerr := sm.search.OutgoingAtCommit(ctx, rt.Branch, rel, item.CommitHash)
+				edges, eerr := sm.graph.OutgoingAtCommit(ctx, rt.Branch, rel, item.CommitHash)
 				if eerr == nil {
 					for _, e := range edges {
 						k := seenKey(e.Path, e.Commit)

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -12,10 +12,14 @@ import (
 // The text is written for the LLM caller: actionable, no internal detail.
 var errStoreUnavailable = errors.New("knowledge base is unavailable (repo is closed, replacing its store, or still opening) — retry shortly")
 
-// mcpStore bundles the store indices used by MCP handlers.
+// mcpStore bundles the store indices used by MCP handlers. The query surface is
+// split by cluster: MCP uses FactQuery, GraphStore, and HistoryQuery, never
+// MethodologyMatcher.
 type mcpStore struct {
 	facts       store.FactIndex
-	search      store.SearchIndex
+	factQuery   store.FactQuery
+	graph       store.GraphStore
+	history     store.HistoryQuery
 	toolSession store.ToolSessionIndex
 	pipeline    store.PipelineIndex
 	branches    store.BranchIndex
@@ -36,7 +40,9 @@ func storeIndices(ri *repos.RepoInstance) (mcpStore, func(), error) {
 	}
 	return mcpStore{
 		facts:       svc.Facts(),
-		search:      svc.Search(),
+		factQuery:   svc.FactQuery(),
+		graph:       svc.GraphStore(),
+		history:     svc.HistoryQuery(),
 		toolSession: svc.ToolSession(),
 		pipeline:    svc.Pipeline(),
 		branches:    svc.Branches(),

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -391,7 +391,7 @@ func applyDedupMerge(
 		if dedupVecs != nil && i < len(dedupVecs) && len(dedupVecs[i]) > 0 {
 			sq.QueryVec = dedupVecs[i]
 		}
-		results, err := s.search.Search(ctx, agentBranch, sq)
+		results, err := s.factQuery.Search(ctx, agentBranch, sq)
 		if err != nil || len(results) == 0 {
 			continue
 		}

--- a/internal/mcp/query.go
+++ b/internal/mcp/query.go
@@ -260,7 +260,7 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 				return
 			}
 			defer release()
-			lists[i], _, errs[i] = sm.search.RecentFacts(ctx, t.RT.Branch, mq)
+			lists[i], _, errs[i] = sm.factQuery.RecentFacts(ctx, t.RT.Branch, mq)
 		}(i, t)
 	}
 	wg.Wait()
@@ -415,7 +415,7 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 				return
 			}
 			defer release()
-			lists[i], errs[i] = sm.search.Search(ctx, t.RT.Branch, mq)
+			lists[i], errs[i] = sm.factQuery.Search(ctx, t.RT.Branch, mq)
 		}(i, t)
 	}
 	wg.Wait()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -23,7 +23,7 @@ import (
 // "code".
 //
 // Review clustering runs in-process over the per-review subgraph via the
-// per-repo store.SearchIndex (SubgraphEdges) — no cluster cache or background
+// per-repo store.GraphStore (SubgraphEdges) — no cluster cache or background
 // warmer is involved.
 func NewServer(defaultOntologyRoot string, mgr *repos.Manager, readOnly bool, embedders ...store.BatchEmbedder) *server.MCPServer {
 	hooks := &server.Hooks{}

--- a/internal/store/blast_radius.go
+++ b/internal/store/blast_radius.go
@@ -21,7 +21,7 @@ import (
 // invariant means a retracted intermediate's node + edges persist; a
 // dependent declared against an older version of the target still transmits
 // reach.
-func (si *searchIndex) reverseDependentPaths(ctx context.Context, path string) (map[string]struct{}, error) {
+func (gs *graphStore) reverseDependentPaths(ctx context.Context, path string) (map[string]struct{}, error) {
 	const q = `
 WITH RECURSIVE
   seed(node_id) AS (
@@ -47,7 +47,7 @@ SELECT DISTINCT np.value
   JOIN node_props_text np ON np.node_id = deps.node_id
   JOIN property_keys k ON k.id = np.key_id AND k.key = 'path'
  WHERE np.value <> ?`
-	rows, err := conn(ctx, si.rh.db).QueryContext(ctx, q,
+	rows, err := conn(ctx, gs.rh.db).QueryContext(ctx, q,
 		NodeFact, path, EdgeDerivedFrom, EdgeDerivedFrom, path)
 	if err != nil {
 		return nil, fmt.Errorf("reverseDependentPaths %q: %w", path, err)
@@ -71,8 +71,8 @@ SELECT DISTINCT np.value
 // of `path` (all historical versions are seeded), NOT liveness-filtered.
 // Membership among live members is the consumer's responsibility.
 // It is a thin exported wrapper over the private reverseDependentPaths.
-func (si *searchIndex) ReverseDependentPaths(ctx context.Context, path string) (map[string]struct{}, error) {
-	return si.reverseDependentPaths(ctx, path)
+func (gs *graphStore) ReverseDependentPaths(ctx context.Context, path string) (map[string]struct{}, error) {
+	return gs.reverseDependentPaths(ctx, path)
 }
 
 // BlastRadius counts the distinct facts that are LIVE on `branch` at HEAD and
@@ -80,15 +80,15 @@ func (si *searchIndex) ReverseDependentPaths(ctx context.Context, path string) (
 // metric: how much of the live corpus would be invalidated if `path` were
 // false. Returns 0 for a leaf fact (nothing depends on it), or for a path
 // whose dependents are all retracted at HEAD.
-func (si *searchIndex) BlastRadius(ctx context.Context, branch, path string) (int, error) {
-	deps, err := si.reverseDependentPaths(ctx, path)
+func (gs *graphStore) BlastRadius(ctx context.Context, branch, path string) (int, error) {
+	deps, err := gs.reverseDependentPaths(ctx, path)
 	if err != nil {
 		return 0, err
 	}
 	if len(deps) == 0 {
 		return 0, nil
 	}
-	branchID, err := si.rh.branchID(ctx, branch)
+	branchID, err := gs.rh.branchID(ctx, branch)
 	if err != nil {
 		return 0, fmt.Errorf("BlastRadius: branchID: %w", err)
 	}
@@ -114,7 +114,7 @@ func (si *searchIndex) BlastRadius(ctx context.Context, branch, path string) (in
 		}
 		var n int
 		q := "SELECT COUNT(*) FROM branch_facts WHERE branch_id = ? AND path IN (" + ph + ")"
-		if err := conn(ctx, si.rh.db).QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
+		if err := conn(ctx, gs.rh.db).QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
 			return 0, fmt.Errorf("BlastRadius: liveness count: %w", err)
 		}
 		count += n

--- a/internal/store/blast_radius_test.go
+++ b/internal/store/blast_radius_test.go
@@ -42,8 +42,7 @@ func TestReverseDependentPathsDiamond(t *testing.T) {
 	writeFact(t, svc, branch, "kb/x/c.md", []string{"kb/x/d.md"})
 	writeFact(t, svc, branch, "kb/x/a.md", []string{"kb/x/b.md", "kb/x/c.md"})
 
-	si := svc.Search().(*searchIndex)
-	deps, err := si.reverseDependentPaths(ctx, "kb/x/d.md")
+	deps, err := svc.gq.reverseDependentPaths(ctx, "kb/x/d.md")
 	require.NoError(t, err)
 
 	want := map[string]struct{}{"kb/x/a.md": {}, "kb/x/b.md": {}, "kb/x/c.md": {}}
@@ -73,8 +72,7 @@ func TestReverseDependentPathsCycleTerminates(t *testing.T) {
 		testFactBody("a", 0.5, []string{"kb/x/c.md"}), "close cycle", "")
 	require.NoError(t, err)
 
-	si := svc.Search().(*searchIndex)
-	deps, err := si.reverseDependentPaths(ctx, "kb/x/b.md")
+	deps, err := svc.gq.reverseDependentPaths(ctx, "kb/x/b.md")
 	require.NoError(t, err)
 	// Reverse from b: c derives from b; a derives from c. Cycle reaches a back to b
 	// but b is excluded by the path-self filter.
@@ -98,8 +96,7 @@ func TestReverseDependentPathsRetractedIntermediate(t *testing.T) {
 	_, err := svc.Facts().DeleteFact(ctx, branch, "kb/x/b.md", "retract b")
 	require.NoError(t, err)
 
-	si := svc.Search().(*searchIndex)
-	deps, err := si.reverseDependentPaths(ctx, "kb/x/c.md")
+	deps, err := svc.gq.reverseDependentPaths(ctx, "kb/x/c.md")
 	require.NoError(t, err)
 	_, hasA := deps["kb/x/a.md"]
 	require.True(t, hasA, "retracted intermediate must still transmit reach: %v", deps)
@@ -168,8 +165,7 @@ func TestBlastRadiusExcludesRetractedDependent(t *testing.T) {
 	_, err = svc.Facts().DeleteFact(ctx, branch, "kb/x/b.md", "retract b")
 	require.NoError(t, err)
 
-	si := svc.Search().(*searchIndex)
-	deps, err := si.reverseDependentPaths(ctx, "kb/x/d.md")
+	deps, err := svc.gq.reverseDependentPaths(ctx, "kb/x/d.md")
 	require.NoError(t, err)
 	_, hasB := deps["kb/x/b.md"]
 	require.True(t, hasB, "historical graph still records the dependent: %v", deps)

--- a/internal/store/derived_from.go
+++ b/internal/store/derived_from.go
@@ -131,8 +131,8 @@ func (fq *factQuery) FactExistsAt(ctx context.Context, branch, path, commit stri
 //
 // First-parent (not wall-clock) ancestry is the correct semantic — see
 // resolveTargetCommit's doc-comment for the merge-branch rationale.
-// resolveActiveCommitForPath lives on repoHandler (it only needs rh.db) so all
-// query sub-services (factQuery, graphStore) and factIndex share it directly —
+// resolveActiveCommitForPath lives on repoHandler (it only needs rh.db) so its
+// callers — factIndex, searchIndex, factQuery and graphStore — share it directly —
 // factIndex's fallback-before read resolves the last-valid version through the
 // SAME index walk the graph resolver uses, instead of a divergent go-git walk.
 func (rh *repoHandler) resolveActiveCommitForPath(ctx context.Context, branch, path, fromCommit string) (string, bool, error) {

--- a/internal/store/derived_from.go
+++ b/internal/store/derived_from.go
@@ -55,7 +55,7 @@ func (si *searchIndex) resolveTargetCommit(ctx context.Context, branch, sourcePa
 		}
 		cur = parent
 	}
-	return si.resolveActiveCommitForPath(ctx, branch, refPath, cur)
+	return si.rh.resolveActiveCommitForPath(ctx, branch, refPath, cur)
 }
 
 // FactExistsAt reports whether `path` has any valid (added/modified)
@@ -67,17 +67,17 @@ func (si *searchIndex) resolveTargetCommit(ctx context.Context, branch, sourcePa
 // the user can navigate to via fallback-before. A target retracted long
 // before the source's commit still has a navigable last-valid blob, so
 // the ref is not broken from the user's perspective.
-func (si *searchIndex) FactExistsAt(ctx context.Context, branch, path, commit string) (bool, error) {
+func (fq *factQuery) FactExistsAt(ctx context.Context, branch, path, commit string) (bool, error) {
 	if commit == "" {
 		// HEAD anchor: a fact is "live on the branch" iff there's a
 		// branch_facts row for (branch, path). branch_facts is the live
 		// view of which paths are currently un-retracted on the branch.
-		branchID, err := si.rh.branchID(ctx, branch)
+		branchID, err := fq.rh.branchID(ctx, branch)
 		if err != nil {
 			return false, fmt.Errorf("FactExistsAt: branchID: %w", err)
 		}
 		var n int
-		err = conn(ctx, si.rh.db).QueryRowContext(ctx,
+		err = conn(ctx, fq.rh.db).QueryRowContext(ctx,
 			`SELECT 1 FROM branch_facts WHERE branch_id = ? AND path = ?`,
 			branchID, path,
 		).Scan(&n)
@@ -85,11 +85,11 @@ func (si *searchIndex) FactExistsAt(ctx context.Context, branch, path, commit st
 			// Live row absent — but the fact may still be historically
 			// reachable via fallback-before. Walk back from the branch
 			// HEAD to find any prior add/modify.
-			head, herr := si.rh.HeadCommit(ctx, branch)
+			head, herr := fq.rh.HeadCommit(ctx, branch)
 			if herr != nil {
 				return false, fmt.Errorf("FactExistsAt: HeadCommit: %w", herr)
 			}
-			_, ok, werr := si.resolveActiveCommitForPath(ctx, branch, path, head)
+			_, ok, werr := fq.rh.resolveActiveCommitForPath(ctx, branch, path, head)
 			if werr != nil {
 				return false, fmt.Errorf("FactExistsAt: walk-back at HEAD: %w", werr)
 			}
@@ -100,7 +100,7 @@ func (si *searchIndex) FactExistsAt(ctx context.Context, branch, path, commit st
 		}
 		return true, nil
 	}
-	_, ok, err := si.resolveActiveCommitForPath(ctx, branch, path, commit)
+	_, ok, err := fq.rh.resolveActiveCommitForPath(ctx, branch, path, commit)
 	if err != nil {
 		return false, err
 	}
@@ -131,14 +131,10 @@ func (si *searchIndex) FactExistsAt(ctx context.Context, branch, path, commit st
 //
 // First-parent (not wall-clock) ancestry is the correct semantic — see
 // resolveTargetCommit's doc-comment for the merge-branch rationale.
-func (si *searchIndex) resolveActiveCommitForPath(ctx context.Context, branch, path, fromCommit string) (string, bool, error) {
-	return si.rh.resolveActiveCommitForPath(ctx, branch, path, fromCommit)
-}
-
-// resolveActiveCommitForPath lives on repoHandler (it only needs rh.db) so
-// both searchIndex and factIndex can share it — factIndex's fallback-before
-// read resolves the last-valid version through the SAME index walk the graph
-// resolver uses, instead of a divergent go-git history walk.
+// resolveActiveCommitForPath lives on repoHandler (it only needs rh.db) so all
+// query sub-services (factQuery, graphStore) and factIndex share it directly —
+// factIndex's fallback-before read resolves the last-valid version through the
+// SAME index walk the graph resolver uses, instead of a divergent go-git walk.
 func (rh *repoHandler) resolveActiveCommitForPath(ctx context.Context, branch, path, fromCommit string) (string, bool, error) {
 	if fromCommit == "" {
 		return "", false, nil
@@ -179,13 +175,13 @@ func (rh *repoHandler) resolveActiveCommitForPath(ctx context.Context, branch, p
 //
 // Returns false (not an error) when the path was never written in the
 // ancestry of `commit`. Errors propagate.
-func (si *searchIndex) FactLiveAtCommit(ctx context.Context, branch, path, commit string) (bool, error) {
+func (fq *factQuery) FactLiveAtCommit(ctx context.Context, branch, path, commit string) (bool, error) {
 	if commit == "" {
 		return false, nil
 	}
 
 	var action string
-	err := conn(ctx, si.rh.db).QueryRowContext(ctx, firstParentChainCTE+`
+	err := conn(ctx, fq.rh.db).QueryRowContext(ctx, firstParentChainCTE+`
 		SELECT cl.action
 		  FROM fpc
 		  JOIN commit_log cl ON cl.commit_hash = fpc.commit_hash

--- a/internal/store/derived_from_test.go
+++ b/internal/store/derived_from_test.go
@@ -36,7 +36,7 @@ func TestResolveTargetCommit(t *testing.T) {
 	require.NoError(t, err)
 	c2 := c2Res.CommitHash
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// (1) D's ref to E at c2: most recent ancestor touching E is c1 (added) → target_commit = c1.
 	got, ok, err := si.resolveTargetCommit(ctx, branch, "kb/d.md", "kb/e.md", c2)
@@ -108,7 +108,7 @@ func TestResolveTargetCommit_WalksPastMultipleRetractions(t *testing.T) {
 	require.NoError(t, err)
 	c5 := c5Res.CommitHash
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// Walk past the c4 retraction → land at c3 (the most recent add).
 	got, ok, err := si.resolveTargetCommit(ctx, branch, "kb/f.md", "kb/e.md", c5)
@@ -146,7 +146,7 @@ func TestResolveTargetCommit_SelfRef_ResolvesToPriorVersion(t *testing.T) {
 	require.NoError(t, err)
 	c2 := c2Res.CommitHash
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	got, ok, err := si.resolveTargetCommit(ctx, branch, "kb/x.md", "kb/x.md", c2)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestResolveTargetCommit_SelfRef_FirstCreation_ReturnsNotOk(t *testing.T) {
 	require.NoError(t, err)
 	c1 := c1Res.CommitHash
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	_, ok, err := si.resolveTargetCommit(ctx, branch, "kb/x.md", "kb/x.md", c1)
 	require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestGraphAddDerivedFromAtCommitTx_WritesEdgeWithBothCommits(t *testing.T) {
 	c2 := c2Res.CommitHash
 	dBlobHash := c2Res.BlobHash
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// Reset DERIVED_FROM edges written by the upsert pipeline so we can
 	// verify graphAddDerivedFromAtCommitTx's standalone behaviour without
@@ -360,7 +360,7 @@ func TestUpsert_WritesDerivedFromEdges_PostCommit(t *testing.T) {
 	_, err = svc.Facts().WriteFact(ctx, branch, "kb/d.md", testFactBody("d", 0.8, []string{"kb/e.md"}), "d→e", "")
 	require.NoError(t, err)
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	var count int
 	require.NoError(t, si.rh.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM edges WHERE type = ?`, EdgeDerivedFrom).Scan(&count))
@@ -385,7 +385,7 @@ func TestGraphAddDerivedFromAtCommitTx_SkipsForwardBroken(t *testing.T) {
 	c := dRes.CommitHash
 	dBlobHash := dRes.BlobHash
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// Reset DERIVED_FROM edges written by the upsert pipeline so we can
 	// verify graphAddDerivedFromAtCommitTx's standalone behaviour without
@@ -437,8 +437,8 @@ func TestResolveActiveCommitForPath_DepthRegression(t *testing.T) {
 		tip = res.CommitHash
 	}
 
-	si := svc.Search().(*searchIndex)
-	got, ok, err := si.resolveActiveCommitForPath(ctx, branch, "kb/target.md", tip)
+	si := svc.si
+	got, ok, err := si.rh.resolveActiveCommitForPath(ctx, branch, "kb/target.md", tip)
 	require.NoError(t, err)
 	require.True(t, ok, "must resolve target through 20 unrelated commits")
 	require.Equal(t, c1, got, "must resolve to the original add commit")
@@ -475,7 +475,7 @@ func TestResolveActiveCommitForPath_ConcurrentNoDeadlock(t *testing.T) {
 		tip = res.CommitHash
 	}
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	const N = 8
 	var wg sync.WaitGroup
@@ -484,7 +484,7 @@ func TestResolveActiveCommitForPath_ConcurrentNoDeadlock(t *testing.T) {
 	for i := 0; i < N; i++ {
 		go func() {
 			defer wg.Done()
-			got, ok, rerr := si.resolveActiveCommitForPath(ctx, branch, "kb/target.md", tip)
+			got, ok, rerr := si.rh.resolveActiveCommitForPath(ctx, branch, "kb/target.md", tip)
 			if rerr != nil {
 				errs <- fmt.Errorf("resolveActiveCommitForPath: %w", rerr)
 				return

--- a/internal/store/edge_props_test.go
+++ b/internal/store/edge_props_test.go
@@ -17,7 +17,7 @@ func TestGraphSetEdgeProps_WritesAndReadsText(t *testing.T) {
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	ctx := context.Background()
 
 	// Two Fact nodes, distinct (path, blob_hash).

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -93,8 +93,8 @@ func extractBody(raw []byte) string {
 // Completions returns autocomplete suggestions for a given filter category and prefix,
 // scoped to the given branch.
 // Supported categories: "domain", "entity", "type", "ep", "path".
-func (si *searchIndex) Completions(ctx context.Context, branch, category, prefix string, limit int) ([]string, error) {
-	branchID, err := si.rh.branchID(ctx, branch)
+func (fq *factQuery) Completions(ctx context.Context, branch, category, prefix string, limit int) ([]string, error) {
+	branchID, err := fq.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, fmt.Errorf("completions: %w", err)
 	}
@@ -113,13 +113,13 @@ func (si *searchIndex) Completions(ctx context.Context, branch, category, prefix
 		if prefix != "" && canonPrefix == "" {
 			return []string{}, nil
 		}
-		return si.queryDistinct(ctx,
+		return fq.queryDistinct(ctx,
 			`SELECT DISTINCT fd.domain FROM fact_domains fd
 			 JOIN branch_facts bf ON bf.fact_id = fd.fact_id
 			 WHERE bf.branch_id = ? AND fd.domain LIKE ? LIMIT ?`,
 			branchID, canonPrefix+"%", limit)
 	case "entity":
-		return si.queryDistinct(ctx,
+		return fq.queryDistinct(ctx,
 			`SELECT DISTINCT fe.entity FROM fact_entities fe
 			 JOIN branch_facts bf ON bf.fact_id = fe.fact_id
 			 WHERE bf.branch_id = ? AND fe.entity LIKE ? LIMIT ?`,
@@ -138,7 +138,7 @@ func (si *searchIndex) Completions(ctx context.Context, branch, category, prefix
 	case "ep":
 		return []string{"learn", "update", "retract", "subsume", "synthesize", "sync"}, nil
 	case "path":
-		rows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+		rows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 			`SELECT DISTINCT f.path
 			 FROM branch_facts bf
 			 JOIN facts f ON f.id = bf.fact_id
@@ -179,8 +179,8 @@ func (si *searchIndex) Completions(ctx context.Context, branch, category, prefix
 }
 
 // queryDistinct executes a query and returns distinct non-empty string values.
-func (si *searchIndex) queryDistinct(ctx context.Context, query string, args ...any) ([]string, error) {
-	rows, err := conn(ctx, si.rh.db).QueryContext(ctx, query, args...)
+func (fq *factQuery) queryDistinct(ctx context.Context, query string, args ...any) ([]string, error) {
+	rows, err := conn(ctx, fq.rh.db).QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -208,13 +208,13 @@ type StatsResult struct {
 
 // Stats returns aggregate statistics over all indexed facts on a branch,
 // optionally filtered to those whose path starts with pathPrefix.
-func (si *searchIndex) Stats(ctx context.Context, branch, pathPrefix string) (StatsResult, error) {
+func (fq *factQuery) Stats(ctx context.Context, branch, pathPrefix string) (StatsResult, error) {
 	res := StatsResult{
 		Domains:  make(map[string]int),
 		Entities: make(map[string]int),
 	}
 
-	branchID, err := si.rh.branchID(ctx, branch)
+	branchID, err := fq.rh.branchID(ctx, branch)
 	if err != nil {
 		return res, fmt.Errorf("stats: %w", err)
 	}
@@ -230,7 +230,7 @@ func (si *searchIndex) Stats(ctx context.Context, branch, pathPrefix string) (St
 		q += ` AND f.path LIKE ?`
 		args = append(args, pathPrefix+"%")
 	}
-	if err := conn(ctx, si.rh.db).QueryRowContext(ctx, q, args...).Scan(&res.Total, &avgConf); err != nil {
+	if err := conn(ctx, fq.rh.db).QueryRowContext(ctx, q, args...).Scan(&res.Total, &avgConf); err != nil {
 		return res, err
 	}
 	if avgConf != nil {
@@ -249,7 +249,7 @@ func (si *searchIndex) Stats(ctx context.Context, branch, pathPrefix string) (St
 		dargs = append(dargs, pathPrefix+"%")
 	}
 	dq += ` GROUP BY d.value`
-	drows, err := conn(ctx, si.rh.db).QueryContext(ctx, dq, dargs...)
+	drows, err := conn(ctx, fq.rh.db).QueryContext(ctx, dq, dargs...)
 	if err != nil {
 		return res, err
 	}
@@ -274,7 +274,7 @@ func (si *searchIndex) Stats(ctx context.Context, branch, pathPrefix string) (St
 		eargs = append(eargs, pathPrefix+"%")
 	}
 	eq += ` GROUP BY e.value`
-	erows, err := conn(ctx, si.rh.db).QueryContext(ctx, eq, eargs...)
+	erows, err := conn(ctx, fq.rh.db).QueryContext(ctx, eq, eargs...)
 	if err != nil {
 		return res, err
 	}

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -28,16 +28,23 @@ type FactIndex interface {
 
 //go:generate go run go.uber.org/mock/mockgen -destination=../synthesize/mock_search_index_test.go -package=synthesize knomit/internal/store SearchIndex
 
-// SearchIndex is the interface for querying the fact search index. Implemented by *searchIndex.
-type SearchIndex interface {
+// The fact search index is decomposed into four cohesive query sub-services —
+// FactQuery, GraphStore, HistoryQuery, MethodologyMatcher — each a narrow
+// interface a consumer can depend on in isolation (mcp/web never touch
+// MethodologyMatcher; synthesize never touches HistoryQuery). SearchIndex below
+// composes all four. All are implemented by *searchIndex today; the concrete
+// type is split to match in P1.3 stage 2, at which point each interface gains
+// its own {rh} struct. See .claude/plans/2026-07-21-p1.3-store-decomposition-design.md.
+
+// FactQuery is the interface for fact read/search/existence queries.
+type FactQuery interface {
 	Search(ctx context.Context, branch string, q SearchOptions) ([]SearchResult, error)
 	GetByPath(ctx context.Context, branch, path string) (*FactWithBody, error)
 	LastCommitForPath(ctx context.Context, branch, path string) (string, bool)
 	Stats(ctx context.Context, branch, pathPrefix string) (StatsResult, error)
 	Completions(ctx context.Context, branch, category, prefix string, limit int) ([]string, error)
-	ExplainFact(ctx context.Context, branch, path string) (ExplainResult, error)
-	IncomingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error)
-	OutgoingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error)
+	RecentFacts(ctx context.Context, branch string, opts SearchOptions) ([]RecentFactEntry, int, error)
+	FactsIter(ctx context.Context, branch string) (*FactsIter, error)
 	// FactExistsAt reports whether `path` has any valid (added/modified)
 	// version in the sparse history reachable from `commit` on `branch`,
 	// walking past retractions. Pass commit == "" for a HEAD-anchored check.
@@ -51,22 +58,18 @@ type SearchIndex interface {
 	// gate for the commit-anchored /incoming and /outgoing sub-resources so a
 	// retracted fact 404s in lockstep with the (no-fallback) fact read.
 	FactLiveAtCommit(ctx context.Context, branch, path, commit string) (bool, error)
-	RelevantMethodologyForFact(ctx context.Context, branch, factPath string, sourceDomains, sourceEntities []string, k int, minScore float64) ([]MethodologyMatch, error)
+}
+
+// GraphStore is the interface for DERIVED_FROM / SIMILAR_TO graph queries.
+type GraphStore interface {
+	ExplainFact(ctx context.Context, branch, path string) (ExplainResult, error)
+	IncomingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error)
+	OutgoingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error)
 	// SubgraphEdges returns the undirected SIMILAR_TO adjacency among the given
 	// fact paths (one pair per edge whose both endpoints are non-deleted Fact
 	// nodes in the set). Scoped clustering runs Louvain over this bounded
 	// subgraph in-process instead of clustering the whole repo graph.
 	SubgraphEdges(ctx context.Context, paths []string) ([][2]string, error)
-	RecentFacts(ctx context.Context, branch string, opts SearchOptions) ([]RecentFactEntry, int, error)
-	Log(ctx context.Context, branch, path string) ([]LogEntry, error)
-	LogPaginated(ctx context.Context, branch, path string, limit int, after, from, before string) ([]LogEntryWithTags, string, string, error)
-	// RevisionsBefore returns up to `limit` revisions of `path` in the
-	// first-parent ancestry of `anchorCommit`, newest → oldest. Used by
-	// knomit_explain to build the root fact's bounded evolution history.
-	RevisionsBefore(ctx context.Context, branch, path, anchorCommit string, limit int) ([]RevisionMeta, error)
-	CommitDetail(ctx context.Context, commitHash, pathPrefix string) (*CommitDetailResult, error)
-	Activity(ctx context.Context, branch, path string) (ActivityResult, error)
-	FactsIter(ctx context.Context, branch string) (*FactsIter, error)
 	// BlastRadius counts the facts that are live on `branch` at HEAD and
 	// transitively derive (DERIVED_FROM, any depth) from any version of
 	// `path`. The keystone-impact metric: how much of the live corpus would
@@ -84,6 +87,34 @@ type SearchIndex interface {
 	// version of `path` (all historical versions seeded), NOT
 	// liveness-filtered. Membership among live members is the consumer's job.
 	ReverseDependentPaths(ctx context.Context, path string) (map[string]struct{}, error)
+}
+
+// HistoryQuery is the interface for commit-log / revision history queries.
+type HistoryQuery interface {
+	Log(ctx context.Context, branch, path string) ([]LogEntry, error)
+	LogPaginated(ctx context.Context, branch, path string, limit int, after, from, before string) ([]LogEntryWithTags, string, string, error)
+	// RevisionsBefore returns up to `limit` revisions of `path` in the
+	// first-parent ancestry of `anchorCommit`, newest → oldest. Used by
+	// knomit_explain to build the root fact's bounded evolution history.
+	RevisionsBefore(ctx context.Context, branch, path, anchorCommit string, limit int) ([]RevisionMeta, error)
+	CommitDetail(ctx context.Context, commitHash, pathPrefix string) (*CommitDetailResult, error)
+	Activity(ctx context.Context, branch, path string) (ActivityResult, error)
+}
+
+// MethodologyMatcher is the interface for methodology-fact matching.
+type MethodologyMatcher interface {
+	RelevantMethodologyForFact(ctx context.Context, branch, factPath string, sourceDomains, sourceEntities []string, k int, minScore float64) ([]MethodologyMatch, error)
+}
+
+// SearchIndex composes the four query sub-services. Implemented by *searchIndex.
+// Prefer depending on the narrowest sub-interface a consumer actually needs;
+// this composite exists for callers that genuinely span clusters and for the
+// transitional mock.
+type SearchIndex interface {
+	FactQuery
+	GraphStore
+	HistoryQuery
+	MethodologyMatcher
 }
 
 // IndexManager is the interface for search index lifecycle operations. Implemented by *searchIndex.

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -32,9 +32,10 @@ type FactIndex interface {
 // FactQuery, GraphStore, HistoryQuery, MethodologyMatcher — each a narrow
 // interface a consumer can depend on in isolation (mcp/web never touch
 // MethodologyMatcher; synthesize never touches HistoryQuery). SearchIndex below
-// composes all four. All are implemented by *searchIndex today; the concrete
-// type is split to match in P1.3 stage 2, at which point each interface gains
-// its own {rh} struct. See .claude/plans/2026-07-21-p1.3-store-decomposition-design.md.
+// composes all four. Each interface has its own {rh *repoHandler} implementation
+// in query_services.go — factQuery, graphStore, historyQuery, methodologyMatcher —
+// reaching shared state only UP through repoHandler, never sideways through a
+// sibling. See .claude/plans/2026-07-21-p1.3-store-decomposition-design.md.
 
 // FactQuery is the interface for fact read/search/existence queries.
 type FactQuery interface {
@@ -106,7 +107,8 @@ type MethodologyMatcher interface {
 	RelevantMethodologyForFact(ctx context.Context, branch, factPath string, sourceDomains, sourceEntities []string, k int, minScore float64) ([]MethodologyMatch, error)
 }
 
-// SearchIndex composes the four query sub-services. Implemented by *searchIndex.
+// SearchIndex composes the four query sub-services. Implemented by *searchFacade
+// (see query_services.go); *searchIndex implements IndexManager, not this.
 // Prefer depending on the narrowest sub-interface a consumer actually needs;
 // this composite exists for callers that genuinely span clusters and for the
 // transitional mock.

--- a/internal/store/methodology.go
+++ b/internal/store/methodology.go
@@ -38,7 +38,7 @@ type MethodologyMatch struct {
 // Callers operating over multiple source facts invoke this once per fact
 // and merge the results (keeping the highest score per methodology path).
 // No body concatenation, no re-embedding, no truncation.
-func (si *searchIndex) RelevantMethodologyForFact(
+func (mm *methodologyMatcher) RelevantMethodologyForFact(
 	ctx context.Context,
 	branch string,
 	factPath string,
@@ -47,7 +47,7 @@ func (si *searchIndex) RelevantMethodologyForFact(
 	k int,
 	minScore float64,
 ) ([]MethodologyMatch, error) {
-	branchID, err := si.rh.branchID(ctx, branch)
+	branchID, err := mm.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, fmt.Errorf("RelevantMethodologyForFact: branchID: %w", err)
 	}
@@ -57,7 +57,7 @@ func (si *searchIndex) RelevantMethodologyForFact(
 	// time when the fact was written. If the row is absent (fact not yet
 	// indexed, or no embedding produced), fall through to tag-only.
 	var srcVec []byte
-	err = conn(ctx, si.rh.db).QueryRowContext(ctx, `
+	err = conn(ctx, mm.rh.db).QueryRowContext(ctx, `
 		SELECT fv.embedding
 		FROM facts_vec fv
 		JOIN branch_facts bf ON bf.fact_id = fv.rowid
@@ -74,7 +74,7 @@ func (si *searchIndex) RelevantMethodologyForFact(
 	}
 
 	// Load methodology candidate set visible on this branch.
-	rows, err := conn(ctx, si.rh.db).QueryContext(ctx, `
+	rows, err := conn(ctx, mm.rh.db).QueryContext(ctx, `
 		SELECT f.path, f.title, f.id, f.blob_hash, f.domain, f.entities
 		FROM facts f
 		JOIN branch_facts bf ON bf.fact_id = f.id AND bf.branch_id = ?
@@ -135,7 +135,7 @@ func (si *searchIndex) RelevantMethodologyForFact(
 	simByID := make(map[int64]float64, len(cands))
 	if len(srcVec) > 0 {
 		var totalFacts int64
-		if err := conn(ctx, si.rh.db).QueryRowContext(ctx,
+		if err := conn(ctx, mm.rh.db).QueryRowContext(ctx,
 			`SELECT COUNT(*) FROM facts_vec`,
 		).Scan(&totalFacts); err != nil {
 			log.Warn().Err(err).Msg("RelevantMethodologyForFact: facts_vec count failed; falling back to tag-only ranking")
@@ -146,7 +146,7 @@ func (si *searchIndex) RelevantMethodologyForFact(
 			if minVec < 0 {
 				minVec = 0
 			}
-			knnRows, qErr := conn(ctx, si.rh.db).QueryContext(ctx,
+			knnRows, qErr := conn(ctx, mm.rh.db).QueryContext(ctx,
 				`SELECT f.id, (1.0 - fv.distance) as similarity
 				 FROM facts_vec fv
 				 JOIN facts f ON f.id = fv.rowid
@@ -187,7 +187,7 @@ func (si *searchIndex) RelevantMethodologyForFact(
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("RelevantMethodologyForFact: %w", err)
 		}
-		body, err := si.readFactBodyByBlobHash(ctx, c.blobHash)
+		body, err := mm.readFactBodyByBlobHash(ctx, c.blobHash)
 		if err != nil {
 			log.Warn().Err(err).Str("path", c.path).Str("blob_hash", c.blobHash).
 				Msg("RelevantMethodologyForFact: skipping candidate, blob unreadable")
@@ -274,9 +274,9 @@ func intersectExcludingMarkers(candidateDomains []string, srcSet map[string]stru
 
 // readFactBodyByBlobHash reads the markdown body for a fact identified by
 // its blob_hash via the git object store.
-func (si *searchIndex) readFactBodyByBlobHash(ctx context.Context, blobHash string) (string, error) {
+func (mm *methodologyMatcher) readFactBodyByBlobHash(ctx context.Context, blobHash string) (string, error) {
 	var raw []byte
-	err := conn(ctx, si.rh.db).QueryRowContext(ctx,
+	err := conn(ctx, mm.rh.db).QueryRowContext(ctx,
 		`SELECT data FROM objects WHERE hash = ? AND type = ?`,
 		blobHash, blobObjectType,
 	).Scan(&raw)

--- a/internal/store/query_services.go
+++ b/internal/store/query_services.go
@@ -1,0 +1,40 @@
+package store
+
+// The fact search index's read surface is carved into four cohesive query
+// sub-services (P1.3 stage 2). Each holds only *repoHandler — all shared state
+// and DB access live there — so none reaches sideways to another
+// (invariants…/sub-index-up-not-sideways holds structurally: the only way to
+// another cluster's data is UP through rh). *searchIndex keeps the index
+// lifecycle (IndexManager) plus the write/rebuild/graph-write path.
+//
+// See .claude/plans/2026-07-21-p1.3-store-decomposition-design.md.
+
+// factQuery implements FactQuery: fact read/search/existence queries.
+type factQuery struct{ rh *repoHandler }
+
+// graphStore implements GraphStore: DERIVED_FROM / SIMILAR_TO graph queries.
+type graphStore struct{ rh *repoHandler }
+
+// historyQuery implements HistoryQuery: commit-log / revision history queries.
+type historyQuery struct{ rh *repoHandler }
+
+// methodologyMatcher implements MethodologyMatcher: methodology-fact matching.
+type methodologyMatcher struct{ rh *repoHandler }
+
+// searchFacade composes the four sub-services into the SearchIndex composite
+// returned by Service.Search(). Method promotion from the embedded pointers is
+// what makes it satisfy every SearchIndex method; it holds no state of its own.
+type searchFacade struct {
+	*factQuery
+	*graphStore
+	*historyQuery
+	*methodologyMatcher
+}
+
+var (
+	_ FactQuery          = (*factQuery)(nil)
+	_ GraphStore         = (*graphStore)(nil)
+	_ HistoryQuery       = (*historyQuery)(nil)
+	_ MethodologyMatcher = (*methodologyMatcher)(nil)
+	_ SearchIndex        = (*searchFacade)(nil)
+)

--- a/internal/store/rebuild_concurrency_test.go
+++ b/internal/store/rebuild_concurrency_test.go
@@ -62,7 +62,7 @@ func TestRebuildEmbeddings_DoesNotHoldWriteLockDuringEmbed(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	_, err = si.rh.db.ExecContext(ctx, `DELETE FROM facts_vec`) // force a full re-embed
 	require.NoError(t, err)
 
@@ -129,7 +129,7 @@ func TestRebuildEmbeddings_RejectsBatchLengthMismatch(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	_, err = si.rh.db.ExecContext(ctx, `DELETE FROM facts_vec`) // force a full re-embed
 	require.NoError(t, err)
 
@@ -176,7 +176,7 @@ func TestRebuild_SerializedWithConcurrentSyncLocked(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	_, err = si.rh.db.ExecContext(ctx, `DELETE FROM facts_vec`) // force a full re-embed
 	require.NoError(t, err)
 

--- a/internal/store/rebuild_historical_facts_test.go
+++ b/internal/store/rebuild_historical_facts_test.go
@@ -57,7 +57,7 @@ func TestRebuildGraph_RestoresHistoricalFactNodes(t *testing.T) {
 		testFactBody("a v2", 0.95, nil), "update a", "")
 	require.NoError(t, err)
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// 4) Simulate the corruption observed in production: the v1 facts row
 	//    was GC'd AND its graph node was hard-deleted (or never created

--- a/internal/store/rebuild_no_reembed_test.go
+++ b/internal/store/rebuild_no_reembed_test.go
@@ -48,7 +48,7 @@ func TestRebuild_PreservesRowidsAndDoesNotReEmbed(t *testing.T) {
 	mk("kb/a.md", "Alpha", []string{"ai-governance"})
 	mk("kb/b.md", "Beta", []string{"store/resolver"})
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	rowids := func() map[string]int64 {
 		m := map[string]int64{}
 		rows, err := si.rh.db.QueryContext(ctx, `SELECT path, id FROM facts`)
@@ -109,7 +109,7 @@ func TestNeedsRebuild_TrueWhenVersionStale(t *testing.T) {
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 	ctx := context.Background()
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// Simulate an older deployment: stamp a prior schema version.
 	_, err = si.rh.db.ExecContext(ctx,

--- a/internal/store/replay_suspend_index_test.go
+++ b/internal/store/replay_suspend_index_test.go
@@ -14,7 +14,7 @@ import (
 func countIndexedFacts(t *testing.T, svc *Service, branch string) int {
 	t.Helper()
 	ctx := context.Background()
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	bid, err := si.rh.branchID(ctx, branch)
 	require.NoError(t, err)
 	var n int
@@ -127,7 +127,7 @@ func TestSchemaVersionState(t *testing.T) {
 	require.NoError(t, err)
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	setVersion := func(v string) {
 		_, err := si.rh.db.ExecContext(ctx,

--- a/internal/store/reverse_dependent_paths_test.go
+++ b/internal/store/reverse_dependent_paths_test.go
@@ -18,16 +18,14 @@ func TestReverseDependentPathsExported(t *testing.T) {
 	writeFact(t, svc, branch, "kb/t/a.md", nil)
 	writeFact(t, svc, branch, "kb/t/b.md", []string{"kb/t/a.md"})
 
-	si := svc.Search().(*searchIndex)
-
 	// Exported wrapper must include B as a dependent of A.
-	deps, err := si.ReverseDependentPaths(ctx, "kb/t/a.md")
+	deps, err := svc.gq.ReverseDependentPaths(ctx, "kb/t/a.md")
 	require.NoError(t, err)
 	_, hasB := deps["kb/t/b.md"]
 	require.True(t, hasB, "ReverseDependentPaths must include dependent b: %v", deps)
 
 	// Wrapper must be behavior-preserving: output equals the private method.
-	private, err := si.reverseDependentPaths(ctx, "kb/t/a.md")
+	private, err := svc.gq.reverseDependentPaths(ctx, "kb/t/a.md")
 	require.NoError(t, err)
 	require.Equal(t, private, deps, "exported wrapper must equal private reverseDependentPaths")
 }

--- a/internal/store/revisions_before.go
+++ b/internal/store/revisions_before.go
@@ -43,15 +43,15 @@ type RevisionMeta struct {
 // branch_commits on the resolved branch_id, so revisions reachable only via an
 // off-branch lineage never surface even when anchorCommit was committed
 // elsewhere.
-func (si *searchIndex) RevisionsBefore(ctx context.Context, branch, path, anchorCommit string, limit int) ([]RevisionMeta, error) {
+func (hq *historyQuery) RevisionsBefore(ctx context.Context, branch, path, anchorCommit string, limit int) ([]RevisionMeta, error) {
 	if anchorCommit == "" || limit <= 0 {
 		return nil, nil
 	}
-	branchID, err := si.rh.branchID(ctx, branch)
+	branchID, err := hq.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, fmt.Errorf("RevisionsBefore: branchID: %w", err)
 	}
-	rows, err := conn(ctx, si.rh.db).QueryContext(ctx, firstParentChainCTE+`
+	rows, err := conn(ctx, hq.rh.db).QueryContext(ctx, firstParentChainCTE+`
 		SELECT cl.commit_hash, COALESCE(cl.committed_at, 0), cl.message, cl.action
 		  FROM fpc
 		  JOIN commit_log cl ON cl.commit_hash = fpc.commit_hash

--- a/internal/store/search_crud.go
+++ b/internal/store/search_crud.go
@@ -474,12 +474,12 @@ func (si *searchIndex) delete(ctx context.Context, branch, path string) error {
 
 // GetByPath retrieves a FactWithBody by its path on the given branch,
 // hydrating the body from the objects table. Returns nil, nil if not found.
-func (si *searchIndex) GetByPath(ctx context.Context, branch, path string) (*FactWithBody, error) {
-	branchID, err := si.rh.branchID(ctx, branch)
+func (fq *factQuery) GetByPath(ctx context.Context, branch, path string) (*FactWithBody, error) {
+	branchID, err := fq.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, fmt.Errorf("getByPath: %w", err)
 	}
-	row := conn(ctx, si.rh.db).QueryRowContext(ctx,
+	row := conn(ctx, fq.rh.db).QueryRowContext(ctx,
 		`SELECT f.path, f.title, f.blob_hash, f.kind, f.type, f.domain, f.entities,
 		        f.confidence, f.sources, f.refs, f.evidence_weight,
 		        bf.commit_hash, o.data, cl.committed_at

--- a/internal/store/search_domain_match_test.go
+++ b/internal/store/search_domain_match_test.go
@@ -111,7 +111,7 @@ func TestRebuild_BackfillsTokensForHistoricalVersions(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, svc.IndexManager().Sync(ctx, branch))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	// The historical version: a facts row for kb/x.md not pointed to by branch_facts.
 	var histID int64
 	require.NoError(t, si.rh.db.QueryRowContext(ctx, `

--- a/internal/store/search_graph.go
+++ b/internal/store/search_graph.go
@@ -33,8 +33,8 @@ type ExplainResult struct {
 // HEAD by resolving the path's HEAD-active commit and delegating to the
 // commit-anchored methods. This unifies the HEAD and commit-anchored read
 // paths on a single underlying query.
-func (si *searchIndex) ExplainFact(ctx context.Context, branch, path string) (ExplainResult, error) {
-	branchID, err := si.rh.branchID(ctx, branch)
+func (gs *graphStore) ExplainFact(ctx context.Context, branch, path string) (ExplainResult, error) {
+	branchID, err := gs.rh.branchID(ctx, branch)
 	if err != nil {
 		return ExplainResult{}, fmt.Errorf("ExplainFact: branchID: %w", err)
 	}
@@ -45,7 +45,7 @@ func (si *searchIndex) ExplainFact(ctx context.Context, branch, path string) (Ex
 	// handlers can map it to 404. Older versions may still be reachable via
 	// commit-anchored endpoints; that's outside ExplainFact's HEAD-only scope.
 	var activeCommit string
-	err = conn(ctx, si.rh.db).QueryRowContext(ctx,
+	err = conn(ctx, gs.rh.db).QueryRowContext(ctx,
 		`SELECT commit_hash FROM branch_facts WHERE branch_id = ? AND path = ?`,
 		branchID, path,
 	).Scan(&activeCommit)
@@ -56,11 +56,11 @@ func (si *searchIndex) ExplainFact(ctx context.Context, branch, path string) (Ex
 		return ExplainResult{}, fmt.Errorf("ExplainFact: resolve active commit: %w", err)
 	}
 
-	in, err := si.IncomingAtCommit(ctx, branch, path, activeCommit)
+	in, err := gs.IncomingAtCommit(ctx, branch, path, activeCommit)
 	if err != nil {
 		return ExplainResult{}, fmt.Errorf("ExplainFact incoming: %w", err)
 	}
-	out, err := si.OutgoingAtCommit(ctx, branch, path, activeCommit)
+	out, err := gs.OutgoingAtCommit(ctx, branch, path, activeCommit)
 	if err != nil {
 		return ExplainResult{}, fmt.Errorf("ExplainFact outgoing: %w", err)
 	}

--- a/internal/store/search_graph_query.go
+++ b/internal/store/search_graph_query.go
@@ -30,8 +30,8 @@ import (
 // indistinguishable (via first-parent resolution) from the legitimate
 // merge-carry-forward that TestGraphAtCommit_ResolvesThroughMergeCommit pins,
 // where the edge's target_commit likewise differs from the resolved anchor.
-func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error) {
-	branchID, err := si.rh.branchID(ctx, branch)
+func (gs *graphStore) IncomingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error) {
+	branchID, err := gs.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, fmt.Errorf("IncomingAtCommit: branchID: %w", err)
 	}
@@ -41,7 +41,7 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 	// target path's effective write-commit ≤ commitHash. Without this, queries
 	// at any commit other than the exact write-commit return 0. See the
 	// historical-graph-invariant note.
-	effectiveCommit, ok, err := si.resolveActiveCommitForPath(ctx, branch, path, commitHash)
+	effectiveCommit, ok, err := gs.rh.resolveActiveCommitForPath(ctx, branch, path, commitHash)
 	if err != nil {
 		return nil, fmt.Errorf("IncomingAtCommit: resolve effective commit: %w", err)
 	}
@@ -56,7 +56,7 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 	// lands on the merge) but carries the same blob forward without re-anchoring
 	// the edges, so a target_commit == effectiveCommit filter drops every
 	// incoming edge at a merge-resolved anchor.
-	blobHash, err := si.rh.readBlobHashAtCommit(ctx, path, effectiveCommit)
+	blobHash, err := gs.rh.readBlobHashAtCommit(ctx, path, effectiveCommit)
 	if err != nil {
 		return nil, fmt.Errorf("IncomingAtCommit: blob at %s: %w", effectiveCommit, err)
 	}
@@ -79,7 +79,7 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 	// re-runs the whole query+scan (see withCypherRetry).
 	var candidates []RefSummary
 	if err := withCypherRetry(func() error {
-		rows, qerr := conn(ctx, si.rh.db).QueryContext(ctx, q)
+		rows, qerr := conn(ctx, gs.rh.db).QueryContext(ctx, q)
 		if qerr != nil {
 			return qerr
 		}
@@ -120,7 +120,7 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 		args = append(args, c.Commit)
 		placeholders = append(placeholders, "?")
 	}
-	bcRows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+	bcRows, err := conn(ctx, gs.rh.db).QueryContext(ctx,
 		`SELECT bc.commit_hash, COALESCE(cl.committed_at, 0)
 		   FROM branch_commits bc
 		   LEFT JOIN commit_log cl ON cl.commit_hash = bc.commit_hash
@@ -168,13 +168,13 @@ func (si *searchIndex) IncomingAtCommit(ctx context.Context, branch, path, commi
 // Candidates whose target_commit is missing from commit_log are dropped:
 // returning them would expose self-links that 404. This is the only filter
 // applied — branch reachability is intentionally not enforced here.
-func (si *searchIndex) OutgoingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error) {
+func (gs *graphStore) OutgoingAtCommit(ctx context.Context, branch, path, commitHash string) ([]RefSummary, error) {
 	// Sparse-history walk-back: edges are stored anchored to the source's
 	// actual write-commit. Resolve `commitHash` (the query anchor) into the
 	// source path's effective write-commit ≤ commitHash. Without this, queries
 	// at any commit other than the exact write-commit return 0. See the
 	// historical-graph-invariant note.
-	effectiveCommit, ok, err := si.resolveActiveCommitForPath(ctx, branch, path, commitHash)
+	effectiveCommit, ok, err := gs.rh.resolveActiveCommitForPath(ctx, branch, path, commitHash)
 	if err != nil {
 		return nil, fmt.Errorf("OutgoingAtCommit: resolve effective commit: %w", err)
 	}
@@ -192,7 +192,7 @@ func (si *searchIndex) OutgoingAtCommit(ctx context.Context, branch, path, commi
 	// that resolves to a merge (i.e. at HEAD after a merge-back). The Fact node
 	// is keyed by (path, blob_hash) and the blob is stable across the merge, so
 	// matching the node finds the edges regardless of which commit anchored them.
-	blobHash, err := si.rh.readBlobHashAtCommit(ctx, path, effectiveCommit)
+	blobHash, err := gs.rh.readBlobHashAtCommit(ctx, path, effectiveCommit)
 	if err != nil {
 		return nil, fmt.Errorf("OutgoingAtCommit: blob at %s: %w", effectiveCommit, err)
 	}
@@ -209,7 +209,7 @@ func (si *searchIndex) OutgoingAtCommit(ctx context.Context, branch, path, commi
 	// re-runs the whole query+scan (see withCypherRetry).
 	var candidates []RefSummary
 	if err := withCypherRetry(func() error {
-		rows, qerr := conn(ctx, si.rh.db).QueryContext(ctx, q)
+		rows, qerr := conn(ctx, gs.rh.db).QueryContext(ctx, q)
 		if qerr != nil {
 			return qerr
 		}
@@ -247,7 +247,7 @@ func (si *searchIndex) OutgoingAtCommit(ctx context.Context, branch, path, commi
 		args = append(args, c.Commit)
 		placeholders = append(placeholders, "?")
 	}
-	clRows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+	clRows, err := conn(ctx, gs.rh.db).QueryContext(ctx,
 		`SELECT cl.commit_hash, COALESCE(cl.committed_at, 0)
 		   FROM commit_log cl
 		  WHERE cl.commit_hash IN (`+strings.Join(placeholders, ",")+`)`,

--- a/internal/store/search_graph_query_merge_test.go
+++ b/internal/store/search_graph_query_merge_test.go
@@ -41,25 +41,25 @@ func TestGraphAtCommit_ResolvesThroughMergeCommit(t *testing.T) {
 	head, err := svc.Branches().HeadCommit(ctx, "main")
 	require.NoError(t, err)
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// Precondition: on main, A's effective write-commit resolves to the MERGE
 	// commit (not the feature write) — the exact condition that breaks the
 	// commit-equality edge filter.
-	eff, ok, err := si.resolveActiveCommitForPath(ctx, "main", "kb/a.md", head)
+	eff, ok, err := si.rh.resolveActiveCommitForPath(ctx, "main", "kb/a.md", head)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, head, eff, "precondition: A's effective write-commit on main IS the merge commit")
 
 	// OUTGOING: A→B must be surfaced at HEAD even though the edge is anchored to
 	// the feature write-commit, not the merge.
-	out, err := si.OutgoingAtCommit(ctx, "main", "kb/a.md", head)
+	out, err := svc.gq.OutgoingAtCommit(ctx, "main", "kb/a.md", head)
 	require.NoError(t, err)
 	require.Len(t, out, 1, "A's outgoing edge to B must survive resolving HEAD to the merge commit")
 	require.Equal(t, "kb/b.md", out[0].Path)
 
 	// INCOMING: B←A symmetric.
-	in, err := si.IncomingAtCommit(ctx, "main", "kb/b.md", head)
+	in, err := svc.gq.IncomingAtCommit(ctx, "main", "kb/b.md", head)
 	require.NoError(t, err)
 	require.Len(t, in, 1, "B's incoming edge from A must survive resolving HEAD to the merge commit")
 	require.Equal(t, "kb/a.md", in[0].Path)

--- a/internal/store/search_graph_query_test.go
+++ b/internal/store/search_graph_query_test.go
@@ -360,7 +360,7 @@ func TestOutgoingAtCommit_FiltersStaleSelfLoop(t *testing.T) {
 	xRes, err := svc.Facts().WriteFact(ctx, branch, "kb/x.md", testFactBody("x", 0.9, nil), "init x", "")
 	require.NoError(t, err)
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// Bypass the write-path fix to inject a stale self-loop edge directly.
 	nodeID, err := si.graphNodeIDByBlob(ctx, "kb/x.md", xRes.BlobHash)
@@ -374,11 +374,11 @@ func TestOutgoingAtCommit_FiltersStaleSelfLoop(t *testing.T) {
 		"target_commit": xRes.CommitHash,
 	}))
 
-	out, err := si.OutgoingAtCommit(ctx, branch, "kb/x.md", xRes.CommitHash)
+	out, err := svc.gq.OutgoingAtCommit(ctx, branch, "kb/x.md", xRes.CommitHash)
 	require.NoError(t, err)
 	require.Empty(t, out, "stale self-loop edge (same path & commit both sides) must be filtered from outgoing")
 
-	in, err := si.IncomingAtCommit(ctx, branch, "kb/x.md", xRes.CommitHash)
+	in, err := svc.gq.IncomingAtCommit(ctx, branch, "kb/x.md", xRes.CommitHash)
 	require.NoError(t, err)
 	require.Empty(t, in, "stale self-loop edge must be filtered from incoming")
 }

--- a/internal/store/search_history.go
+++ b/internal/store/search_history.go
@@ -9,8 +9,8 @@ import (
 
 // Log returns up to 50 log entries for commits that modified path on branch.
 // Queries commit_log directly; branch is accepted for interface compatibility.
-func (si *searchIndex) Log(ctx context.Context, branch, path string) ([]LogEntry, error) {
-	rows, _, err := si.rh.commitLogQuery(ctx, branch, path, "", "", "", 50)
+func (hq *historyQuery) Log(ctx context.Context, branch, path string) ([]LogEntry, error) {
+	rows, _, err := hq.rh.commitLogQuery(ctx, branch, path, "", "", "", 50)
 	if err != nil {
 		return nil, fmt.Errorf("Log: %w", err)
 	}
@@ -26,8 +26,8 @@ func (si *searchIndex) Log(ctx context.Context, branch, path string) ([]LogEntry
 }
 
 // LogPaginated returns paginated log entries with file-count tags.
-func (si *searchIndex) LogPaginated(ctx context.Context, branch, path string, limit int, after, from, before string) ([]LogEntryWithTags, string, string, error) {
-	rows, hasMore, err := si.rh.commitLogQuery(ctx, branch, path, after, from, before, limit)
+func (hq *historyQuery) LogPaginated(ctx context.Context, branch, path string, limit int, after, from, before string) ([]LogEntryWithTags, string, string, error) {
+	rows, hasMore, err := hq.rh.commitLogQuery(ctx, branch, path, after, from, before, limit)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("LogPaginated: %w", err)
 	}
@@ -63,13 +63,13 @@ func (si *searchIndex) LogPaginated(ctx context.Context, branch, path string, li
 	}
 
 	if len(entries) > 0 {
-		si.enrichFileCounts(entries)
+		hq.enrichFileCounts(entries)
 	}
 	return entries, nextCursor, prevCursor, nil
 }
 
 // enrichFileCounts batch-queries commit_log for A/M/D counts per commit.
-func (si *searchIndex) enrichFileCounts(entries []LogEntryWithTags) {
+func (hq *historyQuery) enrichFileCounts(entries []LogEntryWithTags) {
 	hashes := make([]string, len(entries))
 	idx := make(map[string]int, len(entries))
 	for i, e := range entries {
@@ -77,7 +77,7 @@ func (si *searchIndex) enrichFileCounts(entries []LogEntryWithTags) {
 		idx[e.Commit] = i
 	}
 
-	counts, err := si.rh.commitLogFileCounts(hashes)
+	counts, err := hq.rh.commitLogFileCounts(hashes)
 	if err != nil {
 		return
 	}
@@ -96,8 +96,8 @@ func (si *searchIndex) enrichFileCounts(entries []LogEntryWithTags) {
 // CommitDetail returns metadata and changed files for a specific commit,
 // queried from commit_log. When pathPrefix is non-empty, only files under
 // that directory are returned.
-func (si *searchIndex) CommitDetail(ctx context.Context, commitHash, pathPrefix string) (*CommitDetailResult, error) {
-	db := conn(ctx, si.rh.db)
+func (hq *historyQuery) CommitDetail(ctx context.Context, commitHash, pathPrefix string) (*CommitDetailResult, error) {
+	db := conn(ctx, hq.rh.db)
 
 	var committedAt int64
 	var message, operation, authorName, authorEmail string
@@ -149,12 +149,12 @@ func (si *searchIndex) CommitDetail(ctx context.Context, commitHash, pathPrefix 
 }
 
 // Activity returns commit-activity metrics for path using SQL aggregates.
-func (si *searchIndex) Activity(ctx context.Context, branch, path string) (ActivityResult, error) {
+func (hq *historyQuery) Activity(ctx context.Context, branch, path string) (ActivityResult, error) {
 	cutoff7 := commitLogAge(7)
 	cutoff30 := commitLogAge(30)
 	cutoff90 := commitLogAge(90)
 
-	r, err := si.rh.commitLogActivity(ctx, branch, path, cutoff7, cutoff30, cutoff90)
+	r, err := hq.rh.commitLogActivity(ctx, branch, path, cutoff7, cutoff30, cutoff90)
 	if err != nil {
 		return ActivityResult{}, fmt.Errorf("Activity: %w", err)
 	}
@@ -174,12 +174,12 @@ func (si *searchIndex) Activity(ctx context.Context, branch, path string) (Activ
 
 // FactsIter opens a cursor over facts for the given branch ordered by fact_id DESC.
 // The caller must call Close() when done to release the underlying database cursor.
-func (si *searchIndex) FactsIter(ctx context.Context, branch string) (*FactsIter, error) {
-	branchID, err := si.rh.branchID(ctx, branch)
+func (fq *factQuery) FactsIter(ctx context.Context, branch string) (*FactsIter, error) {
+	branchID, err := fq.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, err
 	}
-	rows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+	rows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 		`SELECT bf.path, f.blob_hash, bf.commit_hash
 		 FROM branch_facts bf
 		 JOIN facts f ON f.id = bf.fact_id

--- a/internal/store/search_index_test.go
+++ b/internal/store/search_index_test.go
@@ -27,7 +27,9 @@ func (e *configurableEmbedder) embed() []float32 {
 	return out
 }
 
-func (e *configurableEmbedder) EmbedQuery(context.Context, string) ([]float32, error) { return e.embed(), nil }
+func (e *configurableEmbedder) EmbedQuery(context.Context, string) ([]float32, error) {
+	return e.embed(), nil
+}
 func (e *configurableEmbedder) EmbedDocument(context.Context, string, string) ([]float32, error) {
 	return e.embed(), nil
 }
@@ -55,7 +57,7 @@ func TestNeedsRebuildDetectsModelChange(t *testing.T) {
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 
 	ctx := context.Background()
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// Persist a current schema version + a matching embedding identity.
 	emb := &configurableEmbedder{id: "embeddinggemma", dim: 768}
@@ -93,9 +95,9 @@ func TestRebuild_BumpsGraphSchemaVersion(t *testing.T) {
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 
-	require.NoError(t, svc.Search().(*searchIndex).Rebuild(context.Background(), "main", nil))
+	require.NoError(t, svc.si.Rebuild(context.Background(), "main", nil))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	var version string
 	require.NoError(t, si.rh.db.QueryRow(`SELECT value FROM meta WHERE key = 'graph_schema_version'`).Scan(&version))
 	require.Equal(t, GraphSchemaVersion, version)
@@ -125,7 +127,7 @@ func TestRebuildGraph_WritesEdgePerRefEvent(t *testing.T) {
 
 	require.NoError(t, svc.IndexManager().Rebuild(ctx, branch, nil))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	var count int
 	require.NoError(t, si.rh.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM edges WHERE type = ?`, EdgeDerivedFrom).Scan(&count))
@@ -173,7 +175,7 @@ func TestRebuild_RepopulatesDomainAndEntityJunctions(t *testing.T) {
 
 	require.NoError(t, svc.IndexManager().Rebuild(ctx, branch, nil))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// fact_domains must contain one row per (fact, domain-value) pair.
 	var domainRows int
@@ -225,7 +227,7 @@ func TestUpsert_DuplicateEntitiesAndDomains_NoError(t *testing.T) {
 		Refs:       []string{},
 	}
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 
 	// upsert should succeed without constraint violation.
 	err = si.upsert(ctx, branch, "test-commit-hash", rec)

--- a/internal/store/search_query.go
+++ b/internal/store/search_query.go
@@ -30,12 +30,12 @@ type RecentFactEntry struct {
 // (Path, IncludeKinds/ExcludeKinds, IncludeTypes/ExcludeTypes, Domain,
 // Entities, EpisodeOps) are applied; vector-search-only fields (QueryVec,
 // QueryByPath, MinSimilarity) are inert here.
-func (si *searchIndex) RecentFacts(ctx context.Context, branch string, opts SearchOptions) ([]RecentFactEntry, int, error) {
+func (fq *factQuery) RecentFacts(ctx context.Context, branch string, opts SearchOptions) ([]RecentFactEntry, int, error) {
 	if opts.Text != "" {
-		return si.recentFactsSearch(ctx, branch, opts)
+		return fq.recentFactsSearch(ctx, branch, opts)
 	}
 
-	branchID, err := si.rh.branchID(ctx, branch)
+	branchID, err := fq.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, 0, fmt.Errorf("RecentFacts: %w", err)
 	}
@@ -56,7 +56,7 @@ func (si *searchIndex) RecentFacts(ctx context.Context, branch string, opts Sear
 
 	countArgs := append(append([]any{branchID}, flt.args...), epArgs...)
 	var total int
-	if err := conn(ctx, si.rh.db).QueryRowContext(ctx,
+	if err := conn(ctx, fq.rh.db).QueryRowContext(ctx,
 		`SELECT COUNT(*)
 		 FROM branch_facts bf
 		 JOIN facts f ON f.id = bf.fact_id
@@ -68,7 +68,7 @@ func (si *searchIndex) RecentFacts(ctx context.Context, branch string, opts Sear
 	}
 
 	queryArgs := append(append(append([]any{branchID}, flt.args...), epArgs...), opts.Limit, opts.Offset)
-	rows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+	rows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 		`SELECT f.path, f.title, f.kind, f.type, f.domain, f.entities,
 		        COALESCE(cl.committed_at, 0), COALESCE(cl.operation, ''), bf.commit_hash
 		 FROM branch_facts bf
@@ -100,8 +100,8 @@ func (si *searchIndex) RecentFacts(ctx context.Context, branch string, opts Sear
 
 // recentFactsSearch uses semantic search to find matching facts, then returns
 // them ordered by committed_at with pagination.
-func (si *searchIndex) recentFactsSearch(ctx context.Context, branch string, opts SearchOptions) ([]RecentFactEntry, int, error) {
-	branchID, err := si.rh.branchID(ctx, branch)
+func (fq *factQuery) recentFactsSearch(ctx context.Context, branch string, opts SearchOptions) ([]RecentFactEntry, int, error) {
+	branchID, err := fq.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, 0, fmt.Errorf("RecentFacts search: %w", err)
 	}
@@ -112,7 +112,7 @@ func (si *searchIndex) recentFactsSearch(ctx context.Context, branch string, opt
 	searchOpts := opts
 	searchOpts.Limit = 500
 	searchOpts.Offset = 0
-	results, err := si.Search(ctx, branch, searchOpts)
+	results, err := fq.Search(ctx, branch, searchOpts)
 	if err != nil {
 		return nil, 0, fmt.Errorf("RecentFacts search: %w", err)
 	}
@@ -131,7 +131,7 @@ func (si *searchIndex) recentFactsSearch(ctx context.Context, branch string, opt
 		scoreByPath[r.Path] = r.Score
 	}
 
-	rows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+	rows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 		`SELECT f.path, f.title, f.kind, f.type, f.domain, f.entities,
 		        COALESCE(cl.committed_at, 0), COALESCE(cl.operation, ''), bf.commit_hash
 		 FROM branch_facts bf
@@ -189,13 +189,13 @@ func (si *searchIndex) recentFactsSearch(ctx context.Context, branch string, opt
 // LastCommitForPath returns the commit hash of the most recent commit_log
 // entry for the given path, provided that entry's action is not 'deleted'.
 // Returns ("", false) if the path is not found or its latest action is deleted.
-func (si *searchIndex) LastCommitForPath(ctx context.Context, branch, path string) (string, bool) {
-	branchID, err := si.rh.branchID(ctx, branch)
+func (fq *factQuery) LastCommitForPath(ctx context.Context, branch, path string) (string, bool) {
+	branchID, err := fq.rh.branchID(ctx, branch)
 	if err != nil {
 		return "", false
 	}
 	var hash, action string
-	err = conn(ctx, si.rh.db).QueryRowContext(ctx,
+	err = conn(ctx, fq.rh.db).QueryRowContext(ctx,
 		`SELECT cl.commit_hash, cl.action
 		 FROM commit_log cl
 		 JOIN branch_commits bc ON bc.commit_hash = cl.commit_hash
@@ -384,7 +384,7 @@ func newFactFilter(q SearchOptions) *factFilter {
 // the allowed set. It performs a single bulk SQL lookup of operations by
 // commit_hash from commit_log (same database). If ops is empty, all results
 // are kept unchanged.
-func (si *searchIndex) filterByEpisodeOps(ctx context.Context, results []SearchResult, ops []string) ([]SearchResult, error) {
+func (fq *factQuery) filterByEpisodeOps(ctx context.Context, results []SearchResult, ops []string) ([]SearchResult, error) {
 	if len(ops) == 0 || len(results) == 0 {
 		return results, nil
 	}
@@ -414,7 +414,7 @@ func (si *searchIndex) filterByEpisodeOps(ctx context.Context, results []SearchR
 		args[i] = h
 	}
 
-	rows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+	rows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 		`SELECT commit_hash, operation FROM commit_log WHERE commit_hash IN (`+ph[:len(ph)-1]+`) GROUP BY commit_hash`,
 		args...,
 	)
@@ -455,8 +455,8 @@ func (si *searchIndex) filterByEpisodeOps(ctx context.Context, results []SearchR
 //
 // If Text is empty, all facts matching the non-text filters are returned with
 // score 100.
-func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOptions) ([]SearchResult, error) {
-	branchID, err := si.rh.branchID(ctx, branch)
+func (fq *factQuery) Search(ctx context.Context, branch string, q SearchOptions) ([]SearchResult, error) {
+	branchID, err := fq.rh.branchID(ctx, branch)
 	if err != nil {
 		return nil, fmt.Errorf("search: %w", err)
 	}
@@ -471,7 +471,7 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 	// ── Text-less path: return all facts matching filters with score 100 ──
 	if q.Text == "" && q.QueryByPath == "" && len(q.QueryVec) == 0 {
 		args := append(append([]any{blobObjectType, branchID}, flt.args...), limit)
-		rows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+		rows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 			`SELECT f.path, f.title, f.blob_hash, f.kind, f.type, f.domain, f.entities,
 			        f.confidence, f.sources, f.refs, f.evidence_weight,
 			        bf.commit_hash, o.data, COALESCE(cl.committed_at, 0)
@@ -498,7 +498,7 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 		if err := rows.Err(); err != nil {
 			return nil, err
 		}
-		return si.filterByEpisodeOps(ctx, out, q.EpisodeOps)
+		return fq.filterByEpisodeOps(ctx, out, q.EpisodeOps)
 	}
 
 	// ── Vector (embedding) search ─────────────────────────────────────────
@@ -508,7 +508,7 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 	}
 
 	// Model-dependent cosine cutoffs (rerank tiers + recall floor below).
-	th := EmbedderThresholds(si.rh.getEmbedder())
+	th := EmbedderThresholds(fq.rh.getEmbedder())
 
 	vecSimByPath := make(map[string]float64)
 	kLimit := limit * 5
@@ -525,7 +525,7 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 	// NULL and the outer query returns no rows (caller falls back to filter
 	// search, same as if there were no embedder).
 	if q.QueryByPath != "" && len(q.QueryVec) == 0 {
-		rows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+		rows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 			`SELECT f.path, (1.0 - fv.distance) as similarity
 			 FROM facts_vec fv
 			 JOIN facts f ON f.id = fv.rowid
@@ -560,7 +560,7 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 			log.Debug().Int("vec_hits", len(vecSimByPath)).Str("source_path", q.QueryByPath).Msg("vec search complete (via path)")
 		}
 	} else {
-		emb := si.rh.getEmbedder()
+		emb := fq.rh.getEmbedder()
 		if emb == nil && len(q.QueryVec) == 0 {
 			log.Debug().Msg("search: no embedder configured, skipping vec search")
 		} else {
@@ -576,7 +576,7 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 				log.Warn().Msg("search: no query vector available")
 			} else {
 				vecBlob := float32SliceToBytes(queryVec)
-				rows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+				rows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 					`SELECT f.path, (1.0 - fv.distance) as similarity
 					 FROM facts_vec fv
 					 JOIN facts f ON f.id = fv.rowid
@@ -636,7 +636,7 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 		pathArgs = append(pathArgs, p)
 	}
 
-	metaRows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+	metaRows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 		`SELECT f.path, f.title, f.blob_hash, f.kind, f.type, f.domain, f.entities,
 		        f.confidence, f.sources, f.refs, f.evidence_weight, bf.commit_hash,
 		        COALESCE(cl.committed_at, 0)
@@ -682,7 +682,7 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 	for _, c := range candidates {
 		bodyArgs = append(bodyArgs, c.rec.BlobHash)
 	}
-	bodyRows, err := conn(ctx, si.rh.db).QueryContext(ctx,
+	bodyRows, err := conn(ctx, fq.rh.db).QueryContext(ctx,
 		`SELECT hash, data FROM objects WHERE type = ? AND hash IN (`+bodyPH[:len(bodyPH)-1]+`)`,
 		bodyArgs...,
 	)
@@ -710,5 +710,5 @@ func (si *searchIndex) Search(ctx context.Context, branch string, q SearchOption
 		c.rec.Body = bodies[c.rec.BlobHash]
 		out = append(out, SearchResult{FactWithBody: c.rec, Score: c.score * 100.0})
 	}
-	return si.filterByEpisodeOps(ctx, out, q.EpisodeOps)
+	return fq.filterByEpisodeOps(ctx, out, q.EpisodeOps)
 }

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -34,9 +34,6 @@ var sessionSchema string
 // blobObjectType is the go-git integer for plumbing.BlobObject.
 const blobObjectType = 3
 
-// Compile-time check (SearchIndex has no assertion in its own file).
-var _ SearchIndex = (*searchIndex)(nil)
-
 // Service is the single entry point for all database and git access. It opens one
 // SQLite file with sqlite-vec + GraphQLite extensions, runs the embedded
 // schema, and provides both a go-git Storer and typed index accessors.
@@ -50,10 +47,18 @@ type Service struct {
 	handler     http.Handler
 	fi          *factIndex
 	si          *searchIndex
-	pi          *pipelineIndex
-	ti          *toolIndex
-	ri          *remoteIndex
-	dbPath      string
+	// The four query sub-services carved out of searchIndex (P1.3). searchIndex
+	// (si) keeps IndexManager + the write/rebuild path; these own the read
+	// surface. search composes all four for the Search() composite.
+	fq     *factQuery
+	gq     *graphStore
+	hq     *historyQuery
+	mq     *methodologyMatcher
+	search *searchFacade
+	pi     *pipelineIndex
+	ti     *toolIndex
+	ri     *remoteIndex
+	dbPath string
 
 	// sessionDB is a separate, ephemeral SQLite file holding all in-flight
 	// session/work-queue state (tool paging cursors + pipeline work-stealing).
@@ -161,6 +166,11 @@ func Open(path string) (*Service, error) {
 	rh.im = si // notifyCommit delegates to im.Sync after every commit.
 	fi := &factIndex{rh: rh}
 	ri := &remoteIndex{rh: rh}
+	fq := &factQuery{rh: rh}
+	gq := &graphStore{rh: rh}
+	hq := &historyQuery{rh: rh}
+	mq := &methodologyMatcher{rh: rh}
+	search := &searchFacade{factQuery: fq, graphStore: gq, historyQuery: hq, methodologyMatcher: mq}
 	canonPath := canonicalizePath(path)
 
 	// Open the ephemeral session DB (separate file, stock driver). This is
@@ -178,6 +188,11 @@ func Open(path string) (*Service, error) {
 		rh:            rh,
 		fi:            fi,
 		si:            si,
+		fq:            fq,
+		gq:            gq,
+		hq:            hq,
+		mq:            mq,
+		search:        search,
 		pi:            &pipelineIndex{rh: rh, sessionDB: sessionDB},
 		ti:            &toolIndex{db: sessionDB},
 		ri:            ri,
@@ -321,22 +336,23 @@ func (s *Service) Remote() RemoteIndex { return s.ri }
 // Facts returns the FactIndex for git-backed fact operations.
 func (s *Service) Facts() FactIndex { return s.fi }
 
-// Search returns the SearchIndex composite. Prefer the narrow accessors below
-// (FactQuery/GraphStore/HistoryQuery/Methodology) — depend on the smallest
-// query surface a caller needs. All five currently return the same *searchIndex.
-func (s *Service) Search() SearchIndex { return s.si }
+// Search returns the SearchIndex composite (a facade over the four query
+// sub-services). Prefer the narrow accessors below (FactQuery/GraphStore/
+// HistoryQuery/Methodology) — depend on the smallest query surface a caller
+// needs.
+func (s *Service) Search() SearchIndex { return s.search }
 
 // FactQuery returns the fact read/search/existence query sub-service.
-func (s *Service) FactQuery() FactQuery { return s.si }
+func (s *Service) FactQuery() FactQuery { return s.fq }
 
 // GraphStore returns the DERIVED_FROM / SIMILAR_TO graph query sub-service.
-func (s *Service) GraphStore() GraphStore { return s.si }
+func (s *Service) GraphStore() GraphStore { return s.gq }
 
 // HistoryQuery returns the commit-log / revision history query sub-service.
-func (s *Service) HistoryQuery() HistoryQuery { return s.si }
+func (s *Service) HistoryQuery() HistoryQuery { return s.hq }
 
 // Methodology returns the methodology-matching query sub-service.
-func (s *Service) Methodology() MethodologyMatcher { return s.si }
+func (s *Service) Methodology() MethodologyMatcher { return s.mq }
 
 // IndexManager returns the IndexManager for search index lifecycle operations.
 func (s *Service) IndexManager() IndexManager { return s.si }

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -321,8 +321,22 @@ func (s *Service) Remote() RemoteIndex { return s.ri }
 // Facts returns the FactIndex for git-backed fact operations.
 func (s *Service) Facts() FactIndex { return s.fi }
 
-// Search returns the SearchIndex for full-text and vector search.
+// Search returns the SearchIndex composite. Prefer the narrow accessors below
+// (FactQuery/GraphStore/HistoryQuery/Methodology) — depend on the smallest
+// query surface a caller needs. All five currently return the same *searchIndex.
 func (s *Service) Search() SearchIndex { return s.si }
+
+// FactQuery returns the fact read/search/existence query sub-service.
+func (s *Service) FactQuery() FactQuery { return s.si }
+
+// GraphStore returns the DERIVED_FROM / SIMILAR_TO graph query sub-service.
+func (s *Service) GraphStore() GraphStore { return s.si }
+
+// HistoryQuery returns the commit-log / revision history query sub-service.
+func (s *Service) HistoryQuery() HistoryQuery { return s.si }
+
+// Methodology returns the methodology-matching query sub-service.
+func (s *Service) Methodology() MethodologyMatcher { return s.si }
 
 // IndexManager returns the IndexManager for search index lifecycle operations.
 func (s *Service) IndexManager() IndexManager { return s.si }

--- a/internal/store/similarity_graph.go
+++ b/internal/store/similarity_graph.go
@@ -71,7 +71,7 @@ func NewSimilarityGraph(pairs [][2]string) SimilarityGraph {
 // given fact paths. Only edges where BOTH endpoints are in paths are kept.
 // Liveness is enforced via NOT n.deleted = true on the neighbor side.
 // An empty or single-element paths slice returns an empty graph.
-func (si *searchIndex) SimilarityAdjacency(ctx context.Context, paths []string) (SimilarityGraph, error) {
+func (gs *graphStore) SimilarityAdjacency(ctx context.Context, paths []string) (SimilarityGraph, error) {
 	g := SimilarityGraph{adj: make(map[string]map[string]struct{})}
 	if len(paths) < 2 {
 		return g, nil
@@ -120,7 +120,7 @@ func (si *searchIndex) SimilarityAdjacency(ctx context.Context, paths []string) 
 			delete(g.adj, k)
 		}
 
-		rows, err := conn(ctx, si.rh.db).QueryContext(ctx, q)
+		rows, err := conn(ctx, gs.rh.db).QueryContext(ctx, q)
 		if err != nil {
 			return err
 		}

--- a/internal/store/similarity_graph_test.go
+++ b/internal/store/similarity_graph_test.go
@@ -82,8 +82,7 @@ func TestSimilarityAdjacency_Integration(t *testing.T) {
 	writeSrcFact(t, svc, "main", "kb/a.md", "alpha beta gamma delta", nil, nil)
 	writeSrcFact(t, svc, "main", "kb/b.md", "alpha beta gamma delta epsilon", nil, nil)
 	writeSrcFact(t, svc, "main", "kb/c.md", "zzz unrelated content", nil, nil)
-	si := svc.Search().(*searchIndex)
-	g, err := si.SimilarityAdjacency(ctx, []string{"kb/a.md", "kb/b.md", "kb/c.md"})
+	g, err := svc.gq.SimilarityAdjacency(ctx, []string{"kb/a.md", "kb/b.md", "kb/c.md"})
 	require.NoError(t, err)
 	// a~b expected (near-dup); assert at least the a-b pair is present and density math holds.
 	if !g.Connected("kb/a.md", "kb/b.md") {
@@ -106,17 +105,16 @@ func TestSimilarityAdjacency_EmptyAndSinglePath(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
-	si := svc.Search().(*searchIndex)
 
 	// Empty input.
-	g, err := si.SimilarityAdjacency(ctx, nil)
+	g, err := svc.gq.SimilarityAdjacency(ctx, nil)
 	require.NoError(t, err)
 	if d := g.Density(nil); d != 0 {
 		t.Errorf("empty density = %v, want 0", d)
 	}
 
 	// Single path.
-	g, err = si.SimilarityAdjacency(ctx, []string{"kb/x.md"})
+	g, err = svc.gq.SimilarityAdjacency(ctx, []string{"kb/x.md"})
 	require.NoError(t, err)
 	if d := g.Density([]string{"kb/x.md"}); d != 0 {
 		t.Errorf("single-member density = %v, want 0", d)
@@ -137,7 +135,7 @@ func TestSimilarityAdjacency_QuoteInPathDoesNotInject(t *testing.T) {
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	ctx := context.Background()
 
 	a := mergeFactNode(t, si, "kb/a.md", "aaaa")
@@ -150,7 +148,7 @@ func TestSimilarityAdjacency_QuoteInPathDoesNotInject(t *testing.T) {
 	sqlInject := `kb/a.md') RETURN f.path AS a, f.path AS b --`
 	cypherInject := `kb/a.md" OR true OR f.path = "x`
 
-	g, err := si.SimilarityAdjacency(ctx, []string{"kb/a.md", "kb/b.md", sqlInject, cypherInject})
+	g, err := svc.gq.SimilarityAdjacency(ctx, []string{"kb/a.md", "kb/b.md", sqlInject, cypherInject})
 	require.NoError(t, err, "injection-shaped paths must keep the query well-formed, not error")
 
 	// Only the real a–b edge may survive; injection paths must not widen the result.

--- a/internal/store/subgraph_edges.go
+++ b/internal/store/subgraph_edges.go
@@ -29,7 +29,7 @@ var subgraphEdgeChunkSize = 400
 // query; the `b` endpoint is filtered against the full set in Go. Every
 // intra-set edge (x,y) is therefore found when x's chunk is queried, so
 // chunking never drops an edge — it only bounds each query's expression depth.
-func (si *searchIndex) SubgraphEdges(ctx context.Context, paths []string) ([][2]string, error) {
+func (gs *graphStore) SubgraphEdges(ctx context.Context, paths []string) ([][2]string, error) {
 	if len(paths) < 2 {
 		return nil, nil
 	}
@@ -90,7 +90,7 @@ func (si *searchIndex) SubgraphEdges(ctx context.Context, paths []string) ([][2]
 		// Best-effort cypher read; retry the transient concurrent-translation
 		// race. Dedup via `seen` makes a retry that re-scans rows idempotent.
 		err := withCypherRetry(func() error {
-			rows, qerr := conn(ctx, si.rh.db).QueryContext(ctx, q)
+			rows, qerr := conn(ctx, gs.rh.db).QueryContext(ctx, q)
 			if qerr != nil {
 				return qerr
 			}

--- a/internal/store/subgraph_edges_test.go
+++ b/internal/store/subgraph_edges_test.go
@@ -51,7 +51,7 @@ func TestSubgraphEdges_ReturnsSimilarToAmongPaths(t *testing.T) {
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	ctx := context.Background()
 
 	a := mergeFactNode(t, si, "kb/a.md", "aaaa")
@@ -66,7 +66,7 @@ func TestSubgraphEdges_ReturnsSimilarToAmongPaths(t *testing.T) {
 	require.NoError(t, si.graphInsertEdge(ctx, c, outside, EdgeSimilarTo))
 
 	paths := []string{"kb/a.md", "kb/b.md", "kb/c.md", "kb/lonely.md"}
-	edges, err := si.SubgraphEdges(ctx, paths)
+	edges, err := svc.gq.SubgraphEdges(ctx, paths)
 	require.NoError(t, err)
 
 	got := normalizePairs(edges)
@@ -90,7 +90,7 @@ func TestSubgraphEdges_ChunksLargePathSets(t *testing.T) {
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	ctx := context.Background()
 
 	a := mergeFactNode(t, si, "kb/a.md", "aaaa")
@@ -104,7 +104,7 @@ func TestSubgraphEdges_ChunksLargePathSets(t *testing.T) {
 	require.NoError(t, si.graphInsertEdge(ctx, b, c, EdgeSimilarTo))
 	require.NoError(t, si.graphInsertEdge(ctx, c, d, EdgeSimilarTo))
 
-	edges, err := si.SubgraphEdges(ctx, []string{"kb/a.md", "kb/b.md", "kb/c.md", "kb/d.md"})
+	edges, err := svc.gq.SubgraphEdges(ctx, []string{"kb/a.md", "kb/b.md", "kb/c.md", "kb/d.md"})
 	require.NoError(t, err)
 
 	got := normalizePairs(edges)
@@ -125,7 +125,7 @@ func TestSubgraphEdges_QuoteInPathDoesNotInject(t *testing.T) {
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	ctx := context.Background()
 
 	a := mergeFactNode(t, si, "kb/a.md", "aaaa")
@@ -138,7 +138,7 @@ func TestSubgraphEdges_QuoteInPathDoesNotInject(t *testing.T) {
 	sqlInject := `kb/a.md') RETURN a.path AS a, a.path AS b --`
 	cypherInject := `kb/a.md" OR true OR a.path = "x`
 
-	edges, err := si.SubgraphEdges(ctx, []string{"kb/a.md", "kb/b.md", sqlInject, cypherInject})
+	edges, err := svc.gq.SubgraphEdges(ctx, []string{"kb/a.md", "kb/b.md", sqlInject, cypherInject})
 	require.NoError(t, err, "injection-shaped paths must keep the query well-formed, not error")
 
 	got := normalizePairs(edges)
@@ -155,7 +155,7 @@ func TestSubgraphEdges_ExcludesDeletedNodes(t *testing.T) {
 	defer svc.Close()
 	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
 
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	ctx := context.Background()
 
 	a := mergeFactNode(t, si, "kb/a.md", "aaaa")
@@ -166,7 +166,7 @@ func TestSubgraphEdges_ExcludesDeletedNodes(t *testing.T) {
 	_, err = si.rh.db.Exec(`SELECT cypher('MATCH (f:Fact {path: "kb/b.md"}) SET f.deleted = true')`)
 	require.NoError(t, err)
 
-	edges, err := si.SubgraphEdges(ctx, []string{"kb/a.md", "kb/b.md"})
+	edges, err := svc.gq.SubgraphEdges(ctx, []string{"kb/a.md", "kb/b.md"})
 	require.NoError(t, err)
 	require.Empty(t, normalizePairs(edges), "edges touching a deleted node must be excluded")
 }

--- a/internal/store/token_df.go
+++ b/internal/store/token_df.go
@@ -19,7 +19,7 @@ import (
 //
 // Liveness + branch scoping come from branch_facts (UNIQUE(branch_id, path) =>
 // one row per live path per branch), exactly as BlastRadius does.
-func (si *searchIndex) TokenDF(ctx context.Context, branch, token, kind string) (int, error) {
+func (gs *graphStore) TokenDF(ctx context.Context, branch, token, kind string) (int, error) {
 	var table, col string
 	switch kind {
 	case "domain":
@@ -29,7 +29,7 @@ func (si *searchIndex) TokenDF(ctx context.Context, branch, token, kind string) 
 	default:
 		return 0, fmt.Errorf("TokenDF: invalid kind %q: must be \"domain\" or \"entity\"", kind)
 	}
-	branchID, err := si.rh.branchID(ctx, branch)
+	branchID, err := gs.rh.branchID(ctx, branch)
 	if err != nil {
 		return 0, fmt.Errorf("TokenDF: branchID: %w", err)
 	}
@@ -39,7 +39,7 @@ func (si *searchIndex) TokenDF(ctx context.Context, branch, token, kind string) 
 		   JOIN %s j ON j.fact_id = bf.fact_id
 		  WHERE bf.branch_id = ? AND j.%s = ?`, table, col)
 	var n int
-	err = conn(ctx, si.rh.db).QueryRowContext(ctx, q, branchID, token).Scan(&n)
+	err = conn(ctx, gs.rh.db).QueryRowContext(ctx, q, branchID, token).Scan(&n)
 	if err == sql.ErrNoRows {
 		return 0, nil
 	}

--- a/internal/store/upsert_donation_test.go
+++ b/internal/store/upsert_donation_test.go
@@ -89,7 +89,7 @@ func TestUpsert_DonatedVectorSkipsEmbedder(t *testing.T) {
 	err = svc.rh.db.QueryRow(`SELECT id FROM facts WHERE path = ?`, "kb/donated.md").Scan(&factID)
 	require.NoError(t, err)
 
-	storedVec, err := svc.Search().(*searchIndex).getEmbeddingByFact(ctx, "kb/donated.md", "")
+	storedVec, err := svc.si.getEmbeddingByFact(ctx, "kb/donated.md", "")
 	// getEmbeddingByFact takes a blob_hash but tolerates "" by ignoring it; if
 	// not, fall back to a direct vec0 query.
 	if err != nil || storedVec == nil {

--- a/internal/store/upsert_embedding_logging_test.go
+++ b/internal/store/upsert_embedding_logging_test.go
@@ -16,7 +16,7 @@ import (
 // facts_vec. The JOIN shape mirrors what RelevantMethodologyForFact does.
 func hasFactsVecRow(t *testing.T, svc *Service, branch, path string) bool {
 	t.Helper()
-	si := svc.Search().(*searchIndex)
+	si := svc.si
 	branchID, err := si.rh.branchID(context.Background(), branch)
 	require.NoError(t, err)
 	var data []byte

--- a/internal/store/vec_table_test.go
+++ b/internal/store/vec_table_test.go
@@ -53,7 +53,7 @@ func openSI(t *testing.T) *searchIndex {
 	svc, err := Open(filepath.Join(dir, "k.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { svc.Close() })
-	return svc.Search().(*searchIndex)
+	return svc.si
 }
 
 // TestEnsureFactsVecCreatesAtDim verifies that on a migrated DB ensureFactsVec

--- a/internal/synthesize/bridge.go
+++ b/internal/synthesize/bridge.go
@@ -296,7 +296,7 @@ func enumerateBridgeCandidates(seeds []factForLLM, clusters ClusterResult, kind 
 // buildScoredBridges sets the Q field on each returned BridgeSeedSet.
 func buildScoredBridges(
 	ctx context.Context,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	branch string,
 	seeds []factForLLM,
 	clusters ClusterResult,
@@ -408,7 +408,7 @@ func buildScoredBridges(
 // so both see identical membership for the same inputs.
 func BuildBackwardBridges(
 	ctx context.Context,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	synthFacts []fact.Fact,
 	branch string,
 	effort Effort,

--- a/internal/synthesize/bridge_filtered.go
+++ b/internal/synthesize/bridge_filtered.go
@@ -245,7 +245,7 @@ func sharedSubToken(members []factForLLM, kind BridgeKind, pool []factForLLM) (t
 // sharedSubToken, never via idx.TokenDF(branch, ...).
 func buildFilteredBridges(
 	ctx context.Context,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	branch string,
 	seeds []factForLLM,
 	clusters ClusterResult,

--- a/internal/synthesize/bridge_report.go
+++ b/internal/synthesize/bridge_report.go
@@ -40,7 +40,7 @@ type ScoredBridge struct {
 // or specificity are propagated immediately.
 func BridgeComponentReport(
 	ctx context.Context,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	branch string,
 	kind BridgeKind,
 	eff Effort,

--- a/internal/synthesize/bridge_score.go
+++ b/internal/synthesize/bridge_score.go
@@ -63,7 +63,7 @@ func separation(members []string, clusterOf map[string]int) int {
 // idx.ReverseDependentPaths. Reverse-dependency sets are memoized: each
 // distinct member path is queried at most once. Returns 0 for fewer than 2
 // members. Propagates the first error from ReverseDependentPaths.
-func derivationGap(ctx context.Context, members []string, idx store.SearchIndex) (float64, error) {
+func derivationGap(ctx context.Context, members []string, idx SearchQuery) (float64, error) {
 	if len(members) < 2 {
 		return 0, nil
 	}
@@ -114,7 +114,7 @@ func derivationGap(ctx context.Context, members []string, idx store.SearchIndex)
 // Cross-bridge normalization is the calibrate tool's job. In Phase 3 a token
 // is always supplied; the token-optional case (Phase 5) is handled by the
 // caller before reaching this function.
-func specificity(ctx context.Context, branch, token, kind string, idx store.SearchIndex) (float64, error) {
+func specificity(ctx context.Context, branch, token, kind string, idx SearchQuery) (float64, error) {
 	df, err := idx.TokenDF(ctx, branch, token, kind)
 	if err != nil {
 		return 0, err
@@ -133,7 +133,7 @@ func scoreBridgeCandidate(
 	kind BridgeKind,
 	token string,
 	g store.SimilarityGraph,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	branch string,
 	clusterOf map[string]int,
 	cfg QualityConfig,

--- a/internal/synthesize/cluster.go
+++ b/internal/synthesize/cluster.go
@@ -37,7 +37,7 @@ const (
 // 4. Fallback to grouping by category path if the edge read fails or yields no clusters
 func ScopedCluster(ctx context.Context,
 	seeds []factForLLM,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	resolution float64,
 	minCommunitySize int,
 	onProgress func(ProgressEvent),

--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -298,7 +298,7 @@ func ApplyDistillDecisions(ctx context.Context,
 func ApplyReflectDecisions(
 	ctx context.Context,
 	gs store.FactIndex,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	result ReflectResult,
 	sess *store.PipelineSession,
 	ontologyRoot string,

--- a/internal/synthesize/dedup.go
+++ b/internal/synthesize/dedup.go
@@ -91,7 +91,7 @@ func dedupCluster(
 	ctx context.Context,
 	cluster []factForLLM,
 	gs store.FactIndex,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	threshold float64,
 	recipeName string,
 	onProgress func(ProgressEvent),

--- a/internal/synthesize/discovery.go
+++ b/internal/synthesize/discovery.go
@@ -221,7 +221,7 @@ func renderDiscoverPrompt(payload DiscoverWorkPayload, ontologyRoot string) stri
 func applyDiscoveredProposals(
 	ctx context.Context,
 	gs store.FactIndex,
-	idx store.SearchIndex,
+	idx SearchQuery,
 	emb store.Embedder,
 	payload DiscoverWorkPayload,
 	proposals []DiscoveredFact,
@@ -362,7 +362,7 @@ func refsCoverSeeds(refs []string, seedPaths map[string]struct{}) bool {
 // isDuplicate computes the document embedding for the proposal and reports
 // whether the live corpus already contains a fact within DedupThreshold cosine
 // similarity. When emb is nil (embeddings disabled), the gate is a no-op.
-func isDuplicate(ctx context.Context, idx store.SearchIndex, emb store.Embedder, branch string, f fact.Fact, threshold float64) (bool, error) {
+func isDuplicate(ctx context.Context, idx SearchQuery, emb store.Embedder, branch string, f fact.Fact, threshold float64) (bool, error) {
 	if emb == nil {
 		return false, nil
 	}

--- a/internal/synthesize/hypothesize_strategy.go
+++ b/internal/synthesize/hypothesize_strategy.go
@@ -438,7 +438,7 @@ func hypothesizeMethodologySection(ctx context.Context, ri *repos.RepoInstance, 
 				Msg("hypothesize: nil store service; methodology disabled")
 			return
 		}
-		f, err := svc.Search().GetByPath(ctx, branch, synthPath)
+		f, err := svc.FactQuery().GetByPath(ctx, branch, synthPath)
 		if err != nil {
 			log.Warn().Err(err).Str("branch", branch).Str("synth_path", synthPath).
 				Msg("hypothesize: synth fact lookup failed; methodology section skipped")
@@ -448,7 +448,7 @@ func hypothesizeMethodologySection(ctx context.Context, ri *repos.RepoInstance, 
 			return
 		}
 		var mErr error
-		matches, mErr = svc.Search().RelevantMethodologyForFact(
+		matches, mErr = svc.Methodology().RelevantMethodologyForFact(
 			ctx, branch,
 			f.Path, f.Domain, f.Entities,
 			methodologyTopK, ri.MethodologyMinScore(),

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -82,9 +82,9 @@ func errf(tool string, format string, args ...any) error {
 }
 
 // storeIndices returns the store indices under the repo read lock.
-func (p *Pipeline) storeIndices() (store.FactIndex, store.SearchIndex, store.PipelineIndex, store.BranchIndex) {
+func (p *Pipeline) storeIndices() (store.FactIndex, SearchQuery, store.PipelineIndex, store.BranchIndex) {
 	var gs store.FactIndex
-	var idx store.SearchIndex
+	var idx SearchQuery
 	var pipelineIdx store.PipelineIndex
 	var branches store.BranchIndex
 	p.ri.WithRead(func(svc *store.Service) {
@@ -338,7 +338,7 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 // load-bearing: discovery seeding excludes origin=discovered facts, and
 // dropping Origin here previously let a discovered fact seed its own
 // discovery.
-func (p *Pipeline) dirtyFacts(ctx context.Context, branch string, gs store.FactIndex, idx store.SearchIndex, pipelineIdx store.PipelineIndex) ([]fact.Fact, error) {
+func (p *Pipeline) dirtyFacts(ctx context.Context, branch string, gs store.FactIndex, idx SearchQuery, pipelineIdx store.PipelineIndex) ([]fact.Fact, error) {
 	tool := p.strategy.Tool()
 
 	watermark, err := pipelineIdx.GetPipelineWatermark(ctx, tool, branch)

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -47,7 +47,7 @@ type Reviewer struct {
 // level are not constrained by it.
 //
 // ScopedCluster clusters the review subgraph in-process via
-// store.SearchIndex.SubgraphEdges on the per-repo Service; no cluster cache is
+// SearchQuery.SubgraphEdges on the per-repo Service; no cluster cache is
 // threaded through the synthesize layer.
 func NewReviewer(ri *repos.RepoInstance, onProgress func(ProgressEvent)) *Reviewer {
 	return NewReviewerWithEffort(ri, onProgress, DefaultEffort)
@@ -147,14 +147,14 @@ func reviewResult(res *PipelineResult, err error) (*ReviewResult, error) {
 // testing behaviour rather than being rewritten around the new seam.
 
 // storeIndices returns the store indices under the repo read lock.
-func (r *Reviewer) storeIndices() (store.FactIndex, store.SearchIndex, store.PipelineIndex, store.BranchIndex) {
+func (r *Reviewer) storeIndices() (store.FactIndex, SearchQuery, store.PipelineIndex, store.BranchIndex) {
 	return r.p.storeIndices()
 }
 
 // dirtyFacts returns the review seed facts (changed since watermark, or the
 // whole epistemic corpus on a full scan), projected onto the prompt-facing
 // shape the review path works in.
-func (r *Reviewer) dirtyFacts(ctx context.Context, branch string, gs store.FactIndex, idx store.SearchIndex, pipelineIdx store.PipelineIndex) ([]factForLLM, error) {
+func (r *Reviewer) dirtyFacts(ctx context.Context, branch string, gs store.FactIndex, idx SearchQuery, pipelineIdx store.PipelineIndex) ([]factForLLM, error) {
 	seeds, err := r.p.dirtyFacts(ctx, branch, gs, idx, pipelineIdx)
 	if err != nil {
 		return nil, err

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -620,7 +620,7 @@ func reflectMethodologySection(ctx context.Context, ri *repos.RepoInstance, bran
 					Msg("loadReflectMethodology: ctx canceled mid-iteration")
 				return
 			}
-			f, err := svc.Search().GetByPath(ctx, branch, t.Path)
+			f, err := svc.FactQuery().GetByPath(ctx, branch, t.Path)
 			if err != nil {
 				log.Warn().Err(err).Str("branch", branch).Str("path", t.Path).
 					Msg("loadReflectMethodology: transition fact lookup failed; skipping")
@@ -629,7 +629,7 @@ func reflectMethodologySection(ctx context.Context, ri *repos.RepoInstance, bran
 			if f == nil {
 				continue
 			}
-			matches, mErr := svc.Search().RelevantMethodologyForFact(
+			matches, mErr := svc.Methodology().RelevantMethodologyForFact(
 				ctx, branch, f.Path, f.Domain, f.Entities, methodologyTopK, minScore,
 			)
 			if mErr != nil {
@@ -672,7 +672,7 @@ func distillMethodologySection(ctx context.Context, ri *repos.RepoInstance, bran
 					Msg("loadDistillMethodology: ctx canceled mid-iteration")
 				return
 			}
-			matches, mErr := svc.Search().RelevantMethodologyForFact(
+			matches, mErr := svc.Methodology().RelevantMethodologyForFact(
 				ctx, branch, f.File, f.Domain, f.Entities, methodologyTopK, minScore,
 			)
 			if mErr != nil {

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -37,6 +37,18 @@ import (
 // indices are resolved once per engine entry point under the repo read lock
 // (see Pipeline.deps) so a single call never sees two different Services.
 //
+// SearchQuery is the store query surface synthesize depends on: fact search
+// (FactQuery), graph queries (GraphStore), and methodology matching
+// (MethodologyMatcher). It deliberately excludes HistoryQuery — synthesize
+// never reads commit-log/revision history — so a strategy cannot reach a
+// history method through this handle. store.SearchIndex (the composite)
+// satisfies it, as does the transitional *MockSearchIndex.
+type SearchQuery interface {
+	store.FactQuery
+	store.GraphStore
+	store.MethodologyMatcher
+}
+
 // Deps deliberately carries NO branch and NO session: a strategy reads the
 // branch off the *store.PipelineSession it is handed, because that is the
 // branch the session was bound to at creation. See
@@ -45,7 +57,7 @@ import (
 type Deps struct {
 	RI         *repos.RepoInstance
 	Facts      store.FactIndex
-	Search     store.SearchIndex
+	Search     SearchQuery
 	Pipeline   store.PipelineIndex
 	Branches   store.BranchIndex
 	Effort     Effort

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -28,15 +28,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Deps is the per-call bundle of everything a Strategy method may reach for:
-// the resolved store indices, the repo instance (config + embedder), and the
-// engine's own dials.
-//
-// It is passed by value into every Strategy method rather than being stored on
-// the strategy, which is what lets strategies stay stateless. The store
-// indices are resolved once per engine entry point under the repo read lock
-// (see Pipeline.deps) so a single call never sees two different Services.
-//
 // SearchQuery is the store query surface synthesize depends on: fact search
 // (FactQuery), graph queries (GraphStore), and methodology matching
 // (MethodologyMatcher). It deliberately excludes HistoryQuery — synthesize
@@ -49,6 +40,15 @@ type SearchQuery interface {
 	store.MethodologyMatcher
 }
 
+// Deps is the per-call bundle of everything a Strategy method may reach for:
+// the resolved store indices, the repo instance (config + embedder), and the
+// engine's own dials.
+//
+// It is passed by value into every Strategy method rather than being stored on
+// the strategy, which is what lets strategies stay stateless. The store
+// indices are resolved once per engine entry point under the repo read lock
+// (see Pipeline.deps) so a single call never sees two different Services.
+//
 // Deps deliberately carries NO branch and NO session: a strategy reads the
 // branch off the *store.PipelineSession it is handed, because that is the
 // branch the session was bound to at creation. See

--- a/internal/web/handlers_activity.go
+++ b/internal/web/handlers_activity.go
@@ -28,7 +28,7 @@ func (defaultActivityProvider) Activity(ctx context.Context, ri *repos.RepoInsta
 		if svc == nil {
 			return
 		}
-		result, err = svc.Search().Activity(ctx, branch, path)
+		result, err = svc.HistoryQuery().Activity(ctx, branch, path)
 	})
 	return result, err
 }

--- a/internal/web/handlers_commits.go
+++ b/internal/web/handlers_commits.go
@@ -52,7 +52,7 @@ func (defaultCommitsProvider) LogPaginated(
 		if svc == nil {
 			return
 		}
-		entries, next, prev, err = svc.Search().LogPaginated(ctx, branch, path, limit, after, from, before)
+		entries, next, prev, err = svc.HistoryQuery().LogPaginated(ctx, branch, path, limit, after, from, before)
 	})
 	return entries, next, prev, err
 }
@@ -64,7 +64,7 @@ func (defaultCommitsProvider) CommitDetail(
 	var (
 		detail *store.CommitDetailResult
 		gs     store.FactIndex
-		idx    store.SearchIndex
+		idx    store.FactQuery
 		err    error
 	)
 	ri.WithRead(func(svc *store.Service) {
@@ -72,8 +72,8 @@ func (defaultCommitsProvider) CommitDetail(
 			return
 		}
 		gs = svc.Facts()
-		idx = svc.Search()
-		detail, err = svc.Search().CommitDetail(ctx, hash, ontologyRoot)
+		idx = svc.FactQuery()
+		detail, err = svc.HistoryQuery().CommitDetail(ctx, hash, ontologyRoot)
 	})
 	if err != nil {
 		return nil, nil, err

--- a/internal/web/handlers_commits.go
+++ b/internal/web/handlers_commits.go
@@ -61,20 +61,23 @@ func (defaultCommitsProvider) CommitDetail(
 	ctx context.Context,
 	ri *repos.RepoInstance, branch, hash, ontologyRoot string,
 ) (*store.CommitDetailResult, []commitFileView, error) {
-	var (
-		detail *store.CommitDetailResult
-		gs     store.FactIndex
-		idx    store.FactQuery
-		err    error
-	)
-	ri.WithRead(func(svc *store.Service) {
-		if svc == nil {
-			return
-		}
-		gs = svc.Facts()
-		idx = svc.FactQuery()
-		detail, err = svc.HistoryQuery().CommitDetail(ctx, hash, ontologyRoot)
-	})
+	// Acquire (not WithRead): the per-file title resolution below reads
+	// through gs/idx long after CommitDetail returns, so the store reference
+	// must outlive a single closure. Copying the handles out of a WithRead
+	// closure would let a concurrent SwapStore/Archive close the DB mid-loop
+	// — see RepoInstance.Acquire's doc-comment.
+	svc, release, err := ri.Acquire()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer release()
+	if svc == nil {
+		return nil, nil, errors.New("commit not found")
+	}
+
+	gs := svc.Facts()
+	idx := svc.FactQuery()
+	detail, err := svc.HistoryQuery().CommitDetail(ctx, hash, ontologyRoot)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/web/handlers_completions.go
+++ b/internal/web/handlers_completions.go
@@ -28,7 +28,7 @@ func (defaultCompletionsProvider) Completions(ctx context.Context, ri *repos.Rep
 		if svc == nil {
 			return
 		}
-		out, err = svc.Search().Completions(ctx, branch, category, prefix, limit)
+		out, err = svc.FactQuery().Completions(ctx, branch, category, prefix, limit)
 	})
 	return out, err
 }

--- a/internal/web/handlers_domains.go
+++ b/internal/web/handlers_domains.go
@@ -33,7 +33,7 @@ func (defaultDomainsProvider) DomainStats(ctx context.Context, ri *repos.RepoIns
 		if svc == nil {
 			return
 		}
-		stats, serr := svc.Search().Stats(ctx, branch, "")
+		stats, serr := svc.FactQuery().Stats(ctx, branch, "")
 		if serr != nil {
 			err = serr
 			return
@@ -52,7 +52,7 @@ func (defaultDomainsProvider) DomainFacts(ctx context.Context, ri *repos.RepoIns
 		if svc == nil {
 			return
 		}
-		out, err = svc.Search().Search(ctx, branch, store.SearchOptions{
+		out, err = svc.FactQuery().Search(ctx, branch, store.SearchOptions{
 			Domain: []string{domain},
 			Limit:  500,
 		})

--- a/internal/web/handlers_fact_read.go
+++ b/internal/web/handlers_fact_read.go
@@ -167,7 +167,7 @@ func (defaultFactReader) Exists(ctx context.Context, ri *repos.RepoInstance, bra
 		if svc == nil {
 			return
 		}
-		ok, err := svc.Search().FactExistsAt(ctx, branch, path, commit)
+		ok, err := svc.FactQuery().FactExistsAt(ctx, branch, path, commit)
 		if err != nil {
 			ev := log.Error()
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/internal/web/handlers_fact_read.go
+++ b/internal/web/handlers_fact_read.go
@@ -145,7 +145,7 @@ func (defaultFactReader) Read(
 	return f, head, err
 }
 
-// Exists routes to SearchIndex.FactExistsAt via the per-request store
+// Exists routes to FactQuery.FactExistsAt via the per-request store
 // snapshot. Honors the historical-graph invariant: passes commit through
 // so commit-anchored reads classify refs against the anchor (with walk-
 // back through retractions), and HEAD reads use branch_facts (with the

--- a/internal/web/handlers_fact_sub.go
+++ b/internal/web/handlers_fact_sub.go
@@ -63,7 +63,7 @@ func (defaultFactSubProvider) LogPaginatedForPath(
 		if svc == nil {
 			return
 		}
-		entries, next, prev, err = svc.Search().LogPaginated(ctx, branch, path, limit, after, from, before)
+		entries, next, prev, err = svc.HistoryQuery().LogPaginated(ctx, branch, path, limit, after, from, before)
 	})
 	return entries, next, prev, err
 }
@@ -80,7 +80,7 @@ func (defaultFactSubProvider) ExplainFact(
 		if svc == nil {
 			return
 		}
-		result, err = svc.Search().ExplainFact(ctx, branch, path)
+		result, err = svc.GraphStore().ExplainFact(ctx, branch, path)
 	})
 	return result, err
 }
@@ -94,7 +94,7 @@ func (defaultFactSubProvider) IncomingAtCommit(ctx context.Context, ri *repos.Re
 		if svc == nil {
 			return
 		}
-		out, err = svc.Search().IncomingAtCommit(ctx, branch, path, commitHash)
+		out, err = svc.GraphStore().IncomingAtCommit(ctx, branch, path, commitHash)
 	})
 	return out, err
 }
@@ -108,7 +108,7 @@ func (defaultFactSubProvider) OutgoingAtCommit(ctx context.Context, ri *repos.Re
 		if svc == nil {
 			return
 		}
-		out, err = svc.Search().OutgoingAtCommit(ctx, branch, path, commitHash)
+		out, err = svc.GraphStore().OutgoingAtCommit(ctx, branch, path, commitHash)
 	})
 	return out, err
 }
@@ -122,7 +122,7 @@ func (defaultFactSubProvider) FactLiveAtCommit(ctx context.Context, ri *repos.Re
 		if svc == nil {
 			return
 		}
-		live, err = svc.Search().FactLiveAtCommit(ctx, branch, path, commit)
+		live, err = svc.FactQuery().FactLiveAtCommit(ctx, branch, path, commit)
 	})
 	return live, err
 }
@@ -136,7 +136,7 @@ func (defaultFactSubProvider) FactExistsAt(ctx context.Context, ri *repos.RepoIn
 		if svc == nil {
 			return
 		}
-		exists, err = svc.Search().FactExistsAt(ctx, branch, path, commit)
+		exists, err = svc.FactQuery().FactExistsAt(ctx, branch, path, commit)
 	})
 	return exists, err
 }

--- a/internal/web/handlers_facts_collection.go
+++ b/internal/web/handlers_facts_collection.go
@@ -39,7 +39,7 @@ func (defaultFactsCollectionProvider) RecentFacts(
 		if svc == nil {
 			return
 		}
-		out, total, err = svc.Search().RecentFacts(ctx, branch, opts)
+		out, total, err = svc.FactQuery().RecentFacts(ctx, branch, opts)
 	})
 	return out, total, err
 }

--- a/internal/web/handlers_origin_session.go
+++ b/internal/web/handlers_origin_session.go
@@ -344,7 +344,7 @@ func handlePreview(sm *SessionManager, agentBranch string) http.HandlerFunc {
 		// Build local path set via FactsIter.
 		localPaths := make(map[string]struct{})
 		if svc != nil {
-			iter, err := svc.Search().FactsIter(r.Context(), agentBranch)
+			iter, err := svc.FactQuery().FactsIter(r.Context(), agentBranch)
 			if err != nil {
 				log.Warn().Err(err).Str("repo", repo).Msg("preview: open facts iter")
 			} else {
@@ -540,7 +540,7 @@ func handleApply(sm *SessionManager, agentBranch string) http.HandlerFunc {
 				return
 			}
 
-			factsIter, err := svc.Search().FactsIter(r.Context(), agentBranch)
+			factsIter, err := svc.FactQuery().FactsIter(r.Context(), agentBranch)
 			if err != nil {
 				sendEvent(map[string]string{"phase": "error", "message": fmt.Sprintf("open facts iterator: %v", err)})
 				return

--- a/internal/web/handlers_search_hal.go
+++ b/internal/web/handlers_search_hal.go
@@ -44,7 +44,7 @@ func (defaultSearchProvider) Search(ctx context.Context, ri *repos.RepoInstance,
 		if svc == nil {
 			return
 		}
-		out, err = svc.Search().Search(ctx, branch, q)
+		out, err = svc.FactQuery().Search(ctx, branch, q)
 	})
 	return out, err
 }

--- a/internal/web/handlers_stats.go
+++ b/internal/web/handlers_stats.go
@@ -28,7 +28,7 @@ func (defaultStatsProvider) Stats(ctx context.Context, ri *repos.RepoInstance, b
 		if svc == nil {
 			return
 		}
-		result, err = svc.Search().Stats(ctx, branch, pathPrefix)
+		result, err = svc.FactQuery().Stats(ctx, branch, pathPrefix)
 	})
 	return result, err
 }

--- a/internal/web/handlers_topics.go
+++ b/internal/web/handlers_topics.go
@@ -48,7 +48,7 @@ func (defaultTopicLister) GetByPath(ctx context.Context, ri *repos.RepoInstance,
 		if svc == nil {
 			return
 		}
-		out, err = svc.Search().GetByPath(ctx, branch, path)
+		out, err = svc.FactQuery().GetByPath(ctx, branch, path)
 	})
 	return out, err
 }

--- a/test/testenv/branch_lifecycle.go
+++ b/test/testenv/branch_lifecycle.go
@@ -157,14 +157,14 @@ func (b *BranchHandle) MustHaveCommitCount(n int) {
 }
 
 // Log returns the production Log entries for a path on this branch.
-// Wraps svc.Search().Log — the path-history view from commit_log.
+// Wraps svc.HistoryQuery().Log — the path-history view from commit_log.
 func (b *BranchHandle) Log(path string) []store.LogEntry {
 	t := b.repo.sb.t
 	t.Helper()
 	var entries []store.LogEntry
 	var err error
 	b.repo.ri.WithRead(func(svc *store.Service) {
-		entries, err = svc.Search().Log(context.Background(), b.name, path)
+		entries, err = svc.HistoryQuery().Log(context.Background(), b.name, path)
 	})
 	if err != nil {
 		t.Fatalf("Log(%s on %s): %v", path, b.name, err)

--- a/test/testenv/incoming.go
+++ b/test/testenv/incoming.go
@@ -10,7 +10,7 @@ import (
 // Incoming returns the incoming-edge view at this fact handle's commit pin.
 // Receiver must be in FactStateExists (enforced via MustExist).
 //
-// Mirrors the production read path: it calls store.SearchIndex.IncomingAtCommit
+// Mirrors the production read path: it calls store.GraphStore.IncomingAtCommit
 // directly, so the result is identical to what the HTTP /incoming endpoint
 // would return — no HTTP round-trip in tests.
 func (f *FactHandle) Incoming() *EdgeView {
@@ -24,7 +24,7 @@ func (f *FactHandle) Incoming() *EdgeView {
 		if svc == nil {
 			return
 		}
-		refs, err = svc.Search().IncomingAtCommit(context.Background(), f.branch.name, f.path, f.commit)
+		refs, err = svc.GraphStore().IncomingAtCommit(context.Background(), f.branch.name, f.path, f.commit)
 	})
 	if err != nil {
 		t.Fatalf("Incoming(%s @ %s): %v", f.path, f.commit, err)


### PR DESCRIPTION
## What

Decomposes the `searchIndex` store god-object (75 methods, 23-method `SearchIndex` interface) into four cohesive, narrowly-scoped read-side sub-services — the P1.3 item from the code-review report (`.claude/plans/2026-07-20-code-review-report.md` §P1.3).

Landed in two independently-green stages:

- **Stage 1** (`9c151766`) — interface segregation: replace the 23-method `SearchIndex` with four narrow interfaces (`FactQuery` / `GraphStore` / `HistoryQuery` / `MethodologyMatcher`), kept composed as `SearchIndex` so nothing breaks mid-migration.
- **Stage 2** (`c0c298e7`) — struct split: move method bodies onto concrete per-cluster structs, each holding only `*repoHandler`.

## End state

| Accessor | Concrete type | Responsibility |
|----------|---------------|----------------|
| `Service.FactQuery()` | `*factQuery` | fact read/search/existence (12 methods incl. helpers) |
| `Service.GraphStore()` | `*graphStore` | DERIVED_FROM / SIMILAR_TO graph queries (9) |
| `Service.HistoryQuery()` | `*historyQuery` | commit-log / revision history (6) |
| `Service.Methodology()` | `*methodologyMatcher` | methodology-fact matching (2) |
| `Service.Search()` | `*searchFacade` | composite of the four (no state) |
| `Service.IndexManager()` | `*searchIndex` | index lifecycle + write/rebuild/graph-write (**unchanged**) |

## Why it's safe

- Every sub-service reaches shared state only **UP** through `repoHandler` — zero new sideways edges, so the `sub-index-up-not-sideways` invariant holds structurally.
- Method bodies moved **verbatim** (behavior-preserving); `resolveActiveCommitForPath` stays on `repoHandler`.
- Test edits are only call-site relocations for moved helpers — no weakened assertions.

## Verification

`go build ./...`, `go vet ./...`, and the full `make test` suite (34 packages) all green, unedited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MP2dmubj58FpGoMYbDuda