### PR TITLE
Reorganize the repo and lens Manage panes, and make descriptions editable

### DIFF
--- a/internal/repos/builder.go
+++ b/internal/repos/builder.go
@@ -75,6 +75,9 @@ func (b *repoBuilder) openStore() error {
 	// stalled remote aborts instead of hanging forever. store.Open does not
 	// know about config, so wire the timeout explicitly here.
 	svc.SetNetworkTimeout(b.cfg.Git.NetworkTimeout)
+	// Same reason: the store decides index membership by location (only the
+	// ontology root holds facts) and has no way to learn the configured root.
+	svc.SetOntologyRoot(b.cfg.OntologyRoot)
 	// Without a Crypt, SetRemote REFUSES to persist any auth token (never
 	// plaintext); configureCrypt logs a warning so that refusal is observable.
 	configureCrypt(svc, b.keyPath, b.name)

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -328,6 +328,7 @@ func (m *Manager) initLocal(ctx context.Context, spec CreateSpec, dbPath string,
 	}
 	defer svc.Close()
 	svc.SetNetworkTimeout(m.deps.Cfg.Git.NetworkTimeout)
+	svc.SetOntologyRoot(m.deps.Cfg.OntologyRoot)
 	if err := svc.InitRepo(map[string]string{
 		"domains/ontology.yaml": string(y),
 	}, m.deps.AgentBranch); err != nil {
@@ -355,6 +356,7 @@ func (m *Manager) initClone(ctx context.Context, spec CreateSpec, dbPath string,
 	}
 	defer svc.Close()
 	svc.SetNetworkTimeout(m.deps.Cfg.Git.NetworkTimeout)
+	svc.SetOntologyRoot(m.deps.Cfg.OntologyRoot)
 	// Without a Crypt, SetRemote refuses to persist the origin token (never
 	// plaintext); configureCrypt logs a warning so that refusal is observable.
 	configureCrypt(svc, m.deps.KeyPath, spec.Name)

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -1,0 +1,98 @@
+package repos
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"knomit/internal/store"
+)
+
+var (
+	// ErrRepoDescriptionTooLong is returned by WriteKBManifest when content
+	// exceeds MaxRepoDescriptionBytes. Mirrors ErrLensDescriptionTooLong: the
+	// cap is a pure input check, enforced here rather than at the HTTP edge so
+	// every writer of kb.md is bound by it.
+	ErrRepoDescriptionTooLong = errors.New("repo description too long")
+	// ErrAgentBranchUnset is returned when the repo has no agent branch yet, so
+	// there is no ref to read the manifest from or commit it to.
+	ErrAgentBranchUnset = errors.New("repo has no agent branch")
+)
+
+// MaxRepoDescriptionBytes caps the kb.md root manifest. Byte length, not rune
+// count: it bounds stored + wire size. Deliberately far larger than
+// MaxLensDescriptionBytes — a lens description is a one-line note about a read
+// union, whereas kb.md is a repo's root manifest and routinely runs to several
+// pages of guidance for the agents reading it.
+const MaxRepoDescriptionBytes = 64 * 1024
+
+// KBManifestPath is the repo's root manifest, at the root of the tree rather
+// than under the ontology root: it is not a fact. The search indexer skips it
+// as unparseable and the commits list filters to ontologyRoot, so writing it
+// moves the file and its commit-log row, never the fact index or the history UI.
+const KBManifestPath = "kb.md"
+
+// kbManifestCommitMsg is the commit subject for every manifest edit, so the
+// git log reads uniformly regardless of which client made the change.
+const kbManifestCommitMsg = "docs: update kb.md root manifest"
+
+// ReadKBManifest returns the verbatim content of kb.md at the tip of the repo's
+// agent branch. A missing manifest is not an error — it returns "" with a nil
+// error, because "this repo has no description" is an ordinary state.
+func (ri *RepoInstance) ReadKBManifest(ctx context.Context) (string, error) {
+	branch := ri.agentBranch
+	if branch == "" {
+		return "", ErrAgentBranchUnset
+	}
+	var content string
+	// WithRead's contract: fn does not run unless a live service is available,
+	// and the error says why — so there is no nil svc to guard against here.
+	err := ri.WithRead(func(svc *store.Service) {
+		res, rerr := svc.Facts().ReadFact(ctx, branch, KBManifestPath, nil)
+		if rerr != nil {
+			return // absent (or unreadable) — no description to report
+		}
+		content = res.Content
+	})
+	return content, err
+}
+
+// WriteKBManifest commits content to kb.md on the repo's agent branch — the
+// exact file and branch ReadKBManifest reads, so an edit round-trips. It
+// reports whether a commit was made: a byte-identical manifest is skipped,
+// because the store's write path always builds a fresh commit object and
+// re-saving unchanged text would otherwise append an empty commit to the agent
+// branch (and push it to the remote).
+//
+// The read-compare-write is not atomic. That is the same last-write-wins
+// contract the fact-write path already has: a racing writer can turn this call
+// into a no-op, and the loser's content is what a subsequent read returns.
+func (ri *RepoInstance) WriteKBManifest(ctx context.Context, content string) (committed bool, err error) {
+	if len(content) > MaxRepoDescriptionBytes {
+		return false, fmt.Errorf("%w: %d bytes exceeds the maximum of %d",
+			ErrRepoDescriptionTooLong, len(content), MaxRepoDescriptionBytes)
+	}
+	branch := ri.agentBranch
+	if branch == "" {
+		return false, ErrAgentBranchUnset
+	}
+	var writeErr error
+	// Capture WithRead's own error separately: it reports a closed or detached
+	// store, in which case fn never ran at all. Dropping it would turn "the
+	// write never happened" into a silent success.
+	acquireErr := ri.WithRead(func(svc *store.Service) {
+		if cur, rerr := svc.Facts().ReadFact(ctx, branch, KBManifestPath, nil); rerr == nil && cur.Content == content {
+			return
+		}
+		if _, werr := svc.Facts().WriteFact(ctx, branch, KBManifestPath,
+			content, kbManifestCommitMsg, "update"); werr != nil {
+			writeErr = werr
+			return
+		}
+		committed = true
+	})
+	if acquireErr != nil {
+		return false, acquireErr
+	}
+	return committed, writeErr
+}

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -1,0 +1,73 @@
+package repos
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/config"
+)
+
+// A write to a torn-down instance must report the failure. WithRead does not
+// invoke fn when no store is reachable, so an implementation that only captures
+// errors set inside the closure returns nil — reporting success for a write
+// that never happened.
+func TestWriteKBManifest_ClosedInstance_ReportsError(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	ri.shutdown()
+
+	committed, err := ri.WriteKBManifest(context.Background(), "# after close")
+	require.ErrorIs(t, err, ErrRepoClosed)
+	require.False(t, committed)
+}
+
+// The cap is enforced in the domain, so every writer of kb.md is bound by it —
+// not only the HTTP handler.
+func TestWriteKBManifest_EnforcesCap(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	_, err := ri.WriteKBManifest(context.Background(), strings.Repeat("x", MaxRepoDescriptionBytes+1))
+	require.ErrorIs(t, err, ErrRepoDescriptionTooLong)
+
+	// The rejected write must not have landed.
+	got, err := ri.ReadKBManifest(context.Background())
+	require.NoError(t, err)
+	require.NotContains(t, got, strings.Repeat("x", 64))
+
+	committed, err := ri.WriteKBManifest(context.Background(), strings.Repeat("x", MaxRepoDescriptionBytes))
+	require.NoError(t, err)
+	require.True(t, committed, "an at-cap description is accepted")
+}
+
+// Round-trip plus the unchanged-content skip: re-writing identical bytes
+// reports committed=false and leaves the content in place.
+func TestWriteKBManifest_RoundTripsAndSkipsUnchanged(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+	ctx := context.Background()
+
+	const md = "# Core\n\n| a | b |\n|---|---|\n| 1 | 2 |\n"
+	committed, err := ri.WriteKBManifest(ctx, md)
+	require.NoError(t, err)
+	require.True(t, committed)
+
+	got, err := ri.ReadKBManifest(ctx)
+	require.NoError(t, err)
+	require.Equal(t, md, got, "stored byte-for-byte")
+
+	committed, err = ri.WriteKBManifest(ctx, md)
+	require.NoError(t, err)
+	require.False(t, committed, "identical content must not produce a commit")
+
+	got, err = ri.ReadKBManifest(ctx)
+	require.NoError(t, err)
+	require.Equal(t, md, got, "a skipped write leaves the manifest intact")
+}

--- a/internal/repos/swapstore.go
+++ b/internal/repos/swapstore.go
@@ -28,6 +28,7 @@ func (m *Manager) rewireStore(svc *store.Service, repoName string) {
 	// store.Open does not restore the network timeout either; re-apply it so a
 	// swapped-in store bounds remote git ops identically to a freshly built one.
 	svc.SetNetworkTimeout(m.deps.Cfg.Git.NetworkTimeout)
+	svc.SetOntologyRoot(m.deps.Cfg.OntologyRoot)
 }
 
 // SwapStore replaces the repo's SQLite database with the one from tempDBPath.

--- a/internal/store/branch.go
+++ b/internal/store/branch.go
@@ -82,6 +82,14 @@ type repoHandler struct {
 
 	name string // repo name, derived from dbPath at Open time
 
+	// factRoot is the ontology root — the one directory facts live under, and
+	// therefore the only part of the tree the index admits (see isFactPath).
+	// Empty means "not configured": ontologyRoot() falls back to the default,
+	// so a bare repoHandler built without a Service still behaves. Set by
+	// Service.SetOntologyRoot from cfg.OntologyRoot at build/swap time, never
+	// mutated afterwards, so no lock is needed.
+	factRoot string
+
 	// netTimeout bounds every remote git network operation (clone/fetch/push/
 	// ls-remote). 0 means no bound (hang-forever, the legacy behavior). Set by
 	// Service.SetNetworkTimeout from cfg.Git.NetworkTimeout at build/swap time;

--- a/internal/store/factpath.go
+++ b/internal/store/factpath.go
@@ -1,0 +1,37 @@
+package store
+
+import "strings"
+
+// defaultOntologyRoot mirrors config.Defaults().OntologyRoot. The store cannot
+// import internal/config (config is the outer layer), so the default lives here
+// and SetOntologyRoot carries the configured value in from the repos builder.
+const defaultOntologyRoot = "kb"
+
+// ontologyRoot returns the root every fact path lives under, defaulting for a
+// bare repoHandler that was never configured (tests, ad-hoc tooling).
+func (rh *repoHandler) ontologyRoot() string {
+	if rh.factRoot == "" {
+		return defaultOntologyRoot
+	}
+	return rh.factRoot
+}
+
+// isFactPath reports whether path is eligible for the fact index: a .md file
+// inside the ontology root.
+//
+// Membership is decided by LOCATION, never by whether the bytes happen to
+// parse. Those are not the same test: fact.ParseFact accepts any file that
+// opens with YAML frontmatter and an H1 heading, which is the ordinary shape of
+// a markdown document — so a parse-based rule hands index membership to whoever
+// authored the file. That became live when the repo description (kb.md, at the
+// tree root) turned into a user-editable field: a manifest written with
+// frontmatter would parse, index as a fact, and then be reported by Verify as a
+// ghost branch_facts row, because checkFactsCoherence builds its expected set
+// from the ontology root alone. Location is the rule Verify already enforces;
+// this is the same rule applied on the way in.
+//
+// Callers still keep their parse-failure skips: this bounds WHERE a fact can
+// live, parsing decides whether a file in that place is a well-formed one.
+func (rh *repoHandler) isFactPath(path string) bool {
+	return strings.HasPrefix(path, rh.ontologyRoot()+"/") && strings.HasSuffix(path, ".md")
+}

--- a/internal/store/index_scope_test.go
+++ b/internal/store/index_scope_test.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// indexedPaths returns every path the index holds for a branch.
+func indexedPaths(t *testing.T, svc *Service, branch string) []string {
+	t.Helper()
+	rows, err := svc.rh.db.QueryContext(context.Background(),
+		`SELECT bf.path FROM branch_facts bf
+		 JOIN branches b ON b.id = bf.branch_id
+		 WHERE b.name = ? ORDER BY bf.path`, branch)
+	require.NoError(t, err)
+	defer rows.Close()
+	var paths []string
+	for rows.Next() {
+		var p string
+		require.NoError(t, rows.Scan(&p))
+		paths = append(paths, p)
+	}
+	require.NoError(t, rows.Err())
+	return paths
+}
+
+// A .md file OUTSIDE the ontology root is not a fact, however well-formed its
+// contents happen to be. kb.md is the live case: it is the repo's root manifest
+// and its content is user-editable through PATCH /repos/{repo}, so "does this
+// parse as a fact" is an attacker-/user-controlled question and cannot be what
+// decides index membership.
+//
+// Verify already encodes the rule this test pins (checkFactsCoherence builds
+// its expected set from kb/ only), so an indexed stray is not merely noise —
+// it is reported as a "ghost" branch_facts row on the next integrity run.
+func TestIndex_SkipsFilesOutsideOntologyRoot(t *testing.T) {
+	svc, err := Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/a"))
+	ctx := context.Background()
+
+	// Frontmatter + an H1 — the ordinary shape of a markdown document, and
+	// enough for fact.ParseFact to accept it.
+	const manifest = "---\ntitle: Core manifest\n---\n\n# Core\n\nGuidance for agents.\n"
+	_, err = svc.Facts().WriteFact(ctx, "agent/a", "kb.md", manifest, "docs: manifest", "update")
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(ctx, "agent/a", "kb/obs/real.md", testFactBody("Real", 0.9, nil), "add", "")
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"kb/obs/real.md"}, indexedPaths(t, svc, "agent/a"),
+		"only files under the ontology root belong in the index")
+
+	// A rebuild must reach the same set — and must EVICT a stray that an
+	// earlier version of the indexer admitted, not merely stop adding new ones.
+	require.NoError(t, svc.IndexManager().Rebuild(ctx, "agent/a", nil))
+	require.Equal(t, []string{"kb/obs/real.md"}, indexedPaths(t, svc, "agent/a"),
+		"rebuild must not re-admit files outside the ontology root")
+
+	// The whole point: the tree and the index agree, so Verify is clean.
+	report, err := svc.Verify(ctx, VerifyOpts{Deep: true})
+	require.NoError(t, err)
+	for _, iss := range report.Issues {
+		require.NotEqual(t, CategoryFactsCoherence, iss.Category,
+			"stray index row would surface here as a ghost: %+v", iss)
+	}
+}
+
+// Deleting a stray still evicts it through the INCREMENTAL sync path. The scope
+// filter guards what goes IN; extending it to deletions would strand rows an
+// older build (or a previous ontology root) had already admitted, since a
+// filtered delete never reaches si.delete.
+func TestIndex_DeleteEvictsPathOutsideOntologyRoot(t *testing.T) {
+	svc, err := Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/a"))
+	ctx := context.Background()
+
+	// A file outside the root, in the tree but (correctly) not indexed...
+	_, err = svc.Facts().WriteFact(ctx, "agent/a", "stray.md", testFactBody("Stray", 0.9, nil), "add", "")
+	require.NoError(t, err)
+	// ...and the legacy state we have to be able to repair: a branch_facts row
+	// for it, left behind by a build that indexed on parseability alone. The
+	// fact_id is borrowed from a real fact — only the stray PATH matters here,
+	// and the FK has to point somewhere.
+	_, err = svc.Facts().WriteFact(ctx, "agent/a", "kb/obs/real.md", testFactBody("Real", 0.9, nil), "add", "")
+	require.NoError(t, err)
+	_, err = svc.rh.db.ExecContext(ctx,
+		`INSERT INTO branch_facts(branch_id, path, fact_id, commit_hash)
+		 SELECT b.id, 'stray.md', f.id, ''
+		 FROM branches b, facts f WHERE b.name = ? AND f.path = 'kb/obs/real.md'`, "agent/a")
+	require.NoError(t, err)
+	require.Contains(t, indexedPaths(t, svc, "agent/a"), "stray.md", "precondition: legacy row present")
+
+	// Removing the file drives the incremental sync's delete branch.
+	_, err = svc.Facts().DeleteFact(ctx, "agent/a", "stray.md", "remove stray")
+	require.NoError(t, err)
+	require.NotContains(t, indexedPaths(t, svc, "agent/a"), "stray.md",
+		"a delete outside the ontology root must still evict the row")
+}
+
+// The root is the CONFIGURED one, not the literal "kb": a deployment with
+// ontology_root = "knowledge" must index that tree and skip kb/.
+func TestIndex_HonoursConfiguredOntologyRoot(t *testing.T) {
+	svc, err := Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	svc.SetOntologyRoot("knowledge")
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/a"))
+	ctx := context.Background()
+
+	_, err = svc.Facts().WriteFact(ctx, "agent/a", "knowledge/obs/a.md", testFactBody("A", 0.9, nil), "add", "")
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(ctx, "agent/a", "kb/obs/b.md", testFactBody("B", 0.9, nil), "add", "")
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"knowledge/obs/a.md"}, indexedPaths(t, svc, "agent/a"))
+}

