### PR TITLE
fix(mcp): surface sources on every explain node, including summaries

### DIFF
--- a/internal/mcp/explain.go
+++ b/internal/mcp/explain.go
@@ -51,13 +51,19 @@ type explainFactEntry struct {
 	Type       string  `json:"type"`
 	Kind       string  `json:"kind"`
 	Confidence float64 `json:"confidence"`
-	Deleted    bool    `json:"deleted,omitempty"`
-	Superseded bool    `json:"superseded,omitempty"`
-	Summary    bool    `json:"summary,omitempty"`
+	// Sources rides with Confidence on every node, summaries included: the two
+	// together are the epistemic weight a caller needs to judge a node it did
+	// not open, and instructions.go requires both for each fact cited in a
+	// hypothesis evidence chain. No omitempty — sources: 0 is the claim "no
+	// independent sources recorded", not an absence, and fact.Fact serializes it
+	// unconditionally, so dropping it here would make explain and query disagree.
+	Sources    int  `json:"sources"`
+	Deleted    bool `json:"deleted,omitempty"`
+	Superseded bool `json:"superseded,omitempty"`
+	Summary    bool `json:"summary,omitempty"`
 
 	// Root-only fields (omitted on summary nodes).
 	Domain         []string        `json:"domain,omitempty"`
-	Sources        int             `json:"sources,omitempty"`
 	Entities       []string        `json:"entities,omitempty"`
 	EvidenceWeight float64         `json:"evidence_weight,omitempty"`
 	Body           string          `json:"body,omitempty"`
@@ -560,6 +566,7 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 				Type:       string(parsed.Type),
 				Kind:       kindString(parsed),
 				Confidence: parsed.Confidence,
+				Sources:    parsed.Sources,
 				Deleted:    deleted,
 				Superseded: superseded,
 				Summary:    true,

--- a/internal/mcp/explain_test.go
+++ b/internal/mcp/explain_test.go
@@ -33,13 +33,16 @@ type expRefs struct {
 }
 
 type expFact struct {
-	Path       string      `json:"path"`
-	Commit     string      `json:"commit"`
-	Depth      int         `json:"depth"`
-	Title      string      `json:"title"`
-	Type       string      `json:"type"`
-	Kind       string      `json:"kind"`
-	Confidence float64     `json:"confidence"`
+	Path       string  `json:"path"`
+	Commit     string  `json:"commit"`
+	Depth      int     `json:"depth"`
+	Title      string  `json:"title"`
+	Type       string  `json:"type"`
+	Kind       string  `json:"kind"`
+	Confidence float64 `json:"confidence"`
+	// Sources is a pointer so a test can tell "key absent" from "present and
+	// zero" — the exact distinction the omitempty on explainFactEntry erased.
+	Sources    *int        `json:"sources"`
 	Body       string      `json:"body"`
 	Summary    bool        `json:"summary"`
 	Deleted    bool        `json:"deleted"`
@@ -60,13 +63,21 @@ const explainTestBranch = "agent/test"
 // ontology validation) and returns the commit hash it was written at.
 func writeExplainFact(t *testing.T, ctx context.Context, ri *repos.RepoInstance, path, title string, conf float64, refs []string) string {
 	t.Helper()
+	return writeExplainFactSources(t, ctx, ri, path, title, conf, 1, refs)
+}
+
+// writeExplainFactSources is writeExplainFact with an explicit sources count.
+// The default of 1 hides the sources: 0 case, which is the common one in real
+// corpora and the one the omitempty defect made invisible.
+func writeExplainFactSources(t *testing.T, ctx context.Context, ri *repos.RepoInstance, path, title string, conf float64, sources int, refs []string) string {
+	t.Helper()
 	f := fact.NewFact(path)
 	f.Title = title
 	f.Body = title + " body text."
 	f.Type = fact.Observation
 	f.Domain = []string{"testing"}
 	f.Confidence = conf
-	f.Sources = 1
+	f.Sources = sources
 	f.Entities = []string{}
 	f.Refs = refs
 	content, err := fact.SerializeFact(f)
@@ -183,6 +194,52 @@ func TestExplain_RootFullNodesAreSummaries(t *testing.T) {
 	require.Equal(t, "observation", child.Type, "summary keeps type")
 	require.Equal(t, "epistemic", child.Kind, "summary keeps kind")
 	require.InDelta(t, 0.88, child.Confidence, 1e-9, "summary keeps confidence")
+}
+
+// TestExplain_SummaryNodesCarrySources pins that sources reaches summary nodes,
+// not just the root. instructions.go requires a hypothesis evidence chain to cite
+// "confidence/sources for each cited fact", and those cited facts arrive from the
+// provenance walk as summaries — so a summary carrying confidence but no sources
+// asks the agent for a number the tool never returned.
+func TestExplain_SummaryNodesCarrySources(t *testing.T) {
+	ri := newLearnTestRepo(t, fact.CodeOntology())
+	ctx := repos.WithRepoInstance(context.Background(), ri)
+
+	writeExplainFactSources(t, ctx, ri, "kb/child.md", "Child", 0.88, 3, nil)
+	writeExplainFactSources(t, ctx, ri, "kb/root.md", "Root", 0.90, 2, []string{"kb/child.md"})
+
+	facts := explainAll(t, ctx, "kb/root.md", "")
+
+	child := findExpFact(facts, "kb/child.md")
+	require.NotNil(t, child)
+	require.True(t, child.Summary, "kb/child.md is a summary node")
+	require.NotNil(t, child.Sources, "summary nodes must carry sources alongside confidence")
+	require.Equal(t, 3, *child.Sources, "summary reports the fact's own sources count")
+}
+
+// TestExplain_ZeroSourcesIsSerialized pins that sources: 0 is emitted rather than
+// dropped. Zero is a claim — "no independent sources recorded" — not an absence.
+// fact.Fact serializes sources without omitempty (internal/fact/format.go), so
+// knomit_query already reports "sources":0 for these facts; omitting it here made
+// the two tools disagree about the same field on the same corpus.
+func TestExplain_ZeroSourcesIsSerialized(t *testing.T) {
+	ri := newLearnTestRepo(t, fact.CodeOntology())
+	ctx := repos.WithRepoInstance(context.Background(), ri)
+
+	writeExplainFactSources(t, ctx, ri, "kb/child.md", "Child", 0.88, 0, nil)
+	writeExplainFactSources(t, ctx, ri, "kb/root.md", "Root", 0.90, 0, []string{"kb/child.md"})
+
+	facts := explainAll(t, ctx, "kb/root.md", "")
+
+	root := findExpFact(facts, "kb/root.md")
+	require.NotNil(t, root)
+	require.NotNil(t, root.Sources, "root must emit sources: 0, not drop the key")
+	require.Equal(t, 0, *root.Sources)
+
+	child := findExpFact(facts, "kb/child.md")
+	require.NotNil(t, child)
+	require.NotNil(t, child.Sources, "summary must emit sources: 0, not drop the key")
+	require.Equal(t, 0, *child.Sources)
 }
 
 // TestExplain_RootHistoryEvolution pins the root's evolution: revisions newest


### PR DESCRIPTION
## Problem

`internal/mcp/instructions.go` tells the agent to trace provenance with `knomit_explain`, then requires the hypothesis evidence chain to cite *"confidence/sources for each cited fact"*. Those cited facts arrive from the walk as **summary nodes** — which carried `confidence` and no `sources` at all. The tool asked the agent for a number it never returned.

Two defects composed to produce that, both on `explainFactEntry`:

| Defect | Effect |
| --- | --- |
| `Sources` sat in the root-only block | No node past depth 0 carried it |
| `json:"sources,omitempty"` | `sources: 0` dropped even on the root — and 0 is the common case in a real corpus |

The `omitempty` was also a straight disagreement with the sibling tool: `fact.Fact` declares `json:"sources"` unconditionally (`internal/fact/format.go:22`), so `knomit_query` reports `"sources":0` for a fact `knomit_explain` reported with no `sources` key. Same field, same corpus, two answers — which is what makes a reader conclude explain doesn't surface it.

## Change

Move `Sources` up beside `Confidence` — together they're the epistemic weight a caller needs to judge a node it hasn't opened — and drop `omitempty`, since `0` is the claim "no independent sources recorded", not an absence.

```json
{
  "path": "kb/architecture/store/graph-schema-version/028172a8.md",
  "depth": 1,
  "confidence": 0.95,
  "sources": 0,
  "summary": true
}
```

Costs ~14 bytes/node on a page of at most 25. The tool description is unchanged: it enumerates only the fields needing interpretation (`deleted`, `superseded`), and `sources` is self-describing.

### Not in scope

`confidence` was reported missing alongside sources. It isn't — `Confidence float64` has no `omitempty` and is set at both construction sites; a live walk returned it on all six depth-1 nodes. Unchanged here.

`evidence_weight` and `refs` stay root-only. `evidence_weight` is only written when `> 0`, so its `omitempty` is correct; `refs.external` on summaries is useful but wants its own driver.

## Tests

Written first, both watched failing with `Expected value not to be nil` before the fix:

- `TestExplain_SummaryNodesCarrySources` — `sources` reaches a depth-1 node.
- `TestExplain_ZeroSourcesIsSerialized` — `sources: 0` is emitted, not dropped, on root and summary.

The test mirror takes `*int` so it can distinguish an absent key from a zero value. `writeExplainFact` hardcoded `Sources = 1`, which made the `omitempty` defect invisible by construction, so it now delegates to a sources-aware variant rather than changing ~30 existing call sites.

`go build ./...`, `go vet ./internal/mcp/`, and `go test ./...` all pass; `gofmt` clean.

## Blast radius

`explainFactEntry` never leaves `explain.go` — no web, CLI, or bridge consumer. No knomit fact pins the root/summary field split, so nothing in the corpus drifts.