### PR TITLE
fix(fact): degrade inconsistent origin on read instead of failing the parse

### DIFF
--- a/internal/fact/format.go
+++ b/internal/fact/format.go
@@ -210,20 +210,31 @@ func ParseFact(path, content string) (Fact, error) {
 	// Resolve origin: explicit value wins; missing → defaultOriginForType.
 	// That helper is shared with SerializeFact's elision rule, so the two
 	// directions cannot drift apart on what an absent field means.
+	//
+	// Origin validation is deliberately ASYMMETRIC with SerializeFact. Writing
+	// an illegal origin is an error; reading one is not. An unrecognized origin
+	// string, or a legal origin on the wrong type, degrades to the type-aware
+	// default instead of failing the parse.
+	//
+	// The reason is that origin enforcement arrived after facts carrying bad
+	// pairings had already been committed (observation+distilled, from the
+	// window when knomit_learn accepted any origin). Rejecting those on read
+	// made them permanently unloadable: every consumer that goes through
+	// ParseFact — the web fact endpoint, MCP query/explain, index rebuild —
+	// returned 500 for that path, so the fact could be neither viewed nor
+	// repaired. Origin is provenance metadata; no reader's correctness depends
+	// on it the way it depends on type. Losing the field beats losing the fact.
+	//
+	// Type is authoritative and origin yields to it, so the degraded value is
+	// always legal for leaf and the fact stays serializable — the next write
+	// self-heals the frontmatter. SerializeFact still rejects both conditions,
+	// which is what stops the corpus from accumulating more of them.
 	origin := Origin(fm.Origin)
 	if origin == "" {
 		origin = defaultOriginForType(leaf)
 	}
-	if err := origin.Validate(); err != nil {
-		return Fact{}, fmt.Errorf("ParseFact %q: %w", path, err)
-	}
-	// The origin×type pairing is checked on read as well as on write, so the
-	// two functions agree on exactly which files are valid. The resolved
-	// default can never fail this: it derives origin *from* leaf, yielding
-	// distilled only for synthesis and authored (unconstrained) otherwise.
-	// So this rejects hand-edited mismatches, never a legacy file.
-	if err := origin.ValidateForType(leaf); err != nil {
-		return Fact{}, fmt.Errorf("ParseFact %q: %w", path, err)
+	if origin.Validate() != nil || origin.ValidateForType(leaf) != nil {
+		origin = defaultOriginForType(leaf)
 	}
 
 	// Extract title from the first # heading in bodyRaw.

--- a/internal/fact/format_test.go
+++ b/internal/fact/format_test.go
@@ -275,10 +275,15 @@ func TestParseFactOriginDefaults(t *testing.T) {
 		t.Errorf("explicit origin = %q, want discovered", fd.Origin)
 	}
 
-	// Invalid origin rejected.
+	// An unreadable origin degrades to the type-aware default rather than
+	// failing the read. See TestParseFact_DegradesOriginTypeMismatch.
 	bad := "---\ntype: observation\norigin: nonsense\ndomain: [x]\nconfidence: 0.9\nsources: 1\nentities: []\nrefs: []\n---\n# T\n\nbody"
-	if _, err := ParseFact("kb/x/bad.md", bad); err == nil {
-		t.Error("ParseFact with invalid origin = nil error, want error")
+	fb, err := ParseFact("kb/x/bad.md", bad)
+	if err != nil {
+		t.Fatalf("ParseFact with invalid origin = %v, want nil", err)
+	}
+	if fb.Origin != Authored {
+		t.Errorf("invalid origin = %q, want authored", fb.Origin)
 	}
 }
 
@@ -319,12 +324,12 @@ func TestSerializeFactOriginRoundTrip(t *testing.T) {
 	}
 }
 
-// TestOriginTypeValidationIsSymmetric pins the round-trip guarantee for the
-// origin axis: a fact SerializeFact accepts must parse back, and one it
-// rejects must not be readable either. Before this was enforced, an
-// origin/type mismatch serialized cleanly and then failed on read-back —
-// producing a file the writer could create but nothing could load.
-func TestOriginTypeValidationIsSymmetric(t *testing.T) {
+// TestOriginTypeValidationRoundTrips pins the round-trip guarantee for the
+// origin axis: a fact SerializeFact accepts must parse back carrying the same
+// origin. Validation itself is intentionally NOT symmetric — a pairing
+// SerializeFact rejects still parses, degraded; see
+// TestParseFact_DegradesOriginTypeMismatch.
+func TestOriginTypeValidationRoundTrips(t *testing.T) {
 	// Every pairing ValidateForType constrains, plus the legal controls.
 	cases := []struct {
 		name   string
@@ -380,14 +385,85 @@ func TestOriginTypeValidationIsSymmetric(t *testing.T) {
 	}
 }
 
-// TestParseFact_RejectsOriginTypeMismatch covers the read side directly: a
-// hand-edited file carrying an illegal pairing must be rejected on parse,
-// not silently loaded. Without this, SerializeFact and ParseFact disagree
-// about which files are valid.
-func TestParseFact_RejectsOriginTypeMismatch(t *testing.T) {
-	bad := "---\ntype: observation\norigin: distilled\ndomain: [x]\nconfidence: 0.9\nsources: 1\nentities: []\nrefs: []\n---\n# T\n\nbody"
-	if _, err := ParseFact("kb/x/bad.md", bad); err == nil {
-		t.Error("ParseFact with distilled/observation = nil error, want error")
+// TestParseFact_DegradesOriginTypeMismatch pins the asymmetry that keeps a
+// corpus readable: the write path rejects an illegal origin×type pairing, but
+// the read path must never fail on one. Facts committed before ValidateForType
+// existed carry pairings like observation+distilled; when ParseFact treated
+// that as an error the fact became permanently unloadable — every read of it
+// (web, MCP, index rebuild) 500'd, with no way to view or repair it.
+//
+// Degrading to the type-aware default rather than erroring keeps the fact
+// renderable and leaves it re-serializable, so the next write self-heals the
+// frontmatter instead of failing.
+func TestParseFact_DegradesOriginTypeMismatch(t *testing.T) {
+	cases := []struct {
+		name   string
+		src    string
+		want   Origin
+		wantTy Type
+	}{
+		{
+			// The reported incident: kb/technology/.../08e6dea1.md.
+			name:   "distilled on observation",
+			src:    "---\ntype: observation\norigin: distilled\ndomain: [x]\nconfidence: 0.9\nsources: 1\nentities: []\nrefs: []\n---\n# T\n\nbody",
+			want:   Authored,
+			wantTy: Observation,
+		},
+		{
+			name:   "discovered on observation",
+			src:    "---\ntype: observation\norigin: discovered\ndomain: [x]\nconfidence: 0.9\nsources: 1\nentities: []\nrefs: []\n---\n# T\n\nbody",
+			want:   Authored,
+			wantTy: Observation,
+		},
+		{
+			name:   "distilled on hypothesis",
+			src:    "---\ntype: hypothesis\norigin: distilled\ndomain: [x]\nconfidence: 0.9\nsources: 1\nentities: []\nrefs: []\n---\n# T\n\nbody",
+			want:   Authored,
+			wantTy: Hypothesis,
+		},
+		{
+			// An origin string no version of knomit ever defined.
+			name:   "unknown origin string",
+			src:    "---\ntype: observation\norigin: nonsense\ndomain: [x]\nconfidence: 0.9\nsources: 1\nentities: []\nrefs: []\n---\n# T\n\nbody",
+			want:   Authored,
+			wantTy: Observation,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := ParseFact("kb/x/bad.md", tc.src)
+			if err != nil {
+				t.Fatalf("ParseFact = %v, want nil (inconsistent origin must not block a read)", err)
+			}
+			if f.Origin != tc.want {
+				t.Errorf("Origin = %q, want %q", f.Origin, tc.want)
+			}
+			if f.Type != tc.wantTy {
+				t.Errorf("Type = %q, want %q (type is authoritative, origin yields)", f.Type, tc.wantTy)
+			}
+			if f.Title != "T" {
+				t.Errorf("Title = %q, want %q — the fact must still render", f.Title, "T")
+			}
+			// The degraded fact must be writable again, or the repair path
+			// (update/re-index) inherits the same dead end.
+			if _, err := SerializeFact(f); err != nil {
+				t.Errorf("SerializeFact after degrade = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestSerializeFact_RejectsOriginTypeMismatch is the other half of that
+// asymmetry: nothing may *create* an illegal pairing, so the corpus stops
+// accumulating facts that need degrading on read.
+func TestSerializeFact_RejectsOriginTypeMismatch(t *testing.T) {
+	f := NewFact("kb/x/bad.md")
+	f.Title, f.Type, f.Origin = "T", Observation, Distilled
+	f.Domain, f.Entities, f.Refs = []string{"x"}, []string{}, []string{}
+	f.Confidence, f.Sources, f.Body = 0.9, 1, "body"
+	if _, err := SerializeFact(f); err == nil {
+		t.Error("SerializeFact with distilled/observation = nil error, want error")
 	}
 }
 


### PR DESCRIPTION
## The bug

Opening a fact in the web UI returned a 500:

```
/api/v1/repos/core/branches/agent:.../facts/kb/technology/ai/models/foundation-models/kimi/08e6dea1.md
→ 500 ParseFact "…/08e6dea1.md": origin "distilled" is reserved for
  synthesis-pipeline output (type synthesis, got "observation")
```

The fact is real and its frontmatter really does say `type: observation` with `origin: distilled`:

```
kb/technology/ai/models/foundation-models/kimi/08e6dea1.md | observation | distilled
```

## Root cause

`ParseFact` enforced the origin×type pairing as a **parse** error, symmetric with `SerializeFact`. That enforcement (434ef132) landed *after* facts carrying bad pairings had already been committed — from the window when `knomit_learn` accepted any origin.

Those facts became permanently unloadable. Every consumer that goes through `ParseFact` — web fact endpoint, MCP query/explain, index rebuild — returned 500 for the path, so the fact could be neither viewed nor repaired.

The comment at the check asserted it "rejects hand-edited mismatches, never a legacy file". That's true of the *resolved default* branch but false of the *explicit value* branch, which is exactly where legacy files land.

## The fix

Validation is now deliberately **asymmetric**:

- **Read** — an unrecognized origin string, or a legal origin on the wrong type, degrades to `defaultOriginForType(leaf)` instead of erroring. Type is authoritative and origin yields to it, so the resolved value is always legal for the leaf and the fact stays serializable; the next write self-heals the frontmatter.
- **Write** — `SerializeFact` and `LearnHandler` stay strict. That is what stops the corpus accumulating more of these.

Origin is provenance metadata; no reader's correctness depends on it the way it depends on `type`. Losing the field beats losing the fact.

## Tests

- `TestParseFact_DegradesOriginTypeMismatch` — the reported pairing, the other two illegal pairings, and an unknown origin string; asserts the fact both renders and re-serializes.
- `TestSerializeFact_RejectsOriginTypeMismatch` — pins the strict half.
- Two tests that asserted reject-on-read were updated, and `TestOriginTypeValidationIsSymmetric` renamed to `…RoundTrips` since validation is no longer symmetric by design.

`go build ./... && go test ./...` passes.

Additionally verified out-of-band by parsing the actual blob from `core.db`: now yields `title="Moonshot launches Kimi K3…" type=observation origin=authored`.

## Note

The SQLite index row for this fact still reads `origin=distilled`; it corrects to `authored` on the next reindex or write of the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
