### PR TITLE
fix(repos): adopt the agent branch on a restored/copied home (#32)

### DIFF
--- a/internal/repos/builder.go
+++ b/internal/repos/builder.go
@@ -253,7 +253,7 @@ func (b *repoBuilder) initDefaultGit() error {
 // the origin remote record for the default repo.
 func (b *repoBuilder) ensureBranch() {
 	if b.agentBranch != "" {
-		if err := b.svc.Branches().CreateBranch(context.Background(), b.agentBranch, b.agentBranch); err != nil {
+		if err := b.svc.Branches().CreateBranch(context.Background(), b.agentBranch, b.seedSourceForAgentBranch()); err != nil {
 			log.Warn().Err(err).Str("repo", b.name).Msg("branch create/ensure failed")
 		}
 	}
@@ -266,6 +266,41 @@ func (b *repoBuilder) ensureBranch() {
 			log.Warn().Err(err).Msg("failed to seed origin in remotes table")
 		}
 	}
+}
+
+// seedSourceForAgentBranch returns the branch CreateBranch should seed the
+// agent branch from. Normally this is the agent branch itself: it already
+// exists, so CreateBranch no-ops and the source is never read.
+//
+// But when a knomit home is restored onto a different machine — or a repo
+// database is copied — the local SSH key, and therefore the agent branch name
+// (derived from the key fingerprint, see app.agentBranch), differs from the one
+// recorded in the database. The configured agent branch is then ABSENT, and
+// seeding it from itself can never succeed, so the branch was never created and
+// every write path on the repo broke (issue #32).
+//
+// In that case adopt the repo's current HEAD branch — the previous machine's
+// agent branch, which carries all accumulated knowledge — as the seed. This
+// mirrors how a fresh clone bootstraps its agent ref from origin/main. The
+// orphaned previous branch is retained, not garbage-collected: it is not this
+// machine's agent branch, so nothing writes to it and (being outside the fetch
+// refspec) it is never pushed.
+//
+// Falls back to the agent branch itself when HEAD is detached or already points
+// at the (missing) agent branch, so CreateBranch fails loudly with the same
+// diagnostic as before rather than silently seeding from a broken source.
+func (b *repoBuilder) seedSourceForAgentBranch() string {
+	ctx := context.Background()
+	if _, err := b.svc.Branches().HeadCommit(ctx, b.agentBranch); err == nil {
+		return b.agentBranch // present: CreateBranch no-ops, source unused
+	}
+	def, err := b.svc.Branches().DefaultBranch(ctx)
+	if err != nil || def == "" || def == b.agentBranch {
+		return b.agentBranch
+	}
+	log.Info().Str("repo", b.name).Str("agent_branch", b.agentBranch).Str("adopt_from", def).
+		Msg("agent branch absent (restored home / copied db); adopting from HEAD")
+	return def
 }
 
 // setupIndex configures the search index with the embedder and runs an initial

--- a/internal/repos/builder.go
+++ b/internal/repos/builder.go
@@ -62,6 +62,11 @@ type repoBuilder struct {
 	// origin is configured (detected from the remote's symbolic HEAD).
 	// Defaults to "main" for repos with no origin.
 	upstreamMain string
+
+	// adoptedFrom is the branch the agent branch was adopted from on a
+	// restored/copied home, set by seedSourceForAgentBranch. Empty on every
+	// normal boot. ensureBranch uses it to decide whether to move HEAD.
+	adoptedFrom string
 }
 
 // openStore opens the SQLite-backed store and configures credential encryption.
@@ -255,6 +260,18 @@ func (b *repoBuilder) ensureBranch() {
 	if b.agentBranch != "" {
 		if err := b.svc.Branches().CreateBranch(context.Background(), b.agentBranch, b.seedSourceForAgentBranch()); err != nil {
 			log.Warn().Err(err).Str("repo", b.name).Msg("branch create/ensure failed")
+		} else if b.adoptedFrom != "" {
+			// Move HEAD onto the branch we just adopted. HEAD is otherwise
+			// written only at init (store.InitRepo / InitFromRemote), so
+			// leaving it on the orphan pins it to the machine that FIRST
+			// created the repo — and seedSourceForAgentBranch reads HEAD.
+			// A second restore would then adopt the original branch again,
+			// silently discarding everything this machine's predecessor
+			// wrote. HEAD is load-bearing here, not cosmetic.
+			if err := b.svc.Branches().SetDefaultBranch(b.agentBranch); err != nil {
+				log.Warn().Err(err).Str("repo", b.name).Str("branch", b.agentBranch).
+					Msg("adopt: could not move HEAD to the adopted branch; a further restore would adopt the wrong branch")
+			}
 		}
 	}
 	if b.isDefault && b.cfg.Git.Origin != "" {
@@ -286,6 +303,12 @@ func (b *repoBuilder) ensureBranch() {
 // machine's agent branch, so nothing writes to it and (being outside the fetch
 // refspec) it is never pushed.
 //
+// Records the source in b.adoptedFrom so ensureBranch can move HEAD onto the
+// adopted branch. That step is REQUIRED, not cosmetic: HEAD is the seed source
+// read here, and it is otherwise written only at init — leaving it on the
+// orphan would make a SECOND restore adopt the original machine's branch again,
+// silently discarding the intervening machine's knowledge.
+//
 // Falls back to the agent branch itself when HEAD is detached or already points
 // at the (missing) agent branch, so CreateBranch fails loudly with the same
 // diagnostic as before rather than silently seeding from a broken source.
@@ -300,6 +323,7 @@ func (b *repoBuilder) seedSourceForAgentBranch() string {
 	}
 	log.Info().Str("repo", b.name).Str("agent_branch", b.agentBranch).Str("adopt_from", def).
 		Msg("agent branch absent (restored home / copied db); adopting from HEAD")
+	b.adoptedFrom = def
 	return def
 }
 

--- a/internal/repos/builder.go
+++ b/internal/repos/builder.go
@@ -62,11 +62,6 @@ type repoBuilder struct {
 	// origin is configured (detected from the remote's symbolic HEAD).
 	// Defaults to "main" for repos with no origin.
 	upstreamMain string
-
-	// adoptedFrom is the branch the agent branch was adopted from on a
-	// restored/copied home, set by seedSourceForAgentBranch. Empty on every
-	// normal boot. ensureBranch uses it to decide whether to move HEAD.
-	adoptedFrom string
 }
 
 // openStore opens the SQLite-backed store and configures credential encryption.
@@ -260,18 +255,8 @@ func (b *repoBuilder) ensureBranch() {
 	if b.agentBranch != "" {
 		if err := b.svc.Branches().CreateBranch(context.Background(), b.agentBranch, b.seedSourceForAgentBranch()); err != nil {
 			log.Warn().Err(err).Str("repo", b.name).Msg("branch create/ensure failed")
-		} else if b.adoptedFrom != "" {
-			// Move HEAD onto the branch we just adopted. HEAD is otherwise
-			// written only at init (store.InitRepo / InitFromRemote), so
-			// leaving it on the orphan pins it to the machine that FIRST
-			// created the repo — and seedSourceForAgentBranch reads HEAD.
-			// A second restore would then adopt the original branch again,
-			// silently discarding everything this machine's predecessor
-			// wrote. HEAD is load-bearing here, not cosmetic.
-			if err := b.svc.Branches().SetDefaultBranch(b.agentBranch); err != nil {
-				log.Warn().Err(err).Str("repo", b.name).Str("branch", b.agentBranch).
-					Msg("adopt: could not move HEAD to the adopted branch; a further restore would adopt the wrong branch")
-			}
+		} else {
+			b.alignHeadWithAgentBranch()
 		}
 	}
 	if b.isDefault && b.cfg.Git.Origin != "" {
@@ -303,11 +288,10 @@ func (b *repoBuilder) ensureBranch() {
 // machine's agent branch, so nothing writes to it and (being outside the fetch
 // refspec) it is never pushed.
 //
-// Records the source in b.adoptedFrom so ensureBranch can move HEAD onto the
-// adopted branch. That step is REQUIRED, not cosmetic: HEAD is the seed source
-// read here, and it is otherwise written only at init — leaving it on the
-// orphan would make a SECOND restore adopt the original machine's branch again,
-// silently discarding the intervening machine's knowledge.
+// ensureBranch then repairs HEAD via alignHeadWithAgentBranch. That step is
+// REQUIRED, not cosmetic: HEAD is the seed source read here, so leaving it on
+// the orphan would make a SECOND restore adopt the original machine's branch
+// again, silently discarding the intervening machine's knowledge.
 //
 // Falls back to the agent branch itself when HEAD is detached or already points
 // at the (missing) agent branch, so CreateBranch fails loudly with the same
@@ -323,8 +307,42 @@ func (b *repoBuilder) seedSourceForAgentBranch() string {
 	}
 	log.Info().Str("repo", b.name).Str("agent_branch", b.agentBranch).Str("adopt_from", def).
 		Msg("agent branch absent (restored home / copied db); adopting from HEAD")
-	b.adoptedFrom = def
 	return def
+}
+
+// alignHeadWithAgentBranch points the repo's HEAD at this machine's agent
+// branch when it isn't there already. Call only once the agent branch is known
+// to exist — a HEAD pointing at a missing ref dangles, and OpenRepo's
+// repo.Head() would then fail the next boot.
+//
+// "HEAD is the local agent branch" is an invariant every repo-creation path
+// establishes: store.InitRepo, InitFromRemote and initFromEmptyRemote all set
+// it, and the runtime lifecycle paths (initLocal / initClone) route through
+// them. Nothing else writes HEAD, and no config lets an operator choose a
+// different one — the name is derived from the local key fingerprint.
+//
+// A restored/copied home is precisely the case that breaks the invariant, and
+// seedSourceForAgentBranch READS HEAD to pick its adoption source. Repairing it
+// on any boot rather than only on the boot that adopts matters because the
+// mismatch is otherwise permanent: once the agent branch exists, no further
+// adoption fires, so a single failed repair would silently re-arm the
+// chained-restore data loss (see the tests in builder_adopt_test.go).
+func (b *repoBuilder) alignHeadWithAgentBranch() {
+	def, err := b.svc.Branches().DefaultBranch(context.Background())
+	if err != nil {
+		log.Warn().Err(err).Str("repo", b.name).Msg("could not read HEAD; leaving it unchanged")
+		return
+	}
+	if def == b.agentBranch {
+		return
+	}
+	if err := b.svc.Branches().SetDefaultBranch(b.agentBranch); err != nil {
+		log.Warn().Err(err).Str("repo", b.name).Str("branch", b.agentBranch).Str("head", def).
+			Msg("could not point HEAD at the agent branch; a further restore would adopt the wrong branch")
+		return
+	}
+	log.Info().Str("repo", b.name).Str("branch", b.agentBranch).Str("was", def).
+		Msg("pointed HEAD at this machine's agent branch")
 }
 
 // setupIndex configures the search index with the embedder and runs an initial

--- a/internal/repos/builder_adopt_test.go
+++ b/internal/repos/builder_adopt_test.go
@@ -30,6 +30,7 @@ func TestEnsureBranch_AdoptsAgentBranchOnRestoredHome(t *testing.T) {
 		AgentBranch: oldAgent,
 	})
 	require.NoError(t, m1.Start())
+	t.Cleanup(func() { _ = m1.Close() })
 
 	ri1 := m1.Get(config.DefaultRepoName)
 	require.NotNil(t, ri1)
@@ -108,4 +109,75 @@ topics:
 		"created",
 	)
 	require.NoError(t, err, "write path must work on the restored home; issue #32")
+
+	// Adoption must also move HEAD onto the newly adopted branch — see
+	// TestEnsureBranch_ChainedRestoreAdoptsMostRecentBranch for why.
+	def, err := svc.Branches().DefaultBranch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, newAgent, def,
+		"adoption must move HEAD to the adopted branch, not leave it on the orphan")
+}
+
+// TestEnsureBranch_ChainedRestoreAdoptsMostRecentBranch covers the SECOND hop
+// of issue #32: a home that is restored, used, and then restored again.
+//
+// Adoption seeds from the repo's HEAD branch. HEAD is written only at init
+// (store.InitRepo / InitFromRemote), so unless adoption moves it, it stays
+// pinned to the branch of the machine that first created the repo. The second
+// restore then adopts from THAT branch and silently loses everything the first
+// restored machine wrote — no error, no warning, the repo just comes up
+// missing knowledge.
+//
+// The fix: ensureBranch moves HEAD onto the adopted branch, so each restore
+// chains off the most recent machine's work rather than the original's.
+func TestEnsureBranch_ChainedRestoreAdoptsMostRecentBranch(t *testing.T) {
+	dir := t.TempDir()
+
+	boot := func(agent string) *Manager {
+		t.Helper()
+		m := New(context.Background(), Deps{
+			Cfg:         config.Config{Home: dir},
+			AgentBranch: agent,
+		})
+		require.NoError(t, m.Start())
+		t.Cleanup(func() { _ = m.Close() })
+		return m
+	}
+
+	write := func(m *Manager, branch, path, content string) {
+		t.Helper()
+		ri := m.Get(config.DefaultRepoName)
+		require.NotNil(t, ri)
+		_, err := testService(t, ri).Facts().WriteFact(
+			context.Background(), branch, path, content, "test: "+path, "created")
+		require.NoError(t, err)
+	}
+
+	const (
+		agentA = "agent/hosta-0badf00d"
+		agentB = "agent/hostb-cafebabe"
+		agentC = "agent/hostc-deadbeef"
+	)
+
+	// --- machine A: original home ---
+	mA := boot(agentA)
+	write(mA, agentA, "kb/notes/from-a.md", "written on the original machine")
+	require.NoError(t, mA.Close())
+
+	// --- machine B: first restore, adopts A, then accumulates its own work ---
+	mB := boot(agentB)
+	write(mB, agentB, "kb/notes/from-b.md", "written after the FIRST restore")
+	require.NoError(t, mB.Close())
+
+	// --- machine C: second restore, must adopt B (not A) ---
+	mC := boot(agentC)
+	svc := testService(t, mC.Get(config.DefaultRepoName))
+
+	for _, path := range []string{"kb/notes/from-a.md", "kb/notes/from-b.md"} {
+		_, err := svc.Facts().ReadFact(context.Background(), agentC, path, nil)
+		require.NoError(t, err,
+			"a twice-restored home must inherit %s; adoption seeds from HEAD, so HEAD "+
+				"must follow each adoption or the second restore silently reverts to the "+
+				"original machine's branch (issue #32)", path)
+	}
 }

--- a/internal/repos/builder_adopt_test.go
+++ b/internal/repos/builder_adopt_test.go
@@ -181,3 +181,62 @@ func TestEnsureBranch_ChainedRestoreAdoptsMostRecentBranch(t *testing.T) {
 				"original machine's branch (issue #32)", path)
 	}
 }
