### PR TITLE
feat(ci): list the commits since the previous dev release in the notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,13 +114,49 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      # Full history + tags: the changelog below diffs this commit against the
+      # commit the previous `dev-latest` release was cut from, which a shallow
+      # clone cannot reach.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           path: artifacts # → artifacts/<job-name>/<file>
       - name: Resolve version
         id: ver
         run: echo "full=$(make -s print-version)" >> "$GITHUB_OUTPUT"
+      # MUST run before the release is deleted below — that deletion takes the
+      # `dev-latest` tag with it, and the tag is what marks the previous build.
+      - name: Collect changes since the previous dev release
+        run: |
+          set -euo pipefail
+          prev="$(git rev-parse -q --verify "refs/tags/dev-latest^{commit}" || true)"
+          if [ -z "$prev" ]; then
+            # Tag missing locally (first ever run, or it was deleted by hand):
+            # ask the API what commit the existing release points at.
+            prev="$(gh release view dev-latest --json targetCommitish \
+                      -q .targetCommitish 2>/dev/null || true)"
+            prev="$(git rev-parse -q --verify "${prev}^{commit}" 2>/dev/null || true)"
+          fi
+
+          {
+            echo "## Changes"
+            echo
+            if [ -z "$prev" ]; then
+              echo "_No previous \`dev-latest\` release to compare against._"
+            elif [ "$prev" = "$GITHUB_SHA" ]; then
+              echo "_No new commits since the previous \`dev-latest\` release._"
+            else
+              # --no-merges: merge commits add no information here, their
+              # constituent commits are already listed.
+              git log --no-merges --reverse \
+                --pretty=format:'- %s (`%h`)' "$prev..$GITHUB_SHA"
+              echo
+              echo
+              echo "[Full diff](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${prev}...${GITHUB_SHA})"
+            fi
+          } > changelog.md
       - name: Write release notes
         env:
           FULL: ${{ steps.ver.outputs.full }}
@@ -130,6 +166,8 @@ jobs:
           Rolling development build from \`dev\` — **$FULL** (\`$GITHUB_SHA\`).
 
           This pre-release is replaced on every run; the download URLs are stable.
+
+          $(cat changelog.md)
 
           ## Downloads
 


### PR DESCRIPTION
The rolling `dev-latest` pre-release said what was built but never what changed. Anchor a changelog on the `dev-latest` tag, which marks the commit the previous build was cut from, and render `git log --no-merges` between that and HEAD into the release body.

Two constraints shape the implementation:

  - The step must run BEFORE the release-recreate step, which deletes the tag it depends on (`gh release delete --cleanup-tag`).
  - Checkout needs `fetch-depth: 0`; the default shallow clone cannot reach the previous release's commit.

Falls back to the release's `targetCommitish` over the API when the tag is missing, and degrades to an explanatory line on the first run or a re-run against an unchanged commit.