### PR TITLE
fix(store): recover from an interrupted migration instead of dropping the repo

### DIFF
--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -535,7 +535,11 @@ func (m *Manager) Start() error {
 			continue
 		}
 		if err := m.Add(name, dbPath); err != nil {
-			log.Warn().Err(err).Str("repo", name).Msg("skipping repo")
+			// ERROR, not WARN: the repo disappears from the API entirely, so
+			// this line is the ONLY signal the user gets. Name the database
+			// file — recovering by hand needs to know which one it is.
+			log.Error().Err(err).Str("repo", name).Str("db", dbPath).
+				Msg("repo failed to open and was skipped; it will not appear in the API")
 		}
 	}
 

--- a/internal/store/migrate/migrate.go
+++ b/internal/store/migrate/migrate.go
@@ -84,49 +84,114 @@ func All(db *sql.DB) error {
 // boot, turning a one-time manual recovery into a permanent one. So the
 // UNDERLYING migration error is returned rather than the dirty flag: that
 // error is the actionable one, and dirty is left set.
+//
+// The bookkeeping being CLEAN is not by itself proof that no interruption
+// happened: a crash inside recovery, between the Force(N-1) above and the
+// re-run committing, leaves exactly that state with N's body already applied.
+// So case 2 is also recognised from a clean start — see forcePastCommittedBody.
 func upWithRecovery(m *migrate.Migrate) error {
 	err := m.Up()
 	if err == nil || errors.Is(err, migrate.ErrNoChange) {
 		return nil
 	}
 	var dirty migrate.ErrDirty
-	if !errors.As(err, &dirty) {
-		return err
+	if errors.As(err, &dirty) {
+		return recoverDirty(m, dirty.Version)
 	}
-	log.Warn().Int("version", dirty.Version).
+
+	// Clean bookkeeping, yet the very first migration attempted collided with
+	// effects already present in the schema. That is the tail of a recovery
+	// interrupted before it finished: this boot re-ran N from a clean N-1 and
+	// hit N's own committed body, so it failed outright instead of with
+	// ErrDirty. Without this the repo is dropped for one more boot — the exact
+	// #33 symptom — before the now-dirty flag routes it through recoverDirty.
+	if alreadyApplied(err) {
+		failed, verr := failedVersion(m)
+		if verr != nil {
+			return err
+		}
+		log.Warn().Int("version", failed).
+			Msg("migration collided with its own committed body; completing an interrupted recovery")
+		if ferr := forcePastCommittedBody(m, failed); ferr != nil {
+			return ferr
+		}
+		return nil
+	}
+	return err
+}
+
+// recoverDirty performs the two-step recovery documented on upWithRecovery for
+// a database left dirty at version.
+func recoverDirty(m *migrate.Migrate, version int) error {
+	log.Warn().Int("version", version).
 		Msg("interrupted migration detected; attempting recovery")
 
-	// Force rejects 0, and read() would then look for a nonexistent migration
-	// version 0, so a dirty FIRST migration rewinds to NilVersion instead.
-	prev := dirty.Version - 1
+	// read() rejects a `from` version that has no migration file, so a dirty
+	// FIRST migration rewinds to NilVersion rather than to 0.
+	prev := version - 1
 	if prev < 1 {
 		prev = database.NilVersion
 	}
 	if err := m.Force(prev); err != nil {
-		return fmt.Errorf("recover dirty version %d: force %d: %w", dirty.Version, prev, err)
+		return fmt.Errorf("recover dirty version %d: force %d: %w", version, prev, err)
 	}
 
 	rerunErr := m.Up()
 	if rerunErr == nil || errors.Is(rerunErr, migrate.ErrNoChange) {
-		log.Warn().Int("version", dirty.Version).
+		log.Warn().Int("version", version).
 			Msg("recovered from interrupted migration (re-applied)")
 		return nil
 	}
 	if !alreadyApplied(rerunErr) {
-		return fmt.Errorf("re-applying migration %d after interruption: %w", dirty.Version, rerunErr)
+		return fmt.Errorf("re-applying migration %d after interruption: %w", version, rerunErr)
 	}
 
-	// The re-run collided with its own committed effects. Record N as applied
-	// — the failed re-run re-dirtied it — and finish the remaining migrations.
-	if err := m.Force(dirty.Version); err != nil {
-		return fmt.Errorf("recover dirty version %d: force %d: %w", dirty.Version, dirty.Version, err)
+	// The re-run runs N *and every migration after it*, so an "already exists"
+	// can just as easily come from a later, never-applied migration that has
+	// nothing to do with the interruption. Only a collision on N itself is
+	// proof N's body committed; anything else is reported as the failure it is
+	// rather than being papered over by forcing past N.
+	failed, err := failedVersion(m)
+	if err != nil {
+		return fmt.Errorf("re-applying migration %d after interruption: %w", version, rerunErr)
 	}
-	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		return fmt.Errorf("continuing past recovered migration %d: %w", dirty.Version, err)
+	if failed != version {
+		return fmt.Errorf("migration %d, applied after recovering %d: %w", failed, version, rerunErr)
 	}
-	log.Warn().Int("version", dirty.Version).
+
+	if err := forcePastCommittedBody(m, version); err != nil {
+		return err
+	}
+	log.Warn().Int("version", version).
 		Msg("recovered from interrupted migration (body had already committed)")
 	return nil
+}
+
+// forcePastCommittedBody records version as applied — its body is known to have
+// committed, and the run that proved it re-dirtied the row — then finishes the
+// remaining migrations.
+func forcePastCommittedBody(m *migrate.Migrate, version int) error {
+	if err := m.Force(version); err != nil {
+		return fmt.Errorf("recover dirty version %d: force %d: %w", version, version, err)
+	}
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("continuing past recovered migration %d: %w", version, err)
+	}
+	return nil
+}
+
+// failedVersion reports the version a failed run left dirty. The driver sets
+// dirty before each body and clears it after, so this is the migration that
+// actually failed — not necessarily the one recovery started from.
+func failedVersion(m *migrate.Migrate) (int, error) {
+	v, dirty, err := m.Version()
+	if err != nil {
+		return 0, err
+	}
+	if !dirty {
+		return 0, errors.New("no dirty version recorded")
+	}
+	return int(v), nil
 }
 
 // alreadyApplied reports whether err is SQLite complaining that an object the

--- a/internal/store/migrate/migrate.go
+++ b/internal/store/migrate/migrate.go
@@ -3,11 +3,15 @@ package migrate
 import (
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
+	"strings"
 
 	migrate "github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/rs/zerolog/log"
 )
 
 //go:embed migrations/*.sql
@@ -16,6 +20,12 @@ var migrationsFS embed.FS
 // Core applies only the standard SQLite migrations (version 1: all base tables).
 // Works with the plain "sqlite3" driver — no extensions required.
 // Used by storegit.NewMemoryStorer and internal/git tests.
+//
+// Core deliberately does NOT self-heal a dirty version the way All does. It
+// targets version 1 explicitly, so rewinding a database that is dirty at some
+// LATER version would make the retry migrate DOWN to 1 and destroy schema. Its
+// callers only ever hand it a fresh :memory: database, where the dirty state
+// cannot arise.
 func Core(db *sql.DB) error {
 	m, err := newMigrator(db)
 	if err != nil {
@@ -35,10 +45,97 @@ func All(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+	if err := upWithRecovery(m); err != nil {
 		return fmt.Errorf("migrate.All: %w", err)
 	}
 	return nil
+}
+
+// upWithRecovery runs every pending migration, recovering ONCE from a dirty
+// version left behind by an interrupted migration.
+//
+// golang-migrate flips schema_migrations.dirty before running a migration body
+// and clears it after, in transactions SEPARATE from the body itself. A crash,
+// SIGKILL, or power loss anywhere in that span leaves dirty = 1 permanently,
+// and every subsequent open fails with ErrDirty — which for knomit means the
+// repo is dropped at startup and looks, from the API, like data loss (#33).
+//
+// Recovery is safe because the migration BODY is transactional: an interrupted
+// migration leaves the schema either fully applied or fully unapplied, never
+// torn. Rewinding the bookkeeping one step and re-running is therefore either a
+// genuine retry or a no-op over idempotent DDL.
+//
+// The dirty flag does not say WHICH side of that boundary the crash fell on —
+// the driver runs the body and the dirty-clearing UPDATE in separate
+// transactions — so recovery tries the two possibilities in turn, each EXACTLY
+// once:
+//
+//  1. Body never landed. Rewind to N-1 and re-run N. This is the case that
+//     must work, so it is tried first.
+//  2. Body landed, and N is not re-runnable. Only reachable when the re-run
+//     fails with SQLite's "already exists" / "duplicate column name" — which
+//     is itself proof the body committed, since the body is transactional and
+//     a partial application would have rolled back. Mark N applied and carry
+//     on with the rest.
+//
+// Anything else is a migration failing deterministically on the data — a
+// UNIQUE index the existing rows violate, say. That re-fails identically
+// forever, and an unguarded loop would clear, re-fail, and re-dirty on every
+// boot, turning a one-time manual recovery into a permanent one. So the
+// UNDERLYING migration error is returned rather than the dirty flag: that
+// error is the actionable one, and dirty is left set.
+func upWithRecovery(m *migrate.Migrate) error {
+	err := m.Up()
+	if err == nil || errors.Is(err, migrate.ErrNoChange) {
+		return nil
+	}
+	var dirty migrate.ErrDirty
+	if !errors.As(err, &dirty) {
+		return err
+	}
+	log.Warn().Int("version", dirty.Version).
+		Msg("interrupted migration detected; attempting recovery")
+
+	// Force rejects 0, and read() would then look for a nonexistent migration
+	// version 0, so a dirty FIRST migration rewinds to NilVersion instead.
+	prev := dirty.Version - 1
+	if prev < 1 {
+		prev = database.NilVersion
+	}
+	if err := m.Force(prev); err != nil {
+		return fmt.Errorf("recover dirty version %d: force %d: %w", dirty.Version, prev, err)
+	}
+
+	rerunErr := m.Up()
+	if rerunErr == nil || errors.Is(rerunErr, migrate.ErrNoChange) {
+		log.Warn().Int("version", dirty.Version).
+			Msg("recovered from interrupted migration (re-applied)")
+		return nil
+	}
+	if !alreadyApplied(rerunErr) {
+		return fmt.Errorf("re-applying migration %d after interruption: %w", dirty.Version, rerunErr)
+	}
+
+	// The re-run collided with its own committed effects. Record N as applied
+	// — the failed re-run re-dirtied it — and finish the remaining migrations.
+	if err := m.Force(dirty.Version); err != nil {
+		return fmt.Errorf("recover dirty version %d: force %d: %w", dirty.Version, dirty.Version, err)
+	}
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("continuing past recovered migration %d: %w", dirty.Version, err)
+	}
+	log.Warn().Int("version", dirty.Version).
+		Msg("recovered from interrupted migration (body had already committed)")
+	return nil
+}
+
+// alreadyApplied reports whether err is SQLite complaining that an object the
+// migration creates is already there — proof the body committed before the
+// crash, since a partially-applied body would have rolled back.
+func alreadyApplied(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already exists") ||
+		strings.Contains(msg, "duplicate column name")
 }
 
 func newMigrator(db *sql.DB) (*migrate.Migrate, error) {

--- a/internal/store/migrate/migrations/000008_fact_domain_tokens.up.sql
+++ b/internal/store/migrate/migrations/000008_fact_domain_tokens.up.sql
@@ -5,10 +5,12 @@
 -- two different domains on the same fact. Populated from the canonical domain on
 -- every Upsert/rebuild; CASCADE-cleaned with the fact row. Derived index state:
 -- rebuilt from git, no data backfill needed here (next rebuild populates it).
-CREATE TABLE fact_domain_tokens (
+-- IF NOT EXISTS throughout: an interrupted migration can leave this body
+-- applied with schema_migrations.dirty still set, and recovery re-runs it.
+CREATE TABLE IF NOT EXISTS fact_domain_tokens (
     fact_id INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
     domain  TEXT NOT NULL,
     token   TEXT NOT NULL,
     PRIMARY KEY (fact_id, domain, token)
 );
-CREATE INDEX fact_domain_tokens_token ON fact_domain_tokens(token);
+CREATE INDEX IF NOT EXISTS fact_domain_tokens_token ON fact_domain_tokens(token);

--- a/internal/store/migrate/recovery_test.go
+++ b/internal/store/migrate/recovery_test.go
@@ -1,0 +1,163 @@
+package migrate
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	migrate "github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database/sqlite3"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+// These exercise upWithRecovery against a synthetic migration set, so each
+// interruption window can be reproduced exactly. TestMigrate_Recovers... in
+// package store covers the real embedded migrations end to end.
+
+func testMigrator(t *testing.T, db *sql.DB, files fstest.MapFS) *migrate.Migrate {
+	t.Helper()
+	src, err := iofs.New(files, ".")
+	require.NoError(t, err)
+	drv, err := sqlite3.WithInstance(db, &sqlite3.Config{})
+	require.NoError(t, err)
+	m, err := migrate.NewWithInstance("iofs", src, "sqlite3", drv)
+	require.NoError(t, err)
+	return m
+}
+
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "m.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func file(body string) *fstest.MapFile { return &fstest.MapFile{Data: []byte(body)} }
+
+// version reads schema_migrations directly — the point of these tests is the
+// bookkeeping row, so they must not read it through the API under test.
+func version(t *testing.T, db *sql.DB) (int, bool) {
+	t.Helper()
+	var v int
+	var dirty bool
+	require.NoError(t, db.QueryRow(`SELECT version, dirty FROM schema_migrations`).Scan(&v, &dirty))
+	return v, dirty
+}
+
+func tableExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRow(
+		`SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, name).Scan(&n))
+	return n == 1
+}
+
+// Window 1: crash BEFORE the body committed. dirty is set at 2, but table `b`
+// was never created. Recovery must rewind and actually re-apply it.
+func TestMigrate_RecoversFromDirtyVersion(t *testing.T) {
+	files := fstest.MapFS{
+		"1_a.up.sql": file(`CREATE TABLE IF NOT EXISTS a (x INT);`),
+		"2_b.up.sql": file(`CREATE TABLE IF NOT EXISTS b (x INT);`),
+	}
+	db := testDB(t)
+	require.NoError(t, upWithRecovery(testMigrator(t, db, files)))
+	require.True(t, tableExists(t, db, "b"))
+
+	// Simulate the interruption: drop the body's effect, re-dirty at 2.
+	_, err := db.Exec(`DROP TABLE b`)
+	require.NoError(t, err)
+	_, err = db.Exec(`UPDATE schema_migrations SET version = 2, dirty = 1`)
+	require.NoError(t, err)
+
+	require.NoError(t, upWithRecovery(testMigrator(t, db, files)))
+
+	v, dirty := version(t, db)
+	require.Equal(t, 2, v)
+	require.False(t, dirty, "dirty flag must be cleared")
+	require.True(t, tableExists(t, db, "b"), "interrupted migration must be re-applied")
+}
+
+// The first migration is the edge case: rewinding to version 0 is invalid, so
+// recovery must go to NilVersion or the re-run silently does nothing.
+func TestMigrate_RecoversFromDirtyFirstVersion(t *testing.T) {
+	files := fstest.MapFS{"1_a.up.sql": file(`CREATE TABLE IF NOT EXISTS a (x INT);`)}
+	db := testDB(t)
+	require.NoError(t, upWithRecovery(testMigrator(t, db, files)))
+
+	_, err := db.Exec(`DROP TABLE a`)
+	require.NoError(t, err)
+	_, err = db.Exec(`UPDATE schema_migrations SET version = 1, dirty = 1`)
+	require.NoError(t, err)
+
+	require.NoError(t, upWithRecovery(testMigrator(t, db, files)))
+
+	v, dirty := version(t, db)
+	require.Equal(t, 1, v)
+	require.False(t, dirty)
+	require.True(t, tableExists(t, db, "a"), "migration 1 must be re-applied, not skipped")
+}
+
+// Window 2: crash AFTER the body committed but before dirty was cleared, on a
+// migration that cannot be re-run (ALTER TABLE ADD COLUMN has no IF NOT EXISTS
+// in SQLite — migrations 5/6/11/12 are exactly this shape). The re-run fails
+// with "duplicate column name", which proves the body landed; recovery must
+// accept version 2 as applied and carry on to 3.
+func TestMigrate_RecoversWhenBodyAlreadyCommitted(t *testing.T) {
+	files := fstest.MapFS{
+		"1_a.up.sql":   file(`CREATE TABLE IF NOT EXISTS a (x INT);`),
+		"2_col.up.sql": file(`ALTER TABLE a ADD COLUMN y INT;`),
+		"3_c.up.sql":   file(`CREATE TABLE IF NOT EXISTS c (x INT);`),
+	}
+	db := testDB(t)
+	require.NoError(t, upWithRecovery(testMigrator(t, db, fstest.MapFS{
+		"1_a.up.sql": files["1_a.up.sql"],
+	})))
+	// Apply 2's body by hand, then mark it dirty: the exact state a crash
+	// between the body's commit and the dirty-clearing UPDATE leaves behind.
+	_, err := db.Exec(`ALTER TABLE a ADD COLUMN y INT`)
+	require.NoError(t, err)
+	_, err = db.Exec(`UPDATE schema_migrations SET version = 2, dirty = 1`)
+	require.NoError(t, err)
+
+	require.NoError(t, upWithRecovery(testMigrator(t, db, files)))
+
+	v, dirty := version(t, db)
+	require.Equal(t, 3, v, "recovery must finish the remaining migrations")
+	require.False(t, dirty)
+	require.True(t, tableExists(t, db, "c"))
+}
+
+// A migration that fails on the DATA fails identically on every retry. Recovery
+// must give up after one attempt, report the underlying error rather than the
+// dirty flag, and leave dirty set — a self-heal loop here would re-dirty on
+// every boot and make a one-time manual recovery permanent.
+func TestMigrate_DoesNotLoopOnDeterministicFailure(t *testing.T) {
+	files := fstest.MapFS{
+		"1_a.up.sql":  file(`CREATE TABLE IF NOT EXISTS a (x INT);`),
+		"2_ux.up.sql": file(`CREATE UNIQUE INDEX IF NOT EXISTS ux_a ON a(x);`),
+	}
+	db := testDB(t)
+	require.NoError(t, upWithRecovery(testMigrator(t, db, fstest.MapFS{
+		"1_a.up.sql": files["1_a.up.sql"],
+	})))
+	// Duplicate rows the unique index cannot tolerate.
+	_, err := db.Exec(`INSERT INTO a (x) VALUES (1), (1)`)
+	require.NoError(t, err)
+
+	err = upWithRecovery(testMigrator(t, db, files))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "UNIQUE constraint failed",
+		"the underlying migration error is the actionable one, not the dirty flag")
+
+	_, dirty := version(t, db)
+	require.True(t, dirty, "dirty must be left set when recovery gives up")
+
+	// A second boot must behave identically: still an error, still no loop.
+	err = upWithRecovery(testMigrator(t, db, files))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "UNIQUE constraint failed")
+}

--- a/internal/store/migrate/recovery_test.go
+++ b/internal/store/migrate/recovery_test.go
@@ -131,6 +131,75 @@ func TestMigrate_RecoversWhenBodyAlreadyCommitted(t *testing.T) {
 	require.True(t, tableExists(t, db, "c"))
 }
 
+// A crash INSIDE recovery, between the rewind to N-1 and the re-run
+// committing, leaves the bookkeeping CLEAN at 1 while migration 2's body is
+// already applied. The next boot re-runs 2 from a clean start, so it fails with
+// "duplicate column name" rather than ErrDirty — recovery must recognise that
+// too, or the repo is dropped for one more boot before the flag routes it back
+// through the dirty path.
+func TestMigrate_RecoversFromInterruptedRecovery(t *testing.T) {
+	files := fstest.MapFS{
+		"1_a.up.sql":   file(`CREATE TABLE IF NOT EXISTS a (x INT);`),
+		"2_col.up.sql": file(`ALTER TABLE a ADD COLUMN y INT;`),
+		"3_c.up.sql":   file(`CREATE TABLE IF NOT EXISTS c (x INT);`),
+	}
+	db := testDB(t)
+	require.NoError(t, upWithRecovery(testMigrator(t, db, fstest.MapFS{
+		"1_a.up.sql": files["1_a.up.sql"],
+	})))
+	_, err := db.Exec(`ALTER TABLE a ADD COLUMN y INT`)
+	require.NoError(t, err)
+	// Note dirty = 0: the interrupted recovery had already forced back to 1.
+	_, err = db.Exec(`UPDATE schema_migrations SET version = 1, dirty = 0`)
+	require.NoError(t, err)
+
+	require.NoError(t, upWithRecovery(testMigrator(t, db, files)),
+		"a recovery interrupted mid-flight must complete on the next boot, not fail it")
+
+	v, dirty := version(t, db)
+	require.Equal(t, 3, v)
+	require.False(t, dirty)
+	require.True(t, tableExists(t, db, "c"))
+}
+
+// The re-run after a rewind replays N *and everything after it*, so an
+// "already exists" can come from a later, never-applied migration. Only a
+// collision on N itself proves N's body committed; a failure at 3 must be
+// reported as a failure at 3, not silently forced past as if it were 2.
+func TestMigrate_DoesNotForcePastAFailureInALaterMigration(t *testing.T) {
+	files := fstest.MapFS{
+		"1_a.up.sql": file(`CREATE TABLE IF NOT EXISTS a (x INT);`),
+		"2_b.up.sql": file(`CREATE TABLE IF NOT EXISTS b (x INT);`),
+		"3_z.up.sql": file(`CREATE TABLE z (x INT);`), // deliberately not idempotent
+	}
+	db := testDB(t)
+	require.NoError(t, upWithRecovery(testMigrator(t, db, fstest.MapFS{
+		"1_a.up.sql": files["1_a.up.sql"],
+		"2_b.up.sql": files["2_b.up.sql"],
+	})))
+	// `z` exists for some reason unrelated to the interruption, so migration 3
+	// will collide with it the first time it is ever applied.
+	_, err := db.Exec(`CREATE TABLE z (x INT)`)
+	require.NoError(t, err)
+
+	// Interrupt 2 in window 1: body never landed, dirty at 2.
+	_, err = db.Exec(`DROP TABLE b`)
+	require.NoError(t, err)
+	_, err = db.Exec(`UPDATE schema_migrations SET version = 2, dirty = 1`)
+	require.NoError(t, err)
+
+	err = upWithRecovery(testMigrator(t, db, files))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "migration 3",
+		"the failure must be attributed to 3, not to the recovered version 2")
+	require.Contains(t, err.Error(), "already exists")
+
+	require.True(t, tableExists(t, db, "b"), "migration 2 was still legitimately re-applied")
+	v, dirty := version(t, db)
+	require.Equal(t, 3, v, "3 must be left dirty as the failing migration")
+	require.True(t, dirty)
+}
+
 // A migration that fails on the DATA fails identically on every retry. Recovery
 // must give up after one attempt, report the underlying error rather than the
 // dirty flag, and leave dirty set — a self-heal loop here would re-dirty on

--- a/internal/store/migration_dirty_test.go
+++ b/internal/store/migration_dirty_test.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store/migrate"
+)
+
+// The issue-33 repro, against the REAL embedded migrations rather than the
+// synthetic set in internal/store/migrate: an interrupted migration leaves
+// schema_migrations.dirty = 1, every later open fails, and Manager.Add drops
+// the repo — so the user's knowledge base vanishes from the API with only a
+// log line. migrate.All must recover instead of failing.
+func TestMigrate_RecoversFromDirtyVersion(t *testing.T) {
+	dir := t.TempDir()
+	registerVec() // migrations 000002/000009 need vec0
+	path := filepath.Join(dir, "m.db") + "?_foreign_keys=1"
+
+	db, err := sql.Open("sqlite3_knomit", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	require.NoError(t, migrate.All(db))
+
+	var applied int
+	require.NoError(t, db.QueryRow(`SELECT version FROM schema_migrations`).Scan(&applied))
+
+	// sqlite3 $KNOMIT_HOME/repos/<repo>.db "UPDATE schema_migrations SET dirty = 1;"
+	_, err = db.Exec(`UPDATE schema_migrations SET dirty = 1`)
+	require.NoError(t, err)
+
+	require.NoError(t, migrate.All(db), "a dirty database must self-heal, not fail the open")
+
+	var version int
+	var dirty bool
+	require.NoError(t, db.QueryRow(
+		`SELECT version, dirty FROM schema_migrations`).Scan(&version, &dirty))
+	require.Equal(t, applied, version, "recovery must not rewind the schema version")
+	require.False(t, dirty, "dirty flag must be cleared")
+
+	// The schema is still whole: the top migration's unique index survived the
+	// rewind-and-re-apply, so the recovery did not leave a half-migrated store.
+	var n int
+	require.NoError(t, db.QueryRow(
+		`SELECT count(*) FROM sqlite_master WHERE type='index' AND name='ux_edges_merge_identity'`,
+	).Scan(&n))
+	require.Equal(t, 1, n)
+
+	// And a second open is a plain no-op — recovery is not sticky.
+	require.NoError(t, migrate.All(db))
+}


### PR DESCRIPTION
Closes #33.

## The bug

golang-migrate's sqlite3 driver runs **three separate transactions** per migration: `SetVersion(N, dirty=true)`, the body, then `SetVersion(N, dirty=false)`. A crash, SIGKILL, or power loss anywhere across that span leaves `dirty = 1` permanently.

knomit had no dirty handling, so every later open failed, `Manager.Add` skipped the repo, and the user's knowledge base simply vanished from `GET /api/v1/repos` behind a single WARN line — indistinguishable from data loss, with no in-product recovery path.

## The fix

`migrate.All` now self-heals via `upWithRecovery`. The dirty flag does not say which side of the body's commit the crash fell on, so recovery tries both possibilities, **each exactly once**:

1. **Body never landed** — rewind to `N-1` and re-run `N`. This is the case that must work, so it is tried first.
2. **Body landed and `N` is not re-runnable** — only entered when the re-run fails with SQLite's `already exists` / `duplicate column name`, which is itself proof the body committed (the body is transactional, so a partial application would have rolled back). `Force(N)`, then continue.

Anything else is a migration failing **deterministically on the data**. Those re-fail identically forever, and an unguarded loop would clear, re-fail and re-dirty on every boot — turning a one-time manual recovery into a permanent one. So the *underlying* migration error is returned rather than the dirty flag, and `dirty` is left set. This is the guard raised in the issue comment.

## One correction to the issue's premise

The issue states that every knomit migration is written idempotently. **It is not**, and that assumption is load-bearing for step 1:

- `000008_fact_domain_tokens` created its table and index without `IF NOT EXISTS` — **fixed in this PR**.
- `000005`, `000006`, `000011`, `000012` are `ALTER TABLE … ADD COLUMN`, which SQLite cannot express idempotently at all. Step 2 above is what covers them.

## Deliberate non-changes

- **`migrate.Core` does not self-heal.** It targets version 1 explicitly, so rewinding a database dirty at a *later* version would migrate it **down** and destroy schema. Its only callers hand it a fresh `:memory:` database, where the dirty state cannot arise. Documented at the call site.
- **The API surface is unchanged** (option 3 in the issue). A repo that fails to open for some *other* reason is still omitted from `/api/v1/repos` — but the skip site is now ERROR rather than WARN and names the database file, since it remains the only signal.

## Tests

Every test below was confirmed to **fail against the pre-fix behaviour** before being kept.

`internal/store/migrate/recovery_test.go` — white-box, synthetic migration set so each interruption window is reproduced exactly:

- `TestMigrate_RecoversFromDirtyVersion` — window 1, body never committed.
- `TestMigrate_RecoversFromDirtyFirstVersion` — the `Force(0)`-is-invalid edge case; rewinding a dirty *first* migration must go to `NilVersion` or the re-run silently no-ops.
- `TestMigrate_RecoversWhenBodyAlreadyCommitted` — window 2, over an `ALTER TABLE ADD COLUMN`.
- `TestMigrate_DoesNotLoopOnDeterministicFailure` — asserts the underlying error surfaces, `dirty` stays set, and a second boot behaves identically.

`internal/store/migration_dirty_test.go` — the issue's literal repro against the **real embedded migrations**: version unchanged, `dirty` cleared, `ux_edges_merge_identity` intact, second open a no-op.

`go build ./...`, `go vet`, and `go test ./internal/store/... ./internal/repos/...` all pass.