### PR TITLE
fix: a recovered remote clears its own error banner

### DIFF
--- a/internal/repos/sync.go
+++ b/internal/repos/sync.go
@@ -56,6 +56,46 @@ const reconcileFailureEscalateThreshold = 5
 // origin but never push back.
 func pushAllowed(readOnly bool) bool { return !readOnly }
 
+// remoteStatusIsError reports whether a persisted remote status column
+// (last_status / last_push_status) holds a failure. The column is NULL until
+// the first attempt, so a nil pointer means "never ran", not "failing".
+func remoteStatusIsError(status *string) bool { return status != nil && *status == "error" }
+
+// syncChanged reports whether a sync tick actually moved either branch. The
+// zero Mode ("") means the step did not run and is treated like ModeNoop.
+func syncChanged(result store.SyncResult) bool {
+	moved := func(m store.Mode) bool { return m != store.ModeNoop && m != "" }
+	return moved(result.Main.Mode) || moved(result.Agent.Mode)
+}
+
+// shouldBroadcastSyncOK reports whether a SUCCESSFUL sync tick must be pushed
+// to SSE subscribers. Two reasons qualify:
+//
+//   - something actually moved (main or agent), which clients render as a
+//     reconcile summary; or
+//   - the previous persisted status was "error", making this tick the
+//     error→ok RECOVERY EDGE.
+//
+// The recovery edge is NOT optional. A client's remote-error banner is raised
+// by sync_error and lowered only by a clean remote event, so an outage that
+// heals on a tick with nothing to pull — the normal case, since the outage
+// itself is what stopped the traffic — would leave the banner standing for the
+// life of the session even though the stored status already says "ok".
+//
+// The edge is read off the PERSISTED status rather than an in-memory failure
+// counter so it survives a server restart, where the counter starts at zero
+// but the recorded status is still "error".
+func shouldBroadcastSyncOK(result store.SyncResult, wasFailing bool) bool {
+	return syncChanged(result) || wasFailing
+}
+
+// shouldBroadcastPushOK is the push-side twin of shouldBroadcastSyncOK: a push
+// that sent nothing is normally silent, but it must still be announced when it
+// is the recovery edge out of a recorded push failure. A credential that starts
+// working again typically has nothing left to send, so `pushed` alone would
+// never clear the banner.
+func shouldBroadcastPushOK(pushed, wasFailing bool) bool { return pushed || wasFailing }
+
 // runReconcileLoop is the single background goroutine for origin sync.
 // On each tick it: (1) calls Sync (fetch + reconcileMain + reconcileAgent),
 // (2) calls Push (force-push agent if local advanced).
@@ -109,6 +149,11 @@ func runReconcileLoop(ctx context.Context, wg *sync.WaitGroup, svc *store.Servic
 			lg.Warn().Err(verr).Msg("reconcile: origin blocked by local-origin policy; skipping tick")
 			return
 		}