--- a/internal/store/search_index.go
+++ b/internal/store/search_index.go
@@ -291,6 +291,12 @@ func (si *searchIndex) Sync(ctx context.Context, branch string) error {
 			return fmt.Errorf("sync: list all: %w", err)
 		}
 		for _, path := range paths {
+			// Facts live under the ontology root; nothing else is one, whatever
+			// it parses as (isFactPath). Skipping here also spares the blob read
+			// and the per-path git log indexFile would do before rejecting it.
+			if !si.rh.isFactPath(path) {
+				continue
+			}
 			rec, err := si.indexFile(ctx, branch, path, head)
 			if err != nil {
 				return err
@@ -311,6 +317,9 @@ func (si *searchIndex) Sync(ctx context.Context, branch string) error {
 			Int("added", len(added)).Int("modified", len(modified)).Int("deleted", len(deleted)).
 			Msg("index sync: incremental update")
 		for _, path := range append(added, modified...) {
+			if !si.rh.isFactPath(path) {
+				continue
+			}
 			rec, err := si.indexFile(ctx, branch, path, head)
 			if err != nil {
 				return err
@@ -319,6 +328,10 @@ func (si *searchIndex) Sync(ctx context.Context, branch string) error {
 				indexed = append(indexed, *rec)
 			}
 		}
+		// Deletions are deliberately NOT scope-filtered. The filter guards what
+		// goes IN; a row admitted by an older build (or under a previous
+		// ontology root) must still be evictable when its file disappears, and
+		// deleting a path that was never indexed is a no-op anyway.
 		for _, path := range deleted {
 			if err := si.delete(ctx, branch, path); err != nil {
 				return fmt.Errorf("sync: delete %q: %w", path, err)
@@ -676,7 +689,14 @@ func (si *searchIndex) rebuildFacts(ctx context.Context, branch, head string, pr
 	}
 	defer stmt.Close()
 
+	// Only the ontology root is a candidate (isFactPath). _rebuild_entries is
+	// also the set the branch_facts repopulate below is driven from, so scoping
+	// it here is what EVICTS a stray admitted by an older build — a rebuild is
+	// the repair path for an index that outran the rule.
 	for i := range paths {
+		if !si.rh.isFactPath(paths[i]) {
+			continue
+		}
 		if _, err := stmt.ExecContext(ctx, paths[i], hashes[i]); err != nil {
 			return 0, fmt.Errorf("rebuildFacts: insert entry %s: %w", paths[i], err)
 		}

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -291,6 +291,18 @@ func (s *Service) SetCrypt(c *Crypt) { s.ri.crypt = c }
 // time and re-applied on SwapStore reopen (store.Open does not restore it).
 func (s *Service) SetNetworkTimeout(d time.Duration) { s.rh.netTimeout = d }
 
+// SetOntologyRoot sets the directory facts live under — the only part of the
+// tree the index admits (see isFactPath). Wired from cfg.OntologyRoot by the
+// repos builder at open time and re-applied on SwapStore reopen, exactly like
+// SetNetworkTimeout; store.Open does not restore it, and an unset root falls
+// back to the package default. Surrounding slashes are trimmed so "kb", "kb/"
+// and "/kb" all name the same root.
+//
+// Changing the root does NOT re-scope an existing index: rows admitted under
+// the previous root survive until the next Rebuild, which repopulates from the
+// tree under the new one.
+func (s *Service) SetOntologyRoot(root string) { s.rh.factRoot = strings.Trim(root, "/") }
+
 // Remote returns the RemoteIndex for git remote configuration and sync.
 func (s *Service) Remote() RemoteIndex { return s.ri }
 

--- a/internal/store/verify.go
+++ b/internal/store/verify.go
@@ -447,7 +447,10 @@ func (s *Service) checkFactsCoherence(ctx context.Context, branch string) []Inte
 	}
 	treeMap := make(map[string]string, len(treePaths))
 	for i, p := range treePaths {
-		if !strings.HasPrefix(p, "kb/") || !strings.HasSuffix(p, ".md") {
+		// Same predicate the indexer admits paths by, so "what Verify expects"
+		// and "what the index holds" cannot drift — and a custom ontology_root
+		// is honoured by both rather than only by the writer.
+		if !s.rh.isFactPath(p) {
 			continue
 		}
 		treeMap[p] = treeBlobs[i]
@@ -710,7 +713,7 @@ func (s *Service) checkFactFormat(ctx context.Context, branch string) []Integrit
 	}
 
 	for _, p := range treePaths {
-		if !strings.HasPrefix(p, "kb/") || !strings.HasSuffix(p, ".md") {
+		if !s.rh.isFactPath(p) {
 			continue
 		}
 		content, err := s.rh.readFile(ctx, branch, p)

--- a/internal/web/handlers_repos_hal.go
+++ b/internal/web/handlers_repos_hal.go
@@ -11,13 +11,8 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"knomit/internal/repos"
-	"knomit/internal/store"
 	"knomit/internal/web/hal"
 )
-
-// errRepoStoreUnavailable is returned when a repo's git store is not open, so
-// its kb.md manifest can be neither read nor written.
-var errRepoStoreUnavailable = errors.New("repo store unavailable")
 
 // repoSummary is the minimal shape for an item inside the /repos collection.
 // Per hard rule §3 #7, embedded items carry only _links.self (plus minimal
@@ -63,23 +58,12 @@ func handleHALRepos(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
 // readKBManifest returns the verbatim content of kb.md at the root of the
 // repo's git store, read at HEAD (the agent branch tip). It returns "" if the
 // store is not yet open, the branch is unknown, or kb.md does not exist — all
-// non-fatal: the repo simply has no description to surface.
+// non-fatal for a view: the repo simply has no description to surface.
 func readKBManifest(r *http.Request, ri *repos.RepoInstance) string {
-	branch := ri.AgentBranch()
-	if branch == "" {
+	content, err := ri.ReadKBManifest(r.Context())
+	if err != nil {
 		return ""
 	}
-	var content string
-	ri.WithRead(func(svc *store.Service) {
-		if svc == nil {
-			return
-		}
-		res, err := svc.Facts().ReadFact(r.Context(), branch, "kb.md", nil)
-		if err != nil {
-			return
-		}
-		content = res.Content
-	})
 	return content
 }
 
@@ -167,36 +151,20 @@ func handleHALRepo(b hal.URLBuilder) http.HandlerFunc {
 	}
 }
 
-// MaxRepoDescriptionBytes caps a repo description. It is deliberately far
-// larger than MaxLensDescriptionBytes: a lens description is a one-line note
-// about a read union, whereas kb.md is a repo's root manifest and routinely
-// runs to several pages of guidance for the agents reading it.
-const MaxRepoDescriptionBytes = 64 * 1024
-
 // patchRepoRequest is the PATCH /repos/{repo} body. Only description is
 // editable — name, id and agent_branch are all derived from the repo itself.
-// A pointer distinguishes "omitted" (keep) from "" (clear the manifest).
+// A pointer distinguishes "omitted" (keep) from "" (empty the manifest).
 type patchRepoRequest struct {
 	Description *string `json:"description"`
 }
 
-// writeKBManifest commits `content` to kb.md at the root of the repo's git
-// store on the agent branch — the exact file and branch readKBManifest reads,
-// so an edit round-trips through GET. kb.md is not a fact: the search indexer
-// skips it as unparseable (see search_index.go), so this only moves the file
-// and its commit-log entry, never the fact index.
-func writeKBManifest(r *http.Request, ri *repos.RepoInstance, branch, content string) error {
-	var err error
-	ri.WithRead(func(svc *store.Service) {
-		if svc == nil {
-			err = errRepoStoreUnavailable
-			return
-		}
-		_, err = svc.Facts().WriteFact(r.Context(), branch, "kb.md",
-			content, "docs: update kb.md root manifest", "update")
-	})
-	return err
-}
+// maxRepoPatchBodyBytes bounds what the decoder will buffer, so the size check
+// on the decoded description is not preceded by an unbounded read. The headroom
+// over MaxRepoDescriptionBytes covers JSON escaping: a control character costs
+// 6 bytes on the wire (\u00XX), so 8× can never reject a description the
+// content cap would have accepted — this limit only stops bodies that are
+// nowhere near a legitimate manifest.
+const maxRepoPatchBodyBytes = 8 * repos.MaxRepoDescriptionBytes
 
 // handleHALRepoPatch serves PATCH /api/v1/repos/{repo}. It edits the repo's
 // description by committing kb.md on the agent branch, then returns the same
@@ -207,8 +175,15 @@ func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 		name := chi.URLParam(r, "repo")
 		ri := repos.RepoFromContext(r.Context())
 
+		r.Body = http.MaxBytesReader(w, r.Body, maxRepoPatchBodyBytes)
 		var req patchRepoRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				hal.WriteProblem(w, http.StatusRequestEntityTooLarge, "Request body too large",
+					fmt.Sprintf("the request body exceeds %d bytes", maxRepoPatchBodyBytes), r.URL.Path)
+				return
+			}
 			hal.WriteProblem(w, http.StatusBadRequest, "Invalid request body", err.Error(), r.URL.Path)
 			return
 		}
@@ -217,22 +192,26 @@ func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 			hal.WriteHAL(w, http.StatusOK, repoView(b, r, name, ri))
 			return
 		}
-		if len(*req.Description) > MaxRepoDescriptionBytes {
-			hal.WriteProblem(w, http.StatusUnprocessableEntity, "Repo description too long",
-				fmt.Sprintf("description is %d bytes; the maximum is %d",
-					len(*req.Description), MaxRepoDescriptionBytes), r.URL.Path)
-			return
-		}
-		branch := ri.AgentBranch()
-		if branch == "" {
-			hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
-				"the repo has no agent branch yet", r.URL.Path)
-			return
-		}
-		if err := writeKBManifest(r, ri, branch, *req.Description); err != nil {
-			log.Error().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write kb.md failed")
-			hal.WriteProblem(w, http.StatusInternalServerError, "Update failed",
-				"could not write the repo description", r.URL.Path)
+		// The cap, the branch check and the unchanged-content skip all live in
+		// WriteKBManifest, so every writer of kb.md gets them; this maps its
+		// errors onto status codes.
+		if _, err := ri.WriteKBManifest(r.Context(), *req.Description); err != nil {
+			switch {
+			case errors.Is(err, repos.ErrRepoDescriptionTooLong):
+				hal.WriteProblem(w, http.StatusUnprocessableEntity, "Repo description too long",
+					err.Error(), r.URL.Path)
+			case errors.Is(err, repos.ErrAgentBranchUnset):
+				hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
+					"the repo has no agent branch yet", r.URL.Path)
+			case errors.Is(err, repos.ErrRepoClosed), errors.Is(err, repos.ErrStoreUnavailable):
+				log.Warn().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write kb.md: store not available")
+				hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
+					"the repo's store is not available; try again", r.URL.Path)
+			default:
+				log.Error().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write kb.md failed")
+				hal.WriteProblem(w, http.StatusInternalServerError, "Update failed",
+					"could not write the repo description", r.URL.Path)
+			}
 			return
 		}
 		hal.WriteHAL(w, http.StatusOK, repoView(b, r, name, ri))

--- a/internal/web/handlers_repos_hal.go
+++ b/internal/web/handlers_repos_hal.go
@@ -1,15 +1,23 @@
 package web
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
 
 	"knomit/internal/repos"
 	"knomit/internal/store"
 	"knomit/internal/web/hal"
 )
+
+// errRepoStoreUnavailable is returned when a repo's git store is not open, so
+// its kb.md manifest can be neither read nor written.
+var errRepoStoreUnavailable = errors.New("repo store unavailable")
 
 // repoSummary is the minimal shape for an item inside the /repos collection.
 // Per hard rule §3 #7, embedded items carry only _links.self (plus minimal
@@ -122,32 +130,111 @@ func handleHALReposRescan(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
 	}
 }
 
+// repoView builds the single-repo body. GET and PATCH share it so a write's
+// response is byte-identical to a subsequent read — the client never has to
+// reconcile two shapes for the same resource.
+func repoView(b hal.URLBuilder, r *http.Request, name string, ri *repos.RepoInstance) map[string]any {
+	// Read the branch from the instance so the advertised agent_branch and
+	// the branch readKBManifest reads kb.md from can never drift apart.
+	branch := ri.AgentBranch()
+	a := hal.Anchor{Branch: branch}
+	body := map[string]any{
+		"name":         name,
+		"id":           ri.ShortID(),
+		"agent_branch": branch,
+		"_links": hal.LinkMap{
+			"self":     {Href: b.Repo(name)},
+			"branches": {Href: b.Branches(name)},
+			"mcp":      {Href: b.Branch(name, a) + "/mcp{?profile}", Templated: true},
+		},
+	}
+	// description is the verbatim kb.md root manifest read at HEAD (the
+	// repo's agent branch tip — HEAD points there). Omitted when the
+	// store is unreadable or kb.md is absent, so the UI shows it only
+	// when available.
+	if desc := readKBManifest(r, ri); desc != "" {
+		body["description"] = desc
+	}
+	return body
+}
+
 // handleHALRepo serves GET /api/v1/repos/{repo}.
 func handleHALRepo(b hal.URLBuilder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := chi.URLParam(r, "repo")
 		ri := repos.RepoFromContext(r.Context())
-		// Read the branch from the instance so the advertised agent_branch and
-		// the branch readKBManifest reads kb.md from can never drift apart.
+		hal.WriteHAL(w, http.StatusOK, repoView(b, r, name, ri))
+	}
+}
+
+// MaxRepoDescriptionBytes caps a repo description. It is deliberately far
+// larger than MaxLensDescriptionBytes: a lens description is a one-line note
+// about a read union, whereas kb.md is a repo's root manifest and routinely
+// runs to several pages of guidance for the agents reading it.
+const MaxRepoDescriptionBytes = 64 * 1024
+
+// patchRepoRequest is the PATCH /repos/{repo} body. Only description is
+// editable — name, id and agent_branch are all derived from the repo itself.
+// A pointer distinguishes "omitted" (keep) from "" (clear the manifest).
+type patchRepoRequest struct {
+	Description *string `json:"description"`
+}
+
+// writeKBManifest commits `content` to kb.md at the root of the repo's git
+// store on the agent branch — the exact file and branch readKBManifest reads,
+// so an edit round-trips through GET. kb.md is not a fact: the search indexer
+// skips it as unparseable (see search_index.go), so this only moves the file
+// and its commit-log entry, never the fact index.
+func writeKBManifest(r *http.Request, ri *repos.RepoInstance, branch, content string) error {
+	var err error
+	ri.WithRead(func(svc *store.Service) {
+		if svc == nil {
+			err = errRepoStoreUnavailable
+			return
+		}
+		_, err = svc.Facts().WriteFact(r.Context(), branch, "kb.md",
+			content, "docs: update kb.md root manifest", "update")
+	})
+	return err
+}
+
+// handleHALRepoPatch serves PATCH /api/v1/repos/{repo}. It edits the repo's
+// description by committing kb.md on the agent branch, then returns the same
+// view GET does — re-read from git, so the response reflects what was actually
+// persisted rather than what was requested.
+func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name := chi.URLParam(r, "repo")
+		ri := repos.RepoFromContext(r.Context())
+
+		var req patchRepoRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid request body", err.Error(), r.URL.Path)
+			return
+		}
+		// Nothing to do — an empty patch is a successful no-op, not an error.
+		if req.Description == nil {
+			hal.WriteHAL(w, http.StatusOK, repoView(b, r, name, ri))
+			return
+		}
+		if len(*req.Description) > MaxRepoDescriptionBytes {
+			hal.WriteProblem(w, http.StatusUnprocessableEntity, "Repo description too long",
+				fmt.Sprintf("description is %d bytes; the maximum is %d",
+					len(*req.Description), MaxRepoDescriptionBytes), r.URL.Path)
+			return
+		}
 		branch := ri.AgentBranch()
-		a := hal.Anchor{Branch: branch}
-		body := map[string]any{
-			"name":         name,
-			"id":           ri.ShortID(),
-			"agent_branch": branch,
-			"_links": hal.LinkMap{
-				"self":     {Href: b.Repo(name)},
-				"branches": {Href: b.Branches(name)},
-				"mcp":      {Href: b.Branch(name, a) + "/mcp{?profile}", Templated: true},
-			},
+		if branch == "" {
+			hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
+				"the repo has no agent branch yet", r.URL.Path)
+			return
 		}
