### PR TITLE
fix(desktop): ad-hoc sign the macOS bundle, which downloads need to l…

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -226,11 +226,18 @@ jobs:
 
           ## Install
 
-          **macOS desktop (unsigned):** not notarized, so Gatekeeper blocks the
-          first launch of a manually downloaded copy:
+          **macOS desktop (ad-hoc signed, not notarized):** Gatekeeper blocks
+          the first launch of a manually downloaded copy. Either:
           \`\`\`sh
-          xattr -dr com.apple.quarantine Knomit.app && open Knomit.app
+          xattr -cr Knomit.app && open Knomit.app
           \`\`\`
+          or open it once from Finder and approve it in System Settings →
+          Privacy & Security → **Open Anyway**.
+
+          Use \`-cr\` (clear every attribute), not the narrower
+          \`-dr com.apple.quarantine\` — the latter has been observed to leave
+          the app blocked.
+
           Updates the app installs itself are not quarantined and need no such step.
 
           **Linux desktop:** a single AppImage; requires GTK 4 + WebKitGTK 6.0

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,39 @@ desktop-app-macos:
 	cp $(LIBDIR)/libonnxruntime.dylib $(APP)/Contents/MacOS/lib/
 	sed -e 's/{{SHORT_VERSION}}/$(VERSION)/g' -e 's/{{BUILD_VERSION}}/$(BUILD_VERSION)/g' tools/desktop/macos/Info.plist > $(APP)/Contents/Info.plist
 	@[ -f tools/desktop/macos/icon.icns ] && cp tools/desktop/macos/icon.icns $(APP)/Contents/Resources/icon.icns || echo "  (no icon.icns — using generic app icon)"
+	# Ad-hoc sign the assembled bundle. LAST in this recipe, and inner code
+	# before the bundle: the bundle's seal covers Contents/, so signing before
+	# Info.plist and the icon land — or re-signing a nested binary afterwards —
+	# seals a tree that no longer matches.
+	#
+	# Without this the bundle carries ONLY the Go linker's ad-hoc signature on
+	# knomit-desktop (Identifier=a.out, flags=adhoc,linker-signed). That
+	# signature declares a sealed resource envelope that does not exist —
+	# there is no Contents/_CodeSignature — so `codesign --verify` fails with
+	# "code has no resources but signature indicates they must be present" and
+	# macOS reports a QUARANTINED copy as "damaged — move it to the Trash".
+	# That dialog is a dead end: no Open Anyway, no right-click override.
+	#
+	# It only ever bites users who DOWNLOAD a release. A locally built or
+	# self-updated bundle is never quarantined, so macOS never runs the strict
+	# validation that trips on the missing envelope — which is exactly why
+	# every test before the first published release missed it.
+	#
+	# Ad-hoc (-), NOT Developer ID: this is not notarization and does not
+	# remove the `xattr -cr` step in the release notes. What it buys is (1) an
+	# unrecoverable "damaged" becoming the ordinary unidentified-developer
+	# prompt, which Open Anyway can clear, and (2) Info.plist bound into the
+	# signature, so the app's signed identity is com.knomit.desktop rather
+	# than `a.out` — which is what UNUserNotificationCenter reads.
+	codesign --force --sign - $(APP)/Contents/MacOS/knomit-bridge
+	codesign --force --sign - $(APP)/Contents/MacOS/knomit-okf
+	codesign --force --sign - $(APP)/Contents/MacOS/lib/libonnxruntime.dylib
+	codesign --force --sign - $(APP)
+	# Assert the seal rather than trusting the exit code above: a bundle that
+	# signs cleanly can still fail validation, and this is the exact check the
+	# user's machine runs on first launch.
+	@codesign --verify --deep --strict $(APP) \
+	  || { echo "$(APP): bundle signature does not validate"; exit 1; }
 
 # Regenerate every desktop icon asset from the canonical logos. Requires
 # rsvg-convert + iconutil (macOS). The outputs are committed (the Go binary


### PR DESCRIPTION
The assembled .app carried only the Go LINKER's ad-hoc signature on knomit-desktop (Identifier=a.out, flags=adhoc,linker-signed). That signature declares a sealed resource envelope the bundle does not have — there is no Contents/_CodeSignature — so codesign --verify fails with "code has no resources but signature indicates they must be present", and macOS reports a QUARANTINED copy as "damaged — move it to the Trash". That dialog offers no Open Anyway and no right-click override: a downloaded release was unlaunchable without the terminal.

Nothing caught it because nothing was ever quarantined. Local builds are copied into place and self-updates are written by the updater; neither path runs the strict validation that trips on the missing envelope. It took downloading a published release from GitHub to see it, which is precisely what the verification gate exists to do.

Signing runs last and inner code before the bundle, because the bundle's seal covers Contents/ — sealing before Info.plist and the icon land, or re-signing a nested binary afterwards, seals a tree that no longer matches. The verify step asserts the result rather than trusting codesign's exit code, since that is the check the user's machine runs on first launch.

Ad-hoc, not Developer ID. This is not notarization and does not remove the xattr step. It buys two things: an unrecoverable "damaged" becomes the ordinary unidentified-developer prompt that Open Anyway can clear, and Info.plist gets bound so the signed identity is com.knomit.desktop instead of a.out — which is the identity UNUserNotificationCenter reads, and a candidate explanation for the update banners being refused on an unsigned bundle.

The release notes also told users to run `xattr -dr com.apple.quarantine`, which was observed to leave the app blocked where `xattr -cr` cleared it. The notes now say -cr and mention the Open Anyway route that signing makes available.

Verified against a real assembled bundle: identity a.out -> com.knomit.desktop, Sealed Resources none -> version=2 rules=13, codesign --verify fail -> OK, and the seal survives the ditto round-trip the release artifact goes through while still producing exactly one top-level entry.