### PR TITLE
fix(review): deliver oversized work items by paging, over clustered input

### DIFF
--- a/internal/mcp/review.go
+++ b/internal/mcp/review.go
@@ -21,9 +21,11 @@ import (
 // timeout. Clients without task support get the original synchronous behavior.
 func reviewTool() mcpgo.Tool {
 	return mcpgo.NewTool("knomit_review",
-		mcpgo.WithDescription("Maintain the existing knowledge base: prune redundant facts, distill clusters into higher-order synthesis facts, and reflect on hypothesis transitions to record methodology. Does NOT generate new hypotheses — that is a separate explicit operation via knomit_hypothesize. When a user asks for a 'review', they want only this tool; do not chain to knomit_hypothesize unless the user explicitly requests hypothesis generation. Call with no arguments to start a new review session. Call with session_id + response to continue. STOP when the result has done: true — the session is finished and that session_id can no longer be continued; calling with it again is an error. A start call may return done: true immediately when there is nothing to review; that is a normal, complete outcome, not a reason to retry."),
+		mcpgo.WithDescription("Maintain the existing knowledge base: prune redundant facts, distill clusters into higher-order synthesis facts, and reflect on hypothesis transitions to record methodology. Does NOT generate new hypotheses — that is a separate explicit operation via knomit_hypothesize. When a user asks for a 'review', they want only this tool; do not chain to knomit_hypothesize unless the user explicitly requests hypothesis generation. Call with no arguments to start a new review session. Call with session_id + response to continue. STOP when the result has done: true — the session is finished and that session_id can no longer be continued; calling with it again is an error. A start call may return done: true immediately when there is nothing to review; that is a normal, complete outcome, not a reason to retry. PAGED ITEMS: a work item whose facts exceed one tool result arrives split across pages. If a result has more_available: true, you have NOT seen the whole item — do not answer it. Call again with session_id, item_id and page = <next page> until more_available is false, accumulating every page, then answer once using the completion_token from the final page. Answering a paged item early is rejected."),
 		mcpgo.WithString("session_id", mcpgo.Description("Session ID from a previous call. Omit to start a new session.")),
 		mcpgo.WithString("response", mcpgo.Description("Your JSON decisions for the previous work item.")),
+		mcpgo.WithNumber("page", mcpgo.Description("Fetch another page of the CURRENT work item, without answering it. Large items are delivered across several pages: when a result carries more_available: true, call again with session_id, item_id and page = <the next page number> until more_available is false, THEN answer. Paging does not answer or advance anything, so pages may be re-fetched freely. Omit when submitting a response.")),
+		mcpgo.WithString("completion_token", mcpgo.Description("Echo back the completion_token from the FINAL page of a multi-page work item. Required to answer such an item: it is the server's proof you read every page, and a response without it is rejected (the item stays available, so you can page properly and resubmit). Not needed for items delivered in a single page — those carry no token.")),
 		mcpgo.WithNumber("item_id", mcpgo.Description("Echo back item.id from the work item you are answering. Optional but strongly recommended: applying a distill item enqueues follow-up items, so the current item can change between calls — echoing the id lets the server reject a stale answer instead of applying it to a different item.")),
 		mcpgo.WithString("effort", mcpgo.Description("Discovery effort dial: 'normal' (default — pre-discovery behaviour), 'medium', or 'high'. Medium/high engage the structural-bridge engine to surface emergent synthesis facts from cross-cluster bridges.")),
 		mcpgo.WithArray("domain", mcpgo.Description("Optional scope filter: restrict the seed pool to facts in these domains. Empty = whole corpus.")),
@@ -78,16 +80,25 @@ func ReviewHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 
 		sessionID := req.GetString("session_id", "")
 		response := req.GetString("response", "")
+		page := int(req.GetFloat("page", 0))
+		itemID := int64(req.GetFloat("item_id", 0))
+		completionToken := req.GetString("completion_token", "")
 
 		var result *synthesize.ReviewResult
 
-		if sessionID == "" {
+		switch {
+		case sessionID == "":
 			result, err = reviewer.StartSession(ctx)
-		} else {
-			if response == "" {
-				return mcpgo.NewToolResultError("response is required when continuing a session"), nil
-			}
-			result, err = reviewer.ContinueSessionForItem(ctx, sessionID, response, int64(req.GetFloat("item_id", 0)))
+		case page > 0 && response == "":
+			// A page fetch, not an answer. Ordered before the response guard
+			// below because paging is the one continue-call that legitimately
+			// carries no decisions — it is a pure read of an item the agent is
+			// still assembling.
+			result, err = reviewer.PageItem(ctx, sessionID, itemID, page)
+		case response == "":
+			return mcpgo.NewToolResultError("response is required when continuing a session (or pass page=N to read another page of the current item)"), nil
+		default:
+			result, err = reviewer.ContinueSessionForItemPaged(ctx, sessionID, response, itemID, completionToken)
 		}
 
 		if err != nil {

--- a/internal/synthesize/paging.go
+++ b/internal/synthesize/paging.go
@@ -1,0 +1,111 @@
+// Package synthesize — work-item paging.
+//
+// A work item can hold more facts than one MCP tool result may carry. Paging is
+// how the agent still sees all of them: the server serves the item in pages,
+// the agent accumulates every page into its context, and answers ONCE at the
+// end. The unit of the cap is a tool result, not a conversation, and this file
+// is where those two stop being the same number.
+//
+// Three properties make this cheap and safe here:
+//
+//   - No new state. PipelineWorkItem.FactsJSON already holds the whole payload,
+//     so a page is a deterministic slice of an existing column. Nothing is
+//     written, no column is added, and the same (item, page) always yields the
+//     same bytes.
+//   - No interaction with the claim protocol. Paging is a pure read that runs
+//     entirely before the claim CAS, so
+//     invariants/synthesize/work-item-claim-protocol is untouched: the CAS still
+//     fires exactly once, on the final response.
+//   - Idempotent under re-serve. An agent that dies mid-page simply starts over
+//     when NextPipelineWorkItem hands it the still-unanswered item.
+package synthesize
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// factPages splits a work item's stored fact array into the pages it will be
+// delivered in. Returns one page per tool result, each already marshalled.
+//
+// A payload that is not a fact array yields a single page carrying it
+// unchanged: prune, reflect and discover interpolate their payloads into the
+// prompt rather than shipping them beside it, so they are single-page by
+// construction and must not be reshaped here.
+func factPages(factsJSON string) ([]json.RawMessage, error) {
+	var facts []factForLLM
+	if err := json.Unmarshal([]byte(factsJSON), &facts); err != nil {
+		return []json.RawMessage{json.RawMessage(factsJSON)}, nil
+	}
+	if len(facts) == 0 {
+		return []json.RawMessage{json.RawMessage(factsJSON)}, nil
+	}
+
+	chunks := chunkFacts(facts, maxPageBytes)
+	pages := make([]json.RawMessage, 0, len(chunks))
+	for i, c := range chunks {
+		b, err := json.Marshal(c)
+		if err != nil {
+			return nil, fmt.Errorf("marshal page %d: %w", i+1, err)
+		}
+		pages = append(pages, json.RawMessage(b))
+	}
+	return pages, nil
+}
+
+// pageCountFor reports how many pages an item will be served in.
+func pageCountFor(factsJSON string) int {
+	pages, err := factPages(factsJSON)
+	if err != nil || len(pages) == 0 {
+		return 1
+	}
+	return len(pages)
+}
+
+// completionTokenFor derives the proof that an agent reached an item's final
+// page. It is a pure function of the item, so it needs no storage and cannot
+// drift from what was served — and because it is only ever emitted ON the last
+// page, holding it is equivalent to having received that page.
+//
+// Not a security boundary, and not meant to be: this is the same trust model as
+// item_id, which the agent has always echoed back. It exists to make "I read
+// the whole item" checkable instead of merely requested — the distinction that
+// fef554d1 established when a response_schema's `required` list turned out to
+// be inert because nothing probed for it.
+func completionTokenFor(itemID int64, factsJSON string) string {
+	h := sha256.Sum256([]byte(strconv.FormatInt(itemID, 10) + ":" + factsJSON))
+	return hex.EncodeToString(h[:])[:16]
+}
+
+// requireCompletionToken enforces the accumulate-then-respond contract for a
+// multi-page item.
+//
+// Called before Decode and therefore before the claim, so a rejected answer
+// leaves the item fully retryable — the agent pages properly and resubmits.
+// Single-page items are exempt: the requirement must track the actual need, or
+// every existing caller breaks for no gain.
+//
+// The error names the token, the page count, and how to obtain it, because the
+// agent that hits this has already produced a synthesis it is about to lose.
+func requireCompletionToken(itemID int64, factsJSON, supplied string) error {
+	pages := pageCountFor(factsJSON)
+	if pages <= 1 {
+		return nil
+	}
+	want := completionTokenFor(itemID, factsJSON)
+	if supplied == want {
+		return nil
+	}
+	if supplied == "" {
+		return fmt.Errorf("work item %d spans %d pages and no completion_token was supplied; "+
+			"read every page (call knomit_review with page=1..%d until more_available is false), "+
+			"then resubmit with the completion_token from the final page",
+			itemID, pages, pages)
+	}
+	return fmt.Errorf("work item %d spans %d pages and the supplied completion_token is not valid for it; "+
+		"re-read the final page (page=%d) and echo the completion_token it returns",
+		itemID, pages, pages)
+}

--- a/internal/synthesize/paging.go
+++ b/internal/synthesize/paging.go
@@ -21,6 +21,7 @@
 package synthesize
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -28,13 +29,80 @@ import (
 	"strconv"
 )
 
+// deliveredIndentPrefix and deliveredIndentUnit reproduce the indentation the
+// facts array receives inside a delivered result. internal/mcp/review.go ships
+// json.MarshalIndent(result, "", "  ") and `facts` sits two objects deep
+// (result → item → facts), so passing that depth as json.Indent's prefix
+// renders an array byte-for-byte as it will appear on the wire.
+const (
+	deliveredIndentPrefix = "    "
+	deliveredIndentUnit   = "  "
+)
+
+// deliveredFactsLen reports how many bytes a compact JSON payload occupies once
+// the delivering MarshalIndent has expanded it at the depth `facts` sits at.
+//
+// This is the measurement the page budget is expressed in. Indentation cost is
+// per JSON token — a newline plus indent for every field and every array
+// element — so it cannot be predicted from the compact byte count, only from
+// the payload's shape. Measuring it is cheap; guessing it was the bug.
+//
+// A payload json.Indent rejects is not a fact array and is never paged, so
+// falling back to its compact length is the honest answer rather than a
+// silently wrong one.
+func deliveredFactsLen(compact []byte) int {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, compact, deliveredIndentPrefix, deliveredIndentUnit); err != nil {
+		return len(compact)
+	}
+	return buf.Len()
+}
+
+// packFactPages greedily fills pages with facts, sizing each candidate page by
+// what it will DELIVER rather than by its compact bytes.
+//
+// A page's delivered length is estimated as the sum of its facts' individually
+// indented lengths. That over-counts a real page by a small fixed amount per
+// fact — joining two elements is shorter than the two singletons — and
+// over-counting is the safe direction for a budget: a page comes out slightly
+// under the cap, never over. TestFactPages_SizeModelNeverUnderCounts pins the
+// direction so a future change to Go's formatting cannot invert it.
+//
+// A single fact larger than the budget still gets its own page, since it cannot
+// be split; the bound is best-effort for a pathological fact exactly as
+// chunkFacts is for the item budget.
+func packFactPages(facts []factForLLM, maxBytes int) [][]factForLLM {
+	var pages [][]factForLLM
+	var current []factForLLM
+	currentSize := 0
+
+	for _, f := range facts {
+		one, err := json.Marshal([]factForLLM{f})
+		if err != nil {
+			continue
+		}
+		size := deliveredFactsLen(one)
+		if currentSize+size > maxBytes && len(current) > 0 {
+			pages = append(pages, current)
+			current = nil
+			currentSize = 0
+		}
+		current = append(current, f)
+		currentSize += size
+	}
+	if len(current) > 0 {
+		pages = append(pages, current)
+	}
+	return pages
+}
+
 // factPages splits a work item's stored fact array into the pages it will be
 // delivered in. Returns one page per tool result, each already marshalled.
 //
 // A payload that is not a fact array yields a single page carrying it
-// unchanged: prune, reflect and discover interpolate their payloads into the
-// prompt rather than shipping them beside it, so they are single-page by
-// construction and must not be reshaped here.
+// unchanged: reflect and discover interpolate their payloads into the prompt
+// rather than shipping them beside it, so they are single-page by construction
+// and must not be reshaped here.
 func factPages(factsJSON string) ([]json.RawMessage, error) {
 	var facts []factForLLM
 	if err := json.Unmarshal([]byte(factsJSON), &facts); err != nil {
@@ -44,7 +112,7 @@ func factPages(factsJSON string) ([]json.RawMessage, error) {
 		return []json.RawMessage{json.RawMessage(factsJSON)}, nil
 	}
 
-	chunks := chunkFacts(facts, maxPageBytes)
+	chunks := packFactPages(facts, maxPageFactBytes)
 	pages := make([]json.RawMessage, 0, len(chunks))
 	for i, c := range chunks {
 		b, err := json.Marshal(c)

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -206,6 +206,14 @@ func (p *Pipeline) ContinueSession(ctx context.Context, sessionID, response stri
 // is accepted — the corpus is left un-maintained rather than corrupted,
 // whereas duplicate synthesis facts are corruption.
 func (p *Pipeline) ContinueSessionForItem(ctx context.Context, sessionID, response string, itemID int64) (*PipelineResult, error) {
+	return p.ContinueSessionForItemPaged(ctx, sessionID, response, itemID, "")
+}
+
+// ContinueSessionForItemPaged is ContinueSessionForItem plus the
+// accumulate-then-respond guard for multi-page items. completionToken is the
+// value the agent read off the item's final page; it is ignored for items that
+// fit one page.
+func (p *Pipeline) ContinueSessionForItemPaged(ctx context.Context, sessionID, response string, itemID int64, completionToken string) (*PipelineResult, error) {
 	tool := p.strategy.Tool()
 	d := p.deps()
 
@@ -239,6 +247,23 @@ func (p *Pipeline) ContinueSessionForItem(ctx context.Context, sessionID, respon
 	if itemID != 0 && itemID != item.ID {
 		return nil, errf(tool, "response targets work item %d but item %d is current; "+
 			"re-read the current item and answer that one", itemID, item.ID)
+	}
+
+	// Accumulate-then-respond guard, ahead of Decode and therefore ahead of the
+	// claim: an answer to a multi-page item is only meaningful if the agent
+	// actually read every page, and a rejection here leaves the item fully
+	// retryable. Enforced rather than instructed — an advisory "page until
+	// exhausted" would let an agent answer on page 1 and be ACCEPTED, turning a
+	// loud transport failure into a silent quality loss. That is the lesson of
+	// invariants/synthesize/response-envelope, where a schema's `required` list
+	// meant nothing because no code probed for it.
+	//
+	// Asked of the strategy, not assumed: only strategies that ship a payload
+	// beside the prompt can page, and hypothesize does not.
+	if ps, ok := p.strategy.(pagedStrategy); ok {
+		if err := ps.RequireCompletion(item, completionToken); err != nil {
+			return nil, wrapf(tool, err, "answer item %d", item.ID)
+		}
 	}
 
 	// Decode and validate first. Every error below this point and above the
@@ -451,6 +476,48 @@ func factFromSearchResult(sr store.SearchResult) fact.Fact {
 }
 
 // ── phase machine ─────────────────────────────────────────────────────────
+
+// CurrentItem re-renders the item currently outstanding on a session without
+// answering it or advancing anything.
+//
+// This is the read half of paging. It deliberately does NOT fall through to
+// nextItem when the queue is empty: nextItem advances the phase machine and can
+// complete the session, which is exactly the side effect a page fetch must not
+// have. An agent asking for a page of an item that is no longer current has
+// lost its place, and being told so is more useful than being silently handed
+// something else.
+//
+// itemID is asserted when non-zero — the same staleness guard the answer path
+// applies, for the same reason: pages from two different items must never be
+// accumulated into one synthesis.
+func (p *Pipeline) CurrentItem(ctx context.Context, sessionID string, itemID int64) (*PipelineResult, error) {
+	tool := p.strategy.Tool()
+	d := p.deps()
+
+	sess, err := d.Pipeline.GetPipelineSession(ctx, sessionID)
+	if err != nil {
+		return nil, wrapf(tool, err, "get session")
+	}
+	if sess == nil {
+		return nil, errf(tool, "session %q not found", sessionID)
+	}
+	if sess.Status != "active" {
+		return nil, errf(tool, "session %q is %s, not active", sessionID, sess.Status)
+	}
+
+	item, err := d.Pipeline.NextPipelineWorkItem(ctx, sessionID)
+	if err != nil {
+		return nil, wrapf(tool, err, "current work item")
+	}
+	if item == nil {
+		return nil, errf(tool, "session %q has no outstanding work item to page", sessionID)
+	}
+	if itemID != 0 && itemID != item.ID {
+		return nil, errf(tool, "requested pages of work item %d but item %d is current; "+
+			"re-read the current item from page 1", itemID, item.ID)
+	}
+	return p.renderWorkItem(ctx, d, sess, item)
+}
 
 // nextItem dispatches on the session's persistent phase. It is intentionally
 // short: all session-scoped state — including "have we considered enqueueing

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -307,9 +307,20 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 			Message: fmt.Sprintf("processing %s work item", result.Item.Type),
 		})
 
+		// A step type that ships its payload beside the prompt (rather than
+		// interpolated into it) must have the two recombined here: an LLM
+		// adapter takes one message, and there is no second channel to put
+		// facts on. Omitting this would hand the model instructions about
+		// facts it was never shown — a silent, total loss of the item's
+		// content that no error surfaces.
+		content := result.Item.Prompt
+		if result.Item.Facts != "" {
+			content += "\n\nFacts in scope:\n" + result.Item.Facts
+		}
+
 		opts := llm.CompletionOptions{ForceJSON: true}
 		response, err := adapter.Complete(ctx, "", []llm.Message{
-			{Role: "user", Content: result.Item.Prompt},
+			{Role: "user", Content: content},
 		}, opts, nil)
 		if err != nil {
 			return fmt.Errorf("RunAll: LLM %s: %w", result.Item.Type, err)
@@ -547,6 +558,7 @@ func (p *Pipeline) renderWorkItem(ctx context.Context, d Deps, sess *store.Pipel
 			Prompt:         view.Prompt,
 			ResponseSchema: view.ResponseSchema,
 			FactsJSON:      item.FactsJSON,
+			Facts:          view.Facts,
 		},
 		Progress: &ReviewProgress{
 			Completed: completed,

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -524,7 +524,13 @@ func factFromSearchResult(sr store.SearchResult) fact.Fact {
 // itemID is asserted when non-zero — the same staleness guard the answer path
 // applies, for the same reason: pages from two different items must never be
 // accumulated into one synthesis.
-func (p *Pipeline) CurrentItem(ctx context.Context, sessionID string, itemID int64) (*PipelineResult, error) {
+//
+// page is not used to slice anything here — that happens at the transport
+// boundary — but it decides how MUCH of the item has to be built. Pages after
+// the first discard the prompt and the schema, so rendering them is pure waste,
+// and expensive waste: review's Render performs a methodology retrieval per
+// fact in the item, so a P-page item cost P× that. Only page 1 pays it.
+func (p *Pipeline) CurrentItem(ctx context.Context, sessionID string, itemID int64, page int) (*PipelineResult, error) {
 	tool := p.strategy.Tool()
 	d := p.deps()
 
@@ -550,7 +556,50 @@ func (p *Pipeline) CurrentItem(ctx context.Context, sessionID string, itemID int
 		return nil, errf(tool, "requested pages of work item %d but item %d is current; "+
 			"re-read the current item from page 1", itemID, item.ID)
 	}
+
+	// Payload-only render for pages the prompt will be stripped from anyway.
+	// A strategy that cannot produce its payload without a full render returns
+	// "", and the fall-through below is then the only correct answer — a page
+	// missing its facts is worse than a page that cost too much to build.
+	if page > 1 {
+		if ps, ok := p.strategy.(pagedStrategy); ok {
+			facts, err := ps.RenderPayload(item)
+			if err != nil {
+				return nil, wrapf(tool, err, "render payload for page %d", page)
+			}
+			if facts != "" {
+				return p.payloadResult(ctx, d, sess, item, facts)
+			}
+		}
+	}
 	return p.renderWorkItem(ctx, d, sess, item)
+}
+
+// payloadResult assembles what renderWorkItem would, minus the two fields a
+// page after the first never carries: Prompt and ResponseSchema. Progress
+// counts are still read — they are one cheap query and the agent tracks the
+// session by them.
+func (p *Pipeline) payloadResult(ctx context.Context, d Deps, sess *store.PipelineSession, item *store.PipelineWorkItem, facts string) (*PipelineResult, error) {
+	tool := p.strategy.Tool()
+
+	completed, remaining, err := d.Pipeline.PipelineWorkItemStats(ctx, sess.ID)
+	if err != nil {
+		return nil, wrapf(tool, err, "work item stats")
+	}
+
+	return &PipelineResult{
+		SessionID: sess.ID,
+		Item: &PipelineItem{
+			ID:        item.ID,
+			Type:      item.StepType,
+			FactsJSON: item.FactsJSON,
+			Facts:     facts,
+		},
+		Progress: &ReviewProgress{
+			Completed: completed,
+			Remaining: remaining,
+		},
+	}, nil
 }
 
 // nextItem dispatches on the session's persistent phase. It is intentionally

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -209,11 +209,39 @@ func (p *Pipeline) ContinueSessionForItem(ctx context.Context, sessionID, respon
 	return p.ContinueSessionForItemPaged(ctx, sessionID, response, itemID, "")
 }
 
+// itemDelivery records HOW the caller answering a work item received it. It is
+// the only thing that decides whether the accumulate-then-respond guard below
+// applies, because the hazard the guard exists for is a property of the
+// DELIVERY, not of the item.
+//
+// The MCP wire splits an oversized item into pages, so an answer arriving over
+// it is only trustworthy with proof the agent read every one. RunAll's
+// in-process consumer is handed the whole item in a single Go value: there are
+// no pages for it to miss, nothing on that path ever issues a token, and
+// demanding one would make every multi-page item permanently unanswerable —
+// which is precisely what it did.
+//
+// Deliberately unexported, and deliberately not a parameter on any exported
+// method: if the wire could select deliveredWhole, the guard would be advisory
+// again, which is the failure the guard was written to end.
+type itemDelivery int
+
+const (
+	// deliveredByPage: the caller may have been served a slice of the item.
+	deliveredByPage itemDelivery = iota
+	// deliveredWhole: the caller holds every fact of the item by construction.
+	deliveredWhole
+)
+
 // ContinueSessionForItemPaged is ContinueSessionForItem plus the
 // accumulate-then-respond guard for multi-page items. completionToken is the
 // value the agent read off the item's final page; it is ignored for items that
 // fit one page.
 func (p *Pipeline) ContinueSessionForItemPaged(ctx context.Context, sessionID, response string, itemID int64, completionToken string) (*PipelineResult, error) {
+	return p.continueSessionForItem(ctx, sessionID, response, itemID, completionToken, deliveredByPage)
+}
+
+func (p *Pipeline) continueSessionForItem(ctx context.Context, sessionID, response string, itemID int64, completionToken string, delivery itemDelivery) (*PipelineResult, error) {
 	tool := p.strategy.Tool()
 	d := p.deps()
 
@@ -259,8 +287,10 @@ func (p *Pipeline) ContinueSessionForItemPaged(ctx context.Context, sessionID, r
 	// meant nothing because no code probed for it.
 	//
 	// Asked of the strategy, not assumed: only strategies that ship a payload
-	// beside the prompt can page, and hypothesize does not.
-	if ps, ok := p.strategy.(pagedStrategy); ok {
+	// beside the prompt can page, and hypothesize does not. Asked only of a
+	// paged DELIVERY: see itemDelivery for why a caller holding the whole item
+	// has nothing to prove.
+	if ps, ok := p.strategy.(pagedStrategy); ok && delivery == deliveredByPage {
 		if err := ps.RequireCompletion(item, completionToken); err != nil {
 			return nil, wrapf(tool, err, "answer item %d", item.ID)
 		}
@@ -338,6 +368,10 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 		// facts on. Omitting this would hand the model instructions about
 		// facts it was never shown — a silent, total loss of the item's
 		// content that no error surfaces.
+		//
+		// This is also what makes the answer below a deliveredWhole one: the
+		// model is shown every fact of the item in one message, so there is no
+		// page it could have missed.
 		content := result.Item.Prompt
 		if result.Item.Facts != "" {
 			content += "\n\nFacts in scope:\n" + result.Item.Facts
@@ -351,7 +385,7 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 			return fmt.Errorf("RunAll: LLM %s: %w", result.Item.Type, err)
 		}
 
-		result, err = p.ContinueSession(ctx, sessionID, response)
+		result, err = p.continueSessionForItem(ctx, sessionID, response, 0, "", deliveredWhole)
 		if err != nil {
 			return fmt.Errorf("RunAll: continue: %w", err)
 		}

--- a/internal/synthesize/prompt_review.go
+++ b/internal/synthesize/prompt_review.go
@@ -9,6 +9,10 @@ import (
 type WorkItemContent struct {
 	Prompt         string `json:"prompt"`
 	ResponseSchema string `json:"response_schema"`
+	// Facts is the item's payload as a structured JSON array, carried beside
+	// the prompt rather than serialized into it. Empty for step types that
+	// still interpolate their payload into the template.
+	Facts string `json:"facts,omitempty"`
 }
 
 const pruneResponseSchema = `{
@@ -161,14 +165,20 @@ func RenderReflectWorkItem(transitionsJSON []byte, ontologyRoot, existingMethodo
 // RenderDistillWorkItem renders a distill prompt for the hosting model.
 // applicableMethodology is the pre-formatted methodology section to inject;
 // pass an empty string when none is relevant.
+// Facts travel in WorkItemContent.Facts rather than interpolated into the
+// prompt. Two reasons, both learned from the payloads this change exists to fix:
+// a fact array embedded in the prompt STRING cannot be sliced without regex
+// surgery on the prompt (and arrives as a handful of enormous lines, so no
+// line-based reader can window it), and every quote inside it is escaped twice
+// on the wire. Compact, not indented: it ships as structural JSON now, and the
+// delivering envelope does its own formatting.
 func RenderDistillWorkItem(facts []factForLLM, ontologyRoot, applicableMethodology string) (*WorkItemContent, error) {
-	factsJSON, err := json.MarshalIndent(facts, "", "  ")
+	factsJSON, err := json.Marshal(facts)
 	if err != nil {
 		return nil, fmt.Errorf("marshal facts for distill work item: %w", err)
 	}
 
 	prompt, err := RenderTemplate("distill", "user", PromptData{
-		Facts:                 string(factsJSON),
 		OntologyRoot:          ontologyRoot,
 		ApplicableMethodology: applicableMethodology,
 	})
@@ -179,5 +189,6 @@ func RenderDistillWorkItem(facts []factForLLM, ontologyRoot, applicableMethodolo
 	return &WorkItemContent{
 		Prompt:         prompt,
 		ResponseSchema: distillResponseSchema,
+		Facts:          string(factsJSON),
 	}, nil
 }

--- a/internal/synthesize/prompt_review.go
+++ b/internal/synthesize/prompt_review.go
@@ -83,13 +83,21 @@ const distillResponseSchema = `{
 // RenderPruneWorkItem renders a prune prompt for the hosting model.
 // ontologyRoot is substituted into the prompt's example paths so the LLM
 // emits paths under the configured root instead of a hardcoded placeholder.
+// Facts travel in WorkItemContent.Facts rather than interpolated into the
+// prompt, for the same reasons as distill — and with more at stake. Prune
+// clusters are deliberately never split across work items, because a duplicate
+// pair straddling the split would simply never be found, so cluster size was
+// bounded only by whatever Louvain happened to produce and had no chunkFacts
+// backstop beneath it. Shipping facts structurally is what lets an oversized
+// cluster be delivered across pages while the merge decision still sees all of
+// it: the delivery splits, the decision does not.
 func RenderPruneWorkItem(facts []factForLLM, ontologyRoot string) (*WorkItemContent, error) {
-	factsJSON, err := json.MarshalIndent(facts, "", "  ")
+	factsJSON, err := json.Marshal(facts)
 	if err != nil {
 		return nil, fmt.Errorf("marshal facts for prune work item: %w", err)
 	}
 
-	prompt, err := RenderTemplate("prune", "user", PromptData{Facts: string(factsJSON), OntologyRoot: ontologyRoot})
+	prompt, err := RenderTemplate("prune", "user", PromptData{OntologyRoot: ontologyRoot})
 	if err != nil {
 		return nil, fmt.Errorf("render prune work item: %w", err)
 	}
@@ -97,6 +105,7 @@ func RenderPruneWorkItem(facts []factForLLM, ontologyRoot string) (*WorkItemCont
 	return &WorkItemContent{
 		Prompt:         prompt,
 		ResponseSchema: pruneResponseSchema,
+		Facts:          string(factsJSON),
 	}, nil
 }
 

--- a/internal/synthesize/prompts/large/distill_user.txt
+++ b/internal/synthesize/prompts/large/distill_user.txt
@@ -1,7 +1,6 @@
 You are synthesizing facts in a knowledge base to find patterns and higher-order insights.
 
-Facts in scope:
-{{.Facts}}
+The facts in scope are delivered beside this prompt as the work item's `facts` field, a JSON array. Read them there — they are deliberately not repeated here, so that the payload can be sliced without cutting a fact in half.
 
 {{if .ApplicableMethodology}}Applicable methodology candidates (ranked by retrieval relevance to this cluster):
 

--- a/internal/synthesize/prompts/large/prune_user.txt
+++ b/internal/synthesize/prompts/large/prune_user.txt
@@ -1,7 +1,6 @@
 You are reviewing facts in a knowledge base for staleness, redundancy, and duplication.
 
-Facts to review:
-{{.Facts}}
+The facts to review are delivered beside this prompt as the work item's `facts` field, a JSON array. Read them there — they are deliberately not repeated here, so that a large cluster can be delivered across several pages without cutting a fact in half. If the work item reports `more_available: true`, you have NOT yet seen the whole cluster: keep requesting pages until it is false, then decide. Judging a cluster you have only partly read is how a duplicate pair that straddles a page boundary goes unmerged.
 
 For each fact, decide:
 - keep: fact is current and valuable

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -124,7 +124,7 @@ func (r *Reviewer) ContinueSessionForItemPaged(ctx context.Context, sessionID, r
 // asserts it: paging a different item than the agent believes it is reading
 // would assemble one synthesis out of two items' facts.
 func (r *Reviewer) PageItem(ctx context.Context, sessionID string, itemID int64, page int) (*ReviewResult, error) {
-	res, err := r.p.CurrentItem(ctx, sessionID, itemID)
+	res, err := r.p.CurrentItem(ctx, sessionID, itemID, page)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -14,7 +14,7 @@ package synthesize
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 
 	"knomit/internal/llm"
 	"knomit/internal/repos"
@@ -102,6 +102,32 @@ func (r *Reviewer) ContinueSessionForItem(ctx context.Context, sessionID, respon
 	return reviewResult(r.p.ContinueSessionForItem(ctx, sessionID, response, itemID))
 }
 
+// ContinueSessionForItemPaged is ContinueSessionForItem carrying the
+// completion token read off a multi-page item's final page. Single-page items
+// ignore it, so passing "" is correct for every caller that never paged.
+func (r *Reviewer) ContinueSessionForItemPaged(ctx context.Context, sessionID, response string, itemID int64, completionToken string) (*ReviewResult, error) {
+	return reviewResult(r.p.ContinueSessionForItemPaged(ctx, sessionID, response, itemID, completionToken))
+}
+
+// PageItem serves one page of the item currently outstanding on a session.
+//
+// A pure read: it neither answers the item nor advances the session, so an
+// agent may fetch pages in any order, re-fetch them, or abandon the item
+// entirely without consequence. That is what keeps
+// invariants/synthesize/work-item-claim-protocol intact — the claim CAS still
+// fires exactly once, on the response, never on a page fetch.
+//
+// itemID is asserted when non-zero, for the same reason ContinueSessionForItem
+// asserts it: paging a different item than the agent believes it is reading
+// would assemble one synthesis out of two items' facts.
+func (r *Reviewer) PageItem(ctx context.Context, sessionID string, itemID int64, page int) (*ReviewResult, error) {
+	res, err := r.p.CurrentItem(ctx, sessionID, itemID)
+	if err != nil {
+		return nil, err
+	}
+	return reviewResultPage(res, page)
+}
+
 // RunAll drives the review session to completion using an LLM adapter.
 func (r *Reviewer) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 	return r.p.RunAll(ctx, adapter)
@@ -119,6 +145,17 @@ func reviewResult(res *PipelineResult, err error) (*ReviewResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	return reviewResultPage(res, 1)
+}
+
+// reviewResultPage is reviewResult for a chosen page.
+//
+// Paging lives HERE, at the transport boundary, and not in the strategy's
+// Render: the engine and its in-process consumers (RunAll, the web synthesis
+// job) want the whole item, and only the MCP wire has a per-result size limit.
+// Slicing in Render would have handed RunAll one page and silently dropped the
+// rest — the model would receive instructions about facts it was never shown.
+func reviewResultPage(res *PipelineResult, page int) (*ReviewResult, error) {
 	if res == nil {
 		return nil, nil
 	}
@@ -128,16 +165,61 @@ func reviewResult(res *PipelineResult, err error) (*ReviewResult, error) {
 		Summary:   res.Summary,
 		Progress:  res.Progress,
 	}
-	if res.Item != nil {
-		out.Item = &ReviewItem{
-			ID:             res.Item.ID,
-			Type:           res.Item.Type,
-			Prompt:         res.Item.Prompt,
-			ResponseSchema: res.Item.ResponseSchema,
-		}
-		if res.Item.Facts != "" {
-			out.Item.Facts = json.RawMessage(res.Item.Facts)
-		}
+	if res.Item == nil {
+		return out, nil
+	}
+
+	out.Item = &ReviewItem{
+		ID:   res.Item.ID,
+		Type: res.Item.Type,
+	}
+	if res.Item.Facts == "" {
+		// Nothing shipped beside the prompt: a single-page step type.
+		out.Item.Prompt = res.Item.Prompt
+		out.Item.ResponseSchema = res.Item.ResponseSchema
+		out.Item.Page, out.Item.Pages = 1, 1
+		return out, nil
+	}
+
+	pages, err := factPages(res.Item.Facts)
+	if err != nil {
+		return nil, err
+	}
+	if page < 1 {
+		page = 1
+	}
+	if page > len(pages) {
+		return nil, fmt.Errorf("work item %d has %d page(s); page %d does not exist",
+			res.Item.ID, len(pages), page)
+	}
+
+	out.Item.Facts = pages[page-1]
+	out.Item.Page = page
+	out.Item.Pages = len(pages)
+	out.Item.MoreAvailable = page < len(pages)
+
+	// Instructions and schema ride page 1 only — by the time page 2 arrives
+	// they are already in the agent's context, and repeating them per page
+	// would spend the very budget paging exists to protect.
+	if page == 1 {
+		out.Item.Prompt = res.Item.Prompt
+		out.Item.ResponseSchema = res.Item.ResponseSchema
+	}
+
+	switch {
+	case len(pages) == 1:
+		// Single-page item: no token, nothing to accumulate, no protocol to
+		// explain. Keeping this case silent is what stops paging leaking into
+		// the overwhelming majority of items that never needed it.
+	case out.Item.MoreAvailable:
+		out.Item.Next = fmt.Sprintf(
+			"Page %d of %d. Do NOT answer yet — call knomit_review again with session_id, item_id=%d and page=%d to continue reading this item.",
+			page, len(pages), res.Item.ID, page+1)
+	default:
+		out.Item.CompletionToken = completionTokenFor(res.Item.ID, res.Item.Facts)
+		out.Item.Next = fmt.Sprintf(
+			"Final page (%d of %d). You have now seen every fact in this item. Submit your response with item_id=%d and completion_token=%q.",
+			page, len(pages), res.Item.ID, out.Item.CompletionToken)
 	}
 	return out, nil
 }

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -14,7 +14,10 @@ package synthesize
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+
+	"github.com/rs/zerolog/log"
 
 	"knomit/internal/llm"
 	"knomit/internal/repos"
@@ -220,6 +223,21 @@ func reviewResultPage(res *PipelineResult, page int) (*ReviewResult, error) {
 		out.Item.Next = fmt.Sprintf(
 			"Final page (%d of %d). You have now seen every fact in this item. Submit your response with item_id=%d and completion_token=%q.",
 			page, len(pages), res.Item.ID, out.Item.CompletionToken)
+	}
+
+	// Last line of defence, and deliberately a measurement of the finished
+	// artifact rather than another prediction of it. maxPageFactBytes bounds the
+	// facts, but two things on a page are not the pager's to bound: the prompt
+	// (distill's methodology section grows with the retrieved titles) and a
+	// single fact too large to split. Either can push a page over the cap, and
+	// the failure mode is the one this whole area keeps hitting — the client
+	// spills the result to disk and the agent sees nothing, with no error
+	// anywhere. Say so in the log instead.
+	if delivered, err := json.MarshalIndent(out, "", "  "); err == nil && len(delivered) > maxDeliveredItemBytes {
+		log.Warn().Int64("item", res.Item.ID).Str("type", res.Item.Type).
+			Int("page", page).Int("pages", len(pages)).
+			Int("bytes", len(delivered)).Int("limit", maxDeliveredItemBytes).
+			Msg("review: delivered page exceeds the tool-result budget; the client may reject it — check for an oversized single fact or an overlong prompt")
 	}
 	return out, nil
 }

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -14,6 +14,7 @@ package synthesize
 
 import (
 	"context"
+	"encoding/json"
 
 	"knomit/internal/llm"
 	"knomit/internal/repos"
@@ -110,9 +111,10 @@ func (r *Reviewer) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 // wire shape. Written to take the (result, error) pair so every delegating
 // method above stays a one-liner.
 //
-// The engine's PipelineItem carries a FactsJSON field that ReviewItem has no
-// place for; dropping it here is deliberate — review renders its payload into
-// the prompt rather than shipping it raw the way hypothesize does.
+// The engine's PipelineItem carries two payload fields and they are not
+// interchangeable. FactsJSON is the raw STORED row, dropped here — hypothesize
+// echoes that one back verbatim, review does not. Facts is what the strategy
+// chose to RENDER beside the prompt, and it becomes ReviewItem.Facts.
 func reviewResult(res *PipelineResult, err error) (*ReviewResult, error) {
 	if err != nil {
 		return nil, err
@@ -132,6 +134,9 @@ func reviewResult(res *PipelineResult, err error) (*ReviewResult, error) {
 			Type:           res.Item.Type,
 			Prompt:         res.Item.Prompt,
 			ResponseSchema: res.Item.ResponseSchema,
+		}
+		if res.Item.Facts != "" {
+			out.Item.Facts = json.RawMessage(res.Item.Facts)
 		}
 	}
 	return out, nil

--- a/internal/synthesize/review_distill_chunk_test.go
+++ b/internal/synthesize/review_distill_chunk_test.go
@@ -21,7 +21,7 @@ import (
 // single "distill-all" item, i.e. one prompt containing the whole knowledge
 // base.
 //
-// The corpus here is sized past 2× maxDistillChunkBytes so a correct
+// The corpus here is sized past 2× maxItemBytes so a correct
 // implementation must split it, and the assertions are on the persisted work
 // items rather than on chunkFacts directly: the defect was never in chunkFacts
 // (which was correct and unused), it was in StartSession not calling it.

--- a/internal/synthesize/review_distill_chunk_test.go
+++ b/internal/synthesize/review_distill_chunk_test.go
@@ -100,8 +100,18 @@ func TestReviewer_DistillItemsAreChunked(t *testing.T) {
 
 	require.GreaterOrEqual(t, len(distillKeys), 4,
 		"a corpus of ~4.5× the chunk budget must yield ≥4 distill items, got %v", distillKeys)
+
+	// Depth-0 distill groups by cluster before chunking, so the key carries the
+	// group it came from. This store has no embeddings, so there are no
+	// SIMILAR_TO edges, Louvain returns singletons, filterSmallClusters removes
+	// them all, and every seed lands in the "distill-rest" remainder — the
+	// documented degradation. The property under test is unchanged and is not
+	// about the group name: chunks of one group are keyed and served in
+	// insertion order, so the prefix is read from the first key rather than
+	// pinned, and only the sequence is asserted.
+	prefix := distillKeys[0][:strings.LastIndex(distillKeys[0], "-")]
 	for i, key := range distillKeys {
-		require.Equal(t, fmt.Sprintf("distill-all-%d", i), key,
+		require.Equal(t, fmt.Sprintf("%s-%d", prefix, i), key,
 			"distill chunks must be keyed and served in insertion order")
 	}
 }

--- a/internal/synthesize/review_distill_chunk_test.go
+++ b/internal/synthesize/review_distill_chunk_test.go
@@ -35,13 +35,13 @@ func TestReviewer_DistillItemsAreChunked(t *testing.T) {
 	branch := "agent/test"
 	ctx := context.Background()
 
-	// 24 facts × ~12 KiB of body ≈ 288 KiB of fact JSON against a 64 KiB
-	// maxDistillChunkBytes, so at least four chunks are required. Each
+	// 24 facts × ~48 KiB of body ≈ 1.1 MiB of fact JSON against a 256 KiB
+	// maxItemBytes, so at least four chunks are required. Each
 	// individual fact stays far below the budget, so every chunk must honour
 	// the bound (chunkFacts only overshoots for a single oversized fact).
 	const (
 		numSeeds = 24
-		bodySize = 12 * 1024
+		bodySize = 48 * 1024
 	)
 	body := strings.Repeat("x", bodySize)
 	for i := 0; i < numSeeds; i++ {
@@ -81,8 +81,8 @@ func TestReviewer_DistillItemsAreChunked(t *testing.T) {
 			break
 		}
 		if item.StepType == "distill" {
-			require.LessOrEqual(t, len(item.FactsJSON), maxDistillChunkBytes,
-				"distill item %q payload exceeds maxDistillChunkBytes", item.ClusterKey)
+			require.LessOrEqual(t, len(item.FactsJSON), maxItemBytes,
+				"distill item %q payload exceeds maxItemBytes", item.ClusterKey)
 
 			// The payload must still be a well-formed fact list — chunking splits
 			// between facts, never inside one.

--- a/internal/synthesize/review_distill_cluster_test.go
+++ b/internal/synthesize/review_distill_cluster_test.go
@@ -1,0 +1,245 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// Depth-0 distill grouping.
+//
+// Depth-0 distill did not use clusters at all: Plan passed the whole flat seed
+// pool to chunkFacts, so an item was an arbitrary byte slice of the corpus in
+// scan order (ClusterKey "distill-all-N"). Prune (one item per Louvain
+// community) and the RAPTOR follow-ups (one item per re-clustered community)
+// both worked on real clusters; depth-0 was the odd one out.
+//
+// Grouping by cluster is what makes a smaller item stop being a quality loss:
+// the bound comes from the corpus's own structure rather than from a byte
+// count. But two properties of ScopedCluster make the naive "iterate clusters"
+// version wrong, and both tests below exist to pin them:
+//
+//   - filterSmallClusters DROPS any community below minCommunitySize, so a seed
+//     that clusters alone would silently vanish from synthesis.
+//   - clusters contain NEIGHBOURS, not just seeds — ScopedCluster pulls the top
+//     10 search hits per seed into the subgraph, and the review path passes no
+//     ExcludeTypes, so a cluster can hold facts AcceptSeed deliberately refuses
+//     (pragmatic ones, which decision.go would rewrite as epistemic on commit).
+//
+// Silent loss on a synthesis path is the exact failure class this whole area
+// has been bitten by, so coverage is asserted as an equality, not a subset.
+
+// seedDistillCorpus writes facts under two clearly separate categories and
+// returns the reviewer plus the full set of seed paths.
+//
+// Category is the lever, not embeddings: with no vectors in the test store the
+// neighbour search returns nothing and the subgraph carries no edges, so
+// ScopedCluster falls through to its groupByCategory fallback. That makes
+// cluster membership deterministic and inspectable — exactly what a test of
+// grouping needs.
+func seedDistillCorpus(t *testing.T, perCategory int) (*Reviewer, *store.Service, string, map[string]string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	branch := "agent/test"
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+	ctx := context.Background()
+
+	// path -> category, so a test can assert an item never mixes categories.
+	categoryOf := map[string]string{}
+	body := strings.Repeat("body text that is long enough to matter. ", 40)
+
+	for _, category := range []string{"alpha", "beta"} {
+		for i := 0; i < perCategory; i++ {
+			f := fact.NewFact(fmt.Sprintf("kb/architecture/%s/seed-%02d.md", category, i))
+			f.Title = fmt.Sprintf("%s seed %02d", category, i)
+			f.Body = body
+			f.Type = fact.Observation
+			f.Domain = []string{"architecture", category}
+			f.Confidence = 0.7
+			f.Sources = 1
+			serialized, serr := fact.SerializeFact(f)
+			require.NoError(t, serr)
+			_, werr := svc.Facts().WriteFact(ctx, branch, f.Path(), serialized, "seed", "")
+			require.NoError(t, werr)
+			categoryOf[f.Path()] = category
+		}
+	}
+
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:         "test",
+		AgentBranch:  branch,
+		Svc:          svc,
+		OntologyRoot: "kb",
+	})
+	return NewReviewer(ri, nil), svc, branch, categoryOf
+}
+
+// collectDistillItems drains the session queue through the store (answering via
+// the pipeline index records an item without applying it, so no RAPTOR
+// follow-ups land mid-walk) and returns the fact paths of every depth-0 distill
+// item, keyed by cluster key.
+func collectDistillItems(t *testing.T, svc *store.Service, sessionID string) map[string][]string {
+	t.Helper()
+	ctx := context.Background()
+
+	out := map[string][]string{}
+	for steps := 0; steps < 500; steps++ {
+		item, err := svc.Pipeline().NextPipelineWorkItem(ctx, sessionID)
+		require.NoError(t, err)
+		if item == nil {
+			break
+		}
+		if item.StepType == "distill" && item.Depth == 0 {
+			var facts []factForLLM
+			require.NoError(t, json.Unmarshal([]byte(item.FactsJSON), &facts),
+				"distill item %q payload is not a fact array", item.ClusterKey)
+			paths := make([]string, 0, len(facts))
+			for _, f := range facts {
+				paths = append(paths, f.File)
+			}
+			out[item.ClusterKey] = paths
+		}
+		claimed, aerr := svc.Pipeline().AnswerPipelineWorkItem(ctx, item.ID, "{}")
+		require.NoError(t, aerr)
+		require.True(t, claimed, "draining must claim each item exactly once")
+	}
+	return out
+}
+
+// TestReviewer_DistillCoversEverySeedExactlyOnce is the regression guard on
+// grouping. Whatever partition Plan chooses, the union of the depth-0 distill
+// items must be exactly the seed pool: no seed dropped, no seed duplicated.
+//
+// The drop half is the one that bites. filterSmallClusters removes communities
+// below minCommunitySize, so grouping straight off ScopedCluster's output would
+// silently exclude any seed that clusters alone — invisible in the summary,
+// invisible in the response, and indistinguishable from "there was nothing to
+// synthesize". That is the same shape as the envelope defect.
+func TestReviewer_DistillCoversEverySeedExactlyOnce(t *testing.T) {
+	r, svc, _, categoryOf := seedDistillCorpus(t, 6)
+	ctx := context.Background()
+
+	res, err := r.StartSession(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.SessionID)
+
+	items := collectDistillItems(t, svc, res.SessionID)
+	require.NotEmpty(t, items, "precondition: the session must enqueue depth-0 distill work")
+
+	seen := map[string]int{}
+	for _, paths := range items {
+		for _, p := range paths {
+			seen[p]++
+		}
+	}
+
+	for p := range categoryOf {
+		require.Equalf(t, 1, seen[p],
+			"seed %s appears in %d depth-0 distill items; every seed must appear in exactly one", p, seen[p])
+	}
+	require.Len(t, seen, len(categoryOf),
+		"depth-0 distill items must contain exactly the seed pool and nothing else")
+}
+
+// paths is a readability helper for the distillGroups tests.
+func groupPaths(g distillGroup) []string {
+	out := make([]string, 0, len(g.Facts))
+	for _, f := range g.Facts {
+		out = append(out, f.File)
+	}
+	return out
+}
+
+func seedsNamed(names ...string) []factForLLM {
+	out := make([]factForLLM, 0, len(names))
+	for _, n := range names {
+		out = append(out, factForLLM{File: n, Title: n, Body: "b", Type: "observation"})
+	}
+	return out
+}
+
+// TestDistillGroups_PartitionsByClusterAndExcludesNeighbours is the core of the
+// change, tested directly rather than through a session.
+//
+// Through a session it cannot be observed at all in a unit environment: with no
+// embeddings there are no SIMILAR_TO edges, Louvain returns every fact as its
+// own community, and filterSmallClusters removes all of them — so clusters
+// arrives empty and everything legitimately lands in the remainder. That is
+// correct degradation, not a bug, but it means cluster-boundary behaviour has
+// to be exercised at the function.
+//
+// Two properties in one test because they are the same decision: a group is the
+// cluster's SEEDS, and only its seeds. Neighbours are in the cluster (search
+// pulls them into the subgraph) and must not leak into distill's input.
+func TestDistillGroups_PartitionsByClusterAndExcludesNeighbours(t *testing.T) {
+	seeds := seedsNamed("kb/a.md", "kb/b.md", "kb/c.md", "kb/d.md", "kb/e.md")
+
+	clusters := [][]factForLLM{
+		// A neighbour the search pulled in — in the cluster, never a seed.
+		append(seedsNamed("kb/a.md", "kb/b.md"), seedsNamed("kb/neighbour.md")...),
+		seedsNamed("kb/c.md", "kb/d.md"),
+	}
+
+	groups := distillGroups(seeds, clusters)
+
+	require.Len(t, groups, 3, "two clusters plus a remainder")
+	require.Equal(t, "distill-c0", groups[0].Key)
+	require.Equal(t, []string{"kb/a.md", "kb/b.md"}, groupPaths(groups[0]),
+		"a group is the cluster's seeds — the neighbour must not leak into distill's input")
+	require.Equal(t, "distill-c1", groups[1].Key)
+	require.Equal(t, []string{"kb/c.md", "kb/d.md"}, groupPaths(groups[1]))
+	require.Equal(t, "distill-rest", groups[2].Key)
+	require.Equal(t, []string{"kb/e.md"}, groupPaths(groups[2]),
+		"a seed in no surviving cluster belongs in the remainder, not nowhere")
+}
+
+// TestDistillGroups_LoneSeedInClusterFallsToRemainder covers the seed whose
+// community held exactly one of them. There is no pattern to find across one
+// fact, so it is not its own group — but dropping it would remove it from
+// synthesis silently, so it must reappear in the remainder.
+func TestDistillGroups_LoneSeedInClusterFallsToRemainder(t *testing.T) {
+	seeds := seedsNamed("kb/a.md", "kb/b.md", "kb/c.md")
+	clusters := [][]factForLLM{
+		seedsNamed("kb/a.md", "kb/b.md"),
+		// c clusters only with non-seed neighbours.
+		append(seedsNamed("kb/c.md"), seedsNamed("kb/n1.md", "kb/n2.md")...),
+	}
+
+	groups := distillGroups(seeds, clusters)
+
+	require.Len(t, groups, 2)
+	require.Equal(t, []string{"kb/a.md", "kb/b.md"}, groupPaths(groups[0]))
+	require.Equal(t, "distill-rest", groups[1].Key)
+	require.Equal(t, []string{"kb/c.md"}, groupPaths(groups[1]))
+}
+
+// TestDistillGroups_NoClustersDegradesToOneOrderedGroup pins the degradation
+// path, which is what a unit environment and any repo without a populated
+// similarity graph actually take. Everything becomes one remainder group — the
+// pre-change behaviour — and seed order is preserved, so the same corpus
+// produces the same work items run to run rather than wandering with Go's map
+// iteration order.
+func TestDistillGroups_NoClustersDegradesToOneOrderedGroup(t *testing.T) {
+	seeds := seedsNamed("kb/a.md", "kb/b.md", "kb/c.md")
+
+	groups := distillGroups(seeds, nil)
+
+	require.Len(t, groups, 1)
+	require.Equal(t, "distill-rest", groups[0].Key)
+	require.Equal(t, []string{"kb/a.md", "kb/b.md", "kb/c.md"}, groupPaths(groups[0]),
+		"degradation must preserve seed order, not map order")
+}

--- a/internal/synthesize/review_paging_test.go
+++ b/internal/synthesize/review_paging_test.go
@@ -247,23 +247,50 @@ func TestPaging_SinglePageItemNeedsNoToken(t *testing.T) {
 	require.NoError(t, err, "a single-page item must not require a token")
 }
 
-// TestPaging_FirstPageFitsTheDeliveredCap ties paging back to the constraint
-// that started all of this: whatever the item's total size, one page must be
+// TestPaging_EveryPageFitsTheDeliveredCap ties paging back to the constraint
+// that started all of this: whatever the item's total size, every page must be
 // deliverable.
-func TestPaging_FirstPageFitsTheDeliveredCap(t *testing.T) {
-	r, svc, sessionID := pagingCorpus(t, 120, 3*1024)
-	ctx := context.Background()
-	item := currentDistillItem(t, svc, sessionID)
+//
+// This is the same property TestDistillWorkItem_EveryPageFitsDeliveredCap
+// asserts, reached through the live session path — StartSession, the planner,
+// and PageItem — rather than by assembling a PipelineResult by hand. Keeping
+// both is deliberate: the unit test sweeps fact SHAPES cheaply, this one proves
+// the shapes it sweeps are the ones a real session actually delivers.
+//
+// Small bodies as well as large. The cap is hardest to meet when facts are
+// SMALL, because indentation cost is per JSON token and a page then holds many
+// more of them — the regime the original single-size test never entered.
+func TestPaging_EveryPageFitsTheDeliveredCap(t *testing.T) {
+	for _, tc := range []struct{ facts, bodyBytes int }{
+		{600, 100},
+		{300, 512},
+		{120, 3 * 1024},
+	} {
+		t.Run(fmt.Sprintf("body=%d", tc.bodyBytes), func(t *testing.T) {
+			r, svc, sessionID := pagingCorpus(t, tc.facts, tc.bodyBytes)
+			ctx := context.Background()
+			item := currentDistillItem(t, svc, sessionID)
 
-	res, err := r.PageItem(ctx, sessionID, item.ID, 1)
-	require.NoError(t, err)
-	require.Greater(t, res.Item.Pages, 2, "precondition: a genuinely large item")
+			first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+			require.NoError(t, err)
+			require.Greater(t, first.Item.Pages, 2, "precondition: a genuinely large item")
 
-	delivered, err := json.MarshalIndent(res, "", "  ")
-	require.NoError(t, err)
-	require.LessOrEqualf(t, len(delivered), maxDeliveredItemBytes,
-		"page 1 of a %d-page item delivers %d bytes, over the %d cap",
-		res.Item.Pages, len(delivered), maxDeliveredItemBytes)
+			for p := 1; p <= first.Item.Pages; p++ {
+				res, perr := r.PageItem(ctx, sessionID, item.ID, p)
+				require.NoError(t, perr)
+
+				delivered, merr := json.MarshalIndent(res, "", "  ")
+				require.NoError(t, merr)
+
+				var onPage []factForLLM
+				require.NoError(t, json.Unmarshal(res.Item.Facts, &onPage))
+
+				require.LessOrEqualf(t, len(delivered), maxDeliveredItemBytes,
+					"body=%d: page %d of %d holds %d facts and delivers %d bytes, over the %d cap",
+					tc.bodyBytes, p, first.Item.Pages, len(onPage), len(delivered), maxDeliveredItemBytes)
+			}
+		})
+	}
 }
 
 // seedDistillCorpusSized writes `total` facts of a given body size into a fresh

--- a/internal/synthesize/review_paging_test.go
+++ b/internal/synthesize/review_paging_test.go
@@ -1,0 +1,306 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// Work-item paging.
+//
+// The MCP tool-result cap bounds ONE tool result, not the conversation. Before
+// paging, those were the same thing — an item shipped in a single response, so
+// the transport limit doubled as a limit on how much one synthesis decision
+// could be built from, and the only lever for an undeliverable item was to show
+// the model less. Paging severs that: the item stays whole, the agent
+// accumulates every page into its context, and answers once at the end.
+//
+// The contract has a hard edge, and it is the reason these tests exist. An
+// agent that answers on page 1 must be REJECTED, not accepted. Merely
+// instructing it to page until exhausted would repeat the defect fixed in
+// fef554d1, where a response_schema's `required` list was inert because nothing
+// probed for it — an advisory rule on a write path is not a rule. So the last
+// page carries a token the agent can only hold by having received that page,
+// and a multi-page item answered without it fails loudly, before the claim, so
+// the item stays retryable.
+
+// pagingCorpus seeds one cluster large enough to span several pages and returns
+// the reviewer, store, and session.
+func pagingCorpus(t *testing.T, facts int, bodyBytes int) (*Reviewer, *store.Service, string) {
+	t.Helper()
+	r, svc, _, _ := seedDistillCorpusSized(t, facts, bodyBytes)
+	res, err := r.StartSession(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, res.SessionID)
+	return r, svc, res.SessionID
+}
+
+// currentDistillItem returns the first unanswered distill item on the session,
+// draining anything ahead of it.
+func currentDistillItem(t *testing.T, svc *store.Service, sessionID string) *store.PipelineWorkItem {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < 200; i++ {
+		item, err := svc.Pipeline().NextPipelineWorkItem(ctx, sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, item, "ran out of items before reaching a distill item")
+		if item.StepType == "distill" {
+			return item
+		}
+		claimed, aerr := svc.Pipeline().AnswerPipelineWorkItem(ctx, item.ID, "{}")
+		require.NoError(t, aerr)
+		require.True(t, claimed)
+	}
+	t.Fatal("no distill item found")
+	return nil
+}
+
+// TestPaging_ItemIsServedInPagesThatPartitionItsFacts is the core read-path
+// contract. Every fact appears on exactly one page, in order, and the last page
+// — and only the last — carries the completion token.
+//
+// Partitioning is asserted as an equality rather than a subset for the same
+// reason as everywhere else in this package: a page boundary that drops a fact
+// would be invisible, and the agent would synthesize over a silently incomplete
+// cluster while believing it had seen everything.
+func TestPaging_ItemIsServedInPagesThatPartitionItsFacts(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+
+	item := currentDistillItem(t, svc, sessionID)
+
+	var stored []factForLLM
+	require.NoError(t, json.Unmarshal([]byte(item.FactsJSON), &stored))
+	require.Greater(t, len(stored), 1)
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.NotNil(t, first.Item)
+	require.Greater(t, first.Item.Pages, 1,
+		"precondition: the corpus must be large enough to span more than one page")
+
+	var seen []string
+	pages := first.Item.Pages
+	for p := 1; p <= pages; p++ {
+		res, perr := r.PageItem(ctx, sessionID, item.ID, p)
+		require.NoErrorf(t, perr, "page %d", p)
+		require.Equal(t, p, res.Item.Page)
+		require.Equal(t, pages, res.Item.Pages)
+
+		var pf []factForLLM
+		require.NoError(t, json.Unmarshal(res.Item.Facts, &pf))
+		require.NotEmptyf(t, pf, "page %d is empty", p)
+		for _, f := range pf {
+			seen = append(seen, f.File)
+		}
+
+		last := p == pages
+		require.Equalf(t, !last, res.Item.MoreAvailable, "more_available on page %d", p)
+		if last {
+			require.NotEmpty(t, res.Item.CompletionToken,
+				"the final page must carry the token that proves the agent reached it")
+		} else {
+			require.Empty(t, res.Item.CompletionToken,
+				"an intermediate page must not carry the token — it is the proof of completion")
+		}
+	}
+
+	want := make([]string, 0, len(stored))
+	for _, f := range stored {
+		want = append(want, f.File)
+	}
+	require.Equal(t, want, seen,
+		"pages must partition the item's facts exactly, in order — no fact dropped, none duplicated")
+}
+
+// TestPaging_PromptOnlyOnFirstPage keeps the repeated cost off later pages: the
+// instructions are already in the agent's context by then, and re-sending them
+// per page would spend the budget this feature exists to protect.
+func TestPaging_PromptOnlyOnFirstPage(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.NotEmpty(t, first.Item.Prompt)
+	require.NotEmpty(t, first.Item.ResponseSchema)
+
+	second, err := r.PageItem(ctx, sessionID, item.ID, 2)
+	require.NoError(t, err)
+	require.Empty(t, second.Item.Prompt, "later pages must not repeat the prompt")
+	require.Empty(t, second.Item.ResponseSchema, "later pages must not repeat the schema")
+}
+
+// TestPaging_IsAPureReadAndNeverClaims pins that paging happens entirely before
+// the claim CAS. Fetching pages must leave the item unanswered and re-fetchable,
+// or an agent that died mid-page would lose the work — and
+// invariants/synthesize/work-item-claim-protocol would be violated by a read.
+func TestPaging_IsAPureReadAndNeverClaims(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	a, err := r.PageItem(ctx, sessionID, item.ID, 2)
+	require.NoError(t, err)
+	b, err := r.PageItem(ctx, sessionID, item.ID, 2)
+	require.NoError(t, err)
+	require.Equal(t, a.Item.Facts, b.Item.Facts, "re-fetching a page must be identical")
+
+	still, err := svc.Pipeline().NextPipelineWorkItem(ctx, sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, still)
+	require.Equal(t, item.ID, still.ID, "paging must leave the item unanswered and current")
+}
+
+// TestPaging_MultiPageAnswerWithoutTokenIsRejected is the enforcement test —
+// the whole reason the token exists.
+//
+// Without this, an agent reasonably answers on page 1 and the server accepts a
+// synthesis built over a fraction of the cluster. That is strictly worse than
+// the bug being fixed: a loud transport failure would become a silent quality
+// loss, with a summary that reads as success.
+func TestPaging_MultiPageAnswerWithoutTokenIsRejected(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.Greater(t, first.Item.Pages, 1, "precondition: item must be multi-page")
+
+	_, err = r.ContinueSessionForItemPaged(ctx, sessionID,
+		`{"synthesize": [], "retract": []}`, item.ID, "")
+	require.Error(t, err, "a multi-page item answered without the completion token must be rejected")
+	require.Contains(t, err.Error(), "completion_token",
+		"the error must name what is missing")
+	require.Contains(t, err.Error(), fmt.Sprint(first.Item.Pages),
+		"the error must say how many pages the agent needs to read")
+
+	// Decode never ran, so the item is untouched and a corrected answer works.
+	still, err := svc.Pipeline().NextPipelineWorkItem(ctx, sessionID)
+	require.NoError(t, err)
+	require.Equal(t, item.ID, still.ID, "a rejected answer must leave the item retryable")
+}
+
+// TestPaging_WrongTokenIsRejected closes the obvious bypass: a token that is
+// present but not this item's proves nothing.
+func TestPaging_WrongTokenIsRejected(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	_, err := r.ContinueSessionForItemPaged(ctx, sessionID,
+		`{"synthesize": [], "retract": []}`, item.ID, "not-the-right-token")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "completion_token")
+}
+
+// TestPaging_CorrectTokenApplies is the happy path: page to the end, echo the
+// token, and the answer is accepted normally.
+func TestPaging_CorrectTokenApplies(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	last, err := r.PageItem(ctx, sessionID, item.ID, first.Item.Pages)
+	require.NoError(t, err)
+	require.NotEmpty(t, last.Item.CompletionToken)
+
+	_, err = r.ContinueSessionForItemPaged(ctx, sessionID,
+		`{"synthesize": [], "retract": []}`, item.ID, last.Item.CompletionToken)
+	require.NoError(t, err, "the token from the last page must be accepted")
+
+	next, err := svc.Pipeline().NextPipelineWorkItem(ctx, sessionID)
+	require.NoError(t, err)
+	if next != nil {
+		require.NotEqual(t, item.ID, next.ID, "the answered item must not be served again")
+	}
+}
+
+// TestPaging_SinglePageItemNeedsNoToken keeps the common case unchanged. Most
+// items fit one page, and requiring a token there would break every existing
+// caller for no gain — presence of the requirement must track the actual need.
+func TestPaging_SinglePageItemNeedsNoToken(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 4, 256)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	res, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Item.Pages, "precondition: this item must fit one page")
+	require.False(t, res.Item.MoreAvailable)
+
+	_, err = r.ContinueSessionForItemPaged(ctx, sessionID,
+		`{"synthesize": [], "retract": []}`, item.ID, "")
+	require.NoError(t, err, "a single-page item must not require a token")
+}
+
+// TestPaging_FirstPageFitsTheDeliveredCap ties paging back to the constraint
+// that started all of this: whatever the item's total size, one page must be
+// deliverable.
+func TestPaging_FirstPageFitsTheDeliveredCap(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 120, 3*1024)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	res, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.Greater(t, res.Item.Pages, 2, "precondition: a genuinely large item")
+
+	delivered, err := json.MarshalIndent(res, "", "  ")
+	require.NoError(t, err)
+	require.LessOrEqualf(t, len(delivered), maxDeliveredItemBytes,
+		"page 1 of a %d-page item delivers %d bytes, over the %d cap",
+		res.Item.Pages, len(delivered), maxDeliveredItemBytes)
+}
+
+// seedDistillCorpusSized writes `total` facts of a given body size into a fresh
+// store and returns a reviewer over it. Separate from seedDistillCorpus because
+// paging tests need to dial the payload to a specific page count rather than a
+// specific cluster shape.
+func seedDistillCorpusSized(t *testing.T, total, bodyBytes int) (*Reviewer, *store.Service, string, map[string]string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	branch := "agent/test"
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+	ctx := context.Background()
+
+	body := strings.Repeat("x", bodyBytes)
+	paths := map[string]string{}
+	for i := 0; i < total; i++ {
+		f := fact.NewFact(fmt.Sprintf("kb/architecture/paging/seed-%03d.md", i))
+		f.Title = fmt.Sprintf("paging seed %03d", i)
+		f.Body = body
+		f.Type = fact.Observation
+		f.Domain = []string{"architecture", "paging"}
+		f.Confidence = 0.7
+		f.Sources = 1
+		serialized, serr := fact.SerializeFact(f)
+		require.NoError(t, serr)
+		_, werr := svc.Facts().WriteFact(ctx, branch, f.Path(), serialized, "seed", "")
+		require.NoError(t, werr)
+		paths[f.Path()] = "paging"
+	}
+
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name: "test", AgentBranch: branch, Svc: svc, OntologyRoot: "kb",
+	})
+	return NewReviewer(ri, nil), svc, branch, paths
+}

--- a/internal/synthesize/review_paging_test.go
+++ b/internal/synthesize/review_paging_test.go
@@ -122,6 +122,52 @@ func TestPaging_ItemIsServedInPagesThatPartitionItsFacts(t *testing.T) {
 		"pages must partition the item's facts exactly, in order — no fact dropped, none duplicated")
 }
 
+// TestPaging_MoreAvailableIsStatedOnEveryPage pins more_available in the
+// DELIVERED form rather than on the Go struct.
+//
+// The distinction is the whole lesson of this area. Every other assertion about
+// more_available reads res.Item.MoreAvailable, which is `false` whether the
+// field ships or is omitted — so an `omitempty` on it is invisible to all of
+// them, while on the wire it deletes the field from the final page entirely.
+// That is the page the agent is waiting on: the tool description, both paged
+// prompt templates, and the `page` argument all phrase the protocol as "until
+// more_available is false", and absent is not false to a reader told to look
+// for false.
+//
+// Marshalled exactly as internal/mcp/review.go ships it, because the struct is
+// not the artifact — the same reason TestDistillWorkItem_EveryPageFitsDeliveredCap
+// measures MarshalIndent instead of trusting a byte count.
+func TestPaging_MoreAvailableIsStatedOnEveryPage(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.Greater(t, first.Item.Pages, 1, "precondition: the item must be multi-page")
+
+	for p := 1; p <= first.Item.Pages; p++ {
+		res, perr := r.PageItem(ctx, sessionID, item.ID, p)
+		require.NoErrorf(t, perr, "page %d", p)
+
+		delivered, merr := json.MarshalIndent(res, "", "  ")
+		require.NoError(t, merr)
+
+		var wire struct {
+			Item map[string]json.RawMessage `json:"item"`
+		}
+		require.NoError(t, json.Unmarshal(delivered, &wire))
+
+		raw, present := wire.Item["more_available"]
+		require.Truef(t, present,
+			"page %d of %d omits more_available from the delivered result; the agent is told to "+
+				"page until it is false, so a page that never states it cannot end the loop",
+			p, first.Item.Pages)
+		require.JSONEqf(t, fmt.Sprint(p < first.Item.Pages), string(raw),
+			"more_available on page %d of %d", p, first.Item.Pages)
+	}
+}
+
 // TestPaging_PromptOnlyOnFirstPage keeps the repeated cost off later pages: the
 // instructions are already in the agent's context by then, and re-sending them
 // per page would spend the budget this feature exists to protect.

--- a/internal/synthesize/review_payload_size_test.go
+++ b/internal/synthesize/review_payload_size_test.go
@@ -58,7 +58,7 @@ func renderMaxDistillChunk(t *testing.T) (*WorkItemContent, []factForLLM) {
 		})
 	}
 
-	chunks := chunkFacts(facts, maxDistillChunkBytes)
+	chunks := chunkFacts(facts, maxPageBytes)
 	require.Greater(t, len(chunks), 1,
 		"precondition: the corpus must be large enough that the chunker closes a full chunk")
 	full := chunks[0]

--- a/internal/synthesize/review_payload_size_test.go
+++ b/internal/synthesize/review_payload_size_test.go
@@ -30,90 +30,200 @@ import (
 //
 // TestReviewer_DistillItemsAreChunked pins len(item.FactsJSON) — the STORED
 // form. Nothing pinned the DELIVERED form, which is why this shipped.
+//
+// The tests below therefore measure the delivered artifact — and measure it
+// across the range of fact shapes, which is the second half of the same lesson.
+// A budget that converted compact bytes to delivered bytes through a PERCENTAGE
+// was still wrong, because indentation cost is per JSON token: the same 25 KB of
+// compact facts delivers 32 KB as eleven 2 KiB-body facts and 46 KB as ninety-nine
+// 50 B-body ones. A test pinned to a single body size cannot see that, so
+// bodySizes below is deliberately a sweep.
 
-// renderMaxDistillChunk builds the worst case a session can actually produce:
-// facts packed by the real chunker until it closes a chunk, then rendered
-// through the real prompt path. Returns the rendered item and the chunk it came
-// from.
-func renderMaxDistillChunk(t *testing.T) (*WorkItemContent, []factForLLM) {
-	t.Helper()
+// maxMethodologySection builds the largest methodology block the distill path
+// can inject. Production calls distillMethodologySection() into this prompt;
+// rendering without it would measure a prompt smaller than any real session
+// sends and leave the margin unverified against the path that consumes it.
+// Sized at the ceiling: methodologyTopK entries, each a long title and a deep
+// path.
+func maxMethodologySection() string {
+	var b strings.Builder
+	for i := 0; i < methodologyTopK; i++ {
+		fmt.Fprintf(&b, "• score=0.87  %s  (kb/meta/reasoning/%s/%08d.md)\n",
+			strings.Repeat("long methodology title ", 8), strings.Repeat("deep-segment/", 4), i)
+	}
+	return b.String()
+}
 
-	// Bodies sized so many facts fit in one chunk, matching the real payloads
-	// (15–29 facts, ~53 KB of body text between them).
-	const (
-		numFacts = 200
-		bodySize = 2 * 1024
-	)
-	facts := make([]factForLLM, 0, numFacts)
-	for i := 0; i < numFacts; i++ {
+// sizedFacts builds facts of a given body size. Everything but the body is held
+// at a realistic ceiling — a deep path, two domains, two entities — because
+// those fields are what indentation expands hardest.
+func sizedFacts(n, bodySize int) []factForLLM {
+	facts := make([]factForLLM, 0, n)
+	for i := 0; i < n; i++ {
 		facts = append(facts, factForLLM{
-			File:       fmt.Sprintf("kb/test/fact-%03d.md", i),
-			Title:      fmt.Sprintf("fact %03d", i),
+			File:       fmt.Sprintf("kb/architecture/subsystem/area/fact-%05d.md", i),
+			Title:      fmt.Sprintf("fact %05d", i),
 			Body:       strings.Repeat("x", bodySize),
 			Type:       "observation",
-			Domain:     []string{"test"},
+			Domain:     []string{"architecture", "test"},
 			Entities:   []string{"alpha", "beta"},
 			Confidence: 0.8,
 			Sources:    1,
 		})
 	}
-
-	chunks := chunkFacts(facts, maxPageBytes)
-	require.Greater(t, len(chunks), 1,
-		"precondition: the corpus must be large enough that the chunker closes a full chunk")
-	full := chunks[0]
-
-	// Render with a methodology section, not an empty one. Production injects
-	// distillMethodologySection() into this prompt; rendering without it would
-	// measure a prompt smaller than any real session ever sends and leave the
-	// margin unverified against the path that actually consumes it. Sized at
-	// the ceiling: methodologyTopK entries, each a long title and a deep path.
-	var methodology strings.Builder
-	for i := 0; i < methodologyTopK; i++ {
-		fmt.Fprintf(&methodology, "• score=0.87  %s  (kb/meta/reasoning/%s/%08d.md)\n",
-			strings.Repeat("long methodology title ", 8), strings.Repeat("deep-segment/", 4), i)
-	}
-
-	content, err := RenderDistillWorkItem(full, "kb", methodology.String())
-	require.NoError(t, err)
-	return content, full
+	return facts
 }
 
-// TestDistillWorkItem_MaxChunkFitsDeliveredCap is the regression the incident
-// needed. It measures what the MCP handler actually returns — a MarshalIndent
-// of the whole ReviewResult (internal/mcp/review.go) — for the largest chunk
-// the chunker will emit.
+// bodySizes spans the range of fact shapes a real corpus produces, and exists
+// because the constant this test guards used to be calibrated on exactly one of
+// them. Indentation cost is per JSON token, not per byte, so the delivered size
+// of a full page RISES as facts get SMALLER — the previous 106% multiplier held
+// at 2 KiB bodies and failed everywhere below: a full page delivered 33.5 KB at
+// 1 KiB, 40.6 KB at 200 B, and 46.4 KB at 50 B, against a 32 KiB cap. Testing
+// one body size is what let that ship.
+var bodySizes = []int{50, 100, 200, 500, 1024, 2 * 1024, 4 * 1024}
+
+// TestDistillWorkItem_EveryPageFitsDeliveredCap is the regression the incident
+// needed. It takes the largest item the planner will emit (chunkFacts at
+// maxItemBytes), renders it through the real prompt path, and measures what the
+// MCP handler actually returns — a MarshalIndent of the whole ReviewResult
+// (internal/mcp/review.go) — for EVERY page of it.
 //
-// The failure this catches: a chunk budget that is honoured exactly and still
-// produces an undeliverable result, because the budget names a different
-// artifact than the transport carries.
-func TestDistillWorkItem_MaxChunkFitsDeliveredCap(t *testing.T) {
-	content, facts := renderMaxDistillChunk(t)
+// Three things it deliberately does that its predecessor did not:
+//
+//   - It sweeps body sizes. The bug it now guards was invisible at 2 KiB.
+//   - It assembles pages through reviewResultPage, so page/pages/more_available
+//     /next/completion_token are present exactly as they ship. Hand-building a
+//     ReviewItem left ~180 bytes of real payload out of a ~400-byte margin.
+//   - It checks every page, not just the first. Page 1 carries the prompt, but
+//     later pages carry more facts for it.
+func TestDistillWorkItem_EveryPageFitsDeliveredCap(t *testing.T) {
+	for _, bodySize := range bodySizes {
+		t.Run(fmt.Sprintf("body=%d", bodySize), func(t *testing.T) {
+			// Enough facts to overflow a whole ITEM, so chunkFacts closes one
+			// and we measure the largest item a session can actually produce.
+			facts := sizedFacts(3*maxItemBytes/(bodySize+200), bodySize)
+			chunks := chunkFacts(facts, maxItemBytes)
+			require.Greater(t, len(chunks), 1,
+				"precondition: the corpus must be large enough that the chunker closes a full item")
 
-	// Assembled exactly as reviewResult() does, Facts included. Omitting Facts
-	// here would measure a result with no payload in it and pass trivially —
-	// the payload is the entire thing under test.
-	result := &ReviewResult{
-		SessionID: "00000000-0000-0000-0000-000000000000",
-		Item: &ReviewItem{
-			ID:             1,
-			Type:           "distill",
-			Prompt:         content.Prompt,
-			ResponseSchema: content.ResponseSchema,
-			Facts:          json.RawMessage(content.Facts),
-		},
-		Progress: &ReviewProgress{Completed: 3, Remaining: 17},
+			content, err := RenderDistillWorkItem(chunks[0], "kb", maxMethodologySection())
+			require.NoError(t, err)
+
+			res := &PipelineResult{
+				SessionID: "00000000-0000-0000-0000-000000000000",
+				Item: &PipelineItem{
+					ID: 1, Type: "distill",
+					Prompt: content.Prompt, ResponseSchema: content.ResponseSchema,
+					Facts: content.Facts, FactsJSON: content.Facts,
+				},
+				Progress: &ReviewProgress{Completed: 3, Remaining: 17},
+			}
+
+			first, err := reviewResultPage(res, 1)
+			require.NoError(t, err)
+			require.NotEmpty(t, first.Item.Facts, "precondition: the item must carry its payload")
+
+			for p := 1; p <= first.Item.Pages; p++ {
+				out, perr := reviewResultPage(res, p)
+				require.NoError(t, perr)
+
+				// MarshalIndent, not Marshal: this is what ReviewHandler ships.
+				delivered, merr := json.MarshalIndent(out, "", "  ")
+				require.NoError(t, merr)
+
+				var onPage []factForLLM
+				require.NoError(t, json.Unmarshal(out.Item.Facts, &onPage))
+
+				require.LessOrEqualf(t, len(delivered), maxDeliveredItemBytes,
+					"body=%d: page %d/%d holds %d facts and delivers %d bytes, over the %d-byte cap; "+
+						"the page budget bounds a different artifact than the one that ships",
+					bodySize, p, first.Item.Pages, len(onPage), len(delivered), maxDeliveredItemBytes)
+			}
+		})
 	}
-	require.NotEmpty(t, result.Item.Facts, "precondition: the item must carry its payload")
+}
 
-	// MarshalIndent, not Marshal: this is what ReviewHandler ships.
-	delivered, err := json.MarshalIndent(result, "", "  ")
-	require.NoError(t, err)
+// TestDeliveredPage_EnvelopeFitsItsReserve pins pageEnvelopeReserveBytes to the
+// thing it reserves for.
+//
+// maxPageFactBytes is maxDeliveredItemBytes minus this reserve, so the whole
+// guarantee rests on the non-facts part of a page — prompt, response schema,
+// paging fields, envelope — actually fitting inside it. That part is NOT under
+// the pager's control: distill's prompt grows with the methodology section, and
+// either prompt file can be edited. Without this test the reserve goes stale
+// silently and the page budget starts over-promising again.
+func TestDeliveredPage_EnvelopeFitsItsReserve(t *testing.T) {
+	one := sizedFacts(1, 16)
 
-	require.LessOrEqualf(t, len(delivered), maxDeliveredItemBytes,
-		"a max-size distill chunk (%d facts) delivers %d bytes, over the %d-byte cap; "+
-			"the chunk budget bounds a smaller artifact than the one that ships",
-		len(facts), len(delivered), maxDeliveredItemBytes)
+	for _, tc := range []struct {
+		name    string
+		content func() (*WorkItemContent, error)
+	}{
+		{"distill", func() (*WorkItemContent, error) {
+			return RenderDistillWorkItem(one, "kb", maxMethodologySection())
+		}},
+		{"prune", func() (*WorkItemContent, error) { return RenderPruneWorkItem(one, "kb") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			content, err := tc.content()
+			require.NoError(t, err)
+
+			res := &PipelineResult{
+				SessionID: "00000000-0000-0000-0000-000000000000",
+				Item: &PipelineItem{
+					ID: 999999, Type: tc.name,
+					Prompt: content.Prompt, ResponseSchema: content.ResponseSchema,
+					Facts: content.Facts, FactsJSON: content.Facts,
+				},
+				Progress: &ReviewProgress{Completed: 3, Remaining: 17},
+			}
+			out, err := reviewResultPage(res, 1)
+			require.NoError(t, err)
+
+			delivered, err := json.MarshalIndent(out, "", "  ")
+			require.NoError(t, err)
+			envelope := len(delivered) - deliveredFactsLen(out.Item.Facts)
+
+			require.LessOrEqualf(t, envelope, pageEnvelopeReserveBytes,
+				"%s: the non-facts part of a delivered page is %d bytes, over the %d reserved for it; "+
+					"maxPageFactBytes is derived by subtracting that reserve, so it now over-promises",
+				tc.name, envelope, pageEnvelopeReserveBytes)
+		})
+	}
+}
+
+// TestFactPages_SizeModelNeverUnderCounts pins the DIRECTION of packFactPages'
+// estimate.
+//
+// It sizes a page as the sum of its facts' individually indented lengths, which
+// over-counts the real array by a few bytes per join. Over-counting is what
+// makes the budget safe — a page lands slightly under the cap, never over — so
+// the property to guard is the inequality, not the exact arithmetic. If a
+// future Go changes json.Indent's formatting such that the sum UNDER-counts,
+// every page silently starts overshooting again.
+func TestFactPages_SizeModelNeverUnderCounts(t *testing.T) {
+	for _, bodySize := range bodySizes {
+		for _, n := range []int{1, 2, 5, 50, 200} {
+			facts := sizedFacts(n, bodySize)
+
+			whole, err := json.Marshal(facts)
+			require.NoError(t, err)
+			actual := deliveredFactsLen(whole)
+
+			estimate := 0
+			for _, f := range facts {
+				one, merr := json.Marshal([]factForLLM{f})
+				require.NoError(t, merr)
+				estimate += deliveredFactsLen(one)
+			}
+
+			require.GreaterOrEqualf(t, estimate, actual,
+				"body=%d n=%d: the page-size estimate (%d) under-counts the delivered array (%d); "+
+					"packFactPages would overfill every page",
+				bodySize, n, estimate, actual)
+		}
+	}
 }
 
 // TestRenderDistillWorkItem_FactsAreStructuralNotSerializedIntoThePrompt pins

--- a/internal/synthesize/review_payload_size_test.go
+++ b/internal/synthesize/review_payload_size_test.go
@@ -1,0 +1,158 @@
+package synthesize
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Payload-delivery contract for review work items.
+//
+// A distill work item is useless if the client cannot receive it. Seven real
+// payloads from sessions 2b56c148-… (2026-07-26) and 284faa87-… (2026-07-27)
+// were rejected by the harness and spilled to disk, so the agent never saw the
+// work at all. Measured, every one of them sat just under maxDistillChunkBytes
+// in COMPACT fact JSON — the chunker did exactly what it was told — and landed
+// at 68.6–73.9 KB once delivered. The bound was applied to an artifact 1.13–1.14×
+// smaller than the one that ships.
+//
+// Two defects, one constant:
+//
+//  1. maxDistillChunkBytes measures len(json.Marshal(f)) — compact fact JSON —
+//     while what ships is MarshalIndent inside a prompt string inside a
+//     JSON-encoded envelope, where every quote in the facts is escaped again.
+//  2. Its stated rationale is a MODEL CONTEXT budget ("~16K tokens: comfortably
+//     inside every hosting model's context window"). The model's context never
+//     bound. The client's MCP tool-result cap did.
+//
+// TestReviewer_DistillItemsAreChunked pins len(item.FactsJSON) — the STORED
+// form. Nothing pinned the DELIVERED form, which is why this shipped.
+
+// renderMaxDistillChunk builds the worst case a session can actually produce:
+// facts packed by the real chunker until it closes a chunk, then rendered
+// through the real prompt path. Returns the rendered item and the chunk it came
+// from.
+func renderMaxDistillChunk(t *testing.T) (*WorkItemContent, []factForLLM) {
+	t.Helper()
+
+	// Bodies sized so many facts fit in one chunk, matching the real payloads
+	// (15–29 facts, ~53 KB of body text between them).
+	const (
+		numFacts = 200
+		bodySize = 2 * 1024
+	)
+	facts := make([]factForLLM, 0, numFacts)
+	for i := 0; i < numFacts; i++ {
+		facts = append(facts, factForLLM{
+			File:       fmt.Sprintf("kb/test/fact-%03d.md", i),
+			Title:      fmt.Sprintf("fact %03d", i),
+			Body:       strings.Repeat("x", bodySize),
+			Type:       "observation",
+			Domain:     []string{"test"},
+			Entities:   []string{"alpha", "beta"},
+			Confidence: 0.8,
+			Sources:    1,
+		})
+	}
+
+	chunks := chunkFacts(facts, maxDistillChunkBytes)
+	require.Greater(t, len(chunks), 1,
+		"precondition: the corpus must be large enough that the chunker closes a full chunk")
+	full := chunks[0]
+
+	// Render with a methodology section, not an empty one. Production injects
+	// distillMethodologySection() into this prompt; rendering without it would
+	// measure a prompt smaller than any real session ever sends and leave the
+	// margin unverified against the path that actually consumes it. Sized at
+	// the ceiling: methodologyTopK entries, each a long title and a deep path.
+	var methodology strings.Builder
+	for i := 0; i < methodologyTopK; i++ {
+		fmt.Fprintf(&methodology, "• score=0.87  %s  (kb/meta/reasoning/%s/%08d.md)\n",
+			strings.Repeat("long methodology title ", 8), strings.Repeat("deep-segment/", 4), i)
+	}
+
+	content, err := RenderDistillWorkItem(full, "kb", methodology.String())
+	require.NoError(t, err)
+	return content, full
+}
+
+// TestDistillWorkItem_MaxChunkFitsDeliveredCap is the regression the incident
+// needed. It measures what the MCP handler actually returns — a MarshalIndent
+// of the whole ReviewResult (internal/mcp/review.go) — for the largest chunk
+// the chunker will emit.
+//
+// The failure this catches: a chunk budget that is honoured exactly and still
+// produces an undeliverable result, because the budget names a different
+// artifact than the transport carries.
+func TestDistillWorkItem_MaxChunkFitsDeliveredCap(t *testing.T) {
+	content, facts := renderMaxDistillChunk(t)
+
+	// Assembled exactly as reviewResult() does, Facts included. Omitting Facts
+	// here would measure a result with no payload in it and pass trivially —
+	// the payload is the entire thing under test.
+	result := &ReviewResult{
+		SessionID: "00000000-0000-0000-0000-000000000000",
+		Item: &ReviewItem{
+			ID:             1,
+			Type:           "distill",
+			Prompt:         content.Prompt,
+			ResponseSchema: content.ResponseSchema,
+			Facts:          json.RawMessage(content.Facts),
+		},
+		Progress: &ReviewProgress{Completed: 3, Remaining: 17},
+	}
+	require.NotEmpty(t, result.Item.Facts, "precondition: the item must carry its payload")
+
+	// MarshalIndent, not Marshal: this is what ReviewHandler ships.
+	delivered, err := json.MarshalIndent(result, "", "  ")
+	require.NoError(t, err)
+
+	require.LessOrEqualf(t, len(delivered), maxDeliveredItemBytes,
+		"a max-size distill chunk (%d facts) delivers %d bytes, over the %d-byte cap; "+
+			"the chunk budget bounds a smaller artifact than the one that ships",
+		len(facts), len(delivered), maxDeliveredItemBytes)
+}
+
+// TestRenderDistillWorkItem_FactsAreStructuralNotSerializedIntoThePrompt pins
+// the shape paging needs.
+//
+// Today the facts are a JSON array serialized INSIDE the prompt string, between
+// the instruction preamble and the response template. Two consequences the
+// incident report documented: the payload cannot be windowed without regex
+// surgery on `prompt`, and the whole array arrives as a handful of enormous
+// lines, so line-based readers cannot chunk it without truncating mid-fact.
+//
+// Carrying facts as their own field is also strictly cheaper on the wire —
+// embedded in a string every quote is escaped, structurally none are — and it
+// is what hypothesize already does (HypothesizeItem.Fact, internal/mcp/
+// hypothesize.go). Review is the outlier.
+func TestRenderDistillWorkItem_FactsAreStructuralNotSerializedIntoThePrompt(t *testing.T) {
+	facts := []factForLLM{{
+		File:       "kb/test/only.md",
+		Title:      "the only fact",
+		Body:       "SENTINEL-BODY-must-not-appear-inside-the-prompt",
+		Type:       "observation",
+		Domain:     []string{"test"},
+		Confidence: 0.9,
+		Sources:    1,
+	}}
+
+	content, err := RenderDistillWorkItem(facts, "kb", "")
+	require.NoError(t, err)
+
+	require.NotContains(t, content.Prompt, "SENTINEL-BODY-must-not-appear-inside-the-prompt",
+		"fact bodies must not be serialized into the prompt string — paging cannot slice them there")
+
+	require.NotEmpty(t, content.Facts,
+		"the rendered item must carry its facts as a structured field")
+
+	var round []factForLLM
+	require.NoError(t, json.Unmarshal([]byte(content.Facts), &round),
+		"the structured facts field must be a well-formed fact array")
+	require.Len(t, round, 1)
+	require.Equal(t, "SENTINEL-BODY-must-not-appear-inside-the-prompt", round[0].Body,
+		"splitting facts out of the prompt must not drop or alter them")
+}

--- a/internal/synthesize/review_prune_paging_test.go
+++ b/internal/synthesize/review_prune_paging_test.go
@@ -1,0 +1,172 @@
+package synthesize
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// Prune paging.
+//
+// Prune was the last unbounded payload path. Its clusters are deliberately NOT
+// chunked — splitting one across work items would silently forbid merges across
+// the boundary, so a duplicate pair that straddled the split would simply never
+// be found — which left cluster size bounded only by what Louvain happens to
+// produce. That held for real corpora (2–13 facts observed) but is a property
+// of the data, not a guarantee, and unlike distill there was no chunkFacts
+// backstop underneath it.
+//
+// Paging is the resolution rather than a workaround: it splits the DELIVERY and
+// keeps the DECISION whole, which is exactly what chunking could not do. Prune
+// therefore has more to gain from paging than distill did.
+
+func bigPruneFacts(n, bodyBytes int) []factForLLM {
+	facts := make([]factForLLM, 0, n)
+	for i := 0; i < n; i++ {
+		facts = append(facts, factForLLM{
+			File:       fmt.Sprintf("kb/architecture/prune/fact-%03d.md", i),
+			Title:      fmt.Sprintf("prune fact %03d", i),
+			Body:       strings.Repeat("y", bodyBytes),
+			Type:       "observation",
+			Domain:     []string{"architecture"},
+			Confidence: 0.7,
+			Sources:    1,
+		})
+	}
+	return facts
+}
+
+// TestRenderPruneWorkItem_FactsAreStructural is the prerequisite: a payload
+// serialized into the prompt STRING cannot be sliced, so prune could not page
+// until its facts moved beside the prompt the way distill's did.
+func TestRenderPruneWorkItem_FactsAreStructural(t *testing.T) {
+	facts := []factForLLM{{
+		File:       "kb/architecture/prune/only.md",
+		Title:      "the only fact",
+		Body:       "PRUNE-SENTINEL-must-not-appear-inside-the-prompt",
+		Type:       "observation",
+		Domain:     []string{"architecture"},
+		Confidence: 0.9,
+		Sources:    1,
+	}}
+
+	content, err := RenderPruneWorkItem(facts, "kb")
+	require.NoError(t, err)
+
+	require.NotContains(t, content.Prompt, "PRUNE-SENTINEL-must-not-appear-inside-the-prompt",
+		"prune fact bodies must not be serialized into the prompt string")
+	require.NotEmpty(t, content.Facts, "prune must carry its facts as a structured field")
+
+	var round []factForLLM
+	require.NoError(t, json.Unmarshal([]byte(content.Facts), &round))
+	require.Len(t, round, 1)
+	require.Equal(t, "PRUNE-SENTINEL-must-not-appear-inside-the-prompt", round[0].Body,
+		"splitting facts out of the prompt must not drop or alter them")
+}
+
+// TestPaging_LargePruneClusterPagesAndRequiresToken exercises the whole path on
+// a cluster too big for one tool result: it must page, and answering it early
+// must be refused.
+//
+// Driven through reviewResultPage and RequireCompletion directly rather than a
+// live session, because a unit store has no similarity edges and therefore
+// produces no prune clusters at all (Louvain returns singletons and
+// filterSmallClusters removes them) — the cluster shape under test cannot be
+// reached from StartSession here.
+func TestPaging_LargePruneClusterPagesAndRequiresToken(t *testing.T) {
+	facts := bigPruneFacts(40, 3*1024)
+	content, err := RenderPruneWorkItem(facts, "kb")
+	require.NoError(t, err)
+
+	res := &PipelineResult{
+		SessionID: "sess",
+		Item: &PipelineItem{
+			ID: 7, Type: "prune",
+			Prompt: content.Prompt, ResponseSchema: content.ResponseSchema,
+			Facts: content.Facts, FactsJSON: content.Facts,
+		},
+	}
+
+	first, err := reviewResultPage(res, 1)
+	require.NoError(t, err)
+	require.Greater(t, first.Item.Pages, 1, "a 40-fact prune cluster must span several pages")
+	require.True(t, first.Item.MoreAvailable)
+	require.Empty(t, first.Item.CompletionToken)
+
+	// Pages must partition the cluster: a prune decision is made per path, so a
+	// dropped page means a fact silently never judged.
+	var seen []string
+	for p := 1; p <= first.Item.Pages; p++ {
+		page, perr := reviewResultPage(res, p)
+		require.NoError(t, perr)
+		var pf []factForLLM
+		require.NoError(t, json.Unmarshal(page.Item.Facts, &pf))
+		for _, f := range pf {
+			seen = append(seen, f.File)
+		}
+	}
+	require.Len(t, seen, len(facts), "pages must cover every fact in the cluster exactly once")
+
+	item := &store.PipelineWorkItem{ID: 7, StepType: "prune", FactsJSON: content.Facts}
+
+	require.Error(t, reviewStrategy{}.RequireCompletion(item, ""),
+		"a multi-page prune item answered without a token must be rejected")
+
+	last, err := reviewResultPage(res, first.Item.Pages)
+	require.NoError(t, err)
+	require.NotEmpty(t, last.Item.CompletionToken)
+	require.NoError(t, reviewStrategy{}.RequireCompletion(item, last.Item.CompletionToken),
+		"the token from the final page must be accepted")
+}
+
+// TestPaging_TokenRequiredOnlyWhereItIsIssued is the wedge guard, and the reason
+// the paged-step list is explicit rather than inferred.
+//
+// RequireCompletion computes page count from item.FactsJSON, while the wire
+// pages item.Facts — what Render chose to ship beside the prompt. For reflect
+// and discover those disagree: their payloads are interpolated into the prompt,
+// so reviewResultPage always returns a single page and never issues a token —
+// but their stored FactsJSON is still JSON that a fact-shaped unmarshal will
+// happily accept (hypothesisTransition even has a "path" field, which maps onto
+// factForLLM.File). Requiring a token from them would demand something the
+// agent was never given, and the item could never be answered at all.
+func TestPaging_TokenRequiredOnlyWhereItIsIssued(t *testing.T) {
+	// Oversized payloads in each non-paged step's own shape.
+	transitions := make([]hypothesisTransition, 0, 400)
+	for i := 0; i < 400; i++ {
+		transitions = append(transitions, hypothesisTransition{
+			Path:         fmt.Sprintf("kb/architecture/hyp/%03d.md", i),
+			OriginalType: "hypothesis",
+			Action:       "promoted",
+			Detail:       strings.Repeat("d", 200),
+		})
+	}
+	reflectJSON, err := json.Marshal(transitions)
+	require.NoError(t, err)
+	require.Greater(t, len(reflectJSON), maxPageBytes,
+		"precondition: the reflect payload must be big enough to page if anything paged it")
+
+	discoverJSON, err := json.Marshal(DiscoverWorkPayload{
+		Direction: DiscoverForward,
+		Bridge:    BridgeSeedSet{Token: "x", Kind: BridgeEntity, Members: bigPruneFacts(40, 3*1024)},
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(discoverJSON), maxPageBytes)
+
+	for _, tc := range []struct {
+		step    string
+		payload string
+	}{
+		{"reflect", string(reflectJSON)},
+		{"discover", string(discoverJSON)},
+	} {
+		item := &store.PipelineWorkItem{ID: 11, StepType: tc.step, FactsJSON: tc.payload}
+		require.NoErrorf(t, reviewStrategy{}.RequireCompletion(item, ""),
+			"%s does not page, so it must never demand a token the agent was never issued", tc.step)
+	}
+}

--- a/internal/synthesize/review_prune_paging_test.go
+++ b/internal/synthesize/review_prune_paging_test.go
@@ -148,7 +148,7 @@ func TestPaging_TokenRequiredOnlyWhereItIsIssued(t *testing.T) {
 	}
 	reflectJSON, err := json.Marshal(transitions)
 	require.NoError(t, err)
-	require.Greater(t, len(reflectJSON), maxPageBytes,
+	require.Greater(t, len(reflectJSON), maxPageFactBytes,
 		"precondition: the reflect payload must be big enough to page if anything paged it")
 
 	discoverJSON, err := json.Marshal(DiscoverWorkPayload{
@@ -156,7 +156,7 @@ func TestPaging_TokenRequiredOnlyWhereItIsIssued(t *testing.T) {
 		Bridge:    BridgeSeedSet{Token: "x", Kind: BridgeEntity, Members: bigPruneFacts(40, 3*1024)},
 	})
 	require.NoError(t, err)
-	require.Greater(t, len(discoverJSON), maxPageBytes)
+	require.Greater(t, len(discoverJSON), maxPageFactBytes)
 
 	for _, tc := range []struct {
 		step    string

--- a/internal/synthesize/review_runall_paging_test.go
+++ b/internal/synthesize/review_runall_paging_test.go
@@ -1,0 +1,108 @@
+package synthesize
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/llm"
+)
+
+// RunAll and paging.
+//
+// Paging exists because ONE MCP tool result cannot carry a large work item. It
+// is a property of that transport and of nothing else. RunAll is the other
+// consumer of the same engine — the in-process synthesis job in
+// internal/web/handlers_jobs.go, driving a local LLM adapter — and it receives
+// the item whole, in a Go value, with no size limit and no pages.
+//
+// So the accumulate-then-respond guard must not fire for it. When it did, every
+// distill item larger than a single page (~24 KiB delivered, against a 256 KiB
+// item budget — i.e. most real items) was permanently unanswerable: RunAll had
+// no token to supply, no way to obtain one, and aborted the whole session on
+// the first oversized item. The guard meant to prevent a synthesis over partial
+// input instead prevented synthesis entirely.
+//
+// The fix is itemDelivery: the guard asks about the DELIVERY, not the item.
+
+// wholeItemAdapter is an llm.LLMAdapter that answers every work item with a
+// response valid for its step type, and records what it was shown.
+//
+// It asserts as it goes rather than only at the end: the failure this guards
+// against is the model being handed instructions about facts that are not in
+// the message, so "the facts arrived" is checked on every call, not inferred
+// from the session completing.
+type wholeItemAdapter struct {
+	t         *testing.T
+	calls     atomic.Int64
+	maxSeen   atomic.Int64
+	sawFactor bool
+}
+
+func (a *wholeItemAdapter) Model() string { return "test/whole-item" }
+
+func (a *wholeItemAdapter) Complete(_ context.Context, _ string, msgs []llm.Message, _ llm.CompletionOptions, _ func(string)) (string, error) {
+	a.calls.Add(1)
+	require.Len(a.t, msgs, 1)
+	content := msgs[0].Content
+
+	if n := int64(len(content)); n > a.maxSeen.Load() {
+		a.maxSeen.Store(n)
+	}
+	if strings.Contains(content, "Facts in scope:") {
+		a.sawFactor = true
+	}
+
+	// A superset response: each step probes only for its own required key, and
+	// unknown keys are ignored, so one string answers every step type.
+	return `{"decisions": [], "synthesize": [], "retract": [], "methodologies": []}`, nil
+}
+
+// TestRunAll_AnswersItemsThatSpanSeveralPages is the regression guard on the
+// blocking defect.
+//
+// The corpus is deliberately the same shape the paging tests use, and the
+// precondition asserts the item really is multi-page — without that, the test
+// would pass against the broken build for the uninteresting reason that
+// nothing triggered the guard.
+func TestRunAll_AnswersItemsThatSpanSeveralPages(t *testing.T) {
+	r, _, _, _ := seedDistillCorpusSized(t, 60, 3*1024)
+	ctx := context.Background()
+
+	adapter := &wholeItemAdapter{t: t}
+	require.NoError(t, r.RunAll(ctx, adapter),
+		"RunAll receives every item whole and must not be asked for a completion token it can never obtain")
+
+	require.Greater(t, adapter.calls.Load(), int64(0), "RunAll must have driven at least one item")
+	require.True(t, adapter.sawFactor,
+		"a step whose payload ships beside the prompt must have it recombined into the message")
+
+	// The precondition, asserted after the fact rather than by starting a
+	// second session: at least one message RunAll sent was larger than a page.
+	// Without this the test would pass against the broken build for the
+	// uninteresting reason that nothing ever triggered the guard.
+	require.Greater(t, adapter.maxSeen.Load(), int64(maxPageFactBytes),
+		"precondition: RunAll must have been handed an item too large for one page")
+}
+
+// TestRunAll_StillRejectsNothing_WireStillEnforces pins the other half: the
+// exemption is for the in-process delivery only. An answer arriving over the
+// wire path for the same item is still refused without a token, or the fix
+// would have quietly deleted the guard instead of scoping it.
+func TestRunAll_WirePathStillEnforcesTheToken(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+	item := currentDistillItem(t, svc, sessionID)
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.Greater(t, first.Item.Pages, 1, "precondition: item must be multi-page")
+
+	_, err = r.ContinueSessionForItemPaged(ctx, sessionID,
+		`{"synthesize": [], "retract": []}`, item.ID, "")
+	require.Error(t, err, "the wire path must still demand proof every page was read")
+	require.Contains(t, err.Error(), "completion_token")
+}

--- a/internal/synthesize/review_runall_paging_test.go
+++ b/internal/synthesize/review_runall_paging_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/llm"
+	"knomit/internal/store"
 )
 
 // RunAll and paging.
@@ -105,4 +106,127 @@ func TestRunAll_WirePathStillEnforcesTheToken(t *testing.T) {
 		`{"synthesize": [], "retract": []}`, item.ID, "")
 	require.Error(t, err, "the wire path must still demand proof every page was read")
 	require.Contains(t, err.Error(), "completion_token")
+}
+
+// TestRenderPayload_MatchesRenderExactly is the correctness condition of the
+// payload-only page render.
+//
+// Pages after the first are built by RenderPayload instead of Render, to skip a
+// prompt they would discard. That is only sound if the two produce identical
+// bytes: the completion token is derived from the SERVED payload and validated
+// against the STORED row, so a payload that differed between the page-1 render
+// and the page-N render would issue a token that can never be accepted, and the
+// item would be unanswerable with no error explaining why.
+func TestRenderPayload_MatchesRenderExactly(t *testing.T) {
+	r, svc, _, _ := seedDistillCorpusSized(t, 12, 512)
+	ctx := context.Background()
+
+	res, err := r.StartSession(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res.Item)
+
+	item, err := svc.Pipeline().NextPipelineWorkItem(ctx, res.SessionID)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	payload, err := reviewStrategy{}.RenderPayload(item)
+	require.NoError(t, err)
+	require.NotEmpty(t, payload)
+
+	// res.Item.Facts is what the full Render produced for the same item. This
+	// corpus is small enough to be single-page, so page 1 carries all of it.
+	require.Equal(t, 1, res.Item.Pages, "precondition: a single-page item, so page 1 is the whole payload")
+	require.Equal(t, string(res.Item.Facts), payload,
+		"RenderPayload must reproduce Render's payload byte-for-byte, or paged items issue tokens that cannot validate")
+
+	// And it must agree with the stored row, which is what RequireCompletion
+	// hashes on the answer side.
+	require.Equal(t, item.FactsJSON, payload,
+		"the served payload and the stored row must hash to the same completion token")
+}
+
+// renderCountingStrategy is reviewStrategy with a tally on the two render
+// entry points, so a test can assert which one a page went through.
+type renderCountingStrategy struct {
+	reviewStrategy
+	renders  *atomic.Int64
+	payloads *atomic.Int64
+}
+
+func (s renderCountingStrategy) Render(ctx context.Context, d Deps, sess *store.PipelineSession, item *store.PipelineWorkItem) (*WorkItemView, error) {
+	s.renders.Add(1)
+	return s.reviewStrategy.Render(ctx, d, sess, item)
+}
+
+func (s renderCountingStrategy) RenderPayload(item *store.PipelineWorkItem) (string, error) {
+	s.payloads.Add(1)
+	return s.reviewStrategy.RenderPayload(item)
+}
+
+// TestPaging_LaterPagesDoNotRerenderThePrompt is the regression guard on the
+// cost of serving a page.
+//
+// Every page used to go through the strategy's full Render, and review's Render
+// runs one methodology retrieval PER FACT in the item
+// (distillMethodologySection). So an N-fact item served across P pages issued
+// N×P store queries where N would do — and every one of the (P−1)×N extra
+// queries built a prompt that reviewResultPage then dropped, since pages after
+// the first carry facts only.
+//
+// Asserted on the render path rather than on a timing, because the property is
+// structural: page 1 renders, later pages must not.
+func TestPaging_LaterPagesDoNotRerenderThePrompt(t *testing.T) {
+	r, svc, _, _ := seedDistillCorpusSized(t, 60, 3*1024)
+	ctx := context.Background()
+
+	var renders, payloads atomic.Int64
+	p := NewPipeline(r.ri, nil, DefaultEffort, ScopeFilter{},
+		renderCountingStrategy{renders: &renders, payloads: &payloads})
+
+	res, err := p.StartSession(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res.Item)
+
+	item, err := svc.Pipeline().NextPipelineWorkItem(ctx, res.SessionID)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	pages, err := reviewResultPage(res, 1)
+	require.NoError(t, err)
+	require.Greater(t, pages.Item.Pages, 2,
+		"precondition: the item must span several pages for this to mean anything")
+
+	renders.Store(0)
+	payloads.Store(0)
+
+	for page := 2; page <= pages.Item.Pages; page++ {
+		out, perr := p.CurrentItem(ctx, res.SessionID, item.ID, page)
+		require.NoErrorf(t, perr, "page %d", page)
+		require.NotEmptyf(t, out.Item.Facts, "page %d must still carry its payload", page)
+	}
+
+	require.Zero(t, renders.Load(),
+		"pages after the first discard the prompt; rendering one costs a methodology retrieval per fact")
+	require.Equal(t, int64(pages.Item.Pages-1), payloads.Load(),
+		"each later page must be built by the cheap payload-only path")
+
+	// Page 1 still pays for the prompt, because it is the page that carries it.
+	first, err := p.CurrentItem(ctx, res.SessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.NotEmpty(t, first.Item.Prompt)
+	require.Equal(t, int64(1), renders.Load())
+}
+
+// TestRenderPayload_EmptyForStepsThatInterpolateTheirPayload keeps the
+// fall-through honest: a step whose facts live inside its prompt has no
+// payload to serve on its own, and the engine must fall back to a full render
+// rather than emit a page with no content.
+func TestRenderPayload_EmptyForStepsThatInterpolateTheirPayload(t *testing.T) {
+	for _, step := range []string{"reflect", "discover"} {
+		got, err := reviewStrategy{}.RenderPayload(&store.PipelineWorkItem{
+			ID: 3, StepType: step, FactsJSON: `[{"path":"kb/a.md"}]`,
+		})
+		require.NoErrorf(t, err, "step %s", step)
+		require.Emptyf(t, got, "%s interpolates its payload into the prompt and has nothing to serve beside it", step)
+	}
 }

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -131,34 +131,45 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 
 	// Store distill work items if >1 seed (lower priority than prune).
 	//
-	// The seed pool is unbounded — a first run scans the whole corpus
-	// (dirtyFacts' full-scan path, Limit: 100_000) — so marshalling it into one
-	// item put an entire knowledge base into a single prompt. Chunking splits it
-	// into items whose payload fits maxDistillChunkBytes. Unlike prune, distill
-	// loses nothing across a chunk boundary: it synthesizes upward from what it
-	// is shown rather than reconciling facts against each other, and RAPTOR
-	// follow-ups (enqueueRaptorFollowups) re-cluster the output of every chunk
-	// together, so cross-chunk synthesis still happens one level up.
+	// Grouped by cluster, then chunked. Depth-0 distill used to pass the whole
+	// flat seed pool to chunkFacts, so an item was an arbitrary byte slice of
+	// the corpus in scan order — prune and the RAPTOR follow-ups both worked on
+	// real communities and depth-0 was the odd one out. Grouping first is what
+	// makes a bounded item stop being a quality loss: the bound comes from the
+	// corpus's own structure rather than from a byte count that happens to land
+	// mid-topic.
 	//
-	// Priority stays 0.0 for every chunk — the same band as before, below
+	// chunkFacts still runs, now as a backstop rather than the primary
+	// mechanism: a single Louvain community can still exceed one payload, and
+	// until work-item paging exists this is the only thing standing between a
+	// first run (dirtyFacts' full-scan path, Limit: 100_000) and a prompt
+	// containing an entire knowledge base. Splitting a group loses less than it
+	// looks — distill synthesizes upward from what it is shown rather than
+	// reconciling facts against each other, and enqueueRaptorFollowups
+	// re-clusters each round's output, so cross-chunk synthesis happens one
+	// level up.
+	//
+	// Priority stays 0.0 for every item — the same band as before, below
 	// prune's positive cluster-size priorities and above the negative
-	// discover/reflect band (see forwardDiscoverPriority). Equal-priority chunks
+	// discover/reflect band (see forwardDiscoverPriority). Equal-priority items
 	// are served in insertion order by NextPipelineWorkItem's `id ASC` tiebreak.
 	if len(llmSeeds) > 1 {
-		for i, chunk := range chunkFacts(llmSeeds, maxDistillChunkBytes) {
-			factsJSON, err := json.Marshal(chunk)
-			if err != nil {
-				return wrapf(reviewTool, err, "marshal seeds for distill chunk %d", i)
-			}
-			item := store.PipelineWorkItem{
-				SessionID:  sess.ID,
-				StepType:   "distill",
-				ClusterKey: fmt.Sprintf("distill-all-%d", i),
-				FactsJSON:  string(factsJSON),
-				Priority:   0.0,
-			}
-			if err := d.Pipeline.InsertPipelineWorkItem(ctx, item); err != nil {
-				return wrapf(reviewTool, err, "insert distill item %d", i)
+		for _, group := range distillGroups(llmSeeds, clusters) {
+			for ci, chunk := range chunkFacts(group.Facts, maxDistillChunkBytes) {
+				factsJSON, err := json.Marshal(chunk)
+				if err != nil {
+					return wrapf(reviewTool, err, "marshal seeds for distill group %s chunk %d", group.Key, ci)
+				}
+				item := store.PipelineWorkItem{
+					SessionID:  sess.ID,
+					StepType:   "distill",
+					ClusterKey: fmt.Sprintf("%s-%d", group.Key, ci),
+					FactsJSON:  string(factsJSON),
+					Priority:   0.0,
+				}
+				if err := d.Pipeline.InsertPipelineWorkItem(ctx, item); err != nil {
+					return wrapf(reviewTool, err, "insert distill item %s-%d", group.Key, ci)
+				}
 			}
 		}
 	}
@@ -212,6 +223,80 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	d.OnProgress(ProgressEvent{Phase: "review-start", Message: fmt.Sprintf("session %s: %d clusters, %d seeds, %d bridges", sess.ID, len(pruneClusters), len(llmSeeds), len(bridges))})
 
 	return nil
+}
+
+// distillGroup is one depth-0 distill work unit before chunking: a coherent
+// set of seeds plus the key its work items are named after.
+type distillGroup struct {
+	Key   string
+	Facts []factForLLM
+}
+
+// distillGroups partitions the seed pool into the groups depth-0 distill
+// reasons over, using the clusters Plan already computed.
+//
+// Two properties of ScopedCluster's output make "just iterate clusters" wrong,
+// and this function exists to reconcile them with the seed pool:
+//
+//   - filterSmallClusters DROPS every community below minCommunitySize, so a
+//     seed that clusters alone is absent from clusters entirely. Grouping
+//     straight off that output would silently exclude it from synthesis — no
+//     error, no counter, indistinguishable from "nothing to synthesize". That
+//     is the failure shape this package has already been bitten by twice.
+//   - Clusters contain NEIGHBOURS, not just seeds: ScopedCluster pulls the top
+//     search hits per seed into the subgraph, and the review path passes no
+//     ExcludeTypes, so a cluster can hold facts AcceptSeed deliberately refuses.
+//     A pragmatic fact reaching distill would be rewritten as epistemic on
+//     commit (decision.go carries no Kind through distillFact) and could be
+//     named in `retract`. Restricting to seeds keeps distill's eligible set
+//     exactly what the seed scan admitted — widening it is a separate decision
+//     with its own hazards, not a side effect of regrouping.
+//
+// The contract: every seed appears in exactly one returned group. Seeds whose
+// community did not survive — and seeds left alone in theirs, where there is
+// nothing to synthesize across — collect into a trailing remainder group rather
+// than being dropped. A one-fact remainder costs one no-op round trip; a
+// dropped seed costs a fact nobody knows is missing.
+func distillGroups(seeds []factForLLM, clusters [][]factForLLM) []distillGroup {
+	isSeed := make(map[string]bool, len(seeds))
+	for _, s := range seeds {
+		isSeed[s.File] = true
+	}
+
+	claimed := make(map[string]bool, len(seeds))
+	var groups []distillGroup
+	for _, c := range clusters {
+		var g []factForLLM
+		for _, f := range c {
+			if isSeed[f.File] && !claimed[f.File] {
+				claimed[f.File] = true
+				g = append(g, f)
+			}
+		}
+		// One seed is not a group — nothing to find a pattern across. Release
+		// it so the remainder picks it up.
+		if len(g) < 2 {
+			for _, f := range g {
+				delete(claimed, f.File)
+			}
+			continue
+		}
+		groups = append(groups, distillGroup{Key: fmt.Sprintf("distill-c%d", len(groups)), Facts: g})
+	}
+
+	// Iterate seeds, not the claimed map: order must not depend on map
+	// iteration, or the same corpus would produce different work items run to
+	// run and the chunk boundaries would wander with it.
+	var remainder []factForLLM
+	for _, s := range seeds {
+		if !claimed[s.File] {
+			remainder = append(remainder, s)
+		}
+	}
+	if len(remainder) > 0 {
+		groups = append(groups, distillGroup{Key: "distill-rest", Facts: remainder})
+	}
+	return groups
 }
 
 // factsForLLM projects the engine's canonical seed type onto the prompt-facing

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -117,6 +117,18 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 		if err != nil {
 			return wrapf(reviewTool, err, "marshal cluster %d", i)
 		}
+		// Prune stays unchunked, so nothing bounds a cluster except what Louvain
+		// happened to produce. Paging makes an oversized one DELIVERABLE — it
+		// arrives across pages — but the agent still has to hold all of it to
+		// decide merges, so a mega-community can exceed what the model can
+		// reason over even though every page fits. Say so rather than letting a
+		// degraded merge pass silently: the whole failure class this area keeps
+		// hitting is caps that nothing reports.
+		if len(factsJSON) > maxItemBytes {
+			log.Warn().Str("session", sess.ID).Str("cluster", fmt.Sprintf("cluster-%d", i)).
+				Int("facts", len(cluster)).Int("bytes", len(factsJSON)).Int("limit", maxItemBytes).
+				Msg("review: prune cluster exceeds maxItemBytes; it will page, but merge quality may suffer — consider raising clustering resolution")
+		}
 		item := store.PipelineWorkItem{
 			SessionID:  sess.ID,
 			StepType:   "prune",
@@ -225,12 +237,28 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	return nil
 }
 
-// RequireCompletion implements pagedStrategy. Only steps that ship their
-// payload beside the prompt can span pages; prune, reflect and discover
-// interpolate theirs into the prompt and are single-page by construction, which
-// factPages already reports.
+// pagedStepTypes are the review steps whose payload ships BESIDE the prompt and
+// can therefore be delivered across pages.
+//
+// Explicit rather than inferred, because the two sides of paging read different
+// fields and only agree for these steps. reviewResultPage pages item.Facts —
+// what Render chose to ship beside the prompt — while RequireCompletion must
+// work from item.FactsJSON, the stored row. reflect and discover interpolate
+// their payloads into the prompt, so they never page and are never issued a
+// token; but their stored JSON is still fact-shaped enough to slice (a
+// hypothesisTransition even has a "path" field, which unmarshals onto
+// factForLLM.File). Inferring "can page" from the stored payload would demand a
+// token that was never issued and leave the item permanently unanswerable.
+//
+// Keep in sync with Render. TestPaging_TokenRequiredOnlyWhereItIsIssued pins it.
+var pagedStepTypes = map[string]bool{
+	"distill": true,
+	"prune":   true,
+}
+
+// RequireCompletion implements pagedStrategy.
 func (reviewStrategy) RequireCompletion(item *store.PipelineWorkItem, completionToken string) error {
-	if item.StepType != "distill" {
+	if !pagedStepTypes[item.StepType] {
 		return nil
 	}
 	return requireCompletionToken(item.ID, item.FactsJSON, completionToken)

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -578,6 +578,7 @@ func (reviewStrategy) Render(ctx context.Context, d Deps, sess *store.PipelineSe
 		Type:           item.StepType,
 		Prompt:         content.Prompt,
 		ResponseSchema: content.ResponseSchema,
+		Facts:          content.Facts,
 	}, nil
 }
 

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -264,6 +264,33 @@ func (reviewStrategy) RequireCompletion(item *store.PipelineWorkItem, completion
 	return requireCompletionToken(item.ID, item.FactsJSON, completionToken)
 }
 
+// RenderPayload implements pagedStrategy: the facts a paged item ships beside
+// its prompt, produced without the prompt.
+//
+// The round-trip through []factForLLM is not redundant with returning
+// item.FactsJSON directly. It is the same construction Render uses — unmarshal
+// the stored row, hand it to the Render*WorkItem function, which marshals it —
+// so the two paths agree by sharing a derivation rather than by both happening
+// to equal the stored bytes. That equality holds today and is what the
+// completion token rests on; making it incidental is how it would stop holding.
+//
+// Everything expensive in Render (methodology retrieval, template execution)
+// is absent here by design, which is the entire point of the method.
+func (reviewStrategy) RenderPayload(item *store.PipelineWorkItem) (string, error) {
+	if !pagedStepTypes[item.StepType] {
+		return "", nil
+	}
+	var facts []factForLLM
+	if err := json.Unmarshal([]byte(item.FactsJSON), &facts); err != nil {
+		return "", wrapf(reviewTool, err, "unmarshal facts for page")
+	}
+	b, err := json.Marshal(facts)
+	if err != nil {
+		return "", wrapf(reviewTool, err, "marshal facts for page")
+	}
+	return string(b), nil
+}
+
 // distillGroup is one depth-0 distill work unit before chunking: a coherent
 // set of seeds plus the key its work items are named after.
 type distillGroup struct {

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -155,7 +155,7 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	// are served in insertion order by NextPipelineWorkItem's `id ASC` tiebreak.
 	if len(llmSeeds) > 1 {
 		for _, group := range distillGroups(llmSeeds, clusters) {
-			for ci, chunk := range chunkFacts(group.Facts, maxDistillChunkBytes) {
+			for ci, chunk := range chunkFacts(group.Facts, maxItemBytes) {
 				factsJSON, err := json.Marshal(chunk)
 				if err != nil {
 					return wrapf(reviewTool, err, "marshal seeds for distill group %s chunk %d", group.Key, ci)
@@ -223,6 +223,17 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	d.OnProgress(ProgressEvent{Phase: "review-start", Message: fmt.Sprintf("session %s: %d clusters, %d seeds, %d bridges", sess.ID, len(pruneClusters), len(llmSeeds), len(bridges))})
 
 	return nil
+}
+
+// RequireCompletion implements pagedStrategy. Only steps that ship their
+// payload beside the prompt can span pages; prune, reflect and discover
+// interpolate theirs into the prompt and are single-page by construction, which
+// factPages already reports.
+func (reviewStrategy) RequireCompletion(item *store.PipelineWorkItem, completionToken string) error {
+	if item.StepType != "distill" {
+		return nil
+	}
+	return requireCompletionToken(item.ID, item.FactsJSON, completionToken)
 }
 
 // distillGroup is one depth-0 distill work unit before chunking: a coherent
@@ -598,7 +609,7 @@ func enqueueRaptorFollowups(
 		// exceed one prompt. Priority stays -nextDepth for every chunk of a
 		// given depth, so depth ordering is preserved and equal-priority chunks
 		// fall back to NextPipelineWorkItem's `id ASC` tiebreak.
-		for chi, chunk := range chunkFacts(cluster, maxDistillChunkBytes) {
+		for chi, chunk := range chunkFacts(cluster, maxItemBytes) {
 			factsJSON, _ := json.Marshal(chunk)
 			wItem := store.PipelineWorkItem{
 				SessionID:  sess.ID,

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -78,6 +78,25 @@ type pagedStrategy interface {
 	// carry proof the agent read every page. Called before Decode and before
 	// the claim, so returning an error leaves the item retryable.
 	RequireCompletion(item *store.PipelineWorkItem, completionToken string) error
+
+	// RenderPayload produces ONLY the payload a paged item ships beside its
+	// prompt — byte-for-byte what Render would put in WorkItemView.Facts,
+	// without building the prompt around it.
+	//
+	// It exists because pages after the first keep the facts and discard the
+	// prompt, and building a prompt to throw it away is not free: review's
+	// Render retrieves methodology once per fact in the item, so serving an
+	// N-fact item across P pages cost N×P store queries where N suffices.
+	//
+	// MUST agree with Render byte-for-byte on the same item. The completion
+	// token is derived from the served payload and validated against the
+	// stored row, so a payload that differed between the two render paths
+	// would make a multi-page item unanswerable. Cheap by contract: no store
+	// access, no retrieval.
+	//
+	// Returns "" for a step type that has no payload to ship beside its
+	// prompt; the engine then falls back to a full Render.
+	RenderPayload(item *store.PipelineWorkItem) (string, error)
 }
 
 // WorkItemView is a strategy's rendering of one work item: what the agent is

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -76,6 +76,10 @@ type WorkItemView struct {
 	Type           string
 	Prompt         string
 	ResponseSchema string
+	// Facts is the item's payload as a structured JSON array, carried beside
+	// the prompt instead of interpolated into it. Empty for step types whose
+	// template still inlines their payload.
+	Facts string
 }
 
 // PipelineItem is the engine's tool-neutral work item. Each tool's MCP facade
@@ -91,6 +95,12 @@ type PipelineItem struct {
 	// hypothesize echoes it back to the agent as the `fact` field. Carrying it
 	// here spares the facades a second read of the work item.
 	FactsJSON string
+	// Facts is the RENDERED payload the strategy chose to ship beside the
+	// prompt — distinct from FactsJSON, which is what the row stores. They
+	// coincide for distill today; keeping them separate is what lets a
+	// strategy ship a projection (or, later, one page) of a larger stored
+	// payload without the store shape leaking onto the wire.
+	Facts string
 }
 
 // PipelineResult is the engine's tool-neutral turn result.

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -65,6 +65,21 @@ type Deps struct {
 	OnProgress func(ProgressEvent)
 }
 
+// pagedStrategy is the optional half of Strategy: implemented only by
+// strategies whose work items can be served across several tool results.
+//
+// Optional rather than part of Strategy because paging is not universal —
+// hypothesize ships one fact per item and has nothing to page — and widening
+// the required interface would force a meaningless implementation on every
+// tool. The engine type-asserts; a strategy that does not implement this is
+// simply never asked.
+type pagedStrategy interface {
+	// RequireCompletion rejects an answer to a multi-page item that does not
+	// carry proof the agent read every page. Called before Decode and before
+	// the claim, so returning an error leaves the item retryable.
+	RequireCompletion(item *store.PipelineWorkItem, completionToken string) error
+}
+
 // WorkItemView is a strategy's rendering of one work item: what the agent is
 // shown and what shape its answer must take. The engine wraps it with the
 // item id and payload (see PipelineItem) — a strategy never has to remember to

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -284,7 +284,16 @@ type ReviewItem struct {
 	Pages int `json:"pages,omitempty"`
 	// MoreAvailable is true while pages remain. An answer submitted before it
 	// goes false is rejected; see CompletionToken.
-	MoreAvailable bool `json:"more_available,omitempty"`
+	//
+	// Deliberately NOT omitempty, unlike every other optional field here. The
+	// tool description, both paged prompt templates, and the `page` argument's
+	// own documentation all tell the agent to keep paging "until more_available
+	// is false" — and omitempty makes the final page carry no such field at all,
+	// so the one condition the protocol is expressed in terms of never appears.
+	// Absent is not false to a reader that was told to look for false. Twenty-two
+	// bytes on the final page against a ~3 KB margin is not a trade worth making
+	// on the single field the accumulate-then-respond contract turns on.
+	MoreAvailable bool `json:"more_available"`
 	// CompletionToken appears on the FINAL page only and must be echoed back
 	// with the response. Emitting it solely on the last page is what makes it
 	// proof the agent got there — the server can check that a multi-page item

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -177,35 +177,36 @@ func parsePruneResponse(text string) (PruneResult, error) {
 // something this package may assume.
 const maxDeliveredItemBytes = 32 * 1024
 
-// renderOverheadFixedBytes and renderOverheadPercent convert the delivered
-// budget above into a budget on the compact fact JSON the chunker can actually
-// measure. Both are measured, not guessed, from the rejected payloads: the
-// prompt preamble, response schema and envelope keys are a fixed cost, and
-// indentation applied by the delivering MarshalIndent is a proportional one.
+// pageEnvelopeReserveBytes reserves everything on a delivered page that is not
+// facts: the prompt, the response schema, the paging fields, and the
+// ReviewResult envelope around them. Page 1 is the tight case — it alone
+// carries the prompt and schema — so later pages simply run with more slack.
 //
-// Keeping the conversion explicit is what stops the two budgets collapsing back
-// into one number. TestDistillWorkItem_MaxChunkFitsDeliveredCap renders a
-// full-size chunk and checks the real delivered result, so if the preamble or
-// schema grows, the test fails rather than the constant silently going stale.
-const (
-	renderOverheadFixedBytes = 6 * 1024
-	renderOverheadPercent    = 106
-)
+// Measured, and pinned: TestDeliveredPage_EnvelopeFitsItsReserve renders every
+// paging step type with a full-size methodology section (the largest prompt the
+// distill path can produce) and fails if the envelope outgrows this. The
+// measured worst case at the time of writing is 5,893 bytes.
+const pageEnvelopeReserveBytes = 8 * 1024
 
-// maxPageBytes bounds the compact fact JSON carried on ONE page, derived so
-// that the rendered page fits maxDeliveredItemBytes.
+// maxPageFactBytes bounds the facts carried on ONE page, measured AS DELIVERED
+// — after the indentation json.MarshalIndent applies in internal/mcp/review.go,
+// not in the compact form the store holds.
 //
-// Page 1 is the tight case — it alone carries the prompt and response schema,
-// which is what renderOverheadFixedBytes reserves. Later pages get the same
-// fact budget and simply run with more slack; sizing them separately would buy
-// a few hundred bytes and cost a second formula to keep honest.
-const maxPageBytes = (maxDeliveredItemBytes - renderOverheadFixedBytes) * 100 / renderOverheadPercent
+// The unit is the whole point, and it is why this is a subtraction rather than
+// a percentage of the compact size. Indentation adds a newline plus indent per
+// JSON TOKEN, not per byte, so the expansion factor is a function of how MANY
+// facts a page holds, not how large each one is. A ratio calibrated on the
+// incident's ~2 KiB-body facts held only there: at 1 KiB bodies a full page
+// delivered 33.5 KB, at 200 B bodies 40.6 KB, at 50 B bodies 46.4 KB — all
+// against a 32 KiB cap, which is the original defect reproduced at a different
+// fact size. deliveredFactsLen measures the artifact instead of predicting it.
+const maxPageFactBytes = maxDeliveredItemBytes - pageEnvelopeReserveBytes
 
 // maxItemBytes bounds what ONE work item holds — i.e. what the agent must
 // accumulate across pages before answering. This is the second of the two
-// budgets whose conflation was the original defect: maxPageBytes is a TRANSPORT
-// limit (client-side, what fits in one tool result), maxItemBytes is a
-// COGNITION limit (model-side, what can be reasoned over at once).
+// budgets whose conflation was the original defect: maxPageFactBytes is a
+// TRANSPORT limit (client-side, what fits in one tool result), maxItemBytes is
+// a COGNITION limit (model-side, what can be reasoned over at once).
 //
 // Paging is what let them separate. Before it, an item shipped in a single
 // response, so the transport limit doubled as the item limit and the only lever

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -160,11 +160,40 @@ func parsePruneResponse(text string) (PruneResult, error) {
 	return result, nil
 }
 
-// maxDistillChunkBytes bounds the marshalled fact payload of a single distill
-// work item. ~64 KiB of fact JSON is roughly 16K tokens: comfortably inside
-// every hosting model's context window, while keeping the per-item reasoning
-// tractable for the small local models this package already accommodates (see
-// extractJSON's <think>-stripping and flexStrings above).
+// maxDeliveredItemBytes bounds ONE delivered work item — the whole marshalled
+// ReviewResult as internal/mcp/review.go returns it, not just its facts.
+//
+// This is the budget that actually binds, and naming it is the point. The
+// previous single constant was derived from a MODEL CONTEXT rationale ("~16K
+// tokens: comfortably inside every hosting model's context window"), which was
+// true and irrelevant: the model's context never rejected anything. The
+// CLIENT's MCP tool-result cap did. Seven real distill payloads (sessions
+// 2b56c148-…, 284faa87-…) each sat just under the old 64 KiB fact budget, were
+// delivered at 68.6–73.9 KB, and were spilled to disk unread.
+//
+// 32 KiB against a limit known only by observation — Claude Code defaults
+// MAX_MCP_OUTPUT_TOKENS to 25,000 — leaves headroom for fact bodies that grow
+// over time. Raising MAX_MCP_OUTPUT_TOKENS is a per-user harness setting, never
+// something this package may assume.
+const maxDeliveredItemBytes = 32 * 1024
+
+// renderOverheadFixedBytes and renderOverheadPercent convert the delivered
+// budget above into a budget on the compact fact JSON the chunker can actually
+// measure. Both are measured, not guessed, from the rejected payloads: the
+// prompt preamble, response schema and envelope keys are a fixed cost, and
+// indentation applied by the delivering MarshalIndent is a proportional one.
+//
+// Keeping the conversion explicit is what stops the two budgets collapsing back
+// into one number. TestDistillWorkItem_MaxChunkFitsDeliveredCap renders a
+// full-size chunk and checks the real delivered result, so if the preamble or
+// schema grows, the test fails rather than the constant silently going stale.
+const (
+	renderOverheadFixedBytes = 6 * 1024
+	renderOverheadPercent    = 106
+)
+
+// maxDistillChunkBytes bounds the compact fact JSON of a single distill work
+// item, derived so that the rendered item fits maxDeliveredItemBytes.
 //
 // Deliberately a const rather than a config knob: there is no evidence yet that
 // anyone needs to tune this per-repo, and promoting it into the [synthesize]
@@ -172,7 +201,7 @@ func parsePruneResponse(text string) (PruneResult, error) {
 // shipping a tunable nobody has a reason to turn.
 //
 // Distill only — prune clusters are NOT chunked; see StartSession.
-const maxDistillChunkBytes = 64 * 1024
+const maxDistillChunkBytes = (maxDeliveredItemBytes - renderOverheadFixedBytes) * 100 / renderOverheadPercent
 
 // chunkFacts splits facts into groups where each group's JSON is ≤ maxBytes.
 //
@@ -221,6 +250,12 @@ type ReviewItem struct {
 	Type           string `json:"type"` // "prune", "distill", or "reflect"
 	Prompt         string `json:"prompt"`
 	ResponseSchema string `json:"response_schema"`
+	// Facts is the item's payload, carried as structural JSON rather than
+	// serialized into Prompt. RawMessage and not string on purpose: as a
+	// string every quote in the payload is escaped a second time on the wire,
+	// which is pure cost on the exact items that are already too large.
+	// Mirrors HypothesizeItem.Fact, which has always shipped this way.
+	Facts json.RawMessage `json:"facts,omitempty"`
 }
 
 // ReviewProgress tracks completed/remaining counts.

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -160,7 +160,7 @@ func parsePruneResponse(text string) (PruneResult, error) {
 	return result, nil
 }
 
-// maxDeliveredItemBytes bounds ONE delivered work item — the whole marshalled
+// maxDeliveredItemBytes bounds ONE delivered PAGE — the whole marshalled
 // ReviewResult as internal/mcp/review.go returns it, not just its facts.
 //
 // This is the budget that actually binds, and naming it is the point. The
@@ -192,16 +192,34 @@ const (
 	renderOverheadPercent    = 106
 )
 
-// maxDistillChunkBytes bounds the compact fact JSON of a single distill work
-// item, derived so that the rendered item fits maxDeliveredItemBytes.
+// maxPageBytes bounds the compact fact JSON carried on ONE page, derived so
+// that the rendered page fits maxDeliveredItemBytes.
 //
-// Deliberately a const rather than a config knob: there is no evidence yet that
-// anyone needs to tune this per-repo, and promoting it into the [synthesize]
-// config section later is a one-line change. Adding the knob now would mean
-// shipping a tunable nobody has a reason to turn.
+// Page 1 is the tight case — it alone carries the prompt and response schema,
+// which is what renderOverheadFixedBytes reserves. Later pages get the same
+// fact budget and simply run with more slack; sizing them separately would buy
+// a few hundred bytes and cost a second formula to keep honest.
+const maxPageBytes = (maxDeliveredItemBytes - renderOverheadFixedBytes) * 100 / renderOverheadPercent
+
+// maxItemBytes bounds what ONE work item holds — i.e. what the agent must
+// accumulate across pages before answering. This is the second of the two
+// budgets whose conflation was the original defect: maxPageBytes is a TRANSPORT
+// limit (client-side, what fits in one tool result), maxItemBytes is a
+// COGNITION limit (model-side, what can be reasoned over at once).
 //
-// Distill only — prune clusters are NOT chunked; see StartSession.
-const maxDistillChunkBytes = (maxDeliveredItemBytes - renderOverheadFixedBytes) * 100 / renderOverheadPercent
+// Paging is what let them separate. Before it, an item shipped in a single
+// response, so the transport limit doubled as the item limit and the only lever
+// for an undeliverable item was to show the model less.
+//
+// It is a backstop, not a routine constraint. Since depth-0 distill groups by
+// cluster (see distillGroups), item size is normally bounded by the community's
+// own size; this catches the pathological mega-community, and — until every
+// step type pages — keeps a first run over a large corpus from becoming one
+// prompt. It is the knob most likely to want per-repo tuning, because unlike
+// the transport limit it genuinely differs per deployment: this package
+// accommodates small local models that cannot hold what a long-context hosted
+// model can, however small each page is.
+const maxItemBytes = 256 * 1024
 
 // chunkFacts splits facts into groups where each group's JSON is ≤ maxBytes.
 //
@@ -250,12 +268,31 @@ type ReviewItem struct {
 	Type           string `json:"type"` // "prune", "distill", or "reflect"
 	Prompt         string `json:"prompt"`
 	ResponseSchema string `json:"response_schema"`
-	// Facts is the item's payload, carried as structural JSON rather than
-	// serialized into Prompt. RawMessage and not string on purpose: as a
-	// string every quote in the payload is escaped a second time on the wire,
-	// which is pure cost on the exact items that are already too large.
+	// Facts is THIS PAGE of the item's payload, carried as structural JSON
+	// rather than serialized into Prompt. RawMessage and not string on purpose:
+	// as a string every quote in the payload is escaped a second time on the
+	// wire, which is pure cost on the exact items that are already too large.
 	// Mirrors HypothesizeItem.Fact, which has always shipped this way.
 	Facts json.RawMessage `json:"facts,omitempty"`
+
+	// Paging. An item whose facts exceed one tool result is served across
+	// several; the agent accumulates every page and answers once at the end.
+	// Page/Pages are 1-based. Prompt and ResponseSchema appear on page 1 only —
+	// they are already in context by the time later pages arrive.
+	Page  int `json:"page,omitempty"`
+	Pages int `json:"pages,omitempty"`
+	// MoreAvailable is true while pages remain. An answer submitted before it
+	// goes false is rejected; see CompletionToken.
+	MoreAvailable bool `json:"more_available,omitempty"`
+	// CompletionToken appears on the FINAL page only and must be echoed back
+	// with the response. Emitting it solely on the last page is what makes it
+	// proof the agent got there — the server can check that a multi-page item
+	// was actually read, rather than asking politely and hoping.
+	CompletionToken string `json:"completion_token,omitempty"`
+	// Next is the human-readable instruction for what to do with this page,
+	// carried beside the value it refers to so the agent does not have to
+	// reconstruct the protocol from the tool description mid-item.
+	Next string `json:"next,omitempty"`
 }
 
 // ReviewProgress tracks completed/remaining counts.


### PR DESCRIPTION
Distill work items exceeded the client's MCP tool-result cap and were spilled to disk, so the agent never saw the work. Reported in `.claude/harness/scratch/knomit-review-oversized-payloads.md`.

## The bug

`maxDistillChunkBytes` measured **compact fact JSON**, but what shipped was `MarshalIndent` inside a prompt string inside a JSON envelope — **1.13–1.14× larger**, measured across the seven spilled payloads. And it was sized from a model-context rationale ("~16K tokens, comfortably inside every hosting model's context window") when the limit that actually binds is the client's tool-result cap.

Chunking was not missing — it landed five days before the incident, and every rejected payload sat just under its budget. The chunker was correct; the number was wrong, and it bounded a different artifact than the transport carried. The existing test pinned the *stored* payload; nothing pinned the *delivered* one.

## What this PR fixes

- **`34f0f553`** — `maxDeliveredItemBytes` names the binding limit. Facts move out of the prompt string into a structural `facts` field, so they can be sliced at all.
- **`eeb2bd9e`** — depth-0 distill groups by cluster instead of byte offset. It previously chunked the flat seed pool, so an item was an arbitrary slice of the corpus in scan order; prune and RAPTOR already worked on real communities.
- **`f61989c7`** — oversized items are served across pages. The agent accumulates every page and answers once, so the transport cap no longer bounds how much one synthesis decision can see. A completion token on the final page is **enforced**, not requested: answering early is rejected before the claim, leaving the item retryable.
- **`46cbc830`** — prune pages too. It gains more than distill: chunking a prune cluster silently forbids merges across the split, whereas paging splits delivery and keeps the decision whole.
- **`e2915329`** — the page budget measures the delivered artifact instead of predicting it. See below; this replaces the conversion `34f0f553` introduced.

Net effect: two separate budgets where there was one. `maxPageFactBytes` bounds a tool result; `maxItemBytes` bounds what the model accumulates.

## Why the first four commits were not enough

`34f0f553` derived the fact budget from the delivered budget through a ratio — `6 KiB + 6%`. Both numbers were measured, but from the incident's payloads, which all had ~2 KiB bodies. **A percentage cannot bound indentation**, because indentation cost is per JSON *token* — a newline plus indent for every field and every array element — not per byte. The expansion factor is therefore a function of how **many** facts a page holds, not how large each one is, and it rises sharply as facts get smaller.

Measured on a full page, rendered exactly as `ReviewHandler` ships it, against the 32 KiB cap:

| body size | facts on page 1 | delivered | |
|---|---|---|---|
| 50 B | 100 | 46,258 | ✗ 41% over |
| 100 B | 84 | 43,994 | ✗ |
| 200 B | 62 | 40,206 | ✗ |
| 500 B | 35 | 35,748 | ✗ |
| 1 KiB | 20 | 33,418 | ✗ |
| 2 KiB | 11 | 32,344 | ✓ by 424 bytes |

That is the original defect reproduced at a different fact size — budget honoured exactly, payload undeliverable, agent sees nothing. A corpus of short facts would have hit it on the first session.

`e2915329` replaces the ratio with a measurement. `deliveredFactsLen` runs a payload through `json.Indent` at the exact depth `facts` occupies inside the delivered result (`result → item → facts`), and `packFactPages` packs against that. Its per-fact estimate over-counts a real page by a few bytes per join — the safe direction for a budget, and now pinned as an inequality rather than assumed. `maxPageBytes` is renamed `maxPageFactBytes`: its unit changed from compact to delivered, and the unit was the bug.

Two things on a page are still not the pager's to bound — distill's methodology section grows with the retrieved titles, and a single fact too large to split cannot be split. `reviewResultPage` now measures the finished result and logs a warning if it is over the cap. Neither case is silent any more, which is the property that failed in the incident.

## Why the tests did not catch it

`TestDistillWorkItem_MaxChunkFitsDeliveredCap` did measure the delivered result — but at a single body size, 2 KiB, the one place the ratio held. It also hand-built a `ReviewItem`, omitting `page`/`pages`/`more_available`/`next`, which is ~180 bytes of real payload out of a ~400-byte margin, and it checked only page 1.

The delivered-size assertions now:

- sweep body sizes from 50 B to 4 KiB (`bodySizes`), since one size cannot see a token-count effect;
- assemble pages through the real `reviewResultPage`, so every paging field is present exactly as it ships;
- check **every** page, not just the first — page 1 carries the prompt, but later pages carry more facts.

`TestPaging_EveryPageFitsTheDeliveredCap` asserts the same property through the live session path (`StartSession` → planner → `PageItem`) at three fact shapes, proving the shapes the unit sweep covers are ones a real session produces. `TestDeliveredPage_EnvelopeFitsItsReserve` pins `pageEnvelopeReserveBytes` — the budget is derived by subtracting it, so it going stale silently is how this over-promises again. `TestFactPages_SizeModelNeverUnderCounts` pins the estimate's direction.

Mutation-verified: restoring the compact measurement and the 106% ratio fails the sweep at 50 B / 100 B / 200 B / 500 B / 1 KiB and **passes** at 2 KiB and 4 KiB — exactly where the old test was pinned.

## Verification

Unit tests plus end-to-end over real MCP — live servers driven by real Claude Code instances:

- **Delivery:** pre-fix build spilled a 67,943-byte item to disk; fixed build delivered 31,504 bytes inline.
- **Grouping:** 38 seeds → distill items matching prune's communities exactly (4/2/2) plus remainder (17/13); 38 fact slots, 38 distinct paths, 0 duplicated.
- **Paging:** a 7-page item delivered 46 distinct facts with no gap or overlap; token on the last page only.
- **Enforcement:** a deliberate early answer was rejected, the item survived, and the corrected resubmission completed the session.

Every load-bearing guard is mutation-tested. The end-to-end runs above predate `e2915329`; that commit is covered by unit tests and the mutation run.

## Known limits, not fixed here

- **A single fact larger than one page** still delivers over the cap — it cannot be split, exactly as `chunkFacts` cannot split it for the item budget. Now warned rather than silent. Nothing caps a fact body.
- **`RunAll` does not page.** The in-process path (`internal/web/handlers_jobs.go`, local LLM adapter) receives the whole item, so `maxItemBytes` at 256 KiB is a 4× rise over the previous 64 KiB bound for that consumer.
- **`pagedStepTypes` is a one-directional guard.** A future step type whose `Render` starts emitting `Facts` but is not added to the map would page without requiring a token — silent partial-cluster synthesis. The reverse direction is tested; this one is not.
- **`more_available` is `omitempty`**, so it is absent rather than `false` on a final page, while the docs say "until it is false".
- **Pages are smaller than before** (~24.5 KB delivered vs. a nominal 25 KB compact), so items page more often. That is the cost of the bound actually holding.

## Not in scope

- Prune paging is unit-tested only — no natural prune cluster large enough to page could be provoked.
- Prune stays unchunked; an oversized cluster is deliverable but can still exceed model context. Logged, not silent.
- `kb/meta/jobs/**` being seeded as knowledge — the report's other finding, where a `retract` on `crawl-state` would destroy crawl history. Independent data-loss path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
