### PR TITLE
ci(release): sign and notarize the macOS bundle

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -77,6 +77,62 @@ jobs:
           node-version: '22'
       - name: Fetch native libs (ONNX Runtime, libtokenizers.a)
         run: make setup
+      # Developer ID lives in a throwaway keychain, never the login keychain:
+      # the runner is ephemeral, but `security unlock-keychain` on the default
+      # keychain would also expose whatever else the image put there to every
+      # later step. Deleted in the always() cleanup below.
+      - name: Import Developer ID certificate
+        env:
+          CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          CODESIGN_IDENTITY: ${{ vars.CODESIGN_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CERT_P12" ]; then
+            echo "::error::secrets.MACOS_CERT_P12 is unset — a stable release must not ship an ad-hoc bundle"
+            exit 1
+          fi
+          keychain="$RUNNER_TEMP/signing.keychain-db"
+          keychain_password="$(uuidgen)"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 3600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
+            -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$RUNNER_TEMP/cert.p12"
+          # Without this, codesign blocks on a GUI authorization prompt that
+          # can never be answered on a headless runner, and the job hangs
+          # until the step timeout rather than failing.
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$keychain_password" "$keychain" >/dev/null
+          # PREPEND to the search list rather than replacing it: codesign still
+          # has to resolve Apple's intermediate CA out of the system keychain
+          # to build a chain, and -s with a single argument would drop it.
+          security list-keychains -d user -s "$keychain" \
+            $(security list-keychains -d user | tr -d '"')
+          # find-identity exits 0 even when it finds nothing, so grep for the
+          # identity rather than trusting the status. A keychain that imported
+          # without a usable signing identity would otherwise surface as an
+          # opaque codesign failure several minutes into `make release`.
+          security find-identity -v -p codesigning "$keychain"
+          security find-identity -v -p codesigning "$keychain" \
+            | grep -q "$CODESIGN_IDENTITY" \
+            || { echo "::error::no '$CODESIGN_IDENTITY' identity in the imported keychain"; exit 1; }
+      # notarytool takes the App Store Connect key as a FILE PATH, so the
+      # secret has to land on disk. umask 077 because $RUNNER_TEMP is not
+      # private by default.
+      - name: Stage notarization API key
+        env:
+          NOTARY_KEY_P8: ${{ secrets.NOTARY_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          if [ -z "$NOTARY_KEY_P8" ]; then
+            echo "::error::secrets.NOTARY_KEY_P8 is unset — the bundle would be signed but never notarized"
+            exit 1
+          fi
+          umask 077
+          echo "$NOTARY_KEY_P8" | base64 --decode > "$RUNNER_TEMP/notary.p8"
       - name: Package server tarball + desktop .app zip
         env:
           # A repo VARIABLE, not a secret: it is public by construction, and
@@ -84,13 +140,32 @@ jobs:
           # binary. Empty here would ship a build with self-update disabled,
           # which is why the guard below is a hard failure rather than a note.
           UPDATE_PUBLIC_KEY: ${{ vars.UPDATE_PUBLIC_KEY }}
+          # Also a variable, and for the second reason above: it is the exact
+          # string codesign matches against, and masking would break the match.
+          # The Makefile reads all four out of the environment via `?=`.
+          CODESIGN_IDENTITY: ${{ vars.CODESIGN_IDENTITY }}
+          NOTARY_KEY: ${{ runner.temp }}/notary.p8
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER }}
         run: |
           set -euo pipefail
           if [ -z "$UPDATE_PUBLIC_KEY" ]; then
             echo "::error::vars.UPDATE_PUBLIC_KEY is unset — this build would ship with self-update disabled"
             exit 1
           fi
+          if [ -z "$CODESIGN_IDENTITY" ]; then
+            echo "::error::vars.CODESIGN_IDENTITY is unset — this build would be ad-hoc signed"
+            exit 1
+          fi
+          # `make release` signs with Developer ID, then blocks in
+          # desktop-notarize on Apple's queue (minutes, not seconds) before
+          # stapling and re-zipping the bundle.
           make release
+      - name: Remove signing credentials
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/notary.p8" "$RUNNER_TEMP/cert.p12"
+          security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
       - uses: actions/upload-artifact@v4
         with:
           name: darwin-arm64
@@ -226,19 +301,17 @@ jobs:
 
           ## Install
 
-          **macOS desktop (ad-hoc signed, not notarized):** Gatekeeper blocks
-          the first launch of a manually downloaded copy. Either:
-          \`\`\`sh
-          xattr -cr Knomit.app && open Knomit.app
-          \`\`\`
-          or open it once from Finder and approve it in System Settings →
-          Privacy & Security → **Open Anyway**.
+          **macOS desktop:** signed with Developer ID and notarized by Apple —
+          drag it to /Applications and open it. No \`xattr\` step, no
+          right-click-Open, no trip through Privacy & Security. The
+          notarization ticket is stapled into the bundle, so a first launch
+          works offline too.
 
-          Use \`-cr\` (clear every attribute), not the narrower
-          \`-dr com.apple.quarantine\` — the latter has been observed to leave
-          the app blocked.
-
-          Updates the app installs itself are not quarantined and need no such step.
+          The server \`.tar.gz\` binaries carry the same Developer ID
+          signature, but a tarball cannot hold a notarization ticket
+          (\`notarytool\` takes .zip/.pkg/.dmg only). Gatekeeper resolves those
+          against Apple online, which needs no action from you on a connected
+          machine.
 
           **Linux desktop:** a single AppImage; requires GTK 4 + WebKitGTK 6.0
           on the host.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,23 @@ concurrency:
 permissions:
   contents: read
 
+# Workflow-level so EVERY `make` in this file agrees on the version — the two
+# builds, the Docker tag, and the release-notes step that shells out to
+# print-version/print-semver. Setting it per-step would let one of them fall
+# back to `stable` and name artifacts after a version the binaries inside do
+# not report.
+#
+# Dev builds report <next patch>-dev.<committer epoch> (see RELEASE_CHANNEL in
+# the Makefile) so they sort above the last release and are distinguishable
+# from it. They still get NO UPDATE_PUBLIC_KEY, deliberately: an empty key is
+# what makes updaterConfig disable self-update in tools/desktop/update.go, and
+# dev builds are not on an update channel. Do not add one here without also
+# publishing a signed dev feed — pkg/updater's verification fails OPEN on
+# releases carrying no verification block, so a key plus an unsigned feed is
+# strictly worse than no key at all.
+env:
+  RELEASE_CHANNEL: dev
+
 jobs:
   macos:
     name: Build macOS (arm64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,72 @@ jobs:
           node-version: '22'
       - name: Fetch native libs (ONNX Runtime, libtokenizers.a)
         run: make setup
+      # Same signing path as release-stable.yml, deliberately: dev is the build
+      # we install most often, so it is where an unsigned bundle costs the most.
+      # See that workflow for why the keychain is a throwaway and why
+      # set-key-partition-list and the prepended search list are both required.
+      #
+      # The guards below are hard failures rather than a fall-through to ad-hoc,
+      # matching stable. A dev release that cannot be signed is one to fix, not
+      # one to ship under install notes that promise a notarized app.
+      - name: Import Developer ID certificate
+        env:
+          CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          CODESIGN_IDENTITY: ${{ vars.CODESIGN_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CERT_P12" ]; then
+            echo "::error::secrets.MACOS_CERT_P12 is unset"
+            exit 1
+          fi
+          keychain="$RUNNER_TEMP/signing.keychain-db"
+          keychain_password="$(uuidgen)"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 3600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$keychain" \
+            -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$RUNNER_TEMP/cert.p12"
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$keychain_password" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain" \
+            $(security list-keychains -d user | tr -d '"')
+          security find-identity -v -p codesigning "$keychain"
+          security find-identity -v -p codesigning "$keychain" \
+            | grep -q "$CODESIGN_IDENTITY" \
+            || { echo "::error::no '$CODESIGN_IDENTITY' identity in the imported keychain"; exit 1; }
+      - name: Stage notarization API key
+        env:
+          NOTARY_KEY_P8: ${{ secrets.NOTARY_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          if [ -z "$NOTARY_KEY_P8" ]; then
+            echo "::error::secrets.NOTARY_KEY_P8 is unset"
+            exit 1
+          fi
+          umask 077
+          echo "$NOTARY_KEY_P8" | base64 --decode > "$RUNNER_TEMP/notary.p8"
       - name: Package server tarball + desktop .app zip
-        run: make release
+        env:
+          CODESIGN_IDENTITY: ${{ vars.CODESIGN_IDENTITY }}
+          NOTARY_KEY: ${{ runner.temp }}/notary.p8
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CODESIGN_IDENTITY" ]; then
+            echo "::error::vars.CODESIGN_IDENTITY is unset — this build would be ad-hoc signed"
+            exit 1
+          fi
+          # Blocks in desktop-notarize on Apple's queue (minutes, not seconds).
+          make release
+      - name: Remove signing credentials
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/notary.p8" "$RUNNER_TEMP/cert.p12"
+          security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
       - uses: actions/upload-artifact@v4
         with:
           name: darwin-arm64
@@ -203,13 +267,9 @@ jobs:
 
           ## Install
 
-          **macOS desktop (unsigned):** the app is not notarized, so Gatekeeper
-          blocks it on first launch. After unzipping, clear the quarantine flag:
-          \`\`\`sh
-          xattr -dr com.apple.quarantine Knomit.app
-          open Knomit.app
-          \`\`\`
-          (or right-click the app → Open the first time).
+          **macOS desktop:** signed with Developer ID and notarized by Apple —
+          unzip and open it, no quarantine step needed. The ticket is stapled
+          into the bundle, so the first launch works offline too.
 
           **Server (macOS/Linux):** extract and run — native libs resolve from the
           bundled \`lib/\` automatically. The embedding model (~600 MB) downloads on

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,13 @@ PLATFORM := $(GOOS)-$(GOARCH)
 DIST    := dist/$(PLATFORM)
 LIBDIR  := $(DIST)/lib
 
-# Build version. VERSION is the Major.Minor.Patch semver and is the single
-# source of truth — bump it here on release. GIT_COMMIT is the short SHA of the
-# build. Both are injected into the internal/version package via -ldflags, so
-# every binary (knomit, knomit-bridge, knomit-okf, knomit-desktop) reports e.g. 0.5.0.2a7ae9d.
+# Build version. BASE_VERSION is the Major.Minor.Patch semver of the last
+# RELEASE and is the single source of truth — bump it here on release.
+# GIT_COMMIT is the short SHA of the build. Both are injected into the
+# internal/version package via -ldflags, so every binary (knomit,
+# knomit-bridge, knomit-okf, knomit-desktop) reports e.g. 0.5.0.2a7ae9d.
 # A bare `go build` (no make) falls back to the package default "dev".
-VERSION    := 0.5.1
+BASE_VERSION := 0.5.1
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 # BUILD_VERSION is the macOS CFBundleVersion, which macOS/LaunchServices use to
 # order builds for upgrade detection — so it MUST increase monotonically across
@@ -29,9 +30,52 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 # integer (~1.78e9, well under 2^32 until ~2106) that grows with every commit,
 # is deterministic per commit, and survives shallow CI clones (unlike a commit
 # count). Commit IDENTITY is NOT encoded here — it lives in GIT_COMMIT (the SHA
-# in internal/version / CFBundleShortVersionString stays the marketing semver).
+# in internal/version), while CFBundleShortVersionString carries the display
+# version, $(VERSION), which differs per RELEASE_CHANNEL below.
 # Falls back to 0 outside a git checkout.
 BUILD_VERSION := $(shell git show -s --format=%ct HEAD 2>/dev/null || echo 0)
+
+# RELEASE_CHANNEL selects what VERSION means, and nothing else in this file
+# branches on it.
+#
+#   stable (default)  VERSION = BASE_VERSION, e.g. 0.5.1. Local builds, the
+#                     stable release workflow, and the tag check in
+#                     release-stable.yml all take this path — print-semver has
+#                     to keep printing the bare BASE_VERSION or that check
+#                     fails on every tag.
+#   dev               VERSION = <next patch>-dev.<BUILD_VERSION>, e.g.
+#                     0.5.2-dev.1785282494. Set by release.yml.
+#
+# WHY the next patch and not BASE_VERSION: semver orders a prerelease BELOW its
+# own release, so 0.5.1-dev.N < 0.5.1 — a dev build cut after v0.5.1 shipped
+# would sort behind the release it was built from. Bumping the patch first puts
+# dev builds where they actually belong, between 0.5.1 and 0.5.2. If the next
+# release turns out to be 0.6.0 rather than 0.5.2 the ordering still holds:
+# 0.5.1 < 0.5.2-dev.N < 0.6.0.
+#
+# WHY BUILD_VERSION as the prerelease counter: it is already the monotonic,
+# deterministic, shallow-clone-safe number this file uses for CFBundleVersion,
+# and semver compares dot-separated numeric prerelease identifiers NUMERICALLY,
+# so 0.5.2-dev.1785299001 > 0.5.2-dev.1785282494. Reusing it keeps one notion
+# of "which build is newer" rather than two that can disagree. `dev-latest` is
+# a ROLLING tag, so without this every dev build reported the same version as
+# the last stable release and was indistinguishable from it.
+#
+# This is deliberately NOT wired to self-update: dev builds still ship with an
+# empty UPDATE_PUBLIC_KEY (see below), which is what disables the updater in
+# them. The versions are ordered so a dev channel COULD exist later, not
+# because one does.
+#
+# awk -F'[.]' rather than -F. because a bare `.` is a regex to some awks, and
+# brackets rather than parens because Make closes $(shell at the first bare
+# `)` regardless of quoting.
+RELEASE_CHANNEL ?= stable
+ifeq ($(RELEASE_CHANNEL),dev)
+  VERSION := $(shell echo $(BASE_VERSION) | awk -F'[.]' '{print $$1"."$$2"."$$3+1}')-dev.$(BUILD_VERSION)
+else
+  VERSION := $(BASE_VERSION)
+endif
+
 # FULL_VERSION is the semver plus the short SHA (e.g. 0.5.0.2a7ae9d) — the same
 # string the binaries report via internal/version. Used as the Docker image tag.
 FULL_VERSION := $(VERSION).$(GIT_COMMIT)
@@ -280,6 +324,12 @@ desktop-app-macos:
 	# /Applications/Knomit.app/Contents/MacOS/knomit-okf is one nobody runs.
 	go build $(GOFLAGS) -ldflags "$(VERSION_LDFLAGS)" -o $(APP)/Contents/MacOS/knomit-okf ./tools/okf
 	cp $(LIBDIR)/libonnxruntime.dylib $(APP)/Contents/MacOS/lib/
+	# CFBundleShortVersionString gets the full $(VERSION), so a dev bundle reads
+	# 0.5.2-dev.<epoch> in Finder's Get Info rather than impersonating the last
+	# stable release — telling the two apart is the point of the dev channel
+	# version. Apple documents this key as three period-separated integers, but
+	# it is a DISPLAY string: upgrade ordering is CFBundleVersion's job, and
+	# that stays the bare monotonic $(BUILD_VERSION) integer on both channels.
 	sed -e 's/{{SHORT_VERSION}}/$(VERSION)/g' -e 's/{{BUILD_VERSION}}/$(BUILD_VERSION)/g' tools/desktop/macos/Info.plist > $(APP)/Contents/Info.plist
 	@[ -f tools/desktop/macos/icon.icns ] && cp tools/desktop/macos/icon.icns $(APP)/Contents/Resources/icon.icns || echo "  (no icon.icns — using generic app icon)"
 	# Ad-hoc sign the assembled bundle. LAST in this recipe, and inner code


### PR DESCRIPTION
Both channels import the Developer ID cert into a throwaway keychain and
hand make release the identity plus App Store Connect credentials, so CI
stops shipping ad-hoc bundles that Gatekeeper blocks on first launch.

Missing credentials are a hard failure rather than a fall-through to
ad-hoc: a release that silently ships unsigned under install notes
promising a notarized app is worse than a failed run.