+		// Snapshot the PRE-tick persisted status: Sync/Push overwrite it before
+		// they return, so the error→ok recovery edge is only visible from here.
+		wasSyncFailing := remoteStatusIsError(fresh.LastStatus)
+		wasPushFailing := remoteStatusIsError(fresh.LastPushStatus)
+
 		auth, authErr := resolveAuth(fresh)
 		if authErr != nil {
 			// Auth RESOLUTION failed (unreadable key, malformed credential).
@@ -137,10 +182,10 @@ func runReconcileLoop(ctx context.Context, wg *sync.WaitGroup, svc *store.Servic
 				lg.Info().Int("after_failures", syncFails).Msg("reconcile: sync recovered")
 				syncFails = 0
 			}
-			mainChanged := syncResult.Main.Mode != store.ModeNoop && syncResult.Main.Mode != ""
-			agentChanged := syncResult.Agent.Mode != store.ModeNoop && syncResult.Agent.Mode != ""
-			if mainChanged || agentChanged {
+			if shouldBroadcastSyncOK(syncResult, wasSyncFailing) {
 				hub.broadcastSyncOK("origin", syncResult)
+			}
+			if syncChanged(syncResult) {
 				lg.Info().
 					Str("main_mode", string(syncResult.Main.Mode)).
 					Str("agent_mode", string(syncResult.Agent.Mode)).
@@ -165,8 +210,10 @@ func runReconcileLoop(ctx context.Context, wg *sync.WaitGroup, svc *store.Servic
 				lg.Info().Int("after_failures", pushFails).Msg("reconcile: push recovered")
 				pushFails = 0
 			}
-			if pushResult.Pushed {
+			if shouldBroadcastPushOK(pushResult.Pushed, wasPushFailing) {
 				hub.broadcastPushOK("origin")
+			}
+			if pushResult.Pushed {
 				lg.Info().Str("branch", agentBranch).Msg("reconcile: pushed changes")
 			} else {
 				lg.Debug().Msg("reconcile: push up to date")

--- a/internal/repos/sync_recovery_test.go
+++ b/internal/repos/sync_recovery_test.go
@@ -1,0 +1,80 @@
+package repos
+
+import (
+	"testing"
+
+	"knomit/internal/store"
+)
+
+func ptrString(s string) *string { return &s }
+
+func TestRemoteStatusIsError(t *testing.T) {
+	if remoteStatusIsError(nil) {
+		t.Fatal("a NULL status is 'never attempted', not a failure")
+	}
+	if remoteStatusIsError(ptrString("ok")) {
+		t.Fatal("'ok' must not read as a failure")
+	}
+	if !remoteStatusIsError(ptrString("error")) {
+		t.Fatal("'error' must read as a failure")
+	}
+}
+
+func TestShouldBroadcastSyncOK(t *testing.T) {
+	noop := store.SyncResult{
+		Main:  store.MainReconcileResult{Mode: store.ModeNoop},
+		Agent: store.AgentReconcileResult{Mode: store.ModeNoop},
+	}
+	mainMoved := store.SyncResult{
+		Main:  store.MainReconcileResult{Mode: store.ModeFF},
+		Agent: store.AgentReconcileResult{Mode: store.ModeNoop},
+	}
+	agentMoved := store.SyncResult{
+		Main:  store.MainReconcileResult{Mode: store.ModeNoop},
+		Agent: store.AgentReconcileResult{Mode: store.ModeMerge},
+	}
+	// A zero Mode is the "step did not run / nothing to report" shape, which
+	// must be treated exactly like noop rather than as a change.
+	empty := store.SyncResult{}
+
+	cases := []struct {
+		name       string
+		result     store.SyncResult
+		wasFailing bool
+		want       bool
+	}{
+		{"steady state, nothing changed", noop, false, false},
+		{"steady state, empty modes", empty, false, false},
+		{"main moved", mainMoved, false, true},
+		{"agent moved", agentMoved, false, true},
+		// The reported bug: a transient outage recovers on a tick with nothing
+		// to pull. Without this edge the client's banner is never lowered.
+		{"recovery with nothing to pull", noop, true, true},
+		{"recovery with empty modes", empty, true, true},
+		{"recovery that also pulled", mainMoved, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldBroadcastSyncOK(tc.result, tc.wasFailing); got != tc.want {
+				t.Fatalf("shouldBroadcastSyncOK = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldBroadcastPushOK(t *testing.T) {
+	if shouldBroadcastPushOK(false, false) {
+		t.Fatal("a push with nothing to send and no prior failure is silent")
+	}
+	if !shouldBroadcastPushOK(true, false) {
+		t.Fatal("an actual push must be broadcast")
+	}
+	// Same recovery edge as sync: an expired token that starts working again
+	// usually has nothing left to push, so 'pushed' alone never clears the banner.
+	if !shouldBroadcastPushOK(false, true) {
+		t.Fatal("recovery from a push failure must be broadcast even with nothing to send")
+	}
+	if !shouldBroadcastPushOK(true, true) {
+		t.Fatal("a push that also recovers must be broadcast")
+	}
+}

--- a/web/src/App.sse.test.tsx
+++ b/web/src/App.sse.test.tsx
@@ -512,6 +512,46 @@ describe('App — remote-error banner lifecycle', () => {
     await waitFor(() => expect(screen.queryByTestId('remote-error-banner')).toBeNull());
   });
 
+  // Every other way down is edge-triggered — a remote event, a reconnect, a
+  // repo switch, a manager close. A stream that stalls SILENTLY fires none of
+  // them (no 'error', no 'open'), and sync/push events have no reconnect replay
+  // at all, so without a poll the banner could still outlive its failure.
+  it('re-checks the stored status on a timer while the banner is up', async () => {
+    const api = await apiMock();
+    const es = await mountApp();
+    // Fake timers go in BEFORE the banner is raised: the recheck interval is
+    // armed by the effect that reacts to it, and a real-timer interval would
+    // never see advanceTimersByTime.
+    vi.useFakeTimers();
+    try {
+      await act(async () => { es.emit('sync_error', { error: 'auth failed' }); });
+      expect(screen.getByTestId('remote-error-banner')).toBeTruthy();
+
+      api.getOrigin.mockResolvedValue(ORIGIN_OK);
+      await act(async () => { vi.advanceTimersByTime(70_000); });
+      expect(screen.queryByTestId('remote-error-banner')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT poll while the banner is down', async () => {
+    const api = await apiMock();
+    await mountApp();
+    await waitFor(() => expect(api.getOrigin.mock.calls.length).toBeGreaterThan(0));
+    const callsBefore = api.getOrigin.mock.calls.length;
+
+    vi.useFakeTimers();
+    try {
+      // A healthy remote costs nothing: the recheck exists only to bound how
+      // long a STALE banner can survive, not to poll the origin forever.
+      await act(async () => { vi.advanceTimersByTime(600_000); });
+      expect(api.getOrigin.mock.calls.length).toBe(callsBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('the dismiss button clears the banner', async () => {
     const es = await mountApp();
     act(() => { es.emit('sync_error', { error: 'auth failed' }); });

--- a/web/src/App.sse.test.tsx
+++ b/web/src/App.sse.test.tsx
@@ -102,6 +102,10 @@ vi.mock('./api', async (importOriginal) => {
       fact: vi.fn(),
       factCommits: vi.fn(),
       commitDetail: vi.fn(),
+      // Reached only when a test opens the repo manager; without them
+      // RepoDetail throws and the manager renders its error boundary instead.
+      getRepo: vi.fn(),
+      listBranchNames: vi.fn(),
     },
   };
 });
@@ -125,6 +129,8 @@ async function primeApi() {
   api.stats.mockResolvedValue(null);
   api.activity.mockResolvedValue(null);
   api.completions.mockResolvedValue([]);
+  api.getRepo.mockResolvedValue({ name: 'alpha', description: '' });
+  api.listBranchNames.mockResolvedValue(['main', 'machine/test']);
   return api;
 }
 
@@ -383,6 +389,116 @@ describe('App SSE — status and remote events', () => {
     act(() => { es.emit('sync_ok', {}); });
 
     expect(diagLines().filter(l => l.includes('[remote]'))).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The banner is a view of the PERSISTED remote status, not just a latch on the
+// last event. It used to be raise-only: a failure that healed on a tick with
+// nothing to pull left it standing for the life of the session, which is
+// exactly what a long-lived desktop window hit after a transient DNS outage.
+// ---------------------------------------------------------------------------
+describe('App — remote-error banner lifecycle', () => {
+  const ORIGIN_OK = {
+    name: 'origin', url: 'https://example.test/kb.git', branch: 'main', interval: 300,
+    last_sync_at: '2026-08-04T14:30:29Z', last_status: 'ok', last_error: null,
+    push_interval: 300, last_push_at: '2026-08-04T14:30:29Z', last_push_status: 'ok',
+    last_push_error: null, auth_method: 'token',
+  };
+  const ORIGIN_FAILING = { ...ORIGIN_OK, last_status: 'error', last_error: 'dial tcp: no such host' };
+
+  it('seeds the banner from a persisted sync failure on load', async () => {
+    const api = await apiMock();
+    api.getOrigin.mockResolvedValue(ORIGIN_FAILING);
+    await mountApp();
+
+    await waitFor(() => expect(screen.getByTestId('remote-error-banner')).toHaveTextContent('dial tcp: no such host'));
+  });
+
+  it('seeds it from a persisted PUSH failure too', async () => {
+    const api = await apiMock();
+    api.getOrigin.mockResolvedValue({ ...ORIGIN_OK, last_push_status: 'error', last_push_error: 'token expired' });
+    await mountApp();
+
+    await waitFor(() => expect(screen.getByTestId('remote-error-banner')).toHaveTextContent('token expired'));
+  });
+
+  it('lowers a stale banner on reconnect when the stored status has recovered', async () => {
+    const api = await apiMock();
+    api.getOrigin.mockResolvedValue(ORIGIN_FAILING);
+    const es = await mountApp();
+    await waitFor(() => expect(screen.queryByTestId('remote-error-banner')).toBeTruthy());
+
+    // The reconcile loop healed while the stream was down, so the sync_ok that
+    // would have cleared this never reached us. Reconnecting re-reads the truth.
+    api.getOrigin.mockResolvedValue(ORIGIN_OK);
+    es.readyState = FakeEventSource.CONNECTING;
+    await act(async () => { es.emit('error'); });
+    await act(async () => { es.emit('open'); });
+
+    await waitFor(() => expect(screen.queryByTestId('remote-error-banner')).toBeNull());
+  });
+
+  it('leaves the banner alone when the origin read itself fails', async () => {
+    const api = await apiMock();
+    const es = await mountApp();
+    act(() => { es.emit('sync_error', { error: 'auth failed' }); });
+
+    // A failed read teaches us nothing about the remote — clearing here would
+    // hide a real failure behind an unrelated network hiccup.
+    api.getOrigin.mockRejectedValue(new Error('offline'));
+    es.readyState = FakeEventSource.CONNECTING;
+    await act(async () => { es.emit('error'); });
+    await act(async () => { es.emit('open'); });
+
+    expect(screen.getByTestId('remote-error-banner')).toHaveTextContent('auth failed');
+  });
+
+  it('clears the banner when the repo has no origin at all', async () => {
+    const api = await apiMock();
+    const es = await mountApp();
+    act(() => { es.emit('sync_error', { error: 'auth failed' }); });
+
+    // A disconnected repo cannot be out of sync, so a leftover banner is stale.
+    api.getOrigin.mockResolvedValue(null);
+    es.readyState = FakeEventSource.CONNECTING;
+    await act(async () => { es.emit('error'); });
+    await act(async () => { es.emit('open'); });
+
+    await waitFor(() => expect(screen.queryByTestId('remote-error-banner')).toBeNull());
+  });
+
+  it('the dismiss button clears the banner', async () => {
+    const es = await mountApp();
+    act(() => { es.emit('sync_error', { error: 'auth failed' }); });
+
+    await act(async () => { fireEvent.click(screen.getByTestId('remote-error-dismiss')); });
+    expect(screen.queryByTestId('remote-error-banner')).toBeNull();
+  });
+
+  it('Reconnect… clears the banner and opens the repo manager', async () => {
+    const es = await mountApp();
+    act(() => { es.emit('sync_error', { error: 'auth failed' }); });
+
+    await act(async () => { fireEvent.click(screen.getByTestId('remote-error-reconnect')); });
+
+    expect(screen.getByRole('dialog', { name: 'Repo Manager' })).toBeTruthy(); // the manager is up
+    expect(screen.queryByTestId('remote-error-banner')).toBeNull();
+  });
+
+  it('re-reads the stored status when the repo manager closes', async () => {
+    const api = await apiMock();
+    api.getOrigin.mockResolvedValue(ORIGIN_FAILING);
+    await mountApp();
+    await waitFor(() => expect(screen.queryByTestId('remote-error-banner')).toBeTruthy());
+
+    // Open the manager, "fix" the remote there, close it: the banner must
+    // reflect the repaired connection without waiting for a reconcile tick.
+    await act(async () => { fireEvent.click(screen.getByTestId('remote-error-reconnect')); });
+    api.getOrigin.mockResolvedValue(ORIGIN_OK);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Close' })); });
+
+    await waitFor(() => expect(screen.queryByTestId('remote-error-banner')).toBeNull());
   });
 });
 

--- a/web/src/App.sse.test.tsx
+++ b/web/src/App.sse.test.tsx
@@ -483,6 +483,51 @@ describe('App — remote-error banner lifecycle', () => {
     await waitFor(() => expect(screen.queryByTestId('remote-error-banner')).toBeNull());
   });
 
+  // The two halves of a remote fail independently, and each event speaks for
+  // one of them. A sync_ok that lowered a banner an expired push token had
+  // raised would be undone by the very next failing push tick — a banner
+  // blinking once per reconcile interval for as long as the token stayed dead,
+  // and one that disagrees with the persisted status the poll reads back.
+  it('a clean sync does NOT clear a banner raised by a failing push', async () => {
+    const es = await mountApp();
+    await act(async () => { es.emit('push_error', { error: 'token expired' }); });
+    expect(screen.getByTestId('remote-error-banner')).toHaveTextContent('token expired');
+
+    // The fetch half is fine — origin is reachable, it is the push that is
+    // rejected — so sync_ok arrives on every tick that pulls anything.
+    await act(async () => { es.emit('sync_ok', { main: { mode: 'ff' }, agent: { mode: 'noop' } }); });
+    expect(screen.getByTestId('remote-error-banner')).toHaveTextContent('token expired');
+
+    // Only the push recovering takes it down.
+    await act(async () => { es.emit('push_ok', {}); });
+    expect(screen.queryByTestId('remote-error-banner')).toBeNull();
+  });
+
+  it('a clean push does NOT clear a banner raised by a failing sync', async () => {
+    const es = await mountApp();
+    await act(async () => { es.emit('sync_error', { error: 'no such host' }); });
+    await act(async () => { es.emit('push_ok', {}); });
+    expect(screen.getByTestId('remote-error-banner')).toHaveTextContent('no such host');
+  });
+
+  it('keeps rechecking while only the PUSH half is failing', async () => {
+    const api = await apiMock();
+    const es = await mountApp();
+    vi.useFakeTimers();
+    try {
+      await act(async () => { es.emit('push_error', { error: 'token expired' }); });
+      expect(screen.getByTestId('remote-error-banner')).toBeTruthy();
+
+      // The recheck is gated on "either side is failing", not on the sync side
+      // alone, or a stale push banner would never be re-read.
+      api.getOrigin.mockResolvedValue(ORIGIN_OK);
+      await act(async () => { vi.advanceTimersByTime(70_000); });
+      expect(screen.queryByTestId('remote-error-banner')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('leaves the banner alone when the origin read itself fails', async () => {
     const api = await apiMock();
     const es = await mountApp();

--- a/web/src/App.sse.test.tsx
+++ b/web/src/App.sse.test.tsx
@@ -314,6 +314,50 @@ describe('App SSE — task events', () => {
     expect(errorLines().filter(l => l.includes('[sync] boom'))).toHaveLength(1);
   });
 
+  // The post-task refresh reads the branch status but used to keep only the
+  // head off it, so index_state was thrown away — a rebuild that repaired the
+  // index left the "indexing did not complete" banner on screen.
+  it('applies the WHOLE status on a completed task, not just the head', async () => {
+    const api = await apiMock();
+    api.status.mockResolvedValue({ ...STATUS, index_state: 'error' });
+    const es = await mountApp();
+    await waitFor(() => expect(screen.getByTestId('index-error-banner')).toBeTruthy());
+
+    api.status.mockResolvedValue({ ...STATUS, index_state: 'ready' });
+    await act(async () => { es.emit('task', { op: 'rebuild', status: 'done', message: 'rebuild complete' }); });
+
+    await waitFor(() => expect(screen.queryByTestId('index-error-banner')).toBeNull());
+  });
+
+  // Nothing ever returned a task to 'idle', so the footer kept the LAST
+  // terminal result for the rest of the session — "[sync] ok" from hours ago
+  // reading as something happening now.
+  it('a finished task stops occupying the footer once it goes stale', async () => {
+    const es = await mountApp();
+    vi.useFakeTimers();
+    try {
+      await act(async () => { es.emit('task', { op: 'sync', status: 'done', message: 'ok' }); });
+      expect(screen.getByText('[sync] ok')).toBeTruthy();
+
+      await act(async () => { vi.advanceTimersByTime(10_000); });
+      expect(screen.queryByText('[sync] ok')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a RUNNING task on the footer no matter how long it runs', async () => {
+    const es = await mountApp();
+    vi.useFakeTimers();
+    try {
+      await act(async () => { es.emit('task', { op: 'rebuild', status: 'running', message: '40/900' }); });
+      await act(async () => { vi.advanceTimersByTime(120_000); });
+      expect(screen.getByText('[rebuild] 40/900')).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does NOT refresh head for a running task', async () => {
     const api = await apiMock();
     const es = await mountApp();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -373,6 +373,33 @@ export default function App() {
     return () => { cancelled = true; clearInterval(id); };
   }, [state.indexState, state.repo, state.branch]);
 
+  // Reconcile the remote-error banner with the PERSISTED remote status.
+  //
+  // This is the only thing that reads that status back, and it must work in
+  // BOTH directions. Raising it shows a failure that happened while the app was
+  // closed (an expired token, say) without waiting for the next reconcile tick.
+  // Lowering it is what keeps the banner honest: it is otherwise cleared only by
+  // a clean remote event, so any client that missed that one event — asleep,
+  // stream dropped, opened after the fact — kept a banner up for a failure the
+  // server had long since recorded as "ok". That is the sticky banner a
+  // long-lived desktop window used to show for hours after a blip had healed.
+  const syncRemoteError = useCallback((repo: string, alive: () => boolean = () => true) => {
+    if (!repo) return;
+    api.getOrigin(repo).then(o => {
+      if (!alive()) return;
+      // A repo with NO remote (204 → null) cannot be out of sync, so a banner
+      // left over from before it was disconnected is stale too.
+      const error = o && (o.last_status === 'error' || o.last_push_status === 'error')
+        ? (o.last_error || o.last_push_error || 'remote sync failed')
+        : '';
+      dispatch({ type: 'SET_REMOTE_ERROR', error });
+    }).catch(() => {
+      // The read itself failed, so we learned nothing about the remote. Leave
+      // the banner as it is rather than clearing a real failure on the strength
+      // of an unrelated hiccup.
+    });
+  }, [dispatch]);
+
   // SSE for task and status events — reconnects when repo/branch changes.
   useEffect(() => {
     if (!state.branch) return; // wait until branch is known from status bootstrap
@@ -418,6 +445,14 @@ export default function App() {
       // stopping it.
       if (loggedDisconnect && !suppressed) {
         diag('info', '[events] reconnected');
+        // A gap in the stream is a gap in the remote events, and the one that
+        // clears the banner (sync_ok / push_ok) is broadcast once, never
+        // replayed — so a failure that healed while we were disconnected would
+        // otherwise leave the banner standing. Re-read the stored status.
+        // Riding on the same condition as the log line keeps this off the hot
+        // path of a flapping stream, which must not also become a request storm
+        // against the origin endpoint.
+        syncRemoteError(state.repo);
       }
       loggedDisconnect = false;
     });
@@ -489,21 +524,13 @@ export default function App() {
     es.addEventListener('push_ok', handleRemoteEvent);
     es.addEventListener('push_error', handleRemoteEvent);
     return () => es.close();
-  }, [state.repo, state.branch]);
+  }, [state.repo, state.branch, syncRemoteError]);
 
-  // Seed the remote-error banner from persisted status on repo load, so a
-  // failure that happened while the app was closed (e.g. an expired token) is
-  // visible immediately instead of only after the next live reconcile tick.
   useEffect(() => {
     let cancelled = false;
-    api.getOrigin(state.repo).then(o => {
-      if (cancelled || !o) return;
-      if (o.last_status === 'error' || o.last_push_status === 'error') {
-        dispatch({ type: 'SET_REMOTE_ERROR', error: o.last_error || o.last_push_error || 'remote sync failed' });
-      }
-    }).catch(() => {});
+    syncRemoteError(state.repo, () => !cancelled);
     return () => { cancelled = true; };
-  }, [state.repo]);
+  }, [state.repo, syncRemoteError]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -565,7 +592,13 @@ export default function App() {
   // inert — the panels would re-render on every splitter drag frame and every
   // repos/lenses refresh even though nothing they display changed.
   const openRepoMgr = useCallback(() => setRepoMgrOpen(true), []);
-  const closeRepoMgr = useCallback(() => setRepoMgrOpen(false), []);
+  const closeRepoMgr = useCallback(() => {
+    setRepoMgrOpen(false);
+    // The manager is where a remote is repaired, replaced, or disconnected —
+    // exactly the state the banner reports. Re-read it on the way out instead
+    // of leaving the user to wonder why the banner outlived the fix.
+    syncRemoteError(stateRef.current.repo);
+  }, [syncRemoteError]);
   const jumpTrail = useCallback((i: number) => {
     // Crumbs map 1:1 to navStack hops since the live root, so jumping to crumb i
     // means unwinding (depth - i) entries — pop, don't push. Reads the CURRENT
@@ -631,16 +664,33 @@ export default function App() {
           {state.notice}
         </div>
       )}
+      {/* The banner reports a REMEMBERED failure, so it needs a way out that
+          does not depend on the next remote event arriving. Both buttons clear
+          it: acting on it (Reconnect…) and acknowledging it (✕). Nothing is
+          lost by clearing — the repo manager's remote card still shows the
+          stored "✗ sync failed" line, and a remote that is still broken raises
+          the banner again on the next failing tick. */}
       {state.remoteError && (
         <div data-testid="remote-error-banner" style={{ background: '#2b1c1c', color: '#e0a0a0', fontSize: 12, padding: '4px 14px', borderBottom: '1px solid #3a2a2a', flexShrink: 0, display: 'flex', alignItems: 'center', gap: 10 }}>
           <span>⚠ Remote sync failed — {state.remoteError}</span>
           <button
             type="button"
             data-testid="remote-error-reconnect"
-            onClick={() => setRepoMgrOpen(true)}
+            onClick={() => { dispatch({ type: 'SET_REMOTE_ERROR', error: '' }); setRepoMgrOpen(true); }}
             style={{ background: '#7f1d1d', color: '#eee', border: '1px solid #5c2a2a', borderRadius: 4, padding: '2px 8px', fontSize: 11, cursor: 'pointer', flexShrink: 0 }}
           >
             Reconnect…
+          </button>
+          <div style={{ flex: 1 }} />
+          <button
+            type="button"
+            data-testid="remote-error-dismiss"
+            aria-label="Dismiss the remote sync error"
+            title="Dismiss"
+            onClick={() => dispatch({ type: 'SET_REMOTE_ERROR', error: '' })}
+            style={{ background: 'none', color: '#b98080', border: 'none', fontSize: 14, lineHeight: 1, padding: '0 2px', cursor: 'pointer', flexShrink: 0 }}
+          >
+            ✕
           </button>
         </div>
       )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useReducer, useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import type { Dispatch } from 'react';
-import { reducer, init, isReadOnly, isLive, selectTrail, currentPath, lensResolutionPending } from './state';
+import { reducer, init, isReadOnly, isLive, selectTrail, currentPath, lensResolutionPending, remoteErrorText } from './state';
 import type { Action, BrowseContext } from './state';
 import { api, apiUrl, fetchVersion } from './api';
 import type { RepoInfo, Lens, Status } from './api';
@@ -416,12 +416,15 @@ export default function App() {
     if (!repo) return;
     api.getOrigin(repo).then(o => {
       if (!alive()) return;
-      // A repo with NO remote (204 → null) cannot be out of sync, so a banner
+      // Each side is applied from its OWN column, independently — this read is
+      // the wholesale form of what the sync_*/push_* events do incrementally,
+      // and the two must agree or the banner flaps between them. A repo with NO
+      // remote (204 → null) cannot be out of sync on either side, so a banner
       // left over from before it was disconnected is stale too.
-      const error = o && (o.last_status === 'error' || o.last_push_status === 'error')
-        ? (o.last_error || o.last_push_error || 'remote sync failed')
-        : '';
-      dispatch({ type: 'SET_REMOTE_ERROR', error });
+      const errorOn = (status?: string | null, message?: string | null) =>
+        status === 'error' ? (message || 'remote sync failed') : '';
+      dispatch({ type: 'SET_REMOTE_ERROR', side: 'sync', error: o ? errorOn(o.last_status, o.last_error) : '' });
+      dispatch({ type: 'SET_REMOTE_ERROR', side: 'push', error: o ? errorOn(o.last_push_status, o.last_push_error) : '' });
     }).catch(() => {
       // The read itself failed, so we learned nothing about the remote. Leave
       // the banner as it is rather than clearing a real failure on the strength
@@ -513,12 +516,19 @@ export default function App() {
     });
     const handleRemoteEvent = (e: MessageEvent) => {
       const ev = JSON.parse(e.data);
+      // Every one of these events speaks for ONE half of the remote: sync_* for
+      // the fetch/reconcile half, push_* for the push half, each mirroring the
+      // column Sync/Push just wrote. Scoping the update by side makes them the
+      // incremental form of the same truth syncRemoteError reads wholesale, so
+      // the two can never contradict each other. Clearing both on any clean
+      // event is what let a sync_ok lower a banner a failing push had raised.
+      const side: 'sync' | 'push' = e.type.startsWith('push') ? 'push' : 'sync';
       if (ev.error) {
-        dispatch({ type: 'SET_REMOTE_ERROR', error: ev.error });
+        dispatch({ type: 'SET_REMOTE_ERROR', side, error: ev.error });
         diag('error', `[remote] ${ev.error}`);
         return;
       }
-      dispatch({ type: 'SET_REMOTE_ERROR', error: '' });
+      dispatch({ type: 'SET_REMOTE_ERROR', side, error: '' });
       // Sync events now carry structured Main + Agent reconcile detail.
       // Surface a human-readable summary in the console so users can see
       // *what* changed on each side of the reconcile.
@@ -577,12 +587,17 @@ export default function App() {
   // all. The cost is one request a minute, only while a failure is on screen,
   // and the benefit is that a stale banner cannot outlive its failure by more
   // than one interval.
+  //
+  // "Up" means EITHER side is failing, which is what remoteErrorText reports —
+  // a recheck must keep running while a broken push is on screen even though
+  // the fetch half is perfectly healthy.
+  const remoteError = remoteErrorText(state);
   useEffect(() => {
-    if (!state.remoteError) return;
+    if (!remoteError) return;
     let cancelled = false;
     const id = setInterval(() => syncRemoteError(state.repo, () => !cancelled), REMOTE_RECHECK_MS);
     return () => { cancelled = true; clearInterval(id); };
-  }, [state.remoteError, state.repo, syncRemoteError]);
+  }, [remoteError, state.repo, syncRemoteError]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -735,13 +750,13 @@ export default function App() {
           lost by clearing — the repo manager's remote card still shows the
           stored "✗ sync failed" line, and a remote that is still broken raises
           the banner again on the next failing tick. */}
-      {state.remoteError && (
+      {remoteError && (
         <div data-testid="remote-error-banner" style={{ background: '#2b1c1c', color: '#e0a0a0', fontSize: 12, padding: '4px 14px', borderBottom: '1px solid #3a2a2a', flexShrink: 0, display: 'flex', alignItems: 'center', gap: 10 }}>
-          <span>⚠ Remote sync failed — {state.remoteError}</span>
+          <span>⚠ Remote sync failed — {remoteError}</span>
           <button
             type="button"
             data-testid="remote-error-reconnect"
-            onClick={() => { dispatch({ type: 'SET_REMOTE_ERROR', error: '' }); setRepoMgrOpen(true); }}
+            onClick={() => { dispatch({ type: 'CLEAR_REMOTE_ERRORS' }); setRepoMgrOpen(true); }}
             style={{ background: '#7f1d1d', color: '#eee', border: '1px solid #5c2a2a', borderRadius: 4, padding: '2px 8px', fontSize: 11, cursor: 'pointer', flexShrink: 0 }}
           >
             Reconnect…
@@ -752,7 +767,7 @@ export default function App() {
             data-testid="remote-error-dismiss"
             aria-label="Dismiss the remote sync error"
             title="Dismiss"
-            onClick={() => dispatch({ type: 'SET_REMOTE_ERROR', error: '' })}
+            onClick={() => dispatch({ type: 'CLEAR_REMOTE_ERRORS' })}
             style={{ background: 'none', color: '#b98080', border: 'none', fontSize: 14, lineHeight: 1, padding: '0 2px', cursor: 'pointer', flexShrink: 0 }}
           >
             ✕

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,6 +42,10 @@ const FLAP_LIMIT = 3;
 // it never reads as current.
 const TASK_LINGER_MS = 8_000;
 
+// How often the remote-error banner re-checks the stored status while it is on
+// screen. Nothing polls while the remote is healthy — see the recheck effect.
+const REMOTE_RECHECK_MS = 60_000;
+
 function loadLeftPanelWidth(): number {
   const fallback = Math.max(LEFT_PANEL_MIN, Math.round(window.innerWidth * LEFT_PANEL_DEFAULT_FRACTION));
   try {
@@ -559,6 +563,26 @@ export default function App() {
     syncRemoteError(state.repo, () => !cancelled);
     return () => { cancelled = true; };
   }, [state.repo, syncRemoteError]);
+
+  // While the banner is UP, re-check on a timer. Every other way it comes down
+  // is edge-triggered — a remote event, a reconnect, a repo switch, a manager
+  // close — and none of those fire for a stream that stalls SILENTLY (a slept
+  // laptop, a half-open proxy connection): the browser reports no 'error' and
+  // no 'open', so nothing prompts a re-read. Sync and push events also have no
+  // reconnect replay — TaskHub.Subscribe's snapshot carries task events only —
+  // so a missed one is missed for good.
+  //
+  // This is the backstop that makes the banner self-healing whatever the stream
+  // does, and it is deliberately conditional: a healthy remote polls nothing at
+  // all. The cost is one request a minute, only while a failure is on screen,
+  // and the benefit is that a stale banner cannot outlive its failure by more
+  // than one interval.
+  useEffect(() => {
+    if (!state.remoteError) return;
+    let cancelled = false;
+    const id = setInterval(() => syncRemoteError(state.repo, () => !cancelled), REMOTE_RECHECK_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [state.remoteError, state.repo, syncRemoteError]);
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import type { Dispatch } from 'react';
 import { reducer, init, isReadOnly, isLive, selectTrail, currentPath, lensResolutionPending } from './state';
 import type { Action, BrowseContext } from './state';
 import { api, apiUrl, fetchVersion } from './api';
-import type { RepoInfo, Lens } from './api';
+import type { RepoInfo, Lens, Status } from './api';
 import { pageview, track } from './telemetry';
 import { useNavigationManager } from './useNavigationManager';
 import { useFactEdges } from './useFactEdges';
@@ -36,6 +36,11 @@ const LEFT_PANEL_STORAGE_KEY = 'knomit.leftPanelWidth';
 // 500-entry ring in minutes.
 const FLAP_WINDOW_MS = 60_000;
 const FLAP_LIMIT = 3;
+
+// How long a FINISHED task keeps the footer's task line before it retires. Long
+// enough to read the outcome of something you just triggered, short enough that
+// it never reads as current.
+const TASK_LINGER_MS = 8_000;
 
 function loadLeftPanelWidth(): number {
   const fallback = Math.max(LEFT_PANEL_MIN, Math.round(window.innerWidth * LEFT_PANEL_DEFAULT_FRACTION));
@@ -143,6 +148,28 @@ export async function refreshContextAfterChange(
 function diag(level: 'info' | 'error', message: string): void {
   if (level === 'error') console.error(message);
   else console.info(message);
+}
+
+/**
+ * statusAction turns a branch-status response into the SET_STATUS action.
+ *
+ * Three call sites read that endpoint — the bootstrap, the indexing poll, and
+ * the post-task refresh — and every one of them must apply the WHOLE payload.
+ * A refresh that cherry-picks the head silently drops index_state, which is how
+ * an index error survived the rebuild that fixed it.
+ */
+function statusAction(s: Status): Action {
+  return {
+    type: 'SET_STATUS',
+    head: s.head,
+    branch: s.branch,
+    embeddingsEnabled: s.embeddings_enabled,
+    ontologyRoot: s.ontology_root,
+    indexState: s.index_state,
+    indexDone: s.index_done,
+    indexTotal: s.index_total,
+    indexPercent: s.index_percent,
+  };
 }
 
 export default function App() {
@@ -348,9 +375,7 @@ export default function App() {
       initialBranch: state.branch,
       getAgentBranch: api.getAgentBranch,
       getStatus: api.status,
-      onSuccess: (s) => {
-        dispatch({ type: 'SET_STATUS', head: s.head, branch: s.branch, embeddingsEnabled: s.embeddings_enabled, ontologyRoot: s.ontology_root, indexState: s.index_state, indexDone: s.index_done, indexTotal: s.index_total, indexPercent: s.index_percent });
-      },
+      onSuccess: (s) => { dispatch(statusAction(s)); },
       onAttemptFailed: (err, attempt) => {
         diag('error', `[bootstrap] attempt ${attempt + 1} failed: ${String(err)}`);
       },
@@ -367,7 +392,7 @@ export default function App() {
     let cancelled = false;
     const id = setInterval(() => {
       api.status(state.repo, state.branch)
-        .then(s => { if (!cancelled) dispatch({ type: 'SET_STATUS', head: s.head, branch: s.branch, embeddingsEnabled: s.embeddings_enabled, ontologyRoot: s.ontology_root, indexState: s.index_state, indexDone: s.index_done, indexTotal: s.index_total, indexPercent: s.index_percent }); })
+        .then(s => { if (!cancelled) dispatch(statusAction(s)); })
         .catch(() => {});
     }, 2000);
     return () => { cancelled = true; clearInterval(id); };
@@ -468,10 +493,13 @@ export default function App() {
       dispatch({ type: 'SET_TASK', op: ev.op, status: ev.status, message: ev.message || '' });
       const repo = ev.repo ? `${ev.repo}/` : '';
       diag(ev.status === 'error' ? 'error' : 'info', `[${repo}${ev.op}] ${ev.message || ev.status}`);
-      // Refresh head when a task completes.
+      // Refresh the branch status when a task completes. The WHOLE payload is
+      // applied, not just the head: a task like a rebuild changes index_state
+      // too, and keeping only the head meant the index banner kept reporting a
+      // failure the task had just repaired.
       if (ev.status === 'done' || ev.status === 'error') {
         api.status(state.repo, state.branch)
-          .then(s => dispatch({ type: 'SET_HEAD', head: s.head }))
+          .then(s => dispatch(statusAction(s)))
           .catch(err => diag('error', `[status] refresh failed: ${String(err)}`));
       }
     });
@@ -578,6 +606,19 @@ export default function App() {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [navigate, state, tt]);
+
+  // A finished task is news for a moment, not for the session. Nothing used to
+  // return a task to idle, so the footer kept the LAST terminal result forever
+  // — "[sync] ok" from three hours ago reading as something happening now.
+  // Running tasks are untouched (see CLEAR_TASK), however long they run.
+  useEffect(() => {
+    const finished = Object.entries(state.tasks)
+      .filter(([, t]) => t.status === 'done' || t.status === 'error')
+      .map(([op]) => op);
+    if (finished.length === 0) return;
+    const timers = finished.map(op => setTimeout(() => dispatch({ type: 'CLEAR_TASK', op }), TASK_LINGER_MS));
+    return () => timers.forEach(clearTimeout);
+  }, [state.tasks]);
 
   // Transient amber notice (e.g. "fact was retracted — returned to now").
   // Auto-clears after ~6s; the effect re-arms whenever a new notice is set.

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -2,7 +2,7 @@ import { memo, useState, useRef } from 'react';
 import type { Dispatch, CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { AppState, Action } from './state';
-import { isLensContext, selectAnchorCommit } from './state';
+import { isLensContext, selectAnchorCommit, remoteErrorText } from './state';
 import type { RepoInfo, Lens } from './api';
 import { useDismiss } from './hooks';
 import { BookIcon, GitBranchIcon, ChevronDownIcon, GearIcon, LayersIcon, PencilIcon } from './icons';
@@ -28,6 +28,9 @@ export const TopBar = memo(function TopBar({ state, repos, lenses = [], dispatch
   const [menuPos, setMenuPos] = useState({ top: 0, left: 0, minWidth: 0 });
 
   const lensCtx = isLensContext(state);
+  // The gear's red dot marks an unhealthy remote of EITHER kind — a rejected
+  // push is as much a reason to open the manager as an unreachable origin.
+  const remoteError = remoteErrorText(state);
   // The switcher trigger appears when there's more than one surface to pick:
   // multiple repos, any lens (even with a single repo), or a lens context.
   const showTrigger = repos.length > 1 || lenses.length > 0 || lensCtx;
@@ -256,12 +259,12 @@ export const TopBar = memo(function TopBar({ state, repos, lenses = [], dispatch
           data-nodrag
           onClick={onManageRepos}
           title="Manage repositories"
-          style={{ background: 'none', border: 'none', color: state.remoteError ? '#f44336' : '#666', cursor: 'pointer', padding: 4, display: 'flex', alignItems: 'center', position: 'relative', flexShrink: 0, ...noDrag }}
-          onMouseEnter={e => { if (!state.remoteError) e.currentTarget.style.color = '#aaa'; }}
-          onMouseLeave={e => { e.currentTarget.style.color = state.remoteError ? '#f44336' : '#666'; }}
+          style={{ background: 'none', border: 'none', color: remoteError ? '#f44336' : '#666', cursor: 'pointer', padding: 4, display: 'flex', alignItems: 'center', position: 'relative', flexShrink: 0, ...noDrag }}
+          onMouseEnter={e => { if (!remoteError) e.currentTarget.style.color = '#aaa'; }}
+          onMouseLeave={e => { e.currentTarget.style.color = remoteError ? '#f44336' : '#666'; }}
         >
           <GearIcon color="currentColor" size={15} />
-          {state.remoteError && (
+          {remoteError && (
             <span style={{ position: 'absolute', top: 2, right: 2, width: 6, height: 6, borderRadius: '50%', background: '#f44336' }} />
           )}
         </button>

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { reducer, init, currentPath, selectAnchorCommit, selectTrail, isLive, isReadOnly, isLensContext, lensResolutionPending, openFactSource, factHistoryAnchor, edgeAnchorCommit } from './state';
+import { reducer, init, currentPath, selectAnchorCommit, selectTrail, isLive, isReadOnly, isLensContext, lensResolutionPending, openFactSource, factHistoryAnchor, edgeAnchorCommit, remoteErrorText } from './state';
 import type { AppState, FilterChip } from './state';
 import type { Lens, LensSource } from './api';
 
@@ -216,7 +216,7 @@ describe('reducer — SET_REPO', () => {
     expect(s.navStack).toHaveLength(0);
     expect(s.headCommit).toBe('');
     expect(s.branch).toBe('');
-    expect(s.remoteError).toBe('');
+    expect(remoteErrorText(s)).toBe('');
     expect(s.rightPanelFocused).toBe(false);
   });
 
@@ -252,7 +252,7 @@ describe('reducer — BrowseContext (SET_CONTEXT / SET_REPO wrapper)', () => {
     expect(s.navStack).toHaveLength(0);
     expect(s.headCommit).toBe('');
     expect(s.branch).toBe('');
-    expect(s.remoteError).toBe('');
+    expect(remoteErrorText(s)).toBe('');
     expect(s.rightPanelFocused).toBe(false);
     expect(s.lens).toBeNull();
     expect(s.lensSources).toBeNull();
@@ -479,9 +479,51 @@ describe('reducer — shared infrastructure', () => {
     expect(next.branch).toBe(init.branch);
   });
 
-  it('SET_REMOTE_ERROR sets remoteError', () => {
-    const s = reducer(init, { type: 'SET_REMOTE_ERROR', error: 'auth failed' });
-    expect(s.remoteError).toBe('auth failed');
+  it('SET_REMOTE_ERROR sets the side it names, and remoteErrorText reports it', () => {
+    const s = reducer(init, { type: 'SET_REMOTE_ERROR', side: 'sync', error: 'auth failed' });
+    expect(s.remoteSyncError).toBe('auth failed');
+    expect(s.remotePushError).toBe('');
+    expect(remoteErrorText(s)).toBe('auth failed');
+  });
+
+  // The bug this split exists for: sync_ok reports that the FETCH half is
+  // healthy and says nothing about the push half. Clearing both would lower a
+  // banner an expired push token had raised, and the next failing push tick
+  // would raise it again — a banner blinking once per reconcile interval.
+  it('a clean sync does not clear a push failure', () => {
+    let s = reducer(init, { type: 'SET_REMOTE_ERROR', side: 'push', error: 'token expired' });
+    s = reducer(s, { type: 'SET_REMOTE_ERROR', side: 'sync', error: '' });
+    expect(remoteErrorText(s)).toBe('token expired');
+  });
+
+  it('a clean push does not clear a sync failure', () => {
+    let s = reducer(init, { type: 'SET_REMOTE_ERROR', side: 'sync', error: 'no such host' });
+    s = reducer(s, { type: 'SET_REMOTE_ERROR', side: 'push', error: '' });
+    expect(remoteErrorText(s)).toBe('no such host');
+  });
+
+  it('the fetch error wins the banner while both sides are failing', () => {
+    let s = reducer(init, { type: 'SET_REMOTE_ERROR', side: 'push', error: 'token expired' });
+    s = reducer(s, { type: 'SET_REMOTE_ERROR', side: 'sync', error: 'no such host' });
+    expect(remoteErrorText(s)).toBe('no such host');
+    // ...and clearing only the fetch half falls back to the push error rather
+    // than reading as a fully recovered remote.
+    s = reducer(s, { type: 'SET_REMOTE_ERROR', side: 'sync', error: '' });
+    expect(remoteErrorText(s)).toBe('token expired');
+  });
+
+  it('CLEAR_REMOTE_ERRORS acknowledges both sides at once', () => {
+    let s = reducer(init, { type: 'SET_REMOTE_ERROR', side: 'sync', error: 'no such host' });
+    s = reducer(s, { type: 'SET_REMOTE_ERROR', side: 'push', error: 'token expired' });
+    s = reducer(s, { type: 'CLEAR_REMOTE_ERRORS' });
+    expect(remoteErrorText(s)).toBe('');
+  });
+
+  it('SET_REMOTE_ERROR is identity-stable when re-confirming a side', () => {
+    const s = reducer(init, { type: 'SET_REMOTE_ERROR', side: 'push', error: 'token expired' });
+    expect(reducer(s, { type: 'SET_REMOTE_ERROR', side: 'push', error: 'token expired' })).toBe(s);
+    expect(reducer(s, { type: 'SET_REMOTE_ERROR', side: 'sync', error: '' })).toBe(s);
+    expect(reducer(init, { type: 'CLEAR_REMOTE_ERRORS' })).toBe(init);
   });
 
   it('FOCUS_RIGHT_PANEL sets rightPanelFocused to true', () => {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -99,6 +99,7 @@ export type Action =
   | { type: 'CLEAR_FILTERS' }
   | { type: 'NAV_BACK' }
   | { type: 'SET_TASK'; op: string; status: 'idle' | 'running' | 'done' | 'error'; message: string }
+  | { type: 'CLEAR_TASK'; op: string }
   | { type: 'SET_STATUS'; head: string; branch: string; embeddingsEnabled: boolean; ontologyRoot: string; indexState?: string; indexDone?: number; indexTotal?: number; indexPercent?: number }
   | { type: 'SET_HEAD'; head: string }
   | { type: 'SET_REPO'; repo: string }
@@ -267,6 +268,16 @@ function applyAction(s: AppState, a: Action): AppState {
       const cur = s.tasks[a.op];
       if (cur && cur.status === a.status && cur.message === a.message) return s;
       return { ...s, tasks: { ...s.tasks, [a.op]: { status: a.status, message: a.message } } };
+    }
+    case 'CLEAR_TASK': {
+      // Retires a FINISHED task back to idle. Only the terminal states are
+      // retired: a running task owns the footer for as long as it runs, and
+      // dropping one mid-flight would hide live progress. Without this nothing
+      // ever left the footer, so the last "done" of the session sat there
+      // reading like something still happening.
+      const cur = s.tasks[a.op];
+      if (!cur || cur.status === 'idle' || cur.status === 'running') return s;
+      return { ...s, tasks: { ...s.tasks, [a.op]: { status: 'idle', message: '' } } };
     }
     case 'SET_STATUS':
       return {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -340,6 +340,11 @@ function applyAction(s: AppState, a: Action): AppState {
     case 'SET_FACT_SOURCE':
       return { ...s, factSource: a.source };
     case 'SET_REMOTE_ERROR':
+      // Identity-stable when nothing changed. This action is now dispatched by
+      // POLLS (the persisted-status re-read on repo switch, reconnect, and
+      // repo-manager close), not just by remote events, and re-confirming the
+      // same value must not mint a new AppState and re-render every panel.
+      if (s.remoteError === a.error) return s;
       return { ...s, remoteError: a.error };
     case 'FOCUS_RIGHT_PANEL':
       return { ...s, rightPanelFocused: true };

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -68,7 +68,13 @@ export interface AppState {
   indexTotal: number;
   indexPercent: number;  // 0–100; 100 when ready
   navStack: NavEntry[];
-  remoteError: string;
+  // The remote's two halves fail INDEPENDENTLY — a fetch can recover while a
+  // push is still rejected — and each maps 1:1 onto the column Sync/Push write
+  // (remotes.last_status / last_push_status). Tracking them apart is what stops
+  // a sync_ok from clearing a banner a still-broken push raised. Read them
+  // through remoteErrorText, never directly.
+  remoteSyncError: string;
+  remotePushError: string;
   rightPanelFocused: boolean;
   librarySort: LibrarySort;
   notice: string;
@@ -108,7 +114,8 @@ export type Action =
   | { type: 'SET_LENS'; lens: Lens }
   | { type: 'SET_LENS_SOURCES'; repos: string[] | null }
   | { type: 'SET_FACT_SOURCE'; source: LensSource | null }
-  | { type: 'SET_REMOTE_ERROR'; error: string }
+  | { type: 'SET_REMOTE_ERROR'; side: 'sync' | 'push'; error: string }
+  | { type: 'CLEAR_REMOTE_ERRORS' }
   | { type: 'FOCUS_RIGHT_PANEL' }
   | { type: 'BLUR_RIGHT_PANEL' }
   | { type: 'SET_AS_OF'; asOf: AsOf }
@@ -144,7 +151,8 @@ export const init: AppState = {
   indexTotal: 0,
   indexPercent: 100,
   navStack: [],
-  remoteError: '',
+  remoteSyncError: '',
+  remotePushError: '',
   rightPanelFocused: false,
   librarySort: 'recent',
   notice: '',
@@ -313,7 +321,8 @@ function applyAction(s: AppState, a: Action): AppState {
         filters: [],
         freeText: '',
         navStack: [],
-        remoteError: '',
+        remoteSyncError: '',
+        remotePushError: '',
         rightPanelFocused: false,
         factSource: null,
       };
@@ -351,12 +360,28 @@ function applyAction(s: AppState, a: Action): AppState {
     case 'SET_FACT_SOURCE':
       return { ...s, factSource: a.source };
     case 'SET_REMOTE_ERROR':
-      // Identity-stable when nothing changed. This action is now dispatched by
+      // Scoped to ONE side. sync_ok says the fetch half is healthy and says
+      // NOTHING about the push half, so clearing both here is how a sync_ok
+      // used to wipe a banner an expired push token had raised — leaving the
+      // next failing push tick to put it straight back, once per reconcile
+      // interval, for as long as the token stayed broken.
+      //
+      // Identity-stable when nothing changed. This action is dispatched by
       // POLLS (the persisted-status re-read on repo switch, reconnect, and
       // repo-manager close), not just by remote events, and re-confirming the
       // same value must not mint a new AppState and re-render every panel.
-      if (s.remoteError === a.error) return s;
-      return { ...s, remoteError: a.error };
+      if (a.side === 'push') {
+        if (s.remotePushError === a.error) return s;
+        return { ...s, remotePushError: a.error };
+      }
+      if (s.remoteSyncError === a.error) return s;
+      return { ...s, remoteSyncError: a.error };
+    case 'CLEAR_REMOTE_ERRORS':
+      // The user dismissing the banner acknowledges BOTH sides — it is one
+      // banner, and there is no way to acknowledge half of it. Nothing is lost:
+      // a side that is still broken re-raises on its next failing tick.
+      if (!s.remoteSyncError && !s.remotePushError) return s;
+      return { ...s, remoteSyncError: '', remotePushError: '' };
     case 'FOCUS_RIGHT_PANEL':
       return { ...s, rightPanelFocused: true };
     case 'BLUR_RIGHT_PANEL':
@@ -512,6 +537,16 @@ export function factHistoryAnchor(
 // the default live view). Repo context is byte-identical (always state.headCommit).
 export function edgeAnchorCommit(s: AppState): string {
   return selectAnchorCommit(s) ?? (isLensContext(s) ? '' : s.headCommit);
+}
+
+// remoteErrorText is the single line the banner shows for an unhealthy remote,
+// and the condition everything else gates on: empty means healthy on BOTH sides.
+// The two halves are tracked apart (see remoteSyncError / remotePushError) but
+// only one message fits one banner, so the fetch side wins when both are set —
+// a fetch that cannot reach origin is the more fundamental failure, and the push
+// error is usually a consequence of it rather than separate news.
+export function remoteErrorText(s: AppState): string {
+  return s.remoteSyncError || s.remotePushError;
 }
 
 export function isReadOnly(s: AppState): boolean {


### PR DESCRIPTION
A sync error banner stayed up in the desktop window for hours after the outage
behind it had healed. The web tab looked fine, which made it read as a desktop
bug. It wasn't: the recovery was never announced.

## The banner

`runReconcileLoop` broadcast `sync_ok` only when main or agent actually moved,
and `push_ok` only when something was pushed. Both are one-shot SSE events,
never replayed. The client raises `state.remoteError` on `sync_error` and
lowers it **only** on a clean remote event. So an outage that healed on a tick
with nothing left to pull or push — the usual way an outage ends, since the
outage is what stopped the traffic — emitted nothing, and the banner outlived
it by the length of the session.

Confirmed against the live DB while the banner was still up:

```
sqlite3 ~/.knomit/repos/agentic-engineering.db \
  'select last_status, last_push_status from remotes'
ok|ok
```

A fresh page looked clean only because a new client starts at `remoteError: ''`
— the old seed effect could raise the banner from persisted status but never
lower it.

**Server.** A tick that succeeds while the *persisted* status was `error` now
broadcasts on that edge alone. The edge is read off `last_status` /
`last_push_status` snapshotted before `Sync`/`Push` overwrite them, not off the
loop's in-memory failure counters — those start at zero after a restart with
the failure still recorded. `shouldBroadcastSyncOK` / `shouldBroadcastPushOK` /
`remoteStatusIsError` carry the decision and are unit-tested. Steady-state ticks
stay as quiet as before, and the edge fires at most once per outage because
`Sync`/`Push` write `ok` unconditionally on success.

**Client.** The banner stops depending on the event arriving at all. It is
re-read from the stored status on repo switch, on SSE reconnect, and when the
repo manager closes; it clears when that read reports ok or no remote at all,
and deliberately does *not* clear when the read itself fails — a network hiccup
teaches us nothing about the remote. `Reconnect…` and a new `✕` both clear it;
nothing is lost, since the manager's remote card still carries the stored
failure and a broken remote raises the banner again on its next failing tick.

## The banner can no longer be stuck at all

Two backstops, because the wire is not trustworthy on its own.

**A dismiss.** `✕` clears the banner, and `Reconnect…` clears it on the way to
the manager. Nothing is lost: a broken remote re-broadcasts `sync_error` on
every failing tick, so the banner comes straight back if the failure is real.

**A recheck while it is up.** Every other way it comes down is edge-triggered,
and a stream that stalls *silently* — slept laptop, half-open proxy connection
— fires neither `error` nor `open`, so nothing prompts a re-read. There is no
replay to fall back on either: `TaskHub.Subscribe`'s reconnect snapshot carries
task events only, so a missed `sync_ok` is missed for good. While a failure is
on screen the client re-reads the stored status once a minute. A healthy remote
polls nothing at all.

## Two more of the same shape

Found while auditing the UI for state raised by an event and cleared only by
another event that may never come:

- The post-task status refresh read the whole branch status and kept only the
  head, discarding `index_state` — so a rebuild that repaired the index left
  the "indexing did not complete" banner up. All three readers of that endpoint
  now share one `statusAction` helper that applies the whole payload.
- Nothing ever returned a task to idle, so the footer kept the last terminal
  result for the rest of the session. Finished tasks retire after a beat;
  running ones are untouched however long they run.

`SET_REMOTE_ERROR` is also identity-stable now — it is dispatched by polls, not
just events, and re-confirming the same value must not re-render every panel.

## Not in this PR

`handleStartRebuild` never clears `ri.indexState` on success, so a manual
rebuild can't lift an index error until restart. Fixing it honestly is a
semantics call — `Rebuild` covers one branch while `indexState` covers all
indexed branches, so `markIndexReady()` there could lie. Left alone
deliberately; the banner's "it will retry on the next restart" is still true.

## Verification

- `go test ./...` passes, `go vet` clean.
- `npx vitest run` — 689 pass, including 12 new tests covering the banner
  lifecycle end to end. Both commits were checked independently; the first
  builds and passes on its own.
- `npm run build` clean; lint unchanged (86 pre-existing problems).
- Not exercised against a live outage — no real DNS failure was induced.

Reviewers running this need `make build` for the server and `make desktop` for
the app; the desktop embeds the web bundle, so both sides need rebuilding.