+
+// TestEnsureBranch_RepairsHeadWhenAgentBranchAlreadyExists covers the recovery
+// case: the agent branch is already present, but HEAD points somewhere else.
+//
+// Every path that creates a knomit repo — store.InitRepo, InitFromRemote,
+// initFromEmptyRemote, and the runtime lifecycle.initLocal / initClone that
+// route through them — sets HEAD to the local agent branch. "HEAD is this
+// machine's agent branch" is therefore an invariant, and a restored home
+// violating it is exactly what issue #32 is about.
+//
+// Adoption alone does not restore the invariant: if SetDefaultBranch fails
+// once (or the branch was adopted by a build that did not move HEAD at all),
+// the agent branch exists on every later boot, so no adoption fires and HEAD
+// stays wrong forever — re-arming the chained-restore data loss with nothing
+// but a stale warn log to show for it. ensureBranch repairs the mismatch on
+// any boot instead of only on the boot that adopts.
+func TestEnsureBranch_RepairsHeadWhenAgentBranchAlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+
+	const (
+		agentA = "agent/hosta-0badf00d"
+		agentB = "agent/hostb-cafebabe"
+	)
+
+	boot := func(agent string) *Manager {
+		t.Helper()
+		m := New(context.Background(), Deps{
+			Cfg:         config.Config{Home: dir},
+			AgentBranch: agent,
+		})
+		require.NoError(t, m.Start())
+		t.Cleanup(func() { _ = m.Close() })
+		return m
+	}
+
+	// Machine A creates the repo; HEAD is agentA.
+	mA := boot(agentA)
+	svcA := testService(t, mA.Get(config.DefaultRepoName))
+	_, err := svcA.Facts().WriteFact(context.Background(), agentA,
+		"kb/notes/from-a.md", "written on the original machine", "test: a", "created")
+	require.NoError(t, err)
+
+	// Hand-build the damaged state: agentB exists (seeded from agentA) but HEAD
+	// was never moved off agentA — what a failed SetDefaultBranch leaves behind.
+	require.NoError(t, svcA.Branches().CreateBranch(context.Background(), agentB, agentA))
+	def, err := svcA.Branches().DefaultBranch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, agentA, def, "precondition: HEAD still on the orphan")
+	require.NoError(t, mA.Close())
+
+	// Boot as machine B. No adoption fires — agentB already exists — so the
+	// repair must come from the mismatch check, not the adoption path.
+	mB := boot(agentB)
+	svcB := testService(t, mB.Get(config.DefaultRepoName))
+	def, err = svcB.Branches().DefaultBranch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, agentB, def,
+		"HEAD must be repaired to this machine's agent branch even when no adoption fires")
+}

