### PR TITLE
perf(store): single git walk in rebuildGraph

### DIFF
--- a/internal/store/branch.go
+++ b/internal/store/branch.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -92,7 +93,18 @@ type repoHandler struct {
 	embedMu  sync.RWMutex // guards embedder
 	embedder Embedder
 	branchMu sync.Map // per-branch write serialization
+
+	// gitTreeReads counts calls to readFileAtCommit + readBlobHashAtCommit —
+	// the two commit-tree lookups that dominate rebuildGraph's I/O. It is
+	// cheap observability (one atomic add per go-git tree walk) and lets
+	// rebuild-path tests assert that each (commit, path) is read from git at
+	// most once rather than once per phase. Never load-bearing for behaviour.
+	gitTreeReads atomic.Int64
 }
+
+// gitTreeReadCount returns the number of commit-tree reads performed so far.
+// Test-only observability into rebuild/graph I/O; see repoHandler.gitTreeReads.
+func (rh *repoHandler) gitTreeReadCount() int64 { return rh.gitTreeReads.Load() }
 
 // lockBranch acquires the per-branch write lock and returns an unlock function.
 // Used by factIndex, remoteIndex, and MergeBranch to serialize writes on a
@@ -422,6 +434,7 @@ func (rh *repoHandler) resolveRef(ctx context.Context, branch string) (plumbing.
 // walk so that normalised (lowercase) index paths resolve correctly against
 // pre-normalisation commits that stored paths with mixed case.
 func (rh *repoHandler) readFileAtCommit(ctx context.Context, path, commitHash string) (string, error) {
+	rh.gitTreeReads.Add(1)
 	hash := plumbing.NewHash(commitHash)
 	commit, err := rh.repo.CommitObject(hash)
 	if err != nil {
@@ -472,6 +485,7 @@ func (rh *repoHandler) firstParentCommit(ctx context.Context, commitHash string)
 // sufficient. Compare with readFileAtCommit above which falls back for
 // pre-normalisation legacy paths.
 func (rh *repoHandler) readBlobHashAtCommit(ctx context.Context, path, commitHash string) (string, error) {
+	rh.gitTreeReads.Add(1)
 	hash := plumbing.NewHash(commitHash)
 	commit, err := rh.repo.CommitObject(hash)
 	if err != nil {

--- a/internal/store/rebuild_git_read_dedup_test.go
+++ b/internal/store/rebuild_git_read_dedup_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRebuildGraph_ReadsEachCommitPathAtMostOnce pins the P2 git-read dedupe.
+//
+// rebuildGraph runs two phases that BOTH walk the identical commit_log query
+// (Phase A.5 restores historical Fact nodes; Phase B writes DERIVED_FROM
+// edges). Historically each phase independently called readBlobHashAtCommit +
+// readFileAtCommit per (commit, path), so every commit_log ref-event was read
+// from git ~3× (Phase A.5: one blob read/event + content for historical
+// versions; Phase B: one content + one blob read/event). The fix walks the
+// union of events once, caching blob_hash + parsed content, so each unique
+// (commit, path) costs at most one blob read + one content read — a bound of
+// 2× the commit_log ref-event count.
+//
+// The gitTreeReads counter on repoHandler (branch.go) is the observability
+// seam: it increments once per readFileAtCommit / readBlobHashAtCommit tree
+// walk. Within rebuildGraph, the shared walk reads happen ONLY in Phase A.5
+// and Phase B, so measuring the counter delta across a single rebuildGraph
+// call isolates exactly the double-walk.
+//
+// The corpus is deliberately ref-free: DERIVED_FROM edge writes call
+// resolveTargetCommit -> readBlobHashAtCommit per ref target (derived_from.go),
+// which are inherent edge-resolution reads NOT attributable to the walk. This
+// test isolates the walk dedup; edge-writing-with-cache correctness is locked
+// separately by TestRebuildGraph_RestoresHistoricalFactNodes (which has refs,
+// historical versions, and asserts the edges).
+func TestRebuildGraph_ReadsEachCommitPathAtMostOnce(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
+
+	ctx := context.Background()
+	branch := "main"
+
+	// Build a corpus with historical (updated) versions but NO refs, so both
+	// phases walk the full commit_log but no edge-target resolution occurs.
+	//   A v1, A v2  -> A_v1 becomes historical
+	//   B v1, B v2  -> B_v1 becomes historical
+	//   C v1        -> current only
+	write := func(path, title, msg string) {
+		t.Helper()
+		_, werr := svc.Facts().WriteFact(ctx, branch, path,
+			testFactBody(title, 0.9, nil), msg, "")
+		require.NoError(t, werr)
+	}
+	write("kb/a.md", "a v1", "init a")
+	write("kb/b.md", "b v1", "init b")
+	write("kb/a.md", "a v2", "update a")
+	write("kb/b.md", "b v2", "update b")
+	write("kb/c.md", "c v1", "init c")
+
+	si := svc.si
+
+	// N = number of (commit, path) ref-events rebuildGraph's two phases each
+	// walk. This is the SAME query both phases run; computing it here keeps
+	// the bound honest instead of hard-coding a magic number.
+	var n int
+	require.NoError(t, si.rh.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM commit_log cl
+		JOIN branch_commits bc ON bc.commit_hash = cl.commit_hash
+		WHERE bc.branch_id = (SELECT id FROM branches WHERE name = ?)
+		  AND cl.action != 'deleted'`, branch).Scan(&n))
+	require.Greater(t, n, 0, "corpus must produce commit_log events")
+
+	before := si.rh.gitTreeReadCount()
+	_, err = si.rebuildGraph(ctx, branch, nil)
+	require.NoError(t, err)
+	delta := si.rh.gitTreeReadCount() - before
+
+	// A single-walk rebuildGraph reads each unique (commit, path) at most
+	// once for its blob hash and once for its content: 2×N. The old
+	// double-walk reads ~3×N, so this bound fails until the phases share one
+	// walk + a parsed-fact cache.
+	require.LessOrEqualf(t, delta, int64(2*n),
+		"rebuildGraph made %d git tree reads for %d commit_log events (bound %d = 2×N); "+
+			"Phase A.5 and Phase B are re-reading the same (commit, path) from git",
+		delta, n, 2*n)
+}

--- a/internal/store/search_index.go
+++ b/internal/store/search_index.go
@@ -970,6 +970,82 @@ func (si *searchIndex) rebuildGraph(ctx context.Context, branch string, progress
 		progress("graph", 0, total)
 	}
 
+	// P2 git-read dedupe: Phase A.5 (historical Fact-node restore) and Phase B
+	// (DERIVED_FROM edges) both walk the identical commit_log ref-event list,
+	// and each historically re-read every (commit, path) from git
+	// independently (~3 reads per event). Read each unique event ONCE here —
+	// blob hash + content, parsed once — and let both phases consume the
+	// cache. Git reads (go-git) touch no DB connection, so building the cache
+	// here (before the write-locked tx) also keeps this I/O off the
+	// _txlock=immediate critical section.
+	currentSet := make(map[string]struct{}, len(facts))
+	for _, f := range facts {
+		currentSet[f.Path+"|"+f.BlobHash] = struct{}{}
+	}
+	// commit_log ref-events on this branch, oldest first — the shared walk
+	// order for both phases. Queried before the tx so its connection is
+	// released before BEGIN IMMEDIATE (no pool straddle under
+	// _txlock=immediate). commit_log/branch_commits are regular tables.
+	evRows, err := conn(ctx, si.rh.db).QueryContext(ctx, `
+		SELECT cl.commit_hash, cl.path
+		FROM commit_log cl
+		JOIN branch_commits bc ON bc.commit_hash = cl.commit_hash
+		WHERE bc.branch_id = (SELECT id FROM branches WHERE name = ?)
+		  AND cl.action != 'deleted'
+		ORDER BY cl.committed_at ASC, cl.rowid ASC`, branch)
+	if err != nil {
+		return 0, fmt.Errorf("rebuildGraph: query commit_log: %w", err)
+	}
+	type commitPath struct{ commitHash, path string }
+	var events []commitPath
+	for evRows.Next() {
+		var e commitPath
+		if err := evRows.Scan(&e.commitHash, &e.path); err != nil {
+			evRows.Close()
+			return 0, fmt.Errorf("rebuildGraph: scan commit_log: %w", err)
+		}
+		events = append(events, e)
+	}
+	evRows.Close()
+
+	// One git read per unique (commit, path): blob hash + content, parsed
+	// once. ok=true means all three succeeded — the gate both phases need.
+	type commitFact struct {
+		blobHash string
+		rec      FactRecord
+		ok       bool
+	}
+	factAtCommit := make(map[string]commitFact, len(events))
+	for _, e := range events {
+		key := e.commitHash + "|" + e.path
+		if _, seen := factAtCommit[key]; seen {
+			continue
+		}
+		var cf commitFact
+		blobHash, err := si.rh.readBlobHashAtCommit(ctx, e.path, e.commitHash)
+		if err != nil {
+			log.Debug().Err(err).Str("path", e.path).Str("commit", e.commitHash[:8]).
+				Msg("rebuildGraph: skip (blob_hash lookup failed)")
+			factAtCommit[key] = cf
+			continue
+		}
+		content, err := si.rh.readFileAtCommit(ctx, e.path, e.commitHash)
+		if err != nil {
+			log.Debug().Err(err).Str("path", e.path).Str("commit", e.commitHash[:8]).
+				Msg("rebuildGraph: skip (file not at commit)")
+			factAtCommit[key] = cf
+			continue
+		}
+		rec, err := parseFact(e.path, content)
+		if err != nil {
+			log.Debug().Err(err).Str("path", e.path).Msg("rebuildGraph: skip (parse failed)")
+			factAtCommit[key] = cf
+			continue
+		}
+		rec.BlobHash = blobHash
+		factAtCommit[key] = commitFact{blobHash: blobHash, rec: rec, ok: true}
+	}
+
 	// Single transaction for all graph sync operations.
 	tx, err := si.rh.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -997,53 +1073,15 @@ func (si *searchIndex) rebuildGraph(ctx context.Context, branch string, progress
 	// We dedup by (path, blob_hash) since the same blob can appear in
 	// multiple commits (no-op recommits, merges that don't change content).
 	// Versions still in `facts` are skipped — Phase A above already gave
-	// them live nodes.
-	currentSet := make(map[string]struct{}, len(facts))
-	for _, f := range facts {
-		currentSet[f.Path+"|"+f.BlobHash] = struct{}{}
-	}
-	// Read on the tx's own connection — NOT conn(ctx, db), which would fall
-	// through to the bare pool and need a SECOND connection while this tx holds
-	// the write lock. Under _txlock=immediate that straddle can starve the pool
-	// (the held write lock blocks other connections' BEGIN IMMEDIATE) during a
-	// rebuild that races concurrent writers. commit_log/branch_commits are
-	// regular tables (not GraphQLite EAV), so reading them inside the tx is safe.
-	histRows, err := tx.QueryContext(ctx, `
-		SELECT cl.commit_hash, cl.path
-		FROM commit_log cl
-		JOIN branch_commits bc ON bc.commit_hash = cl.commit_hash
-		WHERE bc.branch_id = (SELECT id FROM branches WHERE name = ?)
-		  AND cl.action != 'deleted'
-		ORDER BY cl.committed_at ASC, cl.rowid ASC`,
-		branch)
-	if err != nil {
-		return 0, fmt.Errorf("rebuildGraph phaseA.5: query commit_log: %w", err)
-	}
-	type histKey struct {
-		commitHash string
-		path       string
-	}
-	var histEntries []histKey
-	for histRows.Next() {
-		var h histKey
-		if err := histRows.Scan(&h.commitHash, &h.path); err != nil {
-			histRows.Close()
-			return 0, fmt.Errorf("rebuildGraph phaseA.5: scan: %w", err)
-		}
-		histEntries = append(histEntries, h)
-	}
-	histRows.Close()
-
+	// them live nodes. Consumes the shared git-read cache built above.
 	seenHistorical := make(map[string]struct{})
 	historicalSynced := 0
-	for _, h := range histEntries {
-		blobHash, err := si.rh.readBlobHashAtCommit(ctx, h.path, h.commitHash)
-		if err != nil {
-			log.Debug().Err(err).Str("path", h.path).Str("commit", h.commitHash[:8]).
-				Msg("rebuildGraph phaseA.5: skip (blob_hash lookup failed)")
+	for _, e := range events {
+		cf := factAtCommit[e.commitHash+"|"+e.path]
+		if !cf.ok {
 			continue
 		}
-		key := h.path + "|" + blobHash
+		key := e.path + "|" + cf.blobHash
 		if _, ok := currentSet[key]; ok {
 			continue // current version, Phase A already handled
 		}
@@ -1052,20 +1090,8 @@ func (si *searchIndex) rebuildGraph(ctx context.Context, branch string, progress
 		}
 		seenHistorical[key] = struct{}{}
 
-		content, err := si.rh.readFileAtCommit(ctx, h.path, h.commitHash)
-		if err != nil {
-			log.Debug().Err(err).Str("path", h.path).Str("commit", h.commitHash[:8]).
-				Msg("rebuildGraph phaseA.5: skip (file not at commit)")
-			continue
-		}
-		rec, err := parseFact(h.path, content)
-		if err != nil {
-			log.Debug().Err(err).Str("path", h.path).Msg("rebuildGraph phaseA.5: skip (parse failed)")
-			continue
-		}
-		rec.BlobHash = blobHash
-		if err := si.graphSyncHistoricalFactTx(ctx, tx, rec); err != nil {
-			log.Warn().Err(err).Str("path", h.path).Str("blob", blobHash[:8]).
+		if err := si.graphSyncHistoricalFactTx(ctx, tx, cf.rec); err != nil {
+			log.Warn().Err(err).Str("path", e.path).Str("blob", cf.blobHash[:8]).
 				Msg("rebuildGraph phaseA.5: historical sync failed")
 			continue
 		}
@@ -1096,51 +1122,15 @@ func (si *searchIndex) rebuildGraph(ctx context.Context, branch string, progress
 	// each ref's target_commit is resolved independently by
 	// resolveTargetCommit's first-parent topological walk, so the outer
 	// order does not affect correctness on branches with merge commits.
-	clRows, err := conn(ctx, si.rh.db).QueryContext(ctx, `
-	    SELECT cl.commit_hash, cl.path
-	    FROM commit_log cl
-	    JOIN branch_commits bc ON bc.commit_hash = cl.commit_hash
-	    WHERE bc.branch_id = (SELECT id FROM branches WHERE name = ?)
-	      AND cl.action != 'deleted'
-	    ORDER BY cl.committed_at ASC, cl.rowid ASC
-	`, branch)
-	if err != nil {
-		return total, fmt.Errorf("rebuildGraph phaseB: query commit_log: %w", err)
-	}
-	type historicalRow struct {
-		commitHash string
-		path       string
-	}
-	var rows2 []historicalRow
-	for clRows.Next() {
-		var r historicalRow
-		if err := clRows.Scan(&r.commitHash, &r.path); err != nil {
-			clRows.Close()
-			return total, fmt.Errorf("rebuildGraph phaseB: scan: %w", err)
-		}
-		rows2 = append(rows2, r)
-	}
-	clRows.Close()
-
-	for _, r := range rows2 {
-		content, err := si.rh.readFileAtCommit(ctx, r.path, r.commitHash)
-		if err != nil {
-			log.Debug().Err(err).Str("path", r.path).Str("commit", r.commitHash[:8]).Msg("rebuildGraph phaseB: skip (file not at commit)")
-			continue
-		}
-		rec, err := parseFact(r.path, content)
-		if err != nil {
-			log.Debug().Err(err).Str("path", r.path).Msg("rebuildGraph phaseB: skip (parse failed)")
-			continue
-		}
-		blobHash, err := si.rh.readBlobHashAtCommit(ctx, r.path, r.commitHash)
-		if err != nil {
-			log.Warn().Err(err).Str("path", r.path).Str("commit", r.commitHash[:8]).Msg("rebuildGraph phaseB: blob_hash lookup failed")
+	// Consumes the shared git-read cache built above (same `events` order).
+	for _, e := range events {
+		cf := factAtCommit[e.commitHash+"|"+e.path]
+		if !cf.ok {
 			continue
 		}
 
 		var localRefs []string
-		for _, ref := range rec.Refs {
+		for _, ref := range cf.rec.Refs {
 			if !strings.HasPrefix(ref, "http://") && !strings.HasPrefix(ref, "https://") {
 				localRefs = append(localRefs, ref)
 			}
@@ -1159,19 +1149,19 @@ func (si *searchIndex) rebuildGraph(ctx context.Context, branch string, progress
 		// edges from the orphaned source — there's no graph node to
 		// write from, so we silently skip. Mirrors the symmetric
 		// missing-target handling inside graphAddDerivedFromAtCommitTx.
-		srcID, err := si.graphNodeIDByBlob(ctx, r.path, blobHash)
+		srcID, err := si.graphNodeIDByBlob(ctx, e.path, cf.blobHash)
 		if err != nil {
-			log.Warn().Err(err).Str("path", r.path).Str("commit", r.commitHash[:8]).Msg("rebuildGraph phaseB: source node lookup failed")
+			log.Warn().Err(err).Str("path", e.path).Str("commit", e.commitHash[:8]).Msg("rebuildGraph phaseB: source node lookup failed")
 			continue
 		}
 		if srcID == 0 {
-			log.Debug().Str("path", r.path).Str("commit", r.commitHash[:8]).Str("blob", blobHash[:8]).
+			log.Debug().Str("path", e.path).Str("commit", e.commitHash[:8]).Str("blob", cf.blobHash[:8]).
 				Msg("rebuildGraph phaseB: skip (source blob orphaned out of facts; no graph node)")
 			continue
 		}
 
-		if err := si.graphAddDerivedFromAtCommitTx(ctx, si.rh.db, branch, r.path, blobHash, r.commitHash, localRefs); err != nil {
-			log.Warn().Err(err).Str("path", r.path).Str("commit", r.commitHash[:8]).Msg("rebuildGraph phaseB: edge write failed")
+		if err := si.graphAddDerivedFromAtCommitTx(ctx, si.rh.db, branch, e.path, cf.blobHash, e.commitHash, localRefs); err != nil {
+			log.Warn().Err(err).Str("path", e.path).Str("commit", e.commitHash[:8]).Msg("rebuildGraph phaseB: edge write failed")
 		}
 	}
 


### PR DESCRIPTION
## What

`rebuildGraph` ran two phases that each independently walked the identical `commit_log` ref-event list and re-read every `(commit, path)` from git:

- **Phase A.5** (historical Fact-node restore) — one blob-hash read per event, plus content for historical versions
- **Phase B** (DERIVED_FROM edges) — content *and* blob hash per event, again

Every event was fetched from git ~3×, and unparseable paths (e.g. the seed `kb.md`) were read and parse-failed twice per rebuild.

This queries `commit_log` once and reads each unique `(commit, path)` exactly once — blob hash + content, parsed a single time — into a cache both phases consume. Reads drop from **~3×N to at most 2×N**.

Edge-target resolution reads (`resolveTargetCommit`) are unchanged; they're inherent to edge writing, not part of the walk.

## Also

The shared walk is hoisted ahead of the write-locked transaction. go-git reads touch no DB connection, so this removes the prior in-tx `commit_log` query and keeps all git I/O off the `_txlock=immediate` critical section. The old code read `commit_log` on the transaction's own connection specifically to avoid a second pooled connection while holding the write lock; that concern is now moot.

## Behaviour

Unchanged: same walk order (`committed_at`, `rowid`), same `currentSet` skip, same historical dedup, same orphan-source skip, same edges.

## Testing

New regression test pins the bound using a `gitTreeReads` counter on `repoHandler`. Measured against the old implementation it failed at **21 reads for 6 events** (bound 12); it passes now. The test corpus is deliberately ref-free so it isolates the walk from inherent edge-resolution reads.

Full store, synthesize, repos and storytests suites pass; build and vet clean.

## Notes for review

This is the measured P2 performance item from `2026-07-20-code-review-report.md`. It was originally developed alongside the GraphQLite removal but is independent of it — split out so each lands on its own merits.