-		// description is the verbatim kb.md root manifest read at HEAD (the
-		// repo's agent branch tip — HEAD points there). Omitted when the
-		// store is unreadable or kb.md is absent, so the UI shows it only
-		// when available.
-		if desc := readKBManifest(r, ri); desc != "" {
-			body["description"] = desc
+		if err := writeKBManifest(r, ri, branch, *req.Description); err != nil {
+			log.Error().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write kb.md failed")
+			hal.WriteProblem(w, http.StatusInternalServerError, "Update failed",
+				"could not write the repo description", r.URL.Path)
+			return
 		}
-		hal.WriteHAL(w, http.StatusOK, body)
+		hal.WriteHAL(w, http.StatusOK, repoView(b, r, name, ri))
 	}
 }

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -489,6 +489,16 @@ func TestHandleHALRepos_IncludesRescanLink(t *testing.T) {
 // kb.md holds the default root manifest, and returns its API router.
 func newRepoPatchServer(t *testing.T) http.Handler {
 	t.Helper()
+	r, _ := newRepoPatchServerWithManager(t)
+	return r
+}
+
+// newRepoPatchServerWithManager is newRepoPatchServer for tests that must also
+// reach past HTTP — asserting on the git ref itself, which no read endpoint
+// exposes unfiltered (the commits list is scoped to the ontology root, so a
+// root-level kb.md commit never appears there).
+func newRepoPatchServerWithManager(t *testing.T) (http.Handler, *repos.Manager) {
+	t.Helper()
 	home := t.TempDir()
 	m := repos.New(context.Background(), repos.Deps{
 		Cfg:                   config.Config{Home: home, ClusterCache: config.ClusterCacheConfig{}},
@@ -504,7 +514,7 @@ func newRepoPatchServer(t *testing.T) http.Handler {
 		t.Fatalf("rescan: %v", err)
 	}
 	s := &Server{Manager: m, AgentBranch: "machine/test"}
-	return s.NewAPIRouter()
+	return s.NewAPIRouter(), m
 }
 
 func patchRepo(t *testing.T, r http.Handler, repo, body string) *httptest.ResponseRecorder {
@@ -607,7 +617,7 @@ func TestHandleHALRepoPatch_RejectsOversizeDescription(t *testing.T) {
 	r := newRepoPatchServer(t)
 	before := repoDescription(t, r, "work")
 
-	body := mustJSON(t, map[string]any{"description": strings.Repeat("x", MaxRepoDescriptionBytes+1)})
+	body := mustJSON(t, map[string]any{"description": strings.Repeat("x", repos.MaxRepoDescriptionBytes+1)})
 	rec := patchRepo(t, r, "work", body)
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
@@ -617,10 +627,74 @@ func TestHandleHALRepoPatch_RejectsOversizeDescription(t *testing.T) {
 	}
 
 	// Exactly at the cap is accepted.
-	atCap := mustJSON(t, map[string]any{"description": strings.Repeat("x", MaxRepoDescriptionBytes)})
+	atCap := mustJSON(t, map[string]any{"description": strings.Repeat("x", repos.MaxRepoDescriptionBytes)})
 	if rec := patchRepo(t, r, "work", atCap); rec.Code != http.StatusOK {
 		t.Fatalf("at-cap status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
+}
+
+// A body far larger than any legitimate manifest is refused by the reader
+// before it is buffered, as a 413 rather than a decode error.
+func TestHandleHALRepoPatch_RejectsOversizeBody(t *testing.T) {
+	r := newRepoPatchServer(t)
+	body := mustJSON(t, map[string]any{"description": strings.Repeat("x", maxRepoPatchBodyBytes+1)})
+	if rec := patchRepo(t, r, "work", body); rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status: got %d, want 413; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// Re-saving byte-identical content must not append an empty commit: the store's
+// write path always builds a fresh commit object, so an unchanged Save would
+// otherwise grow the agent branch (and push) for nothing.
+func TestHandleHALRepoPatch_UnchangedDescriptionMakesNoCommit(t *testing.T) {
+	r, m := newRepoPatchServerWithManager(t)
+
+	const md = "# Work\n\nManifest.\n"
+	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": md})); rec.Code != http.StatusOK {
+		t.Fatalf("seed PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	before := repoHeadCommit(t, m, "work")
+
+	// Same bytes again — accepted, but the branch tip must not move.
+	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": md})); rec.Code != http.StatusOK {
+		t.Fatalf("no-op PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoHeadCommit(t, m, "work"); got != before {
+		t.Errorf("unchanged description committed: HEAD moved %s → %s", before, got)
+	}
+	if got := repoDescription(t, r, "work"); got != md {
+		t.Errorf("description after no-op PATCH: got %q, want %q", got, md)
+	}
+
+	// A real change still commits.
+	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": md + "More.\n"})); rec.Code != http.StatusOK {
+		t.Fatalf("changed PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoHeadCommit(t, m, "work"); got == before {
+		t.Error("a changed description must produce a commit; HEAD did not move")
+	}
+}
+
+// repoHeadCommit returns the agent branch's tip commit hash straight from the
+// store, so a test can assert whether a request produced a commit.
+func repoHeadCommit(t *testing.T, m *repos.Manager, repo string) string {
+	t.Helper()
+	ri := m.Get(repo)
+	if ri == nil {
+		t.Fatalf("repo %q not registered", repo)
+	}
+	var head string
+	if err := ri.WithRead(func(svc *store.Service) {
+		h, herr := svc.Branches().HeadCommit(context.Background(), "machine/test")
+		if herr != nil {
+			t.Errorf("head commit: %v", herr)
+			return
+		}
+		head = h
+	}); err != nil {
+		t.Fatalf("with read: %v", err)
+	}
+	return head
 }
 
 // Malformed JSON is a 400, not a 500.

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -484,3 +484,166 @@ func TestHandleHALRepos_IncludesRescanLink(t *testing.T) {
 		t.Errorf("rescan href: got %q, want /api/v1/repos:rescan", rescan.Href)
 	}
 }
+
+// newRepoPatchServer boots a real manager with one on-disk repo ("work") whose
+// kb.md holds the default root manifest, and returns its API router.
+func newRepoPatchServer(t *testing.T) http.Handler {
+	t.Helper()
+	home := t.TempDir()
+	m := repos.New(context.Background(), repos.Deps{
+		Cfg:                   config.Config{Home: home, ClusterCache: config.ClusterCacheConfig{}},
+		AgentBranch:           "machine/test",
+		DisableBackgroundSync: true,
+	})
+	if err := m.Start(); err != nil {
+		t.Fatalf("manager start: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+	initRepoFile(t, home, "work")
+	if _, err := m.Rescan(); err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+	s := &Server{Manager: m, AgentBranch: "machine/test"}
+	return s.NewAPIRouter()
+}
+
+func patchRepo(t *testing.T, r http.Handler, repo, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/repos/"+repo, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func repoDescription(t *testing.T, r http.Handler, repo string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/repos/"+repo, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return body.Description
+}
+
+// A PATCHed description is committed to kb.md and is visible to the very next
+// GET — the write and the read must agree on file AND branch, or the edit
+// silently disappears.
+func TestHandleHALRepoPatch_WritesKBMdAndRoundTrips(t *testing.T) {
+	r := newRepoPatchServer(t)
+
+	const md = "# Work\n\nA **markdown** manifest.\n\n- one\n- two\n"
+	rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": md}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	// The PATCH response is the re-read view, not an echo of the request.
+	var patched struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &patched); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if patched.Name != "work" {
+		t.Errorf("name: got %q", patched.Name)
+	}
+	if patched.Description != md {
+		t.Errorf("PATCH description: got %q, want %q", patched.Description, md)
+	}
+	if got := repoDescription(t, r, "work"); got != md {
+		t.Errorf("GET after PATCH: got %q, want %q", got, md)
+	}
+}
+
+// Markdown is stored verbatim — no normalization, no trailing-newline fixups.
+func TestHandleHALRepoPatch_StoresMarkdownVerbatim(t *testing.T) {
+	r := newRepoPatchServer(t)
+	const md = "|a|b|\n|---|---|\n|1|2|"
+	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": md})); rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoDescription(t, r, "work"); got != md {
+		t.Errorf("got %q, want %q (byte-identical)", got, md)
+	}
+}
+
+// An omitted description is a no-op, not a clear — PATCH is a merge.
+func TestHandleHALRepoPatch_OmittedDescriptionKeepsCurrent(t *testing.T) {
+	r := newRepoPatchServer(t)
+	before := repoDescription(t, r, "work")
+	if before == "" {
+		t.Fatal("precondition: seeded repo should have a kb.md description")
+	}
+	if rec := patchRepo(t, r, "work", `{}`); rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoDescription(t, r, "work"); got != before {
+		t.Errorf("omitted description changed the manifest: got %q, want %q", got, before)
+	}
+}
+
+// An explicit empty string clears the manifest — the description then drops out
+// of the GET body entirely (readKBManifest treats "" as absent).
+func TestHandleHALRepoPatch_EmptyDescriptionClears(t *testing.T) {
+	r := newRepoPatchServer(t)
+	if rec := patchRepo(t, r, "work", `{"description":""}`); rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoDescription(t, r, "work"); got != "" {
+		t.Errorf("description should be cleared; got %q", got)
+	}
+}
+
+// Over-cap descriptions are refused with 422, and the stored manifest is
+// untouched — a rejected write must not partially land.
+func TestHandleHALRepoPatch_RejectsOversizeDescription(t *testing.T) {
+	r := newRepoPatchServer(t)
+	before := repoDescription(t, r, "work")
+
+	body := mustJSON(t, map[string]any{"description": strings.Repeat("x", MaxRepoDescriptionBytes+1)})
+	rec := patchRepo(t, r, "work", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoDescription(t, r, "work"); got != before {
+		t.Errorf("rejected write must not change the manifest; got %q", got)
+	}
+
+	// Exactly at the cap is accepted.
+	atCap := mustJSON(t, map[string]any{"description": strings.Repeat("x", MaxRepoDescriptionBytes)})
+	if rec := patchRepo(t, r, "work", atCap); rec.Code != http.StatusOK {
+		t.Fatalf("at-cap status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// Malformed JSON is a 400, not a 500.
+func TestHandleHALRepoPatch_RejectsMalformedBody(t *testing.T) {
+	r := newRepoPatchServer(t)
+	if rec := patchRepo(t, r, "work", `{"description":`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// An unknown repo 404s via the repo middleware, before any write is attempted.
+func TestHandleHALRepoPatch_UnknownRepo404s(t *testing.T) {
+	r := newRepoPatchServer(t)
+	if rec := patchRepo(t, r, "nope", `{"description":"x"}`); rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -111,6 +111,7 @@ func (s *Server) NewAPIRouter() chi.Router {
 			r.Use(RepoMiddleware(s.Manager))
 
 			r.Get("/", handleHALRepo(b))
+			r.Patch("/", handleHALRepoPatch(b))
 
 			r.Get("/origin", handleHALGetOrigin(b, p.origin))
 			r.Put("/origin", handleHALSetOrigin(b, s.Manager, p.origin))

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -157,8 +157,13 @@ paths:
 
         `description` is markdown and is stored byte-for-byte — no
         normalization. Omitting the field leaves the manifest unchanged; an
-        explicit empty string clears it, after which `description` is absent
-        from the response. The maximum size is 65536 bytes.
+        explicit empty string empties `kb.md` (the file stays, and
+        `description` is then absent from the response). The maximum size is
+        65536 bytes; a larger request body is refused with 413 before it is
+        read, and an over-cap description with 422.
+
+        Content identical to the current manifest is accepted but makes no
+        commit, so re-saving unchanged text does not grow the branch.
 
         The response is the re-read repository view, identical in shape to GET.
       operationId: updateRepo
@@ -181,8 +186,10 @@ paths:
               schema: { $ref: "#/components/schemas/Repo" }
         "400": { $ref: "#/components/responses/Problem" }
         "404": { $ref: "#/components/responses/Problem" }
+        "413": { $ref: "#/components/responses/Problem" }
         "422": { $ref: "#/components/responses/Problem" }
         "500": { $ref: "#/components/responses/Problem" }
+        "503": { $ref: "#/components/responses/Problem" }
     delete:
       tags: [repos]
       summary: Archive a repository

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -146,6 +146,43 @@ paths:
               schema: { $ref: "#/components/schemas/Repo" }
         "404": { $ref: "#/components/responses/Problem" }
         "500": { $ref: "#/components/responses/Problem" }
+    patch:
+      tags: [repos]
+      summary: Update repository description
+      description: |
+        Edits the repo's description, which is the verbatim content of the
+        `kb.md` root manifest. The new content is committed to `kb.md` on the
+        repo's agent branch, so the change is part of the repo's git history
+        and syncs with it.
+
+        `description` is markdown and is stored byte-for-byte — no
+        normalization. Omitting the field leaves the manifest unchanged; an
+        explicit empty string clears it, after which `description` is absent
+        from the response. The maximum size is 65536 bytes.
+
+        The response is the re-read repository view, identical in shape to GET.
+      operationId: updateRepo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  description: Markdown content for kb.md; omit to keep the current manifest.
+                  maxLength: 65536
+      responses:
+        "200":
+          description: Repository updated
+          content:
+            application/hal+json:
+              schema: { $ref: "#/components/schemas/Repo" }
+        "400": { $ref: "#/components/responses/Problem" }
+        "404": { $ref: "#/components/responses/Problem" }
+        "422": { $ref: "#/components/responses/Problem" }
+        "500": { $ref: "#/components/responses/Problem" }
     delete:
       tags: [repos]
       summary: Archive a repository

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -6,3 +6,10 @@ a { color: inherit; }
 ::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
 @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
 .icon-spin { animation: spin 1s linear infinite; display: inline-block; }
+
+/* Bare buttons (disclosure headers, card icon actions) carry no chrome of
+   their own, so the UA focus ring lands on their full width and reads as a
+   selection box. Suppress it for pointer focus; keep a real ring for keyboard
+   users via :focus-visible. */
+.k-bare:focus { outline: none; }
+.k-bare:focus-visible { outline: 2px solid #4a7ab5; outline-offset: 2px; border-radius: 4px; }

--- a/web/src/RemoteStatus.test.tsx
+++ b/web/src/RemoteStatus.test.tsx
@@ -45,6 +45,16 @@ describe('RemoteCard', () => {
     expect(screen.getByTestId('remote-disconnect')).toBeInTheDocument();
   });
 
+  // A failed load must not render as "no remote" — that state is indistinguishable
+  // from an unconnected repo, and the pane would quietly drop the remote entirely.
+  it('keeps the card and shows the error when the origin cannot be loaded', async () => {
+    (api.getOrigin as unknown as Fn).mockRejectedValueOnce(new Error('network down'));
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
+    expect(await screen.findByTestId('remote-error')).toHaveTextContent(/could not load remote status/i);
+    expect(screen.getByTestId('remote-card')).toBeInTheDocument();
+    expect(screen.getByTestId('remote-retry')).toBeInTheDocument();
+  });
+
   it('hides the card actions in read-only mode', async () => {
     (api.getOrigin as unknown as Fn).mockResolvedValueOnce({
       name: 'origin', url: 'https://github.com/knomit/knowkb.git', branch: 'main', auth_method: 'token',

--- a/web/src/RemoteStatus.test.tsx
+++ b/web/src/RemoteStatus.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { RemoteStatus } from './RemoteStatus';
+import { RemoteCard, useRemote } from './RemoteStatus';
 import { api } from './api';
 
 vi.mock('./api', () => ({
@@ -8,37 +8,40 @@ vi.mock('./api', () => ({
 }));
 type Fn = ReturnType<typeof vi.fn>;
 
-describe('RemoteStatus', () => {
+// RemoteCard is the display half of the remote; RepoDetail owns the loaded
+// state (its ⋯ menu needs it too). Harness pairs them the way RepoDetail does.
+// Disconnect now lives in that menu — covered by RepoManager.test.tsx.
+function Harness({ repo, agentBranch, readOnly, onConnect, onChanged }: {
+  repo: string; agentBranch: string; readOnly: boolean; onConnect: () => void; onChanged: () => void;
+}) {
+  const state = useRemote(repo);
+  return <RemoteCard repo={repo} agentBranch={agentBranch} readOnly={readOnly} state={state} onConnect={onConnect} onChanged={onChanged} />;
+}
+
+describe('RemoteCard', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('shows "Connect a remote" when not connected', async () => {
     (api.getOrigin as unknown as Fn).mockResolvedValueOnce(null);
     const onConnect = vi.fn();
-    render(<RemoteStatus repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={onConnect} onChanged={() => {}} />);
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={onConnect} onChanged={() => {}} />);
     const btn = await screen.findByTestId('remote-connect');
     expect(btn).toBeInTheDocument();
     fireEvent.click(btn);
     expect(onConnect).toHaveBeenCalled();
   });
 
-  it('shows status + actions when connected, and confirms before disconnecting', async () => {
+  it('shows the url and sync status when connected', async () => {
     (api.getOrigin as unknown as Fn).mockResolvedValueOnce({
       name: 'origin', url: 'https://github.com/knomit/knowkb.git', branch: 'main', auth_method: 'token',
       last_sync_at: '2026-06-11T10:00:00Z', last_status: 'ok', last_error: null,
     });
-    (api.deleteOrigin as unknown as Fn).mockResolvedValueOnce(undefined);
-    const onChanged = vi.fn();
-    render(<RemoteStatus repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={onChanged} />);
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
 
     await screen.findByText('https://github.com/knomit/knowkb.git');
     expect(screen.getByText(/last sync/)).toBeInTheDocument();
-
-    // Disconnect requires an inline confirm (no browser prompt).
-    fireEvent.click(screen.getByTestId('remote-disconnect'));
-    expect(api.deleteOrigin).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByTestId('disconnect-confirm'));
-    await waitFor(() => expect(api.deleteOrigin).toHaveBeenCalledWith('work'));
-    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    // The card is display-only: no inline disconnect affordance any more.
+    expect(screen.queryByTestId('remote-disconnect')).not.toBeInTheDocument();
   });
 
   it('renders a sync failure (status "error", not "failed") with the error text', async () => {
@@ -47,7 +50,7 @@ describe('RemoteStatus', () => {
       last_sync_at: null, last_status: 'error', last_error: 'authentication required: Invalid username or token',
       last_push_at: null, last_push_status: null, last_push_error: null,
     });
-    render(<RemoteStatus repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
     const line = await screen.findByTestId('sync-line');
     expect(line).toHaveTextContent(/sync failed/);
     expect(line).toHaveTextContent(/Invalid username or token/);
@@ -59,7 +62,7 @@ describe('RemoteStatus', () => {
       last_sync_at: '2026-06-11T10:00:00Z', last_status: 'ok', last_error: null,
       last_push_at: null, last_push_status: 'error', last_push_error: 'Permission to knomit/knomit-kb.git denied to knomit.',
     });
-    render(<RemoteStatus repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
     const line = await screen.findByTestId('push-line');
     expect(line).toHaveTextContent(/push failed/);
     expect(line).toHaveTextContent(/Permission to knomit\/knomit-kb\.git denied/);
@@ -70,7 +73,7 @@ describe('RemoteStatus', () => {
       name: 'origin', url: 'https://github.com/knomit/knomit-kb.git', branch: 'agent/host-1', auth_method: 'token',
       last_sync_at: null, last_status: null, last_error: null,
     });
-    render(<RemoteStatus repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
 
     await screen.findByTestId('upstream-warning');
     expect(screen.getByTestId('upstream-warning-icon')).toBeInTheDocument();
@@ -82,7 +85,7 @@ describe('RemoteStatus', () => {
       name: 'origin', url: 'https://github.com/knomit/knomit-kb.git', branch: 'main', auth_method: 'token',
       last_sync_at: null, last_status: null, last_error: null,
     });
-    render(<RemoteStatus repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
 
     await screen.findByText('https://github.com/knomit/knomit-kb.git');
     expect(screen.queryByTestId('upstream-warning')).not.toBeInTheDocument();
@@ -99,7 +102,7 @@ describe('RemoteStatus', () => {
     (api.listBranchNames as unknown as Fn).mockResolvedValueOnce(['main', 'agent/host-1']);
     (api.setOriginUpstream as unknown as Fn).mockResolvedValueOnce(undefined);
     const onChanged = vi.fn();
-    render(<RemoteStatus repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={onChanged} />);
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={onChanged} />);
 
     fireEvent.click(await screen.findByTestId('upstream-change'));
     const input = await screen.findByTestId('upstream-input') as HTMLInputElement;

--- a/web/src/RemoteStatus.test.tsx
+++ b/web/src/RemoteStatus.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { RemoteCard, useRemote } from './RemoteStatus';
+import { RemoteCard } from './RemoteStatus';
+import { useRemote } from './useRemote';
 import { api } from './api';
 
 vi.mock('./api', () => ({
@@ -15,23 +16,22 @@ function Harness({ repo, agentBranch, readOnly, onConnect, onChanged }: {
   repo: string; agentBranch: string; readOnly: boolean; onConnect: () => void; onChanged: () => void;
 }) {
   const state = useRemote(repo);
-  return <RemoteCard repo={repo} agentBranch={agentBranch} readOnly={readOnly} state={state} onConnect={onConnect} onChanged={onChanged} />;
+  return <RemoteCard repo={repo} agentBranch={agentBranch} readOnly={readOnly} state={state}
+    onConnect={onConnect} onDisconnect={() => {}} onChanged={onChanged} />;
 }
 
 describe('RemoteCard', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('shows "Connect a remote" when not connected', async () => {
+  // An unconnected repo has no remote state, so there is no card to show —
+  // "Connect a remote…" lives in the detail pane's ⋯ menu instead.
+  it('renders nothing when there is no remote', async () => {
     (api.getOrigin as unknown as Fn).mockResolvedValueOnce(null);
-    const onConnect = vi.fn();
-    render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={onConnect} onChanged={() => {}} />);
-    const btn = await screen.findByTestId('remote-connect');
-    expect(btn).toBeInTheDocument();
-    fireEvent.click(btn);
-    expect(onConnect).toHaveBeenCalled();
+    const { container } = render(<Harness repo="work" agentBranch="agent/host-1" readOnly={false} onConnect={() => {}} onChanged={() => {}} />);
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
-  it('shows the url and sync status when connected', async () => {
+  it('shows the url and sync status when connected, with card-local actions', async () => {
     (api.getOrigin as unknown as Fn).mockResolvedValueOnce({
       name: 'origin', url: 'https://github.com/knomit/knowkb.git', branch: 'main', auth_method: 'token',
       last_sync_at: '2026-06-11T10:00:00Z', last_status: 'ok', last_error: null,
@@ -40,7 +40,19 @@ describe('RemoteCard', () => {
 
     await screen.findByText('https://github.com/knomit/knowkb.git');
     expect(screen.getByText(/last sync/)).toBeInTheDocument();
-    // The card is display-only: no inline disconnect affordance any more.
+    // Reconnect/disconnect edit THIS card's data, so they sit on the card.
+    expect(screen.getByTestId('remote-reconnect')).toBeInTheDocument();
+    expect(screen.getByTestId('remote-disconnect')).toBeInTheDocument();
+  });
+
+  it('hides the card actions in read-only mode', async () => {
+    (api.getOrigin as unknown as Fn).mockResolvedValueOnce({
+      name: 'origin', url: 'https://github.com/knomit/knowkb.git', branch: 'main', auth_method: 'token',
+      last_sync_at: null, last_status: null, last_error: null,
+    });
+    render(<Harness repo="work" agentBranch="agent/host-1" readOnly onConnect={() => {}} onChanged={() => {}} />);
+    await screen.findByText('https://github.com/knomit/knowkb.git');
+    expect(screen.queryByTestId('remote-reconnect')).not.toBeInTheDocument();
     expect(screen.queryByTestId('remote-disconnect')).not.toBeInTheDocument();
   });
 

--- a/web/src/RemoteStatus.tsx
+++ b/web/src/RemoteStatus.tsx
@@ -1,61 +1,28 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import { api, type OriginResponse } from './api';
-import { GlobeIcon } from './icons';
-import { btn, card, cardLabel, confirmBox, linkBtn } from './manageStyles';
-
-/** RemoteState is the loaded remote for one repo. RepoDetail owns it (via
- *  useRemote) because the detail pane's ⋯ menu has to know whether a remote
- *  exists before it can offer Connect vs Reconnect/Disconnect — the card alone
- *  cannot answer that for the header. */
-export interface RemoteState {
-  origin: OriginResponse | null;
-  loading: boolean;
-  err: string;
-  setErr: (m: string) => void;
-  reload: () => void;
-}
-
-/** useRemote loads (and reloads) a repo's origin. `enabled` is false when the
- *  deployment hides remote config — the hook still runs (hooks cannot be
- *  conditional) but issues no request and reports "not connected". */
-export function useRemote(repo: string, enabled = true): RemoteState {
-  const [origin, setOrigin] = useState<OriginResponse | null>(null);
-  const [loading, setLoading] = useState(enabled);
-  const [err, setErr] = useState('');
-  const [nonce, setNonce] = useState(0);
-
-  useEffect(() => {
-    if (!enabled) return;
-    let cancelled = false;
-    setLoading(true); setErr('');
-    api.getOrigin(repo)
-      .then(o => { if (!cancelled) setOrigin(o); })
-      .catch(() => { if (!cancelled) setErr('could not load remote status'); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [repo, enabled, nonce]);
-
-  const reload = useCallback(() => setNonce(n => n + 1), []);
-  // When disabled, report "not connected, not loading" by derivation rather
-  // than by writing state from the effect — nothing was ever fetched.
-  if (!enabled) return { origin: null, loading: false, err: '', setErr, reload };
-  return { origin, loading, err, setErr, reload };
-}
+import type { RemoteState } from './useRemote';
+import { GlobeIcon, PencilIcon, UnlinkIcon } from './icons';
+import { btn, card, cardIconBtn, cardLabel, confirmBox, linkBtn } from './manageStyles';
 
 interface Props {
   repo: string;
-  agentBranch: string;     // this machine's local agent branch (for the upstream warning)
+  agentBranch: string;      // this machine's local agent branch (for the upstream warning)
   readOnly: boolean;
   state: RemoteState;
-  onConnect: () => void;   // open the connect wizard
-  onChanged: () => void;   // remote changed (e.g. upstream) — parent refresh
+  onConnect: () => void;    // open the connect wizard
+  onDisconnect: () => void; // ask RepoDetail to run its disconnect confirm
+  onChanged: () => void;    // remote changed (e.g. upstream) — parent refresh
 }
 
-// RemoteCard is the read-only remote card in the Repo Manager detail pane. It
-// never edits the remote inline except for the upstream branch (an edit of a
-// value it already displays); connecting/changing goes through the wizard and
-// Disconnect lives in RepoDetail's ⋯ menu alongside the other repo actions.
-export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onChanged }: Props) {
+// RemoteCard is the remote's state card in the Repo Manager detail pane. It
+// renders ONLY for a repo that has a remote — an unconnected repo has no remote
+// state worth a card, so "Connect a remote…" lives in the pane's ⋯ menu instead
+// of as a permanent call-to-action.
+//
+// Its two actions are card-local icon buttons rather than pane-level menu
+// items, because they edit the connection this card describes. The pane's ⋯
+// menu is reserved for whole-repo actions (rebuild, archive).
+export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onDisconnect, onChanged }: Props) {
   const { origin, loading, err, setErr, reload } = state;
   const [busy, setBusy] = useState(false);
   const [editingUpstream, setEditingUpstream] = useState(false);
@@ -64,6 +31,11 @@ export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onCh
 
   // No reset-on-repo-switch effect is needed: RepoDetail is keyed by repo name,
   // so switching repos remounts this card and the editor starts closed.
+
+  // No remote and nothing in flight — there is no state to show. RepoDetail
+  // already skips rendering this card in that case; returning null keeps the
+  // component honest if it is ever mounted directly.
+  if (!loading && !origin) return null;
 
   // upstream == this machine's agent branch is a degenerate config: pulls are
   // disabled (push-only) to avoid force-resetting unpushed facts. Warn + offer
@@ -95,23 +67,30 @@ export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onCh
 
   return (
     <div style={card}>
-      <div style={{ ...cardLabel, display: 'flex', alignItems: 'center', gap: 6 }}>
-        <GlobeIcon color="#555" size={11} /> Remote
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <div style={{ ...cardLabel, marginBottom: 0, display: 'flex', alignItems: 'center', gap: 6 }}>
+          <GlobeIcon color="#555" size={11} /> Remote
+        </div>
+        {!loading && origin && !readOnly && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <button type="button" className="k-bare" data-testid="remote-reconnect"
+              title="Reconnect / change remote" aria-label="Reconnect or change remote"
+              style={cardIconBtn} onClick={onConnect}>
+              <PencilIcon color="#888" size={13} />
+            </button>
+            <button type="button" className="k-bare" data-testid="remote-disconnect"
+              title="Disconnect remote" aria-label="Disconnect remote"
+              style={cardIconBtn} onClick={onDisconnect}>
+              <UnlinkIcon color="#a66" size={13} />
+            </button>
+          </div>
+        )}
       </div>
 
-      {loading && <div style={muted}>Loading…</div>}
-
-      {!loading && !origin && (
-        <>
-          <div style={muted}>Not connected to a remote — this is a local-only knowledge base.</div>
-          <button type="button" data-testid="remote-connect" style={btn(readOnly, 'primary')} disabled={readOnly} onClick={onConnect}>
-            Connect a remote…
-          </button>
-        </>
-      )}
+      {loading && <div style={{ ...muted, marginTop: 6 }}>Loading…</div>}
 
       {!loading && origin && (
-        <>
+        <div style={{ marginTop: 6 }}>
           <div style={{ fontSize: 13, color: '#ddd', wordBreak: 'break-all' }}>{origin.url}</div>
           <div style={{ fontSize: 12, color: upstreamIsAgent ? '#e0a23a' : '#888', marginTop: 2, display: 'flex', alignItems: 'center', gap: 6 }}>
             {upstreamIsAgent && <span data-testid="upstream-warning-icon" title="Upstream is this agent branch" aria-label="warning">⚠</span>}
@@ -155,7 +134,7 @@ export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onCh
 
           <SyncLine o={origin} />
           <PushLine o={origin} />
-        </>
+        </div>
       )}
 
       {err && <div style={{ color: '#f88', fontSize: 13, marginTop: 8 }}>{err}</div>}

--- a/web/src/RemoteStatus.tsx
+++ b/web/src/RemoteStatus.tsx
@@ -1,47 +1,69 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { api, type OriginResponse } from './api';
+import { GlobeIcon } from './icons';
+import { btn, card, cardLabel, confirmBox, linkBtn } from './manageStyles';
 
-interface Props {
-  repo: string;
-  agentBranch: string;     // this machine's local agent branch (for the upstream warning)
-  readOnly: boolean;
-  onConnect: () => void;   // open the connect wizard
-  onChanged: () => void;   // remote changed (e.g. disconnected) — parent refresh
+/** RemoteState is the loaded remote for one repo. RepoDetail owns it (via
+ *  useRemote) because the detail pane's ⋯ menu has to know whether a remote
+ *  exists before it can offer Connect vs Reconnect/Disconnect — the card alone
+ *  cannot answer that for the header. */
+export interface RemoteState {
+  origin: OriginResponse | null;
+  loading: boolean;
+  err: string;
+  setErr: (m: string) => void;
+  reload: () => void;
 }
 
-// RemoteStatus is the read-only remote panel in the Repo Manager detail pane.
-// It never edits the remote inline — connecting/changing always goes through
-// the wizard (onConnect); the only inline mutation is Disconnect.
-export function RemoteStatus({ repo, agentBranch, readOnly, onConnect, onChanged }: Props) {
+/** useRemote loads (and reloads) a repo's origin. `enabled` is false when the
+ *  deployment hides remote config — the hook still runs (hooks cannot be
+ *  conditional) but issues no request and reports "not connected". */
+export function useRemote(repo: string, enabled = true): RemoteState {
   const [origin, setOrigin] = useState<OriginResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [confirming, setConfirming] = useState(false);
-  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(enabled);
   const [err, setErr] = useState('');
-  const [editingUpstream, setEditingUpstream] = useState(false);
-  const [branchChoices, setBranchChoices] = useState<string[]>([]);
-  const [newUpstream, setNewUpstream] = useState('');
+  const [nonce, setNonce] = useState(0);
 
-  const loadOrigin = () => {
+  useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
-    setLoading(true); setErr(''); setConfirming(false); setEditingUpstream(false);
+    setLoading(true); setErr('');
     api.getOrigin(repo)
       .then(o => { if (!cancelled) setOrigin(o); })
       .catch(() => { if (!cancelled) setErr('could not load remote status'); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  };
-  useEffect(loadOrigin, [repo]);
+  }, [repo, enabled, nonce]);
 
-  const disconnect = async () => {
-    setErr(''); setBusy(true);
-    try {
-      await api.deleteOrigin(repo);
-      setOrigin(null); setConfirming(false);
-      onChanged();
-    } catch (e) { setErr(String(e)); }
-    finally { setBusy(false); }
-  };
+  const reload = useCallback(() => setNonce(n => n + 1), []);
+  // When disabled, report "not connected, not loading" by derivation rather
+  // than by writing state from the effect — nothing was ever fetched.
+  if (!enabled) return { origin: null, loading: false, err: '', setErr, reload };
+  return { origin, loading, err, setErr, reload };
+}
+
+interface Props {
+  repo: string;
+  agentBranch: string;     // this machine's local agent branch (for the upstream warning)
+  readOnly: boolean;
+  state: RemoteState;
+  onConnect: () => void;   // open the connect wizard
+  onChanged: () => void;   // remote changed (e.g. upstream) — parent refresh
+}
+
+// RemoteCard is the read-only remote card in the Repo Manager detail pane. It
+// never edits the remote inline except for the upstream branch (an edit of a
+// value it already displays); connecting/changing goes through the wizard and
+// Disconnect lives in RepoDetail's ⋯ menu alongside the other repo actions.
+export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onChanged }: Props) {
+  const { origin, loading, err, setErr, reload } = state;
+  const [busy, setBusy] = useState(false);
+  const [editingUpstream, setEditingUpstream] = useState(false);
+  const [branchChoices, setBranchChoices] = useState<string[]>([]);
+  const [newUpstream, setNewUpstream] = useState('');
+
+  // No reset-on-repo-switch effect is needed: RepoDetail is keyed by repo name,
+  // so switching repos remounts this card and the editor starts closed.
 
   // upstream == this machine's agent branch is a degenerate config: pulls are
   // disabled (push-only) to avoid force-resetting unpushed facts. Warn + offer
@@ -65,21 +87,23 @@ export function RemoteStatus({ repo, agentBranch, readOnly, onConnect, onChanged
     try {
       await api.setOriginUpstream(repo, newUpstream);
       setEditingUpstream(false);
-      loadOrigin();
+      reload();
       onChanged();
     } catch (e) { setErr(String(e)); }
     finally { setBusy(false); }
   };
 
   return (
-    <div style={{ marginTop: 20 }}>
-      <div style={sectionLabel}>Remote</div>
+    <div style={card}>
+      <div style={{ ...cardLabel, display: 'flex', alignItems: 'center', gap: 6 }}>
+        <GlobeIcon color="#555" size={11} /> Remote
+      </div>
 
       {loading && <div style={muted}>Loading…</div>}
 
       {!loading && !origin && (
         <>
-          <div style={muted}>Not connected to a remote.</div>
+          <div style={muted}>Not connected to a remote — this is a local-only knowledge base.</div>
           <button type="button" data-testid="remote-connect" style={btn(readOnly, 'primary')} disabled={readOnly} onClick={onConnect}>
             Connect a remote…
           </button>
@@ -97,6 +121,9 @@ export function RemoteStatus({ repo, agentBranch, readOnly, onConnect, onChanged
             )}
           </div>
 
+          {/* The degenerate-upstream warning is load-bearing (it explains why
+              pulls silently stop) and therefore never lives behind a collapsed
+              section — see kb/gotchas/repos/remote-sync/ed75e605.md. */}
           {upstreamIsAgent && !editingUpstream && (
             <div data-testid="upstream-warning" style={warnBox}>
               ⚠ The consensus (“main”) branch is set to this machine’s agent branch, so remote
@@ -128,23 +155,6 @@ export function RemoteStatus({ repo, agentBranch, readOnly, onConnect, onChanged
 
           <SyncLine o={origin} />
           <PushLine o={origin} />
-
-          {!confirming && (
-            <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
-              <button type="button" data-testid="remote-reconnect" style={btn(readOnly)} disabled={readOnly} onClick={onConnect}>Reconnect / change</button>
-              <button type="button" data-testid="remote-disconnect" style={btn(readOnly, 'danger')} disabled={readOnly} onClick={() => setConfirming(true)}>Disconnect</button>
-            </div>
-          )}
-
-          {confirming && (
-            <div style={confirmBox}>
-              <div style={{ fontSize: 13, marginBottom: 10 }}>Stop syncing and remove this remote? The repo stays as a local-only knowledge base — no facts are deleted.</div>
-              <div style={{ display: 'flex', gap: 8 }}>
-                <button type="button" data-testid="disconnect-confirm" style={btn(busy, 'danger')} disabled={busy} onClick={disconnect}>{busy ? 'Disconnecting…' : 'Disconnect'}</button>
-                <button type="button" style={btn(busy)} disabled={busy} onClick={() => setConfirming(false)}>Cancel</button>
-              </div>
-            </div>
-          )}
         </>
       )}
 
@@ -188,12 +198,5 @@ function PushLine({ o }: { o: OriginResponse }) {
   return null;
 }
 
-const sectionLabel: React.CSSProperties = { fontSize: 13, color: '#888', textTransform: 'uppercase', borderBottom: '1px solid #222', paddingBottom: 6, marginBottom: 12 };
-const muted: React.CSSProperties = { fontSize: 13, color: '#888', marginBottom: 12 };
-const confirmBox: React.CSSProperties = { marginTop: 14, padding: 14, background: '#111', border: '1px solid #333', borderRadius: 6 };
+const muted: React.CSSProperties = { fontSize: 13, color: '#888', marginBottom: 10 };
 const warnBox: React.CSSProperties = { marginTop: 8, padding: 10, background: '#2a210e', border: '1px solid #5c4a1a', borderRadius: 6, fontSize: 12, color: '#e8c98a', lineHeight: 1.5 };
-const linkBtn: React.CSSProperties = { background: 'none', border: 'none', color: '#6ea8fe', cursor: 'pointer', fontSize: 12, padding: 0, textDecoration: 'underline' };
-const btn = (disabled: boolean, variant: 'primary' | 'secondary' | 'danger' = 'secondary'): React.CSSProperties => ({
-  background: disabled ? '#222' : variant === 'primary' ? '#1d4ed8' : variant === 'danger' ? '#7f1d1d' : '#2a2a2a',
-  color: disabled ? '#666' : '#eee', border: '1px solid #333', borderRadius: 4, padding: '6px 12px', fontSize: 13, cursor: disabled ? 'default' : 'pointer',
-});

--- a/web/src/RemoteStatus.tsx
+++ b/web/src/RemoteStatus.tsx
@@ -17,7 +17,8 @@ interface Props {
 // RemoteCard is the remote's state card in the Repo Manager detail pane. It
 // renders ONLY for a repo that has a remote — an unconnected repo has no remote
 // state worth a card, so "Connect a remote…" lives in the pane's ⋯ menu instead
-// of as a permanent call-to-action.
+// of as a permanent call-to-action. A failed load is NOT "unconnected": the
+// card stays, carrying the error, because we do not know what is out there.
 //
 // Its two actions are card-local icon buttons rather than pane-level menu
 // items, because they edit the connection this card describes. The pane's ⋯
@@ -32,10 +33,13 @@ export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onDi
   // No reset-on-repo-switch effect is needed: RepoDetail is keyed by repo name,
   // so switching repos remounts this card and the editor starts closed.
 
-  // No remote and nothing in flight — there is no state to show. RepoDetail
-  // already skips rendering this card in that case; returning null keeps the
-  // component honest if it is ever mounted directly.
-  if (!loading && !origin) return null;
+  // No remote, nothing in flight, and nothing went wrong — there is no state to
+  // show. RepoDetail already skips rendering this card in that case; returning
+  // null keeps the component honest if it is ever mounted directly. `err` is
+  // deliberately part of the condition: bailing out on a failed load would make
+  // the error branch at the bottom of this component unreachable in exactly the
+  // case it exists for.
+  if (!loading && !origin && !err) return null;
 
   // upstream == this machine's agent branch is a degenerate config: pulls are
   // disabled (push-only) to avoid force-resetting unpushed facts. Warn + offer
@@ -66,7 +70,7 @@ export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onDi
   };
 
   return (
-    <div style={card}>
+    <div data-testid="remote-card" style={card}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
         <div style={{ ...cardLabel, marginBottom: 0, display: 'flex', alignItems: 'center', gap: 6 }}>
           <GlobeIcon color="#555" size={11} /> Remote
@@ -137,7 +141,15 @@ export function RemoteCard({ repo, agentBranch, readOnly, state, onConnect, onDi
         </div>
       )}
 
-      {err && <div style={{ color: '#f88', fontSize: 13, marginTop: 8 }}>{err}</div>}
+      {/* Retry is offered because a load failure is otherwise a dead end: with
+          no origin loaded the card has no other affordance, and the ⋯ menu
+          deliberately withholds "Connect a remote…" while the state is unknown. */}
+      {err && (
+        <div data-testid="remote-error" style={{ color: '#f88', fontSize: 13, marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span>{err}</span>
+          {!origin && <button type="button" data-testid="remote-retry" style={linkBtn} onClick={reload}>Retry</button>}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -18,6 +18,7 @@ vi.mock('./api', () => ({
     listBranchNames: vi.fn().mockResolvedValue([]),
     getAgentBranch: vi.fn().mockResolvedValue('agent/test'),
     getRepo: vi.fn().mockResolvedValue({ name: 'core' }),
+    updateRepo: vi.fn().mockResolvedValue({ name: 'core' }),
     getOrigin: vi.fn().mockResolvedValue(null),
     deleteOrigin: vi.fn(),
     rebuild: vi.fn().mockResolvedValue({ id: 'job1', state: 'running' }),
@@ -165,12 +166,104 @@ describe('RepoManager', () => {
     expect(desc.querySelector('.k-prose')).not.toBeNull();
   });
 
-  it('omits the description block when the repo has no kb.md', async () => {
+  // With no kb.md the card is still offered so a description can be written —
+  // but only when the user could actually write one.
+  it('offers an empty description card when the repo has no kb.md', async () => {
     (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core' });
     render(<RepoManager {...baseProps} />);
     await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
+
+    const toggle = await screen.findByTestId('repo-description-toggle');
+    expect(toggle).toHaveTextContent(/none yet/i);
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('repo-description')).toHaveTextContent(/No description yet/i);
+  });
+
+  it('hides the description card entirely when read-only and empty', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core' });
+    render(<RepoManager {...baseProps} readOnly />);
+    await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
     expect(screen.queryByTestId('repo-description-toggle')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('repo-description')).not.toBeInTheDocument();
+  });
+
+  // Editing a repo description writes kb.md through PATCH /repos/{repo}, and
+  // the pane adopts the SERVER's re-read value, not the local draft.
+  it('edits a repo description and saves it to kb.md', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '# Old' });
+    (api.updateRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '# New\n\nBody.' });
+    render(<RepoManager {...baseProps} />);
+
+    // The pencil opens the card AND enters edit mode in one click.
+    fireEvent.click(await screen.findByTestId('repo-description-edit'));
+    const input = screen.getByTestId('repo-description-input') as HTMLTextAreaElement;
+    expect(input.value).toBe('# Old'); // seeded with the current markdown
+
+    fireEvent.change(input, { target: { value: '# New\n\nBody.' } });
+    fireEvent.click(screen.getByTestId('repo-description-save'));
+
+    await waitFor(() => expect(api.updateRepo).toHaveBeenCalledWith('core', { description: '# New\n\nBody.' }));
+    // Back to the rendered view, showing what the server returned.
+    await waitFor(() => expect(screen.queryByTestId('repo-description-input')).not.toBeInTheDocument());
+    expect(screen.getByTestId('repo-description')).toHaveTextContent('Body.');
+  });
+
+  it('keeps the editor open and shows the error when a description save fails', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '# Old' });
+    (api.updateRepo as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('description too long'));
+    render(<RepoManager {...baseProps} />);
+
+    fireEvent.click(await screen.findByTestId('repo-description-edit'));
+    fireEvent.change(screen.getByTestId('repo-description-input'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByTestId('repo-description-save'));
+
+    await waitFor(() => expect(screen.getByText(/description too long/)).toBeInTheDocument());
+    // The draft is not lost — the user can fix it and retry.
+    expect((screen.getByTestId('repo-description-input') as HTMLTextAreaElement).value).toBe('x');
+  });
+
+  it('cancelling a description edit discards the draft', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '# Old' });
+    render(<RepoManager {...baseProps} />);
+
+    fireEvent.click(await screen.findByTestId('repo-description-edit'));
+    fireEvent.change(screen.getByTestId('repo-description-input'), { target: { value: 'scratch' } });
+    fireEvent.click(screen.getByTestId('repo-description-cancel'));
+
+    expect(api.updateRepo).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('repo-description-input')).not.toBeInTheDocument();
+    // Re-opening starts from the persisted value again, not the discarded draft.
+    fireEvent.click(screen.getByTestId('repo-description-edit'));
+    expect((screen.getByTestId('repo-description-input') as HTMLTextAreaElement).value).toBe('# Old');
+  });
+
+  it('hides the description edit affordance in read-only mode', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '# Old' });
+    render(<RepoManager {...baseProps} readOnly />);
+    await screen.findByTestId('repo-description-toggle');
+    expect(screen.queryByTestId('repo-description-edit')).not.toBeInTheDocument();
+  });
+
+  // A lens description goes to the lens registry via PATCH /lenses/{name} —
+  // same editor, different destination.
+  it('edits a lens description and saves it via updateLens', async () => {
+    (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }],
+      description: 'old lens note',
+    });
+    (api.updateLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }],
+      description: '# New lens note',
+    });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+
+    fireEvent.click(await screen.findByTestId('repo-description-edit'));
+    fireEvent.change(screen.getByTestId('repo-description-input'), { target: { value: '# New lens note' } });
+    fireEvent.click(screen.getByTestId('repo-description-save'));
+
+    await waitFor(() => expect(api.updateLens).toHaveBeenCalledWith('dev', { description: '# New lens note' }));
+    await waitFor(() => expect(screen.getByTestId('repo-description')).toHaveTextContent('New lens note'));
   });
 
   it('collapses the description by default and expands it on click', async () => {

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { RepoManager } from './RepoManager';
 import { api, MAX_LENS_DESCRIPTION_BYTES } from './api';
 
@@ -117,7 +117,11 @@ describe('RepoManager', () => {
     }
   });
 
-  it('disconnects a remote from the ⋯ menu, behind a confirm', async () => {
+  // Disconnect is a card-local action: it edits the connection the Remote card
+  // describes, so it is an icon button ON that card and NOT a ⋯ menu item.
+  // Asserted by scoping the query to the card — a document-wide getByTestId
+  // would pass against either placement and so could not tell them apart.
+  it('disconnects a remote from the Remote card, behind a confirm', async () => {
     (api.getOrigin as ReturnType<typeof vi.fn>).mockResolvedValue({
       name: 'origin', url: 'https://github.com/knomit/kb.git', branch: 'main', auth_method: 'token',
       last_sync_at: '2026-06-11T10:00:00Z', last_status: 'ok', last_error: null,
@@ -126,13 +130,45 @@ describe('RepoManager', () => {
     const onChanged = vi.fn();
     render(<RepoManager {...baseProps} onChanged={onChanged} />);
 
+    // The ⋯ menu holds whole-repo actions only — no disconnect in there.
     fireEvent.click(await screen.findByTestId('repo-menu'));
-    fireEvent.click(screen.getByTestId('remote-disconnect'));
-    // Selecting the item closes the menu and asks first — no request yet.
+    expect(within(screen.getByRole('menu')).queryByTestId('remote-disconnect')).not.toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+
+    const remoteCard = await screen.findByTestId('remote-card');
+    fireEvent.click(within(remoteCard).getByTestId('remote-disconnect'));
+    // Disconnecting asks first — no request until the confirm is accepted.
     expect(api.deleteOrigin).not.toHaveBeenCalled();
     fireEvent.click(screen.getByTestId('disconnect-confirm'));
     await waitFor(() => expect(api.deleteOrigin).toHaveBeenCalledWith('core'));
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  // A failed origin load is a THIRD state, not "unconnected": the card stays
+  // and carries the error, and the ⋯ menu withholds "Connect a remote…" so the
+  // user is not invited to overwrite a remote that is merely unreadable.
+  it('surfaces a failed remote load instead of rendering it as unconnected', async () => {
+    (api.getOrigin as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+    render(<RepoManager {...baseProps} />);
+
+    await waitFor(() => expect(screen.getByTestId('remote-error')).toHaveTextContent(/could not load remote status/i));
+    expect(screen.getByText('Remote')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('repo-menu'));
+    expect(screen.queryByTestId('remote-connect')).not.toBeInTheDocument();
+  });
+
+  it('retries a failed remote load', async () => {
+    const getOrigin = api.getOrigin as ReturnType<typeof vi.fn>;
+    getOrigin.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({
+      name: 'origin', url: 'https://github.com/knomit/kb.git', branch: 'main', auth_method: 'token',
+      last_sync_at: '2026-06-11T10:00:00Z', last_status: 'ok', last_error: null,
+    });
+    render(<RepoManager {...baseProps} />);
+
+    fireEvent.click(await screen.findByTestId('remote-retry'));
+    await waitFor(() => expect(screen.getByText('https://github.com/knomit/kb.git')).toBeInTheDocument());
+    expect(screen.queryByTestId('remote-error')).not.toBeInTheDocument();
   });
 
   it('closes the ⋯ menu on an outside click', async () => {

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -51,9 +51,63 @@ describe('RepoManager', () => {
     // RepoDetail for core loads its agent branch and inline origin form.
     await waitFor(() => expect(api.getAgentBranch).toHaveBeenCalledWith('core'));
     await waitFor(() => expect(api.getOrigin).toHaveBeenCalledWith('core'));
-    // The Remote status section renders inline within the same dialog.
+    // The Remote status card renders inline within the same dialog.
     await waitFor(() => expect(screen.getByText('Remote')).toBeInTheDocument());
     expect(screen.getByText('Rebuild index')).toBeInTheDocument();
+  });
+
+  // The detail pane leads with state (agent branch, remote) and pushes
+  // reference material behind disclosures — Connect an agent must not render
+  // its snippets until asked.
+  it('collapses "Connect an agent" by default and expands on click', async () => {
+    render(<RepoManager {...baseProps} />);
+    const toggle = await screen.findByTestId('repo-connect-toggle');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('repo-copy')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('repo-copy')).toBeInTheDocument();
+  });
+
+  it('orders the repo pane as branch → remote → description → connect', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: 'Root manifest.' });
+    render(<RepoManager {...baseProps} />);
+    await screen.findByTestId('repo-description-toggle');
+
+    // getOrigin resolves null here, so the Remote card shows its empty state.
+    const order = ['repo-detail-branch', 'remote-connect', 'repo-description-toggle', 'repo-connect-toggle']
+      .map(id => screen.getByTestId(id));
+    // Remote must sit below the repo's own info, and both above the disclosures.
+    for (let i = 1; i < order.length; i++) {
+      expect(order[i - 1].compareDocumentPosition(order[i]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+  });
+
+  it('disconnects a remote from the ⋯ menu, behind a confirm', async () => {
+    (api.getOrigin as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'origin', url: 'https://github.com/knomit/kb.git', branch: 'main', auth_method: 'token',
+      last_sync_at: '2026-06-11T10:00:00Z', last_status: 'ok', last_error: null,
+    });
+    (api.deleteOrigin as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    const onChanged = vi.fn();
+    render(<RepoManager {...baseProps} onChanged={onChanged} />);
+
+    fireEvent.click(await screen.findByTestId('repo-menu'));
+    fireEvent.click(screen.getByTestId('remote-disconnect'));
+    // Selecting the item closes the menu and asks first — no request yet.
+    expect(api.deleteOrigin).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('disconnect-confirm'));
+    await waitFor(() => expect(api.deleteOrigin).toHaveBeenCalledWith('core'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it('closes the ⋯ menu on an outside click', async () => {
+    render(<RepoManager {...baseProps} />);
+    fireEvent.click(await screen.findByTestId('repo-menu'));
+    expect(screen.getByTestId('repo-archive')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('repo-archive')).not.toBeInTheDocument();
   });
 
   it('renders the kb.md description in the detail pane', async () => {
@@ -62,7 +116,8 @@ describe('RepoManager', () => {
     });
     render(<RepoManager {...baseProps} />);
     await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
-    await waitFor(() => expect(screen.getByTestId('repo-description')).toHaveTextContent('Root manifest.'));
+    fireEvent.click(await screen.findByTestId('repo-description-toggle'));
+    expect(screen.getByTestId('repo-description')).toHaveTextContent('Root manifest.');
   });
 
   it('renders GFM in the kb.md description — a table, not literal pipe text', async () => {
@@ -73,7 +128,8 @@ describe('RepoManager', () => {
     render(<RepoManager {...baseProps} />);
     await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
 
-    const desc = await screen.findByTestId('repo-description');
+    fireEvent.click(await screen.findByTestId('repo-description-toggle'));
+    const desc = screen.getByTestId('repo-description');
     expect(desc.querySelector('table')).not.toBeNull();
     expect(desc.querySelectorAll('th')).toHaveLength(2);
     expect(desc.textContent).not.toContain('|---|');
@@ -85,28 +141,25 @@ describe('RepoManager', () => {
     (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core' });
     render(<RepoManager {...baseProps} />);
     await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
+    expect(screen.queryByTestId('repo-description-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('repo-description')).not.toBeInTheDocument();
   });
 
-  it('expands a long description via the Show more toggle', async () => {
-    // jsdom does no layout, so fake the clamp overflow: scrollHeight > clientHeight.
-    const sh = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
-    const ch = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 500 });
-    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 132 });
-    try {
-      (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({
-        name: 'core', description: 'line\n'.repeat(40),
-      });
-      render(<RepoManager {...baseProps} />);
-      const toggle = await screen.findByTestId('repo-description-toggle');
-      expect(toggle).toHaveTextContent('Show more');
-      fireEvent.click(toggle);
-      expect(toggle).toHaveTextContent('Show less');
-    } finally {
-      if (sh) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', sh);
-      if (ch) Object.defineProperty(HTMLElement.prototype, 'clientHeight', ch);
-    }
+  it('collapses the description by default and expands it on click', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'core', description: 'line\n'.repeat(40),
+    });
+    render(<RepoManager {...baseProps} />);
+    const toggle = await screen.findByTestId('repo-description-toggle');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('repo-description')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('repo-description')).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId('repo-description')).not.toBeInTheDocument();
   });
 
   it('rebuild gives immediate feedback and a completion message', async () => {
@@ -135,7 +188,8 @@ describe('RepoManager', () => {
     expect(screen.getByTestId('lens-detail-read-core')).toHaveTextContent('main');
     expect(screen.getByTestId('lens-detail-read-work')).toBeInTheDocument();
 
-    // Delete requires a confirm step, then calls api.deleteLens.
+    // Delete lives in the ⋯ menu and requires a confirm step.
+    fireEvent.click(screen.getByTestId('lens-menu'));
     fireEvent.click(screen.getByTestId('lens-delete'));
     fireEvent.click(screen.getByTestId('lens-delete-confirm'));
     await waitFor(() => expect(api.deleteLens).toHaveBeenCalledWith('dev'));
@@ -175,33 +229,40 @@ describe('RepoManager', () => {
     render(<RepoManager {...baseProps} />);
     await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    fireEvent.click(screen.getByTestId('lens-connect-toggle'));
     fireEvent.click(screen.getByTestId('lens-copy'));
     expect(writeText).toHaveBeenCalledWith('knomit-bridge claude init --lens dev');
   });
 
-  it('renders the lens description via the RepoDescription clamp/Show-more treatment', async () => {
-    // Mirror the repo-description overflow fake: prove the lens reuses the same
-    // clamped component (data-testid=repo-description) with a working Show more toggle.
-    const sh = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
-    const ch = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', { configurable: true, get: () => 500 });
-    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 132 });
-    try {
-      (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
-        name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }],
-        description: '# Dev lens\n\n' + 'Engineering read union.\n'.repeat(40),
-      });
-      render(<RepoManager {...baseProps} />);
-      await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
-      fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
-      await waitFor(() => expect(screen.getByTestId('repo-description')).toHaveTextContent('Engineering read union.'));
-      const toggle = await screen.findByTestId('repo-description-toggle');
-      expect(toggle).toHaveTextContent('Show more');
-      fireEvent.click(toggle);
-      expect(toggle).toHaveTextContent('Show less');
-    } finally {
-      if (sh) Object.defineProperty(HTMLElement.prototype, 'scrollHeight', sh);
-      if (ch) Object.defineProperty(HTMLElement.prototype, 'clientHeight', ch);
+  it('renders the lens description behind the same disclosure as a repo', async () => {
+    (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }],
+      description: '# Dev lens\n\nEngineering read union.',
+    });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+
+    const toggle = await screen.findByTestId('repo-description-toggle');
+    expect(screen.queryByTestId('repo-description')).not.toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('repo-description')).toHaveTextContent('Engineering read union.');
+  });
+
+  it('orders the lens pane as write → mounts → description → connect', async () => {
+    (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'dev', write: 'work', reads: [{ repo: 'core', branch: 'main' }, { repo: 'work' }],
+      description: 'Engineering read union.',
+    });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    await screen.findByTestId('repo-description-toggle');
+
+    const order = ['lens-detail-write', 'lens-detail-read-core', 'repo-description-toggle', 'lens-connect-toggle']
+      .map(id => screen.getByTestId(id));
+    for (let i = 1; i < order.length; i++) {
+      expect(order[i - 1].compareDocumentPosition(order[i]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     }
   });
 
@@ -279,6 +340,7 @@ describe('RepoManager', () => {
     render(<RepoManager {...baseProps} onChanged={onChanged} />);
     await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    fireEvent.click(await screen.findByTestId('lens-menu'));
     fireEvent.click(await screen.findByTestId('lens-delete'));
     fireEvent.click(await screen.findByTestId('lens-delete-confirm'));
     await waitFor(() => expect(api.deleteLens).toHaveBeenCalled());

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -46,14 +46,39 @@ describe('RepoManager', () => {
     await waitFor(() => expect(screen.getByText('old')).toBeInTheDocument());
   });
 
-  it('auto-selects the current repo and shows its detail pane (origin inline, no modal)', async () => {
+  it('auto-selects the current repo and shows its detail pane', async () => {
     render(<RepoManager {...baseProps} />);
-    // RepoDetail for core loads its agent branch and inline origin form.
+    // RepoDetail for core loads its agent branch and its origin.
     await waitFor(() => expect(api.getAgentBranch).toHaveBeenCalledWith('core'));
     await waitFor(() => expect(api.getOrigin).toHaveBeenCalledWith('core'));
-    // The Remote status card renders inline within the same dialog.
+    await waitFor(() => expect(screen.getByTestId('repo-detail-branch')).toBeInTheDocument());
+    // Whole-repo actions live in the ⋯ menu, not as permanent buttons.
+    expect(screen.queryByText('Rebuild index')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('repo-menu'));
+    expect(screen.getByTestId('repo-rebuild')).toBeInTheDocument();
+  });
+
+  // An unconnected repo has no remote state, so it gets no Remote card — the
+  // ⋯ menu offers to create the connection instead of a permanent CTA.
+  it('omits the Remote card when unconnected and offers Connect in the ⋯ menu', async () => {
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(api.getOrigin).toHaveBeenCalledWith('core'));
+    await waitFor(() => expect(screen.queryByText('Remote')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('repo-menu'));
+    expect(screen.getByTestId('remote-connect')).toBeInTheDocument();
+  });
+
+  it('shows the Remote card when connected, and drops Connect from the ⋯ menu', async () => {
+    (api.getOrigin as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'origin', url: 'https://github.com/knomit/kb.git', branch: 'main', auth_method: 'token',
+      last_sync_at: '2026-06-11T10:00:00Z', last_status: 'ok', last_error: null,
+    });
+    render(<RepoManager {...baseProps} />);
     await waitFor(() => expect(screen.getByText('Remote')).toBeInTheDocument());
-    expect(screen.getByText('Rebuild index')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('repo-menu'));
+    expect(screen.queryByTestId('remote-connect')).not.toBeInTheDocument();
   });
 
   // The detail pane leads with state (agent branch, remote) and pushes
@@ -72,11 +97,14 @@ describe('RepoManager', () => {
 
   it('orders the repo pane as branch → remote → description → connect', async () => {
     (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: 'Root manifest.' });
+    (api.getOrigin as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'origin', url: 'https://github.com/knomit/kb.git', branch: 'main', auth_method: 'token',
+      last_sync_at: '2026-06-11T10:00:00Z', last_status: 'ok', last_error: null,
+    });
     render(<RepoManager {...baseProps} />);
     await screen.findByTestId('repo-description-toggle');
 
-    // getOrigin resolves null here, so the Remote card shows its empty state.
-    const order = ['repo-detail-branch', 'remote-connect', 'repo-description-toggle', 'repo-connect-toggle']
+    const order = ['repo-detail-branch', 'sync-line', 'repo-description-toggle', 'repo-connect-toggle']
       .map(id => screen.getByTestId(id));
     // Remote must sit below the repo's own info, and both above the disclosures.
     for (let i = 1; i < order.length; i++) {
@@ -164,9 +192,8 @@ describe('RepoManager', () => {
 
   it('rebuild gives immediate feedback and a completion message', async () => {
     render(<RepoManager {...baseProps} />);
-    await waitFor(() => expect(screen.getByText('Rebuild index')).toBeInTheDocument());
-
-    fireEvent.click(screen.getByText('Rebuild index'));
+    fireEvent.click(await screen.findByTestId('repo-menu'));
+    fireEvent.click(screen.getByTestId('repo-rebuild'));
     await waitFor(() => expect(api.rebuild).toHaveBeenCalledWith('core', 'agent/test'));
     // Visible confirmation that the background rebuild kicked off (the bug: none).
     await waitFor(() => expect(screen.getByTestId('rebuild-status')).toHaveTextContent('Rebuild started'));

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { RepoManager } from './RepoManager';
-import { api } from './api';
+import { api, MAX_LENS_DESCRIPTION_BYTES } from './api';
 
-vi.mock('./api', () => ({
+// Only `api` is stubbed. The module's other exports — the description byte
+// caps — pass through from the real module, so a test asserting on a cap is
+// asserting on the value the app actually ships.
+vi.mock('./api', async importOriginal => ({
+  ...(await importOriginal<typeof import('./api')>()),
   api: {
     listArchived: vi.fn().mockResolvedValue([
       { id: 'old.1', name: 'old', origin: '', archivedAt: '2026-06-01T00:00:00Z' },
@@ -234,6 +238,61 @@ describe('RepoManager', () => {
     // Re-opening starts from the persisted value again, not the discarded draft.
     fireEvent.click(screen.getByTestId('repo-description-edit'));
     expect((screen.getByTestId('repo-description-input') as HTMLTextAreaElement).value).toBe('# Old');
+  });
+
+  // A lens description is capped an order of magnitude below a repo's, and the
+  // two share one editor — so the editor has to name the cap it is holding
+  // rather than let the difference surface as a 422 on Save.
+  it('counts bytes against the lens cap and blocks Save when over', async () => {
+    (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'dev', write: 'work', reads: [{ repo: 'work' }], description: 'note',
+    });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    fireEvent.click(await screen.findByTestId('repo-description-edit'));
+
+    // A short draft is nowhere near the cap: no counter, Save enabled.
+    expect(screen.queryByTestId('repo-description-count')).not.toBeInTheDocument();
+    expect(screen.getByTestId('repo-description-save')).not.toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('repo-description-input'),
+      { target: { value: 'x'.repeat(MAX_LENS_DESCRIPTION_BYTES + 1) } });
+    expect(screen.getByTestId('repo-description-count')).toHaveTextContent('4,097 / 4,096 bytes');
+    expect(screen.getByTestId('repo-description-save')).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('repo-description-save'));
+    expect(api.updateLens).not.toHaveBeenCalled();
+  });
+
+  // Bytes, not characters — the server caps len(string), so multi-byte text
+  // reaches the limit well before the character count suggests.
+  it('measures the draft in bytes, not characters', async () => {
+    (api.getLens as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'dev', write: 'work', reads: [{ repo: 'work' }], description: 'note',
+    });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(screen.getByTestId('repomgr-lens-dev')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('repomgr-lens-dev'));
+    fireEvent.click(await screen.findByTestId('repo-description-edit'));
+
+    // 3-byte characters: under the cap by count, over it by size.
+    fireEvent.change(screen.getByTestId('repo-description-input'),
+      { target: { value: '—'.repeat(2000) } });
+    expect(screen.getByTestId('repo-description-count')).toHaveTextContent('6,000 / 4,096 bytes');
+    expect(screen.getByTestId('repo-description-save')).toBeDisabled();
+  });
+
+  it('uses the much larger repo cap for a repo description', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '# Old' });
+    render(<RepoManager {...baseProps} />);
+    fireEvent.click(await screen.findByTestId('repo-description-edit'));
+
+    // Over a lens's cap, nowhere near a repo's: no counter, Save enabled.
+    fireEvent.change(screen.getByTestId('repo-description-input'),
+      { target: { value: 'x'.repeat(MAX_LENS_DESCRIPTION_BYTES + 1) } });
+    expect(screen.queryByTestId('repo-description-count')).not.toBeInTheDocument();
+    expect(screen.getByTestId('repo-description-save')).not.toBeDisabled();
   });
 
   it('hides the description edit affordance in read-only mode', async () => {

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -361,7 +361,20 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
           onChanged={onChanged} />
       )}
 
-      {description && <DescriptionDisclosure markdown={description} />}
+      {/* Shown whenever there is something to read OR the user could write
+          one; a read-only repo with no manifest has neither. */}
+      {(description || !readOnly) && (
+        <DescriptionCard
+          markdown={description}
+          readOnly={readOnly}
+          saveHint="committed to kb.md on the agent branch"
+          onSave={async md => {
+            const updated = await api.updateRepo(name, { description: md });
+            // Trust the server's re-read over the draft: it is what landed.
+            setDescription(updated.description ?? '');
+          }}
+        />
+      )}
 
       <ConnectPanel kind="repo" name={name} agentBranch={agentBranch} />
     </div>
@@ -372,10 +385,18 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
 // (description, connect snippets). The detail pane's job is to answer "what is
 // this repo/lens wired to" at a glance; anything you only read once belongs
 // behind a header you can open, not in the default vertical budget.
-function Disclosure({ label, hint, testid, bodyTestid, children }: {
-  label: string; hint?: string; testid: string; bodyTestid?: string; children: React.ReactNode;
+function Disclosure({ label, hint, testid, bodyTestid, action, open: openProp, onOpenChange, children }: {
+  label: string; hint?: string; testid: string; bodyTestid?: string;
+  // action renders beside the toggle (never inside it — buttons cannot nest).
+  action?: React.ReactNode;
+  // Optionally controlled, so an owner can force it open (e.g. clicking Edit
+  // on a collapsed card should reveal the editor, not just arm it).
+  open?: boolean; onOpenChange?: (open: boolean) => void;
+  children: React.ReactNode;
 }) {
-  const [open, setOpen] = useState(false);
+  const [openState, setOpenState] = useState(false);
+  const open = openProp ?? openState;
+  const setOpen = (next: boolean) => { setOpenState(next); onOpenChange?.(next); };
   const boxRef = useRef<HTMLDivElement>(null);
 
   // A disclosure near the bottom of the pane would otherwise expand below the
@@ -390,36 +411,103 @@ function Disclosure({ label, hint, testid, bodyTestid, children }: {
 
   return (
     <div ref={boxRef} style={card}>
-      <button
-        type="button"
-        className="k-bare"
-        data-testid={testid}
-        aria-expanded={open}
-        style={disclosureHead}
-        onClick={() => setOpen(o => !o)}
-      >
-        <span style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
-          <span style={{ display: 'flex', transform: open ? 'none' : 'rotate(-90deg)', transition: 'transform 120ms' }}>
-            <ChevronDownIcon color="#888" size={12} />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button
+          type="button"
+          className="k-bare"
+          data-testid={testid}
+          aria-expanded={open}
+          style={{ ...disclosureHead, flex: 1 }}
+          onClick={() => setOpen(!open)}
+        >
+          <span style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+            <span style={{ display: 'flex', transform: open ? 'none' : 'rotate(-90deg)', transition: 'transform 120ms' }}>
+              <ChevronDownIcon color="#888" size={12} />
+            </span>
+            <span style={{ ...cardLabel, marginBottom: 0 }}>{label}</span>
           </span>
-          <span style={{ ...cardLabel, marginBottom: 0 }}>{label}</span>
-        </span>
-        {hint && <span style={{ fontSize: 11, color: '#666' }}>{hint}</span>}
-      </button>
+          {hint && <span style={{ fontSize: 11, color: '#666' }}>{hint}</span>}
+        </button>
+        {action}
+      </div>
       {open && <div data-testid={bodyTestid} style={{ marginTop: 10 }}>{children}</div>}
     </div>
   );
 }
 
-// DescriptionDisclosure renders the repo's (or lens's) kb.md as markdown behind
-// a disclosure. The body scrolls at a fixed height so a long manifest can never
-// take over the detail pane.
-function DescriptionDisclosure({ markdown }: { markdown: string }) {
+// DescriptionCard renders a repo's or lens's description as markdown behind a
+// disclosure, and lets you edit it in place. Reading and writing share one
+// component because the two differ only in where the text lands — saveHint
+// names that destination, since "edit this text" and "commit a file into the
+// repo's git history" are very different acts and the UI should say which.
+//
+// The rendered body scrolls at a fixed height so a long manifest can never take
+// over the detail pane; the editor is a plain textarea over the raw markdown
+// (no rich-text layer that could rewrite what gets committed).
+function DescriptionCard({ markdown, readOnly, saveHint, onSave }: {
+  markdown: string; readOnly: boolean; saveHint: string;
+  onSave: (md: string) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  // Editing a collapsed card must reveal the editor, not merely arm it.
+  const beginEdit = () => { setDraft(markdown); setErr(''); setEditing(true); setOpen(true); };
+  const cancel = () => { setEditing(false); setErr(''); };
+  const save = async () => {
+    setBusy(true); setErr('');
+    try { await onSave(draft); setEditing(false); }
+    catch (e) { setErr(String(e)); }
+    finally { setBusy(false); }
+  };
+
   return (
-    <Disclosure label="Description" testid="repo-description-toggle" bodyTestid="repo-description">
-      <div className="k-prose" style={{ maxHeight: 360, overflowY: 'auto', color: '#bbb', fontSize: 13, lineHeight: 1.6 }}>
-        <ReactMarkdown remarkPlugins={markdownPlugins} components={markdownComponents}>{markdown}</ReactMarkdown>
-      </div>
+    <Disclosure
+      label="Description"
+      hint={markdown ? undefined : 'none yet'}
+      testid="repo-description-toggle"
+      bodyTestid="repo-description"
+      open={open}
+      onOpenChange={setOpen}
+      action={!readOnly && !editing && (
+        <button type="button" className="k-bare" data-testid="repo-description-edit"
+          title="Edit description" aria-label="Edit description"
+          style={cardIconBtn} onClick={beginEdit}>
+          <PencilIcon color="#888" size={13} />
+        </button>
+      )}
+    >
+      {editing ? (
+        <>
+          <textarea
+            data-testid="repo-description-input"
+            value={draft}
+            disabled={busy}
+            onChange={e => setDraft(e.target.value)}
+            style={descTextarea}
+            spellCheck={false}
+          />
+          <div style={{ fontSize: 11, color: '#666', marginTop: 6 }}>Markdown · {saveHint}</div>
+          {err && <div style={{ fontSize: 12, color: '#f88', marginTop: 6 }}>{err}</div>}
+          <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+            <button type="button" data-testid="repo-description-save" style={btn(busy, 'primary')} disabled={busy} onClick={save}>
+              {busy ? 'Saving…' : 'Save'}
+            </button>
+            <button type="button" data-testid="repo-description-cancel" style={btn(busy)} disabled={busy} onClick={cancel}>Cancel</button>
+          </div>
+        </>
+      ) : markdown ? (
+        <div className="k-prose" style={{ maxHeight: 360, overflowY: 'auto', color: '#bbb', fontSize: 13, lineHeight: 1.6 }}>
+          <ReactMarkdown remarkPlugins={markdownPlugins} components={markdownComponents}>{markdown}</ReactMarkdown>
+        </div>
+      ) : (
+        <div style={{ fontSize: 13, color: '#666' }}>
+          No description yet.{!readOnly && ' Use the pencil to write one in markdown.'}
+        </div>
+      )}
     </Disclosure>
   );
 }
@@ -793,7 +881,18 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
         </div>
       )}
 
-      {lens?.description && <DescriptionDisclosure markdown={lens.description} />}
+      {(lens?.description || !readOnly) && (
+        <DescriptionCard
+          markdown={lens?.description ?? ''}
+          readOnly={readOnly}
+          saveHint="saved with the lens"
+          onSave={async md => {
+            const updated = await api.updateLens(name, { description: md });
+            setLens(updated);
+            onSaved();
+          }}
+        />
+      )}
 
       <ConnectPanel kind="lens" name={name} />
     </div>
@@ -906,6 +1005,14 @@ const plusBtn = (disabled: boolean, active: boolean): React.CSSProperties => ({
 // headActions is the detail-pane header's button cluster: primary action,
 // Browse, then the ⋯ overflow. It never wraps under the title.
 const headActions: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 };
+// descTextarea edits raw markdown, so it is monospaced and generously tall —
+// a repo's kb.md is a document, not a caption.
+const descTextarea: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box', minHeight: 240, resize: 'vertical',
+  background: '#0c0c0c', border: '1px solid #333', borderRadius: 5, color: '#ddd',
+  padding: '9px 11px', fontSize: 12.5, lineHeight: 1.6,
+  fontFamily: 'var(--k-font-mono)',
+};
 const disclosureHead: React.CSSProperties = {
   display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%',
   background: 'none', border: 'none', padding: 0, cursor: 'pointer', textAlign: 'left',

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -290,11 +290,15 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
   // (reconnect/disconnect the remote) live on that card instead. "Connect a
   // remote" is here rather than as a permanent button because an unconnected
   // repo renders no Remote card at all — there is no remote state to show.
+  //
+  // remote.err is a THIRD state, distinct from "not connected": the request
+  // failed, so we do not know whether a remote exists. Offering Connect there
+  // would invite the user to overwrite a remote that is merely unreadable.
   const menuItems: MenuItem[] = [{
     label: rebuilding ? 'Rebuilding…' : 'Rebuild index', testid: 'repo-rebuild',
     disabled: readOnly || rebuilding, onSelect: rebuild,
   }];
-  if (!hideRemoteConfig && !remote.loading && !remote.origin) {
+  if (!hideRemoteConfig && !remote.loading && !remote.origin && !remote.err) {
     menuItems.push({ label: 'Connect a remote…', testid: 'remote-connect', disabled: readOnly, onSelect: onConnect });
   }
   menuItems.push({ separator: true });
@@ -354,8 +358,10 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
       </div>
 
       {/* No remote → no card. The pane shows state; the ⋯ menu offers to
-          create the state that isn't there yet. */}
-      {!hideRemoteConfig && (remote.loading || remote.origin) && (
+          create the state that isn't there yet. A load FAILURE still gets a
+          card: "we could not read this" is state, and silently rendering it as
+          "not connected" hides a broken remote behind an empty pane. */}
+      {!hideRemoteConfig && (remote.loading || remote.origin || remote.err) && (
         <RemoteCard repo={name} agentBranch={agentBranch} readOnly={readOnly}
           state={remote} onConnect={onConnect} onDisconnect={() => setConfirming('disconnect')}
           onChanged={onChanged} />

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -1,7 +1,7 @@
 import { createPortal } from 'react-dom';
 import { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { api, type ArchivedRepo, type RepoInfo, type Lens, type LensRead } from './api';
+import { api, MAX_LENS_DESCRIPTION_BYTES, MAX_REPO_DESCRIPTION_BYTES, type ArchivedRepo, type RepoInfo, type Lens, type LensRead } from './api';
 import { CreateRepoForm } from './CreateRepoForm';
 import { markdownPlugins, markdownComponents } from './markdown';
 import { CreateLensForm } from './CreateLensForm';
@@ -368,6 +368,7 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
           markdown={description}
           readOnly={readOnly}
           saveHint="committed to kb.md on the agent branch"
+          maxBytes={MAX_REPO_DESCRIPTION_BYTES}
           onSave={async md => {
             const updated = await api.updateRepo(name, { description: md });
             // Trust the server's re-read over the draft: it is what landed.
@@ -444,8 +445,11 @@ function Disclosure({ label, hint, testid, bodyTestid, action, open: openProp, o
 // The rendered body scrolls at a fixed height so a long manifest can never take
 // over the detail pane; the editor is a plain textarea over the raw markdown
 // (no rich-text layer that could rewrite what gets committed).
-function DescriptionCard({ markdown, readOnly, saveHint, onSave }: {
+function DescriptionCard({ markdown, readOnly, saveHint, maxBytes, onSave }: {
   markdown: string; readOnly: boolean; saveHint: string;
+  // Byte cap the server enforces for THIS destination — a repo's kb.md and a
+  // lens's note share this editor but not their limits.
+  maxBytes: number;
   onSave: (md: string) => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
@@ -463,6 +467,16 @@ function DescriptionCard({ markdown, readOnly, saveHint, onSave }: {
     catch (e) { setErr(String(e)); }
     finally { setBusy(false); }
   };
+
+  // The cap is a byte count server-side, so measure bytes: a draft of em-dashes
+  // and smart quotes hits the limit at a third of its character count. Only
+  // shown once the draft is within sight of the cap — a counter on every edit
+  // is noise for the 200-byte case, but a lens's 4 KiB is close enough to a
+  // page of notes that silence would let the user write past it and lose the
+  // Save to a 422.
+  const bytes = new TextEncoder().encode(draft).length;
+  const over = bytes > maxBytes;
+  const showCount = bytes > maxBytes * 0.8;
 
   return (
     <Disclosure
@@ -490,10 +504,18 @@ function DescriptionCard({ markdown, readOnly, saveHint, onSave }: {
             style={descTextarea}
             spellCheck={false}
           />
-          <div style={{ fontSize: 11, color: '#666', marginTop: 6 }}>Markdown · {saveHint}</div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, fontSize: 11, color: '#666', marginTop: 6 }}>
+            <span>Markdown · {saveHint}</span>
+            {showCount && (
+              <span data-testid="repo-description-count" style={{ color: over ? '#f88' : '#888', whiteSpace: 'nowrap' }}>
+                {bytes.toLocaleString()} / {maxBytes.toLocaleString()} bytes
+              </span>
+            )}
+          </div>
           {err && <div style={{ fontSize: 12, color: '#f88', marginTop: 6 }}>{err}</div>}
           <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
-            <button type="button" data-testid="repo-description-save" style={btn(busy, 'primary')} disabled={busy} onClick={save}>
+            <button type="button" data-testid="repo-description-save" style={btn(busy || over, 'primary')} disabled={busy || over}
+              title={over ? `too long by ${(bytes - maxBytes).toLocaleString()} bytes` : undefined} onClick={save}>
               {busy ? 'Saving…' : 'Save'}
             </button>
             <button type="button" data-testid="repo-description-cancel" style={btn(busy)} disabled={busy} onClick={cancel}>Cancel</button>
@@ -886,6 +908,7 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
           markdown={lens?.description ?? ''}
           readOnly={readOnly}
           saveHint="saved with the lens"
+          maxBytes={MAX_LENS_DESCRIPTION_BYTES}
           onSave={async md => {
             const updated = await api.updateLens(name, { description: md });
             setLens(updated);

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -5,10 +5,11 @@ import { api, type ArchivedRepo, type RepoInfo, type Lens, type LensRead } from 
 import { CreateRepoForm } from './CreateRepoForm';
 import { markdownPlugins, markdownComponents } from './markdown';
 import { CreateLensForm } from './CreateLensForm';
-import { RemoteStatus } from './RemoteStatus';
+import { RemoteCard, useRemote } from './RemoteStatus';
 import { RemoteConnectWizard } from './RemoteConnectWizard';
 import { LENS, repoHue, repoHueBg, repoHueBorder } from './utils';
-import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon, LayersIcon, PencilIcon, TrashIcon, CopyIcon, WrenchIcon } from './icons';
+import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon, LayersIcon, PencilIcon, CopyIcon, WrenchIcon, MoreVerticalIcon, ChevronDownIcon } from './icons';
+import { btn, card, cardLabel, confirmBox, confirmInput } from './manageStyles';
 import type { BrowseContext } from './state';
 
 // BrowseContext names the surface a Browse action should switch the app to:
@@ -232,7 +233,11 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
   const [rebuilding, setRebuilding] = useState(false);
   const [rebuildMsg, setRebuildMsg] = useState('');
   const [busy, setBusy] = useState(false);
+  const [confirming, setConfirming] = useState<'disconnect' | null>(null);
   const mounted = useRef(true);
+  // The detail pane owns the remote so its ⋯ menu can offer Connect vs
+  // Reconnect/Disconnect; RemoteCard is the display half of the same state.
+  const remote = useRemote(name, !hideRemoteConfig);
 
   useEffect(() => {
     mounted.current = true;
@@ -267,26 +272,75 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
     catch (e) { onError(`archive failed: ${String(e)}`); }
     finally { setBusy(false); }
   };
+  const disconnect = async () => {
+    onError(''); setBusy(true);
+    try { await api.deleteOrigin(name); remote.reload(); setConfirming(null); onChanged(); }
+    catch (e) { onError(`disconnect failed: ${String(e)}`); }
+    finally { setBusy(false); }
+  };
+
+  // Every non-routine repo action lives in one ⋯ menu next to Browse, so the
+  // pane's body is pure information. Remote items are omitted entirely when the
+  // deployment hides remote config.
+  const menuItems: MenuItem[] = [];
+  if (!hideRemoteConfig) {
+    if (remote.origin) {
+      menuItems.push({ label: 'Reconnect / change…', testid: 'remote-reconnect', disabled: readOnly, onSelect: onConnect });
+      menuItems.push({ label: 'Disconnect', testid: 'remote-disconnect', danger: true, disabled: readOnly, onSelect: () => setConfirming('disconnect') });
+    } else if (!remote.loading) {
+      menuItems.push({ label: 'Connect a remote…', testid: 'remote-connect-menu', disabled: readOnly, onSelect: onConnect });
+    }
+    if (menuItems.length) menuItems.push({ separator: true });
+  }
+  menuItems.push({
+    label: 'Archive', testid: 'repo-archive', danger: true, disabled: !canArchive || busy,
+    hint: name === 'core' ? 'the default repo cannot be archived' : undefined,
+    onSelect: archive,
+  });
 
   return (
     <div>
       <div style={detailHead}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
           <span style={repoIconBox(name)}><BookIcon color={repoHue(name)} size={16} /></span>
-          <div>
+          <div style={{ minWidth: 0 }}>
             <h3 style={{ margin: 0, fontSize: 16 }}>{name}</h3>
             <div style={{ fontSize: 12, color: '#777', marginTop: 1 }}>repository</div>
           </div>
         </div>
-        <button type="button" data-testid="repo-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'repo', repo: name })}>
-          <BookIcon color={LENS.text} size={13} /> Browse
-        </button>
+        <div style={headActions}>
+          <button type="button" data-testid="repo-rebuild" style={{ ...btn(readOnly || rebuilding), display: 'flex', alignItems: 'center', gap: 6 }}
+            disabled={readOnly || rebuilding} onClick={rebuild}>
+            <WrenchIcon color={readOnly || rebuilding ? '#666' : '#bbb'} size={13} /> {rebuilding ? 'Rebuilding…' : 'Rebuild index'}
+          </button>
+          <button type="button" data-testid="repo-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'repo', repo: name })}>
+            <BookIcon color={LENS.text} size={13} /> Browse
+          </button>
+          <ActionMenu testid="repo-menu" label={`Actions for ${name}`} items={menuItems} />
+        </div>
       </div>
+
+      {rebuildMsg && (
+        <div data-testid="rebuild-status" style={{ fontSize: 12, color: rebuildMsg.startsWith('✓') ? '#9c9' : '#8af', marginTop: 10 }}>{rebuildMsg}</div>
+      )}
+
+      {confirming === 'disconnect' && (
+        <div style={confirmBox}>
+          <div style={{ fontSize: 13, marginBottom: 10 }}>Stop syncing and remove this remote? The repo stays as a local-only knowledge base — no facts are deleted.</div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button type="button" data-testid="disconnect-confirm" style={btn(busy, 'danger')} disabled={busy} onClick={disconnect}>{busy ? 'Disconnecting…' : 'Disconnect'}</button>
+            <button type="button" style={btn(busy)} disabled={busy} onClick={() => setConfirming(null)}>Cancel</button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Information, most-load-bearing first: where writes go, then what
+          this repo is wired to. Reference material collapses below. ── */}
 
       {/* Agent branch — where this repo's facts are written (mirrors the lens
           write-target box, tinted blue to match the branch chip). */}
-      <div style={{ ...descBox, background: '#141c26', borderColor: '#28405c' }}>
-        <div style={{ ...descLabel, color: '#6a86b0' }}>Agent branch</div>
+      <div style={{ ...card, background: '#141c26', borderColor: '#28405c' }}>
+        <div style={{ ...cardLabel, color: '#6a86b0' }}>Agent branch</div>
         <div data-testid="repo-detail-branch" style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, flexWrap: 'wrap' }}>
           <RepoDot repo={name} />
           <b style={{ color: '#eee' }}>{name}</b>
@@ -295,75 +349,120 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
         </div>
       </div>
 
-      <ConnectPanel kind="repo" name={name} agentBranch={agentBranch} />
-
-      {description && <RepoDescription markdown={description} />}
-
-      <div style={{ display: 'flex', gap: 8, marginTop: 16, flexWrap: 'wrap' }}>
-        <button type="button" style={{ ...btn(readOnly || rebuilding), display: 'flex', alignItems: 'center', gap: 6 }}
-          disabled={readOnly || rebuilding} onClick={rebuild}>
-          <WrenchIcon color={readOnly || rebuilding ? '#666' : '#bbb'} size={13} /> {rebuilding ? 'Rebuilding…' : 'Rebuild index'}
-        </button>
-        <button type="button" style={{ ...btn(!canArchive || busy, 'danger'), display: 'flex', alignItems: 'center', gap: 6 }}
-          disabled={!canArchive || busy} onClick={archive}
-          title={name === 'core' ? 'the default repo cannot be archived' : undefined}>
-          <ArchiveIcon color={!canArchive || busy ? '#666' : '#f88'} size={13} /> Archive
-        </button>
-      </div>
-      {rebuildMsg && (
-        <div data-testid="rebuild-status" style={{ fontSize: 12, color: rebuildMsg.startsWith('✓') ? '#9c9' : '#8af', marginTop: 8 }}>{rebuildMsg}</div>
-      )}
       {!hideRemoteConfig && (
-        <RemoteStatus repo={name} agentBranch={agentBranch} readOnly={readOnly} onConnect={onConnect} onChanged={onChanged} />
+        <RemoteCard repo={name} agentBranch={agentBranch} readOnly={readOnly}
+          state={remote} onConnect={onConnect} onChanged={onChanged} />
       )}
+
+      {description && <DescriptionDisclosure markdown={description} />}
+
+      <ConnectPanel kind="repo" name={name} agentBranch={agentBranch} />
     </div>
   );
 }
 
-// RepoDescription renders the repo's kb.md (the API "description") as markdown.
-// It is clamped to a few lines by default; if the content overflows, a toggle
-// expands it into a fixed-height scrollable panel so the whole manifest is
-// readable without taking over the detail pane.
-function RepoDescription({ markdown }: { markdown: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const [overflows, setOverflows] = useState(false);
+// Disclosure is the collapsed-by-default card used for reference material
+// (description, connect snippets). The detail pane's job is to answer "what is
+// this repo/lens wired to" at a glance; anything you only read once belongs
+// behind a header you can open, not in the default vertical budget.
+function Disclosure({ label, hint, testid, bodyTestid, children }: {
+  label: string; hint?: string; testid: string; bodyTestid?: string; children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={card}>
+      <button
+        type="button"
+        data-testid={testid}
+        aria-expanded={open}
+        style={disclosureHead}
+        onClick={() => setOpen(o => !o)}
+      >
+        <span style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+          <span style={{ display: 'flex', transform: open ? 'none' : 'rotate(-90deg)', transition: 'transform 120ms' }}>
+            <ChevronDownIcon color="#888" size={12} />
+          </span>
+          <span style={{ ...cardLabel, marginBottom: 0 }}>{label}</span>
+        </span>
+        {hint && <span style={{ fontSize: 11, color: '#666' }}>{hint}</span>}
+      </button>
+      {open && <div data-testid={bodyTestid} style={{ marginTop: 10 }}>{children}</div>}
+    </div>
+  );
+}
+
+// DescriptionDisclosure renders the repo's (or lens's) kb.md as markdown behind
+// a disclosure. The body scrolls at a fixed height so a long manifest can never
+// take over the detail pane.
+function DescriptionDisclosure({ markdown }: { markdown: string }) {
+  return (
+    <Disclosure label="Description" testid="repo-description-toggle" bodyTestid="repo-description">
+      <div className="k-prose" style={{ maxHeight: 360, overflowY: 'auto', color: '#bbb', fontSize: 13, lineHeight: 1.6 }}>
+        <ReactMarkdown remarkPlugins={markdownPlugins} components={markdownComponents}>{markdown}</ReactMarkdown>
+      </div>
+    </Disclosure>
+  );
+}
+
+// MenuItem is one row of an ActionMenu, or a rule between groups.
+type MenuItem =
+  | { separator: true }
+  | { separator?: false; label: string; testid?: string; danger?: boolean; disabled?: boolean; hint?: string; onSelect: () => void };
+
+// ActionMenu is the ⋯ overflow next to the detail pane's primary buttons. It
+// holds the rare and destructive actions (archive, disconnect, delete) that
+// previously sat as loose buttons at three different scroll depths.
+function ActionMenu({ items, label, testid }: { items: MenuItem[]; label: string; testid: string }) {
+  const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  // Measure overflow only while collapsed: clientHeight is the clamp height,
-  // so scrollHeight > clientHeight means there's more to show. Skip while
-  // expanded (the panel scrolls) so `overflows` keeps the toggle visible.
+  // Close on any click outside the menu. Escape is handled on the container
+  // (not document) so it cannot race the app-wide Escape handler in App.tsx.
   useEffect(() => {
-    if (expanded) return;
-    const el = ref.current;
-    if (el) setOverflows(el.scrollHeight > el.clientHeight + 1);
-  }, [markdown, expanded]);
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
 
   return (
-    <div data-testid="repo-description" style={descBox}>
-      <div style={descLabel}>Description</div>
-      <div style={{ position: 'relative' }}>
-        <div
-          ref={ref}
-          className="k-prose"
-          style={{
-            maxHeight: expanded ? 360 : 132,
-            overflowY: expanded ? 'auto' : 'hidden',
-            color: '#bbb', fontSize: 13, lineHeight: 1.6,
-          }}
-        >
-          <ReactMarkdown remarkPlugins={markdownPlugins} components={markdownComponents}>{markdown}</ReactMarkdown>
+    <div
+      ref={ref}
+      style={{ position: 'relative' }}
+      onKeyDown={e => { if (e.key === 'Escape' && open) { e.stopPropagation(); setOpen(false); } }}
+    >
+      <button
+        type="button"
+        data-testid={testid}
+        aria-label={label}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        style={menuTrigger(open)}
+        onClick={() => setOpen(o => !o)}
+      >
+        <MoreVerticalIcon color={open ? '#eee' : '#aaa'} size={15} />
+      </button>
+      {open && (
+        <div role="menu" style={menuPanel}>
+          {items.map((it, i) => it.separator
+            ? <div key={`sep-${i}`} style={menuSeparator} />
+            : (
+              <button
+                key={it.label}
+                type="button"
+                role="menuitem"
+                data-testid={it.testid}
+                disabled={it.disabled}
+                title={it.hint}
+                style={menuItemStyle(!!it.disabled, !!it.danger)}
+                onClick={() => { setOpen(false); it.onSelect(); }}
+              >
+                {it.label}
+              </button>
+            ))}
         </div>
-        {!expanded && overflows && <div style={descFade} />}
-      </div>
-      {(overflows || expanded) && (
-        <button
-          type="button"
-          data-testid="repo-description-toggle"
-          style={descToggle}
-          onClick={() => setExpanded(e => !e)}
-        >
-          {expanded ? 'Show less' : 'Show more'}
-        </button>
       )}
     </div>
   );
@@ -541,23 +640,46 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
   return (
     <div>
       <div style={detailHead}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
           <span style={lensIconBox}><LayersIcon color={LENS.accent} size={16} /></span>
-          <div>
+          <div style={{ minWidth: 0 }}>
             <h3 style={{ margin: 0, fontSize: 16 }}>{name}</h3>
             <div style={{ fontSize: 12, color: '#777', marginTop: 1 }}>
               lens · {reads.length} mount{reads.length === 1 ? '' : 's'} · writes to {write || '…'}
             </div>
           </div>
         </div>
-        <button type="button" data-testid="lens-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'lens', name })}>
-          <LayersIcon color={LENS.text} size={13} /> Browse
-        </button>
+        {/* Same header grammar as RepoDetail: the one routine action (Edit
+            mounts ≙ Rebuild index), Browse, then the ⋯ overflow. */}
+        <div style={headActions}>
+          <button type="button" data-testid="lens-edit" style={{ ...btn(readOnly || busy || !!editReads), display: 'flex', alignItems: 'center', gap: 6 }}
+            disabled={readOnly || busy || !!editReads} onClick={beginEdit}>
+            <PencilIcon color={readOnly || busy || !!editReads ? '#666' : '#bbb'} size={13} /> Edit mounts
+          </button>
+          <button type="button" data-testid="lens-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'lens', name })}>
+            <LayersIcon color={LENS.text} size={13} /> Browse
+          </button>
+          <ActionMenu
+            testid="lens-menu"
+            label={`Actions for ${name}`}
+            items={[{ label: 'Delete lens', testid: 'lens-delete', danger: true, disabled: readOnly || busy, onSelect: () => setConfirming(true) }]}
+          />
+        </div>
       </div>
 
+      {confirming && (
+        <div style={confirmBox}>
+          <div style={{ fontSize: 13, marginBottom: 8, color: '#f88' }}>Delete lens “{name}”? The underlying repos are not affected.</div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button type="button" data-testid="lens-delete-confirm" style={btn(busy, 'danger')} disabled={busy} onClick={del}>Confirm delete</button>
+            <button type="button" style={btn(busy)} disabled={busy} onClick={() => setConfirming(false)}>Cancel</button>
+          </div>
+        </div>
+      )}
+
       {/* Write target — the one repo new facts land in. */}
-      <div style={{ ...descBox, background: '#1a2a1a', borderColor: '#2a4a2a' }}>
-        <div style={{ ...descLabel, color: '#6a9a6a' }}>Write target</div>
+      <div style={{ ...card, background: '#1a2a1a', borderColor: '#2a4a2a' }}>
+        <div style={{ ...cardLabel, color: '#6a9a6a' }}>Write target</div>
         <div data-testid="lens-detail-write" style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, flexWrap: 'wrap' }}>
           <RepoDot repo={write} />
           <b style={{ color: '#eee' }}>{write || '…'}</b>
@@ -568,9 +690,9 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
 
       {/* Read mounts — the resolved union, in server order. The write repo shows
           here (tagged write · read), never as a separate line. */}
-      <div style={descBox}>
+      <div style={card}>
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <div style={descLabel}>Read mounts (union)</div>
+          <div style={cardLabel}>Read mounts (union)</div>
           <span style={{ fontSize: 11, color: '#777' }}>resolved top → bottom</span>
         </div>
         {reads.length === 0 && <div style={{ color: '#555', fontSize: 13 }}>None</div>}
@@ -591,15 +713,11 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
         })}
       </div>
 
-      <ConnectPanel kind="lens" name={name} />
-
-      {lens?.description && <RepoDescription markdown={lens.description} />}
-
-      {/* Edit mode: toggle read mounts and pin branches, reusing the lens form's
-          checkbox-row language. The write repo is a locked, always-on row. */}
+      {/* Edit mode expands directly under the mounts it edits, so the card you
+          are changing stays in view above the editor. */}
       {editReads && (
-        <div style={{ ...descBox, borderColor: LENS.border }}>
-          <div style={descLabel}>Edit read mounts</div>
+        <div style={{ ...card, borderColor: LENS.border }}>
+          <div style={cardLabel}>Edit read mounts</div>
           {write && (
             <div style={editRow(true)}>
               <span style={editCheckbox(true)}><CheckMark color={LENS.text} /></span>
@@ -640,27 +758,9 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
         </div>
       )}
 
-      {!confirming && !editReads && (
-        <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
-          <button type="button" data-testid="lens-edit" style={{ ...btn(readOnly || busy), display: 'flex', alignItems: 'center', gap: 6 }}
-            disabled={readOnly || busy} onClick={beginEdit}>
-            <PencilIcon color={readOnly || busy ? '#666' : '#bbb'} size={13} /> Edit mounts
-          </button>
-          <button type="button" data-testid="lens-delete" style={{ ...btn(readOnly || busy, 'danger'), display: 'flex', alignItems: 'center', gap: 6 }}
-            disabled={readOnly || busy} onClick={() => setConfirming(true)}>
-            <TrashIcon color={readOnly || busy ? '#666' : '#f88'} size={13} /> Delete
-          </button>
-        </div>
-      )}
-      {confirming && (
-        <div style={confirmBox}>
-          <div style={{ fontSize: 13, marginBottom: 8, color: '#f88' }}>Delete lens “{name}”? The underlying repos are not affected.</div>
-          <div style={{ display: 'flex', gap: 8 }}>
-            <button type="button" data-testid="lens-delete-confirm" style={btn(busy, 'danger')} disabled={busy} onClick={del}>Confirm delete</button>
-            <button type="button" style={btn(busy)} disabled={busy} onClick={() => setConfirming(false)}>Cancel</button>
-          </div>
-        </div>
-      )}
+      {lens?.description && <DescriptionDisclosure markdown={lens.description} />}
+
+      <ConnectPanel kind="lens" name={name} />
     </div>
   );
 }
@@ -715,9 +815,7 @@ function ConnectPanel({ kind, name, agentBranch }: { kind: 'repo' | 'lens'; name
   };
 
   return (
-    <div style={descBox}>
-      <div style={descLabel}>Connect an agent</div>
-
+    <Disclosure label="Connect an agent" hint="copy a command or MCP config" testid={`${kind}-connect-toggle`}>
       {/* Claude Code — the init scaffolding. */}
       <div style={connectClient}>Claude Code<span style={connectHint}>scaffolds skills + hooks</span></div>
       <div style={codeRow}>
@@ -741,7 +839,7 @@ function ConnectPanel({ kind, name, agentBranch }: { kind: 'repo' | 'lens'; name
       <div style={{ fontSize: 12, color: '#666', marginTop: 8 }}>
         MCP endpoint <code style={{ fontFamily: 'var(--k-font-mono)', color: '#aaa' }}>{endpoint}</code>
       </div>
-    </div>
+    </Disclosure>
   );
 }
 
@@ -770,16 +868,31 @@ const plusBtn = (disabled: boolean, active: boolean): React.CSSProperties => ({
   background: active ? '#1d4ed8' : 'transparent', color: disabled ? '#555' : active ? '#fff' : '#9a9a9a',
   border: '1px solid ' + (active ? '#1d4ed8' : '#333'), cursor: disabled ? 'default' : 'pointer', padding: 0,
 });
-const btn = (disabled: boolean, variant: 'primary' | 'secondary' | 'danger' = 'secondary'): React.CSSProperties => ({
-  background: disabled ? '#222' : variant === 'primary' ? '#1d4ed8' : variant === 'danger' ? '#7f1d1d' : '#2a2a2a',
-  color: disabled ? '#666' : '#eee', border: '1px solid #333', borderRadius: 4, padding: '6px 12px', fontSize: 13, cursor: disabled ? 'default' : 'pointer',
+// headActions is the detail-pane header's button cluster: primary action,
+// Browse, then the ⋯ overflow. It never wraps under the title.
+const headActions: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 };
+const disclosureHead: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%',
+  background: 'none', border: 'none', padding: 0, cursor: 'pointer', textAlign: 'left',
+};
+const menuTrigger = (open: boolean): React.CSSProperties => ({
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  width: 30, height: 30, borderRadius: 5, padding: 0,
+  background: open ? '#2a2a2a' : 'transparent', border: '1px solid ' + (open ? '#444' : '#333'),
+  cursor: 'pointer',
 });
-const descBox: React.CSSProperties = { marginTop: 14, padding: '10px 12px', background: '#111', border: '1px solid #2a2a2a', borderRadius: 6 };
-const descLabel: React.CSSProperties = { fontSize: 10, textTransform: 'uppercase', letterSpacing: 1.5, color: '#555', marginBottom: 6 };
-const descFade: React.CSSProperties = { position: 'absolute', left: 0, right: 0, bottom: 0, height: 36, background: 'linear-gradient(transparent, #111)', pointerEvents: 'none' };
-const descToggle: React.CSSProperties = { marginTop: 8, background: 'none', border: 'none', color: '#8af', fontSize: 12, cursor: 'pointer', padding: 0 };
-const confirmBox: React.CSSProperties = { marginTop: 16, padding: 14, background: '#111', border: '1px solid #333', borderRadius: 6 };
-const confirmInput: React.CSSProperties = { width: '100%', boxSizing: 'border-box', background: '#0c0c0c', border: '1px solid #333', color: '#eee', padding: '6px 8px', borderRadius: 4, fontSize: 13 };
+const menuPanel: React.CSSProperties = {
+  position: 'absolute', top: 'calc(100% + 6px)', right: 0, zIndex: 10, minWidth: 190,
+  background: '#1c1c1c', border: '1px solid #383838', borderRadius: 6, padding: 4,
+  boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+};
+const menuSeparator: React.CSSProperties = { height: 1, background: '#2e2e2e', margin: '4px 6px' };
+const menuItemStyle = (disabled: boolean, danger: boolean): React.CSSProperties => ({
+  display: 'block', width: '100%', textAlign: 'left',
+  background: 'none', border: 'none', borderRadius: 4, padding: '7px 10px', fontSize: 13,
+  color: disabled ? '#5a5a5a' : danger ? '#f88' : '#ddd',
+  cursor: disabled ? 'default' : 'pointer',
+});
 
 // browseBtn is the lens-accent "Browse" pill, shared by the lens and repo detail
 // panes (design handoff: LENS.accent fill, LENS.text text, 13px/600, radius 5).

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -5,11 +5,12 @@ import { api, type ArchivedRepo, type RepoInfo, type Lens, type LensRead } from 
 import { CreateRepoForm } from './CreateRepoForm';
 import { markdownPlugins, markdownComponents } from './markdown';
 import { CreateLensForm } from './CreateLensForm';
-import { RemoteCard, useRemote } from './RemoteStatus';
+import { RemoteCard } from './RemoteStatus';
+import { useRemote } from './useRemote';
 import { RemoteConnectWizard } from './RemoteConnectWizard';
 import { LENS, repoHue, repoHueBg, repoHueBorder } from './utils';
-import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon, LayersIcon, PencilIcon, CopyIcon, WrenchIcon, MoreVerticalIcon, ChevronDownIcon } from './icons';
-import { btn, card, cardLabel, confirmBox, confirmInput } from './manageStyles';
+import { BookIcon, ArchiveIcon, PlusIcon, GitBranchIcon, LayersIcon, PencilIcon, CopyIcon, MoreVerticalIcon, ChevronDownIcon } from './icons';
+import { btn, card, cardIconBtn, cardLabel, confirmBox, confirmInput, writeCard, writeCardLabel } from './manageStyles';
 import type { BrowseContext } from './state';
 
 // BrowseContext names the surface a Browse action should switch the app to:
@@ -234,19 +235,26 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
   const [rebuildMsg, setRebuildMsg] = useState('');
   const [busy, setBusy] = useState(false);
   const [confirming, setConfirming] = useState<'disconnect' | null>(null);
-  const mounted = useRef(true);
   // The detail pane owns the remote so its ⋯ menu can offer Connect vs
   // Reconnect/Disconnect; RemoteCard is the display half of the same state.
   const remote = useRemote(name, !hideRemoteConfig);
 
   useEffect(() => {
-    mounted.current = true;
     let cancelled = false;
     api.getAgentBranch(name).then(b => { if (!cancelled) setAgentBranch(b); }).catch(() => {});
     setDescription('');
     api.getRepo(name).then(r => { if (!cancelled) setDescription(r.description ?? ''); }).catch(() => {});
-    return () => { cancelled = true; mounted.current = false; };
+    return () => { cancelled = true; };
   }, [name]);
+
+  // The "rebuild started" banner clears itself after a beat. Owning the timer
+  // in an effect rather than a setTimeout guarded by a mounted ref means
+  // unmounting cancels it for free — and keeps refs out of the render path.
+  useEffect(() => {
+    if (!rebuildMsg.startsWith('✓')) return;
+    const id = setTimeout(() => setRebuildMsg(''), 6000);
+    return () => clearTimeout(id);
+  }, [rebuildMsg]);
 
   // Rebuild is a fire-and-forget background job (TaskHub) — the POST returns as
   // soon as it's queued, the re-index runs server-side. We confirm it started;
@@ -257,13 +265,12 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
       const branch = agentBranch || await api.getAgentBranch(name);
       await api.rebuild(name, branch);
       setRebuildMsg('✓ Rebuild started — re-indexing in the background.');
-      setTimeout(() => { if (mounted.current) setRebuildMsg(''); }, 6000);
     } catch (e) {
       const msg = String(e);
       setRebuildMsg('');
       onError(/409|conflict/i.test(msg) ? 'A rebuild is already running for this repo.' : `rebuild failed: ${msg}`);
     } finally {
-      if (mounted.current) setRebuilding(false);
+      setRebuilding(false);
     }
   };
   const archive = async () => {
@@ -279,19 +286,18 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
     finally { setBusy(false); }
   };
 
-  // Every non-routine repo action lives in one ⋯ menu next to Browse, so the
-  // pane's body is pure information. Remote items are omitted entirely when the
-  // deployment hides remote config.
-  const menuItems: MenuItem[] = [];
-  if (!hideRemoteConfig) {
-    if (remote.origin) {
-      menuItems.push({ label: 'Reconnect / change…', testid: 'remote-reconnect', disabled: readOnly, onSelect: onConnect });
-      menuItems.push({ label: 'Disconnect', testid: 'remote-disconnect', danger: true, disabled: readOnly, onSelect: () => setConfirming('disconnect') });
-    } else if (!remote.loading) {
-      menuItems.push({ label: 'Connect a remote…', testid: 'remote-connect-menu', disabled: readOnly, onSelect: onConnect });
-    }
-    if (menuItems.length) menuItems.push({ separator: true });
+  // The ⋯ menu holds WHOLE-REPO actions. Actions that edit one card's data
+  // (reconnect/disconnect the remote) live on that card instead. "Connect a
+  // remote" is here rather than as a permanent button because an unconnected
+  // repo renders no Remote card at all — there is no remote state to show.
+  const menuItems: MenuItem[] = [{
+    label: rebuilding ? 'Rebuilding…' : 'Rebuild index', testid: 'repo-rebuild',
+    disabled: readOnly || rebuilding, onSelect: rebuild,
+  }];
+  if (!hideRemoteConfig && !remote.loading && !remote.origin) {
+    menuItems.push({ label: 'Connect a remote…', testid: 'remote-connect', disabled: readOnly, onSelect: onConnect });
   }
+  menuItems.push({ separator: true });
   menuItems.push({
     label: 'Archive', testid: 'repo-archive', danger: true, disabled: !canArchive || busy,
     hint: name === 'core' ? 'the default repo cannot be archived' : undefined,
@@ -309,10 +315,6 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
           </div>
         </div>
         <div style={headActions}>
-          <button type="button" data-testid="repo-rebuild" style={{ ...btn(readOnly || rebuilding), display: 'flex', alignItems: 'center', gap: 6 }}
-            disabled={readOnly || rebuilding} onClick={rebuild}>
-            <WrenchIcon color={readOnly || rebuilding ? '#666' : '#bbb'} size={13} /> {rebuilding ? 'Rebuilding…' : 'Rebuild index'}
-          </button>
           <button type="button" data-testid="repo-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'repo', repo: name })}>
             <BookIcon color={LENS.text} size={13} /> Browse
           </button>
@@ -337,10 +339,12 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
       {/* ── Information, most-load-bearing first: where writes go, then what
           this repo is wired to. Reference material collapses below. ── */}
 
-      {/* Agent branch — where this repo's facts are written (mirrors the lens
-          write-target box, tinted blue to match the branch chip). */}
-      <div style={{ ...card, background: '#141c26', borderColor: '#28405c' }}>
-        <div style={{ ...cardLabel, color: '#6a86b0' }}>Agent branch</div>
+      {/* Agent branch — where this repo's facts are written. Shares the lens
+          write-target's green treatment: green already means "writes land
+          here" in this UI (see writeReadTag), and a repo's agent branch is
+          exactly the same statement as a lens's write target. */}
+      <div style={writeCard}>
+        <div style={writeCardLabel}>Agent branch</div>
         <div data-testid="repo-detail-branch" style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, flexWrap: 'wrap' }}>
           <RepoDot repo={name} />
           <b style={{ color: '#eee' }}>{name}</b>
@@ -349,9 +353,12 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
         </div>
       </div>
 
-      {!hideRemoteConfig && (
+      {/* No remote → no card. The pane shows state; the ⋯ menu offers to
+          create the state that isn't there yet. */}
+      {!hideRemoteConfig && (remote.loading || remote.origin) && (
         <RemoteCard repo={name} agentBranch={agentBranch} readOnly={readOnly}
-          state={remote} onConnect={onConnect} onChanged={onChanged} />
+          state={remote} onConnect={onConnect} onDisconnect={() => setConfirming('disconnect')}
+          onChanged={onChanged} />
       )}
 
       {description && <DescriptionDisclosure markdown={description} />}
@@ -369,10 +376,23 @@ function Disclosure({ label, hint, testid, bodyTestid, children }: {
   label: string; hint?: string; testid: string; bodyTestid?: string; children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  // A disclosure near the bottom of the pane would otherwise expand below the
+  // fold, leaving the body it just revealed half off-screen. Pull the whole
+  // card into view once the expanded content has laid out. 'nearest' scrolls
+  // only as far as needed, so an already-visible card never jumps.
+  useEffect(() => {
+    if (!open) return;
+    const id = requestAnimationFrame(() => boxRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' }));
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
   return (
-    <div style={card}>
+    <div ref={boxRef} style={card}>
       <button
         type="button"
+        className="k-bare"
         data-testid={testid}
         aria-expanded={open}
         style={disclosureHead}
@@ -565,6 +585,15 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
   // dropdown can offer it as the "(default)" option and filter it out of the
   // explicit-pin list — never the write repo's agent branch (a different repo).
   const [agentBranches, setAgentBranches] = useState<Record<string, string>>({});
+  const editRef = useRef<HTMLDivElement>(null);
+
+  // Opening the editor reveals content below the mounts card; scroll it in so
+  // Save/Cancel are reachable without hunting for them.
+  useEffect(() => {
+    if (!editReads) return;
+    const id = requestAnimationFrame(() => editRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' }));
+    return () => cancelAnimationFrame(id);
+  }, [editReads]);
 
   useEffect(() => {
     setLens(initial);
@@ -649,13 +678,10 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
             </div>
           </div>
         </div>
-        {/* Same header grammar as RepoDetail: the one routine action (Edit
-            mounts ≙ Rebuild index), Browse, then the ⋯ overflow. */}
+        {/* Same header grammar as RepoDetail: Browse, then the ⋯ overflow for
+            whole-lens actions. Editing the mounts is a card-local action and
+            lives on the Read mounts card itself. */}
         <div style={headActions}>
-          <button type="button" data-testid="lens-edit" style={{ ...btn(readOnly || busy || !!editReads), display: 'flex', alignItems: 'center', gap: 6 }}
-            disabled={readOnly || busy || !!editReads} onClick={beginEdit}>
-            <PencilIcon color={readOnly || busy || !!editReads ? '#666' : '#bbb'} size={13} /> Edit mounts
-          </button>
           <button type="button" data-testid="lens-browse" style={browseBtn} onClick={() => onBrowse({ kind: 'lens', name })}>
             <LayersIcon color={LENS.text} size={13} /> Browse
           </button>
@@ -677,9 +703,10 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
         </div>
       )}
 
-      {/* Write target — the one repo new facts land in. */}
-      <div style={{ ...card, background: '#1a2a1a', borderColor: '#2a4a2a' }}>
-        <div style={{ ...cardLabel, color: '#6a9a6a' }}>Write target</div>
+      {/* Write target — the one repo new facts land in. Same green card as a
+          repo's Agent branch: both answer "where do new facts go". */}
+      <div style={writeCard}>
+        <div style={writeCardLabel}>Write target</div>
         <div data-testid="lens-detail-write" style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, flexWrap: 'wrap' }}>
           <RepoDot repo={write} />
           <b style={{ color: '#eee' }}>{write || '…'}</b>
@@ -691,9 +718,16 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
       {/* Read mounts — the resolved union, in server order. The write repo shows
           here (tagged write · read), never as a separate line. */}
       <div style={card}>
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <div style={cardLabel}>Read mounts (union)</div>
-          <span style={{ fontSize: 11, color: '#777' }}>resolved top → bottom</span>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+          <div style={{ ...cardLabel, marginBottom: 0 }}>Read mounts (union)</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 11, color: '#777' }}>resolved top → bottom</span>
+            <button type="button" className="k-bare" data-testid="lens-edit"
+              title="Edit read mounts" aria-label="Edit read mounts"
+              style={cardIconBtn} disabled={readOnly || busy || !!editReads} onClick={beginEdit}>
+              <PencilIcon color={readOnly || busy || !!editReads ? '#555' : '#888'} size={13} />
+            </button>
+          </div>
         </div>
         {reads.length === 0 && <div style={{ color: '#555', fontSize: 13 }}>None</div>}
         {reads.map((r, i) => {
@@ -714,9 +748,10 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
       </div>
 
       {/* Edit mode expands directly under the mounts it edits, so the card you
-          are changing stays in view above the editor. */}
+          are changing stays in view above the editor. Like a disclosure, it is
+          pulled into view so its Save/Cancel are never left below the fold. */}
       {editReads && (
-        <div style={{ ...card, borderColor: LENS.border }}>
+        <div ref={editRef} style={{ ...card, borderColor: LENS.border }}>
           <div style={cardLabel}>Edit read mounts</div>
           {write && (
             <div style={editRow(true)}>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -72,6 +72,18 @@ async function getRepo(repo: string): Promise<RepoDetails> {
   return fetchJSON<RepoDetails>(repoBase(repo));
 }
 
+// updateRepo PATCHes /api/v1/repos/{repo}. The only editable field is
+// description, which the server commits to the repo's kb.md root manifest on
+// the agent branch — so editing it here writes a real commit into the repo's
+// history. Returns the re-read repo view (same shape as getRepo).
+async function updateRepo(repo: string, body: { description?: string }): Promise<RepoDetails> {
+  return fetchJSON<RepoDetails>(repoBase(repo), {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
 // LensRead is one read-mount of a lens: a source repo, optionally pinned to a
 // branch and/or a source label (the server fills defaults when omitted).
 export interface LensRead { repo: string; branch?: string; source?: string }
@@ -678,6 +690,7 @@ async function deleteLens(name: string): Promise<void> {
 export const api = {
   getAgentBranch,
   getRepo,
+  updateRepo,
 
   repos: (): Promise<RepoInfo[]> =>
     fetchJSON<any>(apiUrl('/api/v1/repos')).then(data => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -72,6 +72,16 @@ async function getRepo(repo: string): Promise<RepoDetails> {
   return fetchJSON<RepoDetails>(repoBase(repo));
 }
 
+/* Description caps, in BYTES (not characters) — mirrors of the server-side
+ * limits, kept here beside the calls they bound. A repo's kb.md is a manifest
+ * that runs to pages; a lens description is a note about a read union, and its
+ * cap is more than an order of magnitude smaller. An editor shared by both must
+ * say which one it is holding, or the difference only surfaces as a 422.
+ *   repos.MaxRepoDescriptionBytes — internal/repos/manifest.go
+ *   repos.MaxLensDescriptionBytes — internal/repos/lens.go */
+export const MAX_REPO_DESCRIPTION_BYTES = 64 * 1024;
+export const MAX_LENS_DESCRIPTION_BYTES = 4096;
+
 // updateRepo PATCHes /api/v1/repos/{repo}. The only editable field is
 // description, which the server commits to the repo's kb.md root manifest on
 // the agent branch — so editing it here writes a real commit into the repo's

--- a/web/src/icons.tsx
+++ b/web/src/icons.tsx
@@ -43,6 +43,16 @@ export const MoreVerticalIcon = ({ color, size = 14 }: IconProps) => (
   </svg>
 );
 
+/** UnlinkIcon — a broken chain link, for disconnecting a remote. */
+export const UnlinkIcon = ({ color, size = 14 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+    <path d="M15 7h2a5 5 0 0 1 4 8" />
+    <line x1="8" y1="12" x2="12" y2="12" />
+    <line x1="2" y1="2" x2="22" y2="22" />
+  </svg>
+);
+
 export const GearIcon = ({ color, size = 14 }: IconProps) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="12" cy="12" r="3"/>

--- a/web/src/manageStyles.ts
+++ b/web/src/manageStyles.ts
@@ -1,0 +1,47 @@
+// Shared visual tokens for the Manage dialog (RepoManager + RemoteStatus).
+//
+// These lived as private consts in RepoManager.tsx, with RemoteStatus.tsx
+// carrying its own near-identical copies of btn/confirmBox and a `sectionLabel`
+// that did NOT match descLabel — which is why the Remote block read as a
+// bolted-on section rather than one of the detail pane's cards. One module, one
+// definition, so every card in the pane is structurally identical.
+
+/** card is the standard detail-pane card: a bordered dark box with a label. */
+export const card: React.CSSProperties = {
+  marginTop: 14, padding: '10px 12px',
+  background: '#111', border: '1px solid #2a2a2a', borderRadius: 6,
+};
+
+/** cardLabel is the small uppercase caption at the top of a card. */
+export const cardLabel: React.CSSProperties = {
+  fontSize: 10, textTransform: 'uppercase', letterSpacing: 1.5,
+  color: '#555', marginBottom: 6,
+};
+
+export const btn = (
+  disabled: boolean,
+  variant: 'primary' | 'secondary' | 'danger' = 'secondary',
+): React.CSSProperties => ({
+  background: disabled ? '#222' : variant === 'primary' ? '#1d4ed8' : variant === 'danger' ? '#7f1d1d' : '#2a2a2a',
+  color: disabled ? '#666' : '#eee',
+  border: '1px solid #333', borderRadius: 4,
+  padding: '6px 12px', fontSize: 13,
+  cursor: disabled ? 'default' : 'pointer',
+});
+
+export const confirmBox: React.CSSProperties = {
+  marginTop: 14, padding: 14,
+  background: '#111', border: '1px solid #333', borderRadius: 6,
+};
+
+export const confirmInput: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box',
+  background: '#0c0c0c', border: '1px solid #333', color: '#eee',
+  padding: '6px 8px', borderRadius: 4, fontSize: 13,
+};
+
+/** linkBtn is the inline blue "change…" affordance inside a card. */
+export const linkBtn: React.CSSProperties = {
+  background: 'none', border: 'none', color: '#6ea8fe',
+  cursor: 'pointer', fontSize: 12, padding: 0, textDecoration: 'underline',
+};

--- a/web/src/manageStyles.ts
+++ b/web/src/manageStyles.ts
@@ -18,6 +18,24 @@ export const cardLabel: React.CSSProperties = {
   color: '#555', marginBottom: 6,
 };
 
+/** writeCard / writeCardLabel: the green "new facts land here" card. Used by
+ *  BOTH a repo's Agent branch and a lens's Write target — they make the same
+ *  statement, so they get the same treatment (green already reads as "write"
+ *  in this UI via the write·read mount tag). */
+export const writeCard: React.CSSProperties = {
+  ...card, background: '#1a2a1a', borderColor: '#2a4a2a',
+};
+export const writeCardLabel: React.CSSProperties = { ...cardLabel, color: '#6a9a6a' };
+
+/** cardIconBtn is a small square icon action in a card's header — for actions
+ *  that edit THAT card's data (reconnect the remote, edit the read mounts), as
+ *  opposed to the pane-level ⋯ menu's whole-object actions. */
+export const cardIconBtn: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  width: 24, height: 24, borderRadius: 4, padding: 0,
+  background: 'none', border: 'none', cursor: 'pointer',
+};
+
 export const btn = (
   disabled: boolean,
   variant: 'primary' | 'secondary' | 'danger' = 'secondary',

--- a/web/src/useRemote.ts
+++ b/web/src/useRemote.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api, type OriginResponse } from './api';
+
+/** RemoteState is the loaded remote for one repo. RepoDetail owns it (rather
+ *  than RemoteCard) because the detail pane's ⋯ menu has to know whether a
+ *  remote exists before it can decide between offering "Connect a remote…" and
+ *  rendering the card at all. */
+export interface RemoteState {
+  origin: OriginResponse | null;
+  loading: boolean;
+  err: string;
+  setErr: (m: string) => void;
+  reload: () => void;
+}
+
+/** useRemote loads (and reloads) a repo's origin. `enabled` is false when the
+ *  deployment hides remote config — the hook still runs (hooks cannot be
+ *  conditional) but issues no request and reports "not connected".
+ *
+ *  Lives in its own module so RemoteStatus.tsx exports only components and
+ *  fast refresh keeps working. */
+export function useRemote(repo: string, enabled = true): RemoteState {
+  const [origin, setOrigin] = useState<OriginResponse | null>(null);
+  const [loading, setLoading] = useState(enabled);
+  const [err, setErr] = useState('');
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    setLoading(true); setErr('');
+    api.getOrigin(repo)
+      .then(o => { if (!cancelled) setOrigin(o); })
+      .catch(() => { if (!cancelled) setErr('could not load remote status'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [repo, enabled, nonce]);
+
+  const reload = useCallback(() => setNonce(n => n + 1), []);
+  // When disabled, report "not connected, not loading" by derivation rather
+  // than by writing state from the effect — nothing was ever fetched.
+  if (!enabled) return { origin: null, loading: false, err: '', setErr, reload };
+  return { origin, loading, err, setErr, reload };
+}


### PR DESCRIPTION
Cleans up the Manage dialog's repo and lens detail panes, then makes both descriptions editable.

## Why

The detail panes had reference material outranking state, and actions scattered across three scroll depths: "Connect an agent" sat expanded near the top with two code blocks, while Rebuild/Archive lived at the bottom and Reconnect/Disconnect below that, inside the remote section. `RemoteStatus` also carried its own copies of `btn`/`confirmBox` and a `sectionLabel` that didn't match `descLabel` — which is why Remote read as a bolted-on section rather than one of the pane's cards.

## What changed

**Layout.** Both panes now read the same way — state first, most load-bearing first, reference material behind disclosures:

| band | repo | lens |
|---|---|---|
| header | Browse · ⋯ | Browse · ⋯ |
| where writes go | Agent branch | Write target |
| what it's wired to | Remote | Read mounts (union) |
| collapsed | ▸ Description, ▸ Connect an agent | ▸ Description, ▸ Connect an agent |

**Action placement** follows one rule: the ⋯ menu holds whole-object actions (Rebuild index, Connect a remote, Archive / Delete lens); card icon buttons hold actions that edit that card's own data (Remote: reconnect + disconnect; Read mounts: edit). An unconnected repo renders **no** Remote card at all — there's no remote state to show, so the permanent "Connect a remote…" call-to-action becomes a menu item and the pane stays quiet.

**Colour.** A repo's Agent branch and a lens's Write target make the same statement — "new facts land here" — so they share one green card instead of blue-vs-green. Green already means *write* in this UI via the `write · read` mount tag.

**Editable descriptions.** New `PATCH /api/v1/repos/{repo}` takes `{"description": md}` and commits it to `kb.md` on the agent branch — the exact file and branch `readKBManifest` reads, so an edit round-trips through GET. The response is the re-read view (identical in shape to GET), not an echo, so the client always shows what actually landed. Markdown is stored byte-for-byte; an omitted field is a no-op, an explicit `""` clears the manifest. The cap is 64 KiB, far above the lens's 4 KiB: a lens description is a note about a read union, `kb.md` is a repo manifest that routinely runs to pages.

Lenses needed no backend work — `PATCH /lenses/{name}` already accepted `description`.

`kb.md` is not a fact, so this moves the file and its git history only. The search indexer already skips it as unparseable, and it stays out of the fact activity feed.

## Notes for review

- **Behaviour preserved deliberately:** Archive still fires without a confirm, as the old red button did. It's now one click deeper and recoverable via Restore, but a confirm step would be a reasonable follow-up.
- **Last-write-wins on `kb.md`.** No `If-Match` on the blob hash, matching the existing fact-write path. Worth revisiting for a file an agent may also be writing.
- **`kb.md` edits leave no trace in the UI.** The commit log tracks only fact commits, so the git commit exists but doesn't surface in history.
- `useRemote` moved to its own module so `RemoteStatus.tsx` exports only components and fast refresh keeps working. `RepoDetail`'s `mounted` ref is gone — the rebuild banner's timer is owned by an effect, which also keeps refs out of the render path.
- Lint on the touched files went from 4 pre-existing `react-hooks` errors to 3.

## Verification

- 644 frontend tests, `internal/web` + `internal/repos` + `internal/store` green; typecheck, eslint, production build, `go vet` clean. OpenAPI updated.
- 7 new Go handler tests (round-trip, verbatim storage, omitted-vs-empty, over/at cap, malformed body, unknown repo) and new UI tests for disclosure defaults, band ordering, menu dismissal, and the description editor.
- Driven end-to-end in a browser against a live server with real repos. Editing the `test` repo's description produced a real `docs: update kb.md root manifest` commit on the agent branch, confirmed byte-identical through a `git clone` of the server's git remote.