--- a/internal/repos/builder_adopt_test.go
+++ b/internal/repos/builder_adopt_test.go
@@ -45,6 +45,27 @@ func TestEnsureBranch_AdoptsAgentBranchOnRestoredHome(t *testing.T) {
 		"created",
 	)
 	require.NoError(t, err)
+
+	// Give the old branch a custom ontology (unique id → not a preset, so the
+	// refresh path leaves it untouched). ensureBranch must run before
+	// loadOntology so the restored instance reads THIS ontology off the adopted
+	// branch rather than falling back to the default on the first boot.
+	const customOntologyYAML = `id: restored-home-custom
+name: Restored Home Custom
+description: an ontology that only existed on the previous machine
+topics:
+  invariants:
+    description: Load-bearing rules
+`
+	_, err = testService(t, ri1).Facts().WriteFact(
+		context.Background(),
+		oldAgent,
+		"domains/ontology.yaml",
+		customOntologyYAML,
+		"test: seed custom ontology",
+		"updated",
+	)
+	require.NoError(t, err)
 	require.NoError(t, m1.Close())
 
 	// --- machine 2: restore the same home under a DIFFERENT agent branch ---
@@ -60,6 +81,12 @@ func TestEnsureBranch_AdoptsAgentBranchOnRestoredHome(t *testing.T) {
 	ri2 := m2.Get(config.DefaultRepoName)
 	require.NotNil(t, ri2)
 	svc := testService(t, ri2)
+
+	// ensureBranch runs before loadOntology, so the restored instance must load
+	// the ontology off the adopted branch — not fall back to the default.
+	require.NotNil(t, ri2.Ontology())
+	require.Equal(t, "restored-home-custom", ri2.Ontology().ID,
+		"restored home must load the adopted branch's ontology, not the default; issue #32")
 
 	// The new agent branch must now exist (ensureBranch adopted it).
 	head, err := svc.Branches().HeadCommit(context.Background(), newAgent)

--- a/internal/repos/builder_adopt_test.go
+++ b/internal/repos/builder_adopt_test.go
@@ -1,0 +1,84 @@
+package repos
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/config"
+)
+
+// TestEnsureBranch_AdoptsAgentBranchOnRestoredHome regression-tests issue #32:
+// when a knomit home is restored onto a different machine — or a repo database
+// is copied — the new instance generates a fresh SSH key, so its agent branch
+// name (derived from the key fingerprint) does not exist in the copied
+// database. ensureBranch used to seed the branch from itself
+// (CreateBranch(agent, agent)), which cannot succeed when the branch is absent,
+// so the branch was never created and EVERY write path on that repo broke.
+//
+// The fix: when the configured agent branch is absent, adopt the repo's current
+// HEAD branch (the previous machine's agent branch) as the seed source, the
+// same way a fresh clone bootstraps its agent ref from origin/main.
+func TestEnsureBranch_AdoptsAgentBranchOnRestoredHome(t *testing.T) {
+	dir := t.TempDir()
+
+	// --- machine 1: boot the default repo under the old key's agent branch ---
+	const oldAgent = "agent/oldhost-0badf00d"
+	m1 := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: dir},
+		AgentBranch: oldAgent,
+	})
+	require.NoError(t, m1.Start())
+
+	ri1 := m1.Get(config.DefaultRepoName)
+	require.NotNil(t, ri1)
+
+	// Accumulate local knowledge on the old agent branch so we can prove the
+	// adopted branch inherits it (rather than seeding from an empty upstream).
+	_, err := testService(t, ri1).Facts().WriteFact(
+		context.Background(),
+		oldAgent,
+		"kb/notes/local-only.md",
+		"a fact that only ever lived on the previous machine's agent branch",
+		"test: seed local-only fact",
+		"created",
+	)
+	require.NoError(t, err)
+	require.NoError(t, m1.Close())
+
+	// --- machine 2: restore the same home under a DIFFERENT agent branch ---
+	// (fresh id_ed25519 → different fingerprint → different branch name).
+	const newAgent = "agent/newhost-cafebabe"
+	m2 := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: dir},
+		AgentBranch: newAgent,
+	})
+	require.NoError(t, m2.Start())
+	t.Cleanup(func() { _ = m2.Close() })
+
+	ri2 := m2.Get(config.DefaultRepoName)
+	require.NotNil(t, ri2)
+	svc := testService(t, ri2)
+
+	// The new agent branch must now exist (ensureBranch adopted it).
+	head, err := svc.Branches().HeadCommit(context.Background(), newAgent)
+	require.NoError(t, err, "new agent branch must exist after restore; issue #32")
+	require.NotEmpty(t, head)
+
+	// Adoption must preserve the previous machine's accumulated knowledge.
+	res, err := svc.Facts().ReadFact(context.Background(), newAgent, "kb/notes/local-only.md", nil)
+	require.NoError(t, err, "adopted branch must inherit the previous agent branch's facts")
+	require.Contains(t, res.Content, "only ever lived on the previous machine")
+
+	// The write path must work on the restored home — the real bug in #32.
+	_, err = svc.Facts().WriteFact(
+		context.Background(),
+		newAgent,
+		"kb/notes/after-restore.md",
+		"a fact written by the new machine after the home was restored",
+		"test: write after restore",
+		"created",
+	)
+	require.NoError(t, err, "write path must work on the restored home; issue #32")
+}

--- a/internal/repos/builder_adopt_test.go
+++ b/internal/repos/builder_adopt_test.go
@@ -2,18 +2,69 @@ package repos
 
 import (
 	"context"
+	"database/sql"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/config"
+	"knomit/internal/store"
 )
+
+// The restored-home tests below all follow the same shape: boot a home under
+// one agent branch, close it, and reopen it under a DIFFERENT one — the state a
+// knomit home lands in when it is restored onto another machine. The agent
+// branch name is agent/<hostname>-<key-fingerprint> (see app.agentBranch), so a
+// fresh SSH key OR a changed hostname is enough to produce it.
+
+// adoptFact wraps body in a well-formed fact. It parses, so writing it
+// exercises the indexing path (branch_facts, facts_vec, the sync watermark)
+// rather than being skipped as unparseable. Adoption clones branch_facts from
+// the seed branch, so a fact that never got indexed leaves that clone untested.
+func adoptFact(body string) string {
+	return "---\ntype: observation\nconfidence: 0.5\nsources: 1\ndomain: [restore]\n" +
+		"entities: []\nrefs: []\n---\n# fact\n\n" + body + "\n"
+}
+
+// bootHome starts a Manager against home dir under the given agent branch. The
+// returned Manager is closed at test end; closing it earlier by hand is safe
+// (Manager.Close is idempotent) and is how these tests simulate a machine
+// shutting down before the home moves on.
+func bootHome(t *testing.T, dir, agentBranch string) *Manager {
+	t.Helper()
+	m := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: dir},
+		AgentBranch: agentBranch,
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+	return m
+}
+
+// writeFactOn writes a parseable fact to branch on the default repo.
+func writeFactOn(t *testing.T, m *Manager, branch, path, body string) {
+	t.Helper()
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+	_, err := testService(t, ri).Facts().WriteFact(
+		context.Background(), branch, path, adoptFact(body),
+		"test: write "+path, "created")
+	require.NoError(t, err)
+}
+
+// headBranch returns the branch the default repo's git HEAD points at.
+func headBranch(t *testing.T, m *Manager) string {
+	t.Helper()
+	def, err := testService(t, m.Get(config.DefaultRepoName)).Branches().DefaultBranch(context.Background())
+	require.NoError(t, err)
+	return def
+}
 
 // TestEnsureBranch_AdoptsAgentBranchOnRestoredHome regression-tests issue #32:
 // when a knomit home is restored onto a different machine — or a repo database
-// is copied — the new instance generates a fresh SSH key, so its agent branch
-// name (derived from the key fingerprint) does not exist in the copied
-// database. ensureBranch used to seed the branch from itself
+// is copied — the new instance looks for an agent branch that does not exist in
+// that database. ensureBranch used to seed the branch from itself
 // (CreateBranch(agent, agent)), which cannot succeed when the branch is absent,
 // so the branch was never created and EVERY write path on that repo broke.
 //
@@ -23,73 +74,27 @@ import (
 func TestEnsureBranch_AdoptsAgentBranchOnRestoredHome(t *testing.T) {
 	dir := t.TempDir()
 
-	// --- machine 1: boot the default repo under the old key's agent branch ---
 	const oldAgent = "agent/oldhost-0badf00d"
-	m1 := New(context.Background(), Deps{
-		Cfg:         config.Config{Home: dir},
-		AgentBranch: oldAgent,
-	})
-	require.NoError(t, m1.Start())
-	t.Cleanup(func() { _ = m1.Close() })
+	const newAgent = "agent/newhost-cafebabe"
 
-	ri1 := m1.Get(config.DefaultRepoName)
-	require.NotNil(t, ri1)
-
-	// Accumulate local knowledge on the old agent branch so we can prove the
-	// adopted branch inherits it (rather than seeding from an empty upstream).
-	_, err := testService(t, ri1).Facts().WriteFact(
-		context.Background(),
-		oldAgent,
-		"kb/notes/local-only.md",
-		"a fact that only ever lived on the previous machine's agent branch",
-		"test: seed local-only fact",
-		"created",
-	)
-	require.NoError(t, err)
-
-	// Give the old branch a custom ontology (unique id → not a preset, so the
-	// refresh path leaves it untouched). ensureBranch must run before
-	// loadOntology so the restored instance reads THIS ontology off the adopted
-	// branch rather than falling back to the default on the first boot.
-	const customOntologyYAML = `id: restored-home-custom
-name: Restored Home Custom
-description: an ontology that only existed on the previous machine
-topics:
-  invariants:
-    description: Load-bearing rules
-`
-	_, err = testService(t, ri1).Facts().WriteFact(
-		context.Background(),
-		oldAgent,
-		"domains/ontology.yaml",
-		customOntologyYAML,
-		"test: seed custom ontology",
-		"updated",
-	)
-	require.NoError(t, err)
-	require.NoError(t, m1.Close())
+	// --- machine 1: accumulate knowledge on the old agent branch ---
+	m1 := bootHome(t, dir, oldAgent)
+	writeFactOn(t, m1, oldAgent, "kb/notes/local-only.md",
+		"a fact that only ever lived on the previous machine's agent branch")
+	_ = m1.Close()
 
 	// --- machine 2: restore the same home under a DIFFERENT agent branch ---
-	// (fresh id_ed25519 → different fingerprint → different branch name).
-	const newAgent = "agent/newhost-cafebabe"
-	m2 := New(context.Background(), Deps{
-		Cfg:         config.Config{Home: dir},
-		AgentBranch: newAgent,
-	})
-	require.NoError(t, m2.Start())
-	t.Cleanup(func() { _ = m2.Close() })
+	m2 := bootHome(t, dir, newAgent)
+	svc := testService(t, m2.Get(config.DefaultRepoName))
 
-	ri2 := m2.Get(config.DefaultRepoName)
-	require.NotNil(t, ri2)
-	svc := testService(t, ri2)
+	// THE bug in #32: every write path was broken, not just index maintenance.
+	// Assert it first so an unfixed tree reports the headline failure.
+	_, err := svc.Facts().WriteFact(
+		context.Background(), newAgent, "kb/notes/after-restore.md",
+		adoptFact("written after the home was restored"),
+		"test: write after restore", "created")
+	require.NoError(t, err, "write path must work on the restored home; issue #32")
 
-	// ensureBranch runs before loadOntology, so the restored instance must load
-	// the ontology off the adopted branch — not fall back to the default.
-	require.NotNil(t, ri2.Ontology())
-	require.Equal(t, "restored-home-custom", ri2.Ontology().ID,
-		"restored home must load the adopted branch's ontology, not the default; issue #32")
-
-	// The new agent branch must now exist (ensureBranch adopted it).
 	head, err := svc.Branches().HeadCommit(context.Background(), newAgent)
 	require.NoError(t, err, "new agent branch must exist after restore; issue #32")
 	require.NotEmpty(t, head)
@@ -99,23 +104,63 @@ topics:
 	require.NoError(t, err, "adopted branch must inherit the previous agent branch's facts")
 	require.Contains(t, res.Content, "only ever lived on the previous machine")
 
-	// The write path must work on the restored home — the real bug in #32.
-	_, err = svc.Facts().WriteFact(
-		context.Background(),
-		newAgent,
-		"kb/notes/after-restore.md",
-		"a fact written by the new machine after the home was restored",
-		"test: write after restore",
-		"created",
-	)
-	require.NoError(t, err, "write path must work on the restored home; issue #32")
+	// The inherited fact must be INDEXED on the adopted branch, not merely
+	// present in the tree — CreateBranch clones branch_facts from the seed, and
+	// a gap there is exactly what Verify's facts-coherence check exists to catch.
+	rep, err := m2.Get(config.DefaultRepoName).Verify(context.Background(), store.VerifyOpts{Deep: true})
+	require.NoError(t, err)
+	require.True(t, rep.IsClean(), "adopted branch must be index-coherent: %+v", rep.Issues)
+
+	// The orphan is RETAINED, not garbage-collected (design decision: it may
+	// hold the only copy of the previous machine's data). Nothing writes to it
+	// and it is outside the fetch refspec, so keeping it is harmless.
+	orphanHead, err := svc.Branches().HeadCommit(context.Background(), oldAgent)
+	require.NoError(t, err, "the previous machine's agent branch must be retained, not GC'd")
+	require.NotEmpty(t, orphanHead)
+	orphanFact, err := svc.Facts().ReadFact(context.Background(), oldAgent, "kb/notes/local-only.md", nil)
+	require.NoError(t, err, "the retained orphan must still carry its facts")
+	require.Contains(t, orphanFact.Content, "only ever lived on the previous machine")
 
 	// Adoption must also move HEAD onto the newly adopted branch — see
 	// TestEnsureBranch_ChainedRestoreAdoptsMostRecentBranch for why.
-	def, err := svc.Branches().DefaultBranch(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, newAgent, def,
+	require.Equal(t, newAgent, headBranch(t, m2),
 		"adoption must move HEAD to the adopted branch, not leave it on the orphan")
+}
+
+// TestOpenOne_EnsureBranchRunsBeforeLoadOntology pins the statement order in
+// Manager.openOne. loadOntology reads — and may rewrite — domains/ontology.yaml
+// on the agent branch, so on a restored home it must run AFTER ensureBranch has
+// adopted that branch. Running it first fell back to the default ontology and
+// skipped the preset refresh on the first boot after a restore, self-correcting
+// only on the next one.
+func TestOpenOne_EnsureBranchRunsBeforeLoadOntology(t *testing.T) {
+	dir := t.TempDir()
+
+	const oldAgent = "agent/oldhost-0badf00d"
+	const newAgent = "agent/newhost-cafebabe"
+
+	// A unique id keeps this off the preset-refresh path, so the ontology the
+	// restored instance loads is unambiguously the one written here.
+	const customOntologyYAML = `id: restored-home-custom
+name: Restored Home Custom
+description: an ontology that only existed on the previous machine
+topics:
+  invariants:
+    description: Load-bearing rules
+`
+	m1 := bootHome(t, dir, oldAgent)
+	_, err := testService(t, m1.Get(config.DefaultRepoName)).Facts().WriteFact(
+		context.Background(), oldAgent, "domains/ontology.yaml", customOntologyYAML,
+		"test: seed custom ontology", "updated")
+	require.NoError(t, err)
+	_ = m1.Close()
+
+	m2 := bootHome(t, dir, newAgent)
+	ri2 := m2.Get(config.DefaultRepoName)
+	require.NotNil(t, ri2)
+	require.NotNil(t, ri2.Ontology())
+	require.Equal(t, "restored-home-custom", ri2.Ontology().ID,
+		"restored home must load the adopted branch's ontology on the FIRST boot, not the default; issue #32")
 }
 
 // TestEnsureBranch_ChainedRestoreAdoptsMostRecentBranch covers the SECOND hop
@@ -133,46 +178,24 @@ topics:
 func TestEnsureBranch_ChainedRestoreAdoptsMostRecentBranch(t *testing.T) {
 	dir := t.TempDir()
 
-	boot := func(agent string) *Manager {
-		t.Helper()
-		m := New(context.Background(), Deps{
-			Cfg:         config.Config{Home: dir},
-			AgentBranch: agent,
-		})
-		require.NoError(t, m.Start())
-		t.Cleanup(func() { _ = m.Close() })
-		return m
-	}
-
-	write := func(m *Manager, branch, path, content string) {
-		t.Helper()
-		ri := m.Get(config.DefaultRepoName)
-		require.NotNil(t, ri)
-		_, err := testService(t, ri).Facts().WriteFact(
-			context.Background(), branch, path, content, "test: "+path, "created")
-		require.NoError(t, err)
-	}
-
 	const (
 		agentA = "agent/hosta-0badf00d"
 		agentB = "agent/hostb-cafebabe"
 		agentC = "agent/hostc-deadbeef"
 	)
 
-	// --- machine A: original home ---
-	mA := boot(agentA)
-	write(mA, agentA, "kb/notes/from-a.md", "written on the original machine")
-	require.NoError(t, mA.Close())
+	mA := bootHome(t, dir, agentA)
+	writeFactOn(t, mA, agentA, "kb/notes/from-a.md", "written on the original machine")
+	_ = mA.Close()
 
-	// --- machine B: first restore, adopts A, then accumulates its own work ---
-	mB := boot(agentB)
-	write(mB, agentB, "kb/notes/from-b.md", "written after the FIRST restore")
-	require.NoError(t, mB.Close())
+	// First restore: adopts A, then accumulates its own work.
+	mB := bootHome(t, dir, agentB)
+	writeFactOn(t, mB, agentB, "kb/notes/from-b.md", "written after the FIRST restore")
+	_ = mB.Close()
 
-	// --- machine C: second restore, must adopt B (not A) ---
-	mC := boot(agentC)
+	// Second restore: must adopt B (the most recent machine), not A.
+	mC := bootHome(t, dir, agentC)
 	svc := testService(t, mC.Get(config.DefaultRepoName))
-
 	for _, path := range []string{"kb/notes/from-a.md", "kb/notes/from-b.md"} {
 		_, err := svc.Facts().ReadFact(context.Background(), agentC, path, nil)
 		require.NoError(t, err,
@@ -205,38 +228,76 @@ func TestEnsureBranch_RepairsHeadWhenAgentBranchAlreadyExists(t *testing.T) {
 		agentB = "agent/hostb-cafebabe"
 	)
 
-	boot := func(agent string) *Manager {
-		t.Helper()
-		m := New(context.Background(), Deps{
-			Cfg:         config.Config{Home: dir},
-			AgentBranch: agent,
-		})
-		require.NoError(t, m.Start())
-		t.Cleanup(func() { _ = m.Close() })
-		return m
-	}
-
 	// Machine A creates the repo; HEAD is agentA.
-	mA := boot(agentA)
+	mA := bootHome(t, dir, agentA)
+	writeFactOn(t, mA, agentA, "kb/notes/from-a.md", "written on the original machine")
 	svcA := testService(t, mA.Get(config.DefaultRepoName))
-	_, err := svcA.Facts().WriteFact(context.Background(), agentA,
-		"kb/notes/from-a.md", "written on the original machine", "test: a", "created")
-	require.NoError(t, err)
 
 	// Hand-build the damaged state: agentB exists (seeded from agentA) but HEAD
 	// was never moved off agentA — what a failed SetDefaultBranch leaves behind.
 	require.NoError(t, svcA.Branches().CreateBranch(context.Background(), agentB, agentA))
-	def, err := svcA.Branches().DefaultBranch(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, agentA, def, "precondition: HEAD still on the orphan")
-	require.NoError(t, mA.Close())
+	require.Equal(t, agentA, headBranch(t, mA), "precondition: HEAD still on the orphan")
+	_ = mA.Close()
 
 	// Boot as machine B. No adoption fires — agentB already exists — so the
 	// repair must come from the mismatch check, not the adoption path.
-	mB := boot(agentB)
-	svcB := testService(t, mB.Get(config.DefaultRepoName))
-	def, err = svcB.Branches().DefaultBranch(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, agentB, def,
+	mB := bootHome(t, dir, agentB)
+	require.Equal(t, agentB, headBranch(t, mB),
 		"HEAD must be repaired to this machine's agent branch even when no adoption fires")
+
+	// Repairing HEAD must not disturb the data on either branch.
+	svcB := testService(t, mB.Get(config.DefaultRepoName))
+	for _, branch := range []string{agentA, agentB} {
+		res, err := svcB.Facts().ReadFact(context.Background(), branch, "kb/notes/from-a.md", nil)
+		require.NoError(t, err, "repairing HEAD must not disturb %s", branch)
+		require.Contains(t, res.Content, "written on the original machine")
+	}
+}
+
+// TestEnsureBranch_DetachedHeadDoesNotDangleHead pins the ordering guard in
+// ensureBranch: HEAD is repaired only AFTER CreateBranch reports success.
+//
+// With a detached HEAD and the agent branch absent, seedSourceForAgentBranch
+// has no source to adopt from, so it falls back to the agent branch itself and
+// CreateBranch fails loudly — the same diagnostic as before the #32 fix. If the
+// repair ran regardless, it would point HEAD at a branch that does not exist;
+// go-git's repo.Head() cannot resolve a dangling HEAD, so the NEXT boot would
+// fail to open the repo at all. Leaving HEAD detached is the safe outcome.
+func TestEnsureBranch_DetachedHeadDoesNotDangleHead(t *testing.T) {
+	dir := t.TempDir()
+
+	const agentA = "agent/hosta-0badf00d"
+	const agentB = "agent/hostb-cafebabe"
+
+	mA := bootHome(t, dir, agentA)
+	writeFactOn(t, mA, agentA, "kb/notes/from-a.md", "written on the original machine")
+	tip, err := testService(t, mA.Get(config.DefaultRepoName)).Branches().HeadCommit(context.Background(), agentA)
+	require.NoError(t, err)
+	_ = mA.Close()
+
+	// Detach HEAD directly in the ref store: point it at a raw commit hash
+	// instead of a branch. DefaultBranch then reports "" (no symbolic target).
+	dbPath := filepath.Join(dir, "repos", config.DefaultRepoName+".db")
+	raw, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = raw.Exec(`UPDATE refs SET target = ?, is_symbolic = 0 WHERE name = 'HEAD'`, tip)
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	// Boot under an agent branch that does not exist. Adoption cannot fire (no
+	// HEAD branch to adopt from) and CreateBranch fails, so HEAD must be left
+	// exactly as it was rather than repointed at the missing branch.
+	mB := bootHome(t, dir, agentB)
+	require.Equal(t, "", headBranch(t, mB),
+		"HEAD must stay detached when CreateBranch failed; pointing it at a missing "+
+			"branch would dangle it and break the next OpenRepo")
+
+	// The repo must still open on a subsequent boot — the actual harm a dangling
+	// HEAD would cause.
+	_ = mB.Close()
+	mC := bootHome(t, dir, agentA)
+	res, err := testService(t, mC.Get(config.DefaultRepoName)).Facts().
+		ReadFact(context.Background(), agentA, "kb/notes/from-a.md", nil)
+	require.NoError(t, err, "repo must still open and read after a failed adoption")
+	require.Contains(t, res.Content, "written on the original machine")
 }

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -681,8 +681,13 @@ func (m *Manager) openOne(name, dbPath string, isDefault bool) (*RepoInstance, e
 		b.close()
 		return nil, err
 	}
-	b.loadOntology()
+	// ensureBranch must run before loadOntology: on a restored/copied home the
+	// configured agent branch is absent until ensureBranch adopts it (issue
+	// #32), and loadOntology reads (and may rewrite) domains/ontology.yaml on
+	// that branch. Running loadOntology first would fall back to the default
+	// ontology and skip the preset-refresh on the first boot after a restore.
 	b.ensureBranch()
+	b.loadOntology()
 	b.setupIndex()
 	b.seedWatermarks()
 


### PR DESCRIPTION
Fixes #32.

## Root cause

The agent branch name derives from the local SSH key fingerprint (`app.agentBranch`). When a knomit home is restored onto a different machine — or a repo DB is copied — a fresh `id_ed25519` yields a **different** branch name that does not exist in that database. `ensureBranch` tried to create it with `CreateBranch(agent, agent)` — seeding the branch **from itself** — which can never resolve a source that is absent. The branch was never created and **every write path** on the repo broke (`HeadCommit` → `resolveRef` → *branch not found*), not just index maintenance.

## Fix

`internal/repos/builder.go`: a new `seedSourceForAgentBranch()` picks the seed source for `CreateBranch`:

- **Agent branch present** (normal case): return itself → `CreateBranch` no-ops, behavior unchanged.
- **Absent** (restored/copied home): adopt the repo's current **HEAD branch** — the previous machine's agent branch, which carries all accumulated knowledge. `CreateBranch` already clones git ref + `branch_commits` + `branch_facts`, so the new machine inherits everything. This mirrors how a fresh clone bootstraps its agent ref from `origin/main`.
- **Degenerate** (HEAD detached / points at the missing branch): fall back to the agent branch itself, so `CreateBranch` fails loudly with the same diagnostic as before rather than seeding from a broken source.

After a successful adoption, `ensureBranch` calls `SetDefaultBranch(agentBranch)` to **move HEAD onto the adopted branch**. This is load-bearing, not cosmetic — see below.

`internal/repos/manager.go`: `ensureBranch` now runs **before** `loadOntology` in `openOne`. On a restored home the configured agent branch is absent until `ensureBranch` adopts it, and `loadOntology` reads (and may rewrite) `domains/ontology.yaml` on that branch. Running `loadOntology` first fell back to the default ontology and skipped the preset-refresh on the first boot after a restore (self-correcting only on the next boot); the reorder loads the adopted branch's ontology on the first boot.

## Why HEAD must follow the adoption

**"HEAD is this machine's agent branch" is an invariant.** Every repo-creation path establishes it — `store.InitRepo`, `InitFromRemote`, `initFromEmptyRemote`, plus the runtime `Manager.Create` paths (`initLocal` / `initClone`) which route through them. Nothing else writes HEAD, and no config lets an operator choose a different one (the name derives from the local key fingerprint). A restored/copied home is exactly the case that violates it.

`ensureBranch` therefore calls `alignHeadWithAgentBranch()` after any successful `CreateBranch`: if HEAD isn't the agent branch, repoint it. Two earlier revisions of this PR got this wrong in different ways, both silent:

1. The first left HEAD on the orphan and called it cosmetic. But `seedSourceForAgentBranch` **reads HEAD** as its adoption source, so HEAD stayed pinned to the machine that first created the repo — a home restored, used, and restored **again** adopted the original branch on the second hop and discarded everything the intervening machine wrote.
2. The second moved HEAD only on the boot that adopted. That made the repair un-retryable: once the agent branch exists no further adoption fires, so a single `SetDefaultBranch` failure pinned HEAD wrong permanently and re-armed the same loss.

Repairing the invariant on *any* boot is what makes it self-healing; it fixes a detached HEAD for free. The check runs only after `CreateBranch` reports success, so HEAD is never pointed at a missing ref (which would dangle it and fail the next `OpenRepo`).

The orphan branch itself is still retained, not garbage-collected — only the HEAD pointer moves off it. Push/sync never consult HEAD (they address the agent ref by name), so this has no remote-facing effect.

## Design decisions

The issue explicitly flagged these (recorded in knomit at `kb/decisions/repos/restored-home-agent-branch-adoption`):

1. **Seed from the existing agent branch, not upstream `main`.** For local-only repos (the dominant case, including knomit's own memory) `main` sits at the init commit — seeding from it would discard every accumulated fact.
2. **Retain the orphaned branch, no GC.** It is not this machine's agent branch (nothing writes to it) and is outside the fetch refspec (never pushed), so it is harmless. GC risks deleting the only copy of data.
3. **Keep HEAD on this machine's agent branch, repairing it on any boot.** Required for correctness across repeated restores (above).

## Notes

- **Origin repos**: an adopted branch has no sync watermark, but `reconcileAgentRebase` already self-heals a missing watermark via a MergeBase fallback — no extra code needed.
- **Latent, not addressed here**: `DropBranch` removes a git ref without checking HEAD, so deleting whatever branch HEAD points at would dangle it and fail the next `OpenRepo`. `DropBranch` has no web/MCP/CLI caller today (tests only), so this is unreachable in production; moving HEAD off the orphan removes the most likely way to stumble into it.

## Testing

- `builder_adopt_test.go` reproduces the restored-home scenario end to end (boot under one agent branch → close → reopen under a different one). It **failed before** with issue #32's exact error and **passes after**. It also asserts the adopted branch inherits the prior branch's facts, that HEAD follows the adoption, and — locking in the ordering fix — that the restored instance loads the previous machine's custom ontology rather than the default (verified this assertion fails under the old `loadOntology`-first ordering).
- `TestEnsureBranch_ChainedRestoreAdoptsMostRecentBranch` covers the second hop: three machines in sequence (A → restore B → restore C), asserting C inherits **both** A's and B's facts. It fails without the HEAD repair.
- `TestEnsureBranch_RepairsHeadWhenAgentBranchAlreadyExists` builds the damaged state directly — agent branch present, HEAD still on the orphan — so the repair is exercised with no adoption firing.
- Full `go test ./...` passes, `internal/repos` + `internal/store/...` also under `-race`; `go build ./...` and `go vet` clean.
