### PR TITLE
fix(llm): the JSON grammar is what breaks a reasoning model's JSON

### DIFF
--- a/internal/llm/adapter.go
+++ b/internal/llm/adapter.go
@@ -39,7 +39,13 @@ type Message struct {
 
 // CompletionOptions controls provider-specific behaviour for a single call.
 type CompletionOptions struct {
-	ForceJSON bool // when true, constrain output to valid JSON (e.g. Ollama format:"json")
+	// ForceJSON asks for a response the caller can parse as JSON. It states the
+	// requirement, deliberately not the mechanism: a provider is free to meet it
+	// with a decoding constraint, a prompt instruction, or both, and at least one
+	// of those is unavailable on some models. Ollama, for instance, cannot use
+	// its format:"json" grammar on a reasoning model without corrupting the
+	// answer (see ollama.go's jsonStrategy), so it asks in the prompt instead.
+	ForceJSON bool
 }
 
 // LLMAdapter is the common interface implemented by every provider.

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -28,10 +28,13 @@ type OllamaAdapter struct {
 	model  string
 	client *http.Client
 	// thinks records whether the server reports this model as capable of
-	// reasoning. It decides how ForceJSON is honoured, so it is resolved once at
-	// construction rather than per request: the answer is a property of the
-	// model, and asking on every completion would put an extra round trip in
-	// front of work that is already the slowest thing in the pipeline.
+	// reasoning. It gates two things, not one: whether think is sent at all
+	// (every completion, ForceJSON or not) and how ForceJSON is honoured when it
+	// is asked for. It is resolved once at construction rather than per request
+	// because the answer is a property of the model, and asking on every
+	// completion would put an extra round trip in front of work that is already
+	// the slowest thing in the pipeline. The cost of getting it wrong is on
+	// reportsThinking.
 	thinks bool
 }
 
@@ -53,10 +56,11 @@ const jsonOnlyInstruction = "Respond with a single valid JSON object and nothing
 // reachable (5-second health check against /api/tags). Returns an error if
 // the server is down or unreachable.
 //
-// It then probes /api/show for the model's capabilities, which decides how
-// ForceJSON is honoured (see jsonStrategy). Only the health check is fatal: an
-// unreachable server has nothing to offer, whereas an unanswered capability
-// probe just picks the more conservative of two working strategies.
+// It then probes /api/show for the model's capabilities, which decides whether
+// reasoning is requested and how ForceJSON is honoured (see jsonStrategy). Only
+// the health check is fatal: an unreachable server has nothing to offer,
+// whereas an unanswered capability probe still leaves an adapter that works,
+// though on a reasoning model it works less well — see reportsThinking.
 func NewOllamaAdapter(ctx context.Context, model string) (*OllamaAdapter, error) {
 	host := os.Getenv("OLLAMA_HOST")
 	if host == "" {
@@ -90,11 +94,18 @@ func NewOllamaAdapter(ctx context.Context, model string) (*OllamaAdapter, error)
 // reportsThinking asks /api/show whether the model advertises the "thinking"
 // capability.
 //
-// A failure here is deliberately not fatal. The probe only selects between two
-// working ways of asking for JSON, so a server that cannot answer it should
-// still yield a usable adapter — and the false it returns lands on the
-// grammar-constrained path, which is what this adapter did before the probe
-// existed. Refusing to construct would turn a cosmetic unknown into an outage.
+// A failure here is deliberately not fatal, but it is not free either. The
+// false it returns is indistinguishable from a genuinely non-reasoning model,
+// and thinks is read on every completion, not just the ForceJSON ones: for the
+// adapter's whole lifetime think is then never set, and ForceJSON falls back to
+// the format:"json" grammar. On a model that does in fact reason, that is
+// precisely the pairing this adapter exists to avoid — 1 parseable answer in 4.
+//
+// The trade is still worth making, because the alternatives are worse. Refusing
+// to construct takes out every model, including the ones that never needed the
+// probe; assuming true on an unknown would put think on models that reject it
+// outright. So an unanswered probe degrades one class of model rather than
+// failing all of them, and says so in the log.
 func (a *OllamaAdapter) reportsThinking(ctx context.Context) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -124,6 +135,7 @@ func (a *OllamaAdapter) reportsThinking(ctx context.Context) bool {
 		Capabilities []string `json:"capabilities"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&show); err != nil {
+		log.Debug().Err(err).Str("model", a.model).Msg("ollama: capability probe unreadable; assuming no thinking")
 		return false
 	}
 	return slices.Contains(show.Capabilities, "thinking")

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -9,7 +9,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
+	"strings"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 // OllamaAdapter calls a local or remote Ollama instance via its /api/chat
@@ -23,11 +27,36 @@ type OllamaAdapter struct {
 	host   string
 	model  string
 	client *http.Client
+	// thinks records whether the server reports this model as capable of
+	// reasoning. It decides how ForceJSON is honoured, so it is resolved once at
+	// construction rather than per request: the answer is a property of the
+	// model, and asking on every completion would put an extra round trip in
+	// front of work that is already the slowest thing in the pipeline.
+	thinks bool
 }
+
+// ollamaUncapped disables the generation limit. Reasoning tokens are generated
+// tokens — ollama counts them against num_predict before any of them reach us —
+// so a cap sized to bound spend on a metered API (defaultMaxTokens) is instead
+// spent on reasoning here, and the answer never gets written. A local model
+// costs nothing per token, so the cap buys nothing and truncates real work; the
+// context window and the caller's attempt timeout are the meaningful bounds.
+const ollamaUncapped = -1
+
+// jsonOnlyInstruction carries the ForceJSON requirement in the prompt, for the
+// case where the grammar constraint cannot. It asks for bare JSON, but the
+// callers that need it also tolerate fences (internal/synthesize's extractJSON),
+// so a model that answers with one anyway still parses.
+const jsonOnlyInstruction = "Respond with a single valid JSON object and nothing else: no prose before or after it, and no markdown code fences."
 
 // NewOllamaAdapter creates an adapter after verifying the Ollama server is
 // reachable (5-second health check against /api/tags). Returns an error if
 // the server is down or unreachable.
+//
+// It then probes /api/show for the model's capabilities, which decides how
+// ForceJSON is honoured (see jsonStrategy). Only the health check is fatal: an
+// unreachable server has nothing to offer, whereas an unanswered capability
+// probe just picks the more conservative of two working strategies.
 func NewOllamaAdapter(ctx context.Context, model string) (*OllamaAdapter, error) {
 	host := os.Getenv("OLLAMA_HOST")
 	if host == "" {
@@ -53,50 +82,144 @@ func NewOllamaAdapter(ctx context.Context, model string) (*OllamaAdapter, error)
 		return nil, fmt.Errorf("ollama: health check returned %d", resp.StatusCode)
 	}
 
-	return &OllamaAdapter{host: host, model: model, client: client}, nil
+	a := &OllamaAdapter{host: host, model: model, client: client}
+	a.thinks = a.reportsThinking(ctx)
+	return a, nil
 }
 
+// reportsThinking asks /api/show whether the model advertises the "thinking"
+// capability.
+//
+// A failure here is deliberately not fatal. The probe only selects between two
+// working ways of asking for JSON, so a server that cannot answer it should
+// still yield a usable adapter — and the false it returns lands on the
+// grammar-constrained path, which is what this adapter did before the probe
+// existed. Refusing to construct would turn a cosmetic unknown into an outage.
+func (a *OllamaAdapter) reportsThinking(ctx context.Context) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	body, err := json.Marshal(map[string]string{"model": a.model})
+	if err != nil {
+		return false
+	}
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodPost, a.host+"/api/show", bytes.NewReader(body))
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		log.Debug().Err(err).Str("model", a.model).Msg("ollama: capability probe failed; assuming no thinking")
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Debug().Int("status", resp.StatusCode).Str("model", a.model).Msg("ollama: capability probe rejected; assuming no thinking")
+		return false
+	}
+
+	var show struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&show); err != nil {
+		return false
+	}
+	return slices.Contains(show.Capabilities, "thinking")
+}
+
+// ollamaChatRequest is the /api/chat body. Format and Think are both omitempty
+// and for the same reason: each is a mode switch, and sending one inertly — an
+// empty format, or think on a model that cannot — is either meaningless or an
+// error, never a no-op worth risking.
 type ollamaChatRequest struct {
 	Model    string          `json:"model"`
 	Messages []ollamaMessage `json:"messages"`
-	Format   string          `json:"format"`
+	Format   string          `json:"format,omitempty"`
+	Think    *bool           `json:"think,omitempty"`
 	Stream   bool            `json:"stream"`
 	Options  ollamaOptions   `json:"options"`
 }
 
+// ollamaMessage carries both channels of a chat turn. Thinking is populated
+// only on responses, and only by models that reason: ollama demultiplexes the
+// reasoning tokens out of the raw stream into their own field, leaving Content
+// as the answer alone. It is omitempty because the same struct is used for the
+// request, where a thinking field has no meaning.
 type ollamaMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role     string `json:"role"`
+	Content  string `json:"content"`
+	Thinking string `json:"thinking,omitempty"`
 }
 
 type ollamaOptions struct {
 	NumPredict int `json:"num_predict"`
 }
 
+// ollamaStreamLine is one NDJSON frame. DoneReason accompanies the final frame
+// and is the only signal distinguishing a completed answer ("stop") from one
+// the server cut short ("length") — both of which arrive as a successful HTTP
+// response with done: true.
 type ollamaStreamLine struct {
-	Message ollamaMessage `json:"message"`
-	Done    bool          `json:"done"`
+	Message    ollamaMessage `json:"message"`
+	Done       bool          `json:"done"`
+	DoneReason string        `json:"done_reason"`
+}
+
+// jsonStrategy returns the system prompt and the format value to send for a
+// request. It is the single place the choice between "constrain the grammar"
+// and "ask in the prompt" is made, so the two can never both apply — belt and
+// braces here would reintroduce exactly the constraint being avoided.
+func (a *OllamaAdapter) jsonStrategy(system string, forceJSON bool) (string, string) {
+	if !forceJSON {
+		return system, ""
+	}
+	if !a.thinks {
+		return system, "json"
+	}
+	if system == "" {
+		return jsonOnlyInstruction, ""
+	}
+	return system + "\n\n" + jsonOnlyInstruction, ""
 }
 
 // Complete implements LLMAdapter by POSTing to /api/chat with stream: true
 // and reading NDJSON lines until done: true.
 func (a *OllamaAdapter) Complete(ctx context.Context, system string, msgs []Message, opts CompletionOptions, onChunk func(string)) (string, error) {
+	// How ForceJSON is honoured depends on whether the model reasons.
+	//
+	// format:"json" is a grammar constraint the runner must suspend for the
+	// reasoning phase and resume for the answer, and on a reasoning model that
+	// seam is where the output breaks: measured against gemma4:26b-mlx, the
+	// constrained request produced parseable JSON 1 time in 4, while the same
+	// request without it produced it 4 times in 4. The constraint meant to
+	// guarantee JSON is what destroys it, so for a thinking model the
+	// requirement moves into the prompt instead.
+	//
+	// On a model that does not reason there is no seam, the constraint holds,
+	// and it stays: a grammar is a guarantee where a prompt is only a strong
+	// convention, and those models never had the problem.
+	format, think := "", (*bool)(nil)
+	system, format = a.jsonStrategy(system, opts.ForceJSON)
+	if a.thinks {
+		think = new(bool)
+		*think = true
+	}
+
 	chatMsgs := make([]ollamaMessage, 0, len(msgs)+1)
 	chatMsgs = append(chatMsgs, ollamaMessage{Role: "system", Content: system})
 	for _, m := range msgs {
 		chatMsgs = append(chatMsgs, ollamaMessage{Role: m.Role, Content: m.Content})
 	}
 
-	format := ""
-	if opts.ForceJSON {
-		format = "json"
-	}
 	reqBody := ollamaChatRequest{
 		Model:    a.model,
 		Messages: chatMsgs,
 		Format:   format,
+		Think:    think,
 		Stream:   true,
-		Options:  ollamaOptions{NumPredict: defaultMaxTokens},
+		Options:  ollamaOptions{NumPredict: ollamaUncapped},
 	}
 
 	body, err := json.Marshal(reqBody)
@@ -121,7 +244,12 @@ func (a *OllamaAdapter) Complete(ctx context.Context, system string, msgs []Mess
 		return "", fmt.Errorf("ollama: HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(errBody))
 	}
 
-	var accumulated string
+	// Only the content channel is the completion. Reasoning arrives in its own
+	// field and is dropped here — deliberately, and it is what makes running a
+	// reasoning model free of consequence for callers: they get the answer, not
+	// the model's private deliberation, and never have to strip it themselves.
+	var accumulated strings.Builder
+	var doneReason string
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		line := scanner.Bytes()
@@ -133,12 +261,13 @@ func (a *OllamaAdapter) Complete(ctx context.Context, system string, msgs []Mess
 			continue
 		}
 		if sl.Message.Content != "" {
-			accumulated += sl.Message.Content
+			accumulated.WriteString(sl.Message.Content)
 			if onChunk != nil {
 				onChunk(sl.Message.Content)
 			}
 		}
 		if sl.Done {
+			doneReason = sl.DoneReason
 			break
 		}
 	}
@@ -146,7 +275,19 @@ func (a *OllamaAdapter) Complete(ctx context.Context, system string, msgs []Mess
 		return "", fmt.Errorf("ollama: read stream: %w", err)
 	}
 
-	return accumulated, nil
+	// A cut-off stream is a *successful* HTTP response, so without this check it
+	// reaches the caller as a completion — and on a reasoning model the text it
+	// carries is routinely empty, the whole limit having gone to thinking before
+	// the answer began. An empty string that parses as "the model said nothing"
+	// is worse than an error, because nothing downstream can tell it apart from
+	// a real answer.
+	if doneReason == "length" {
+		return accumulated.String(), fmt.Errorf(
+			"ollama: response truncated (done_reason=length) after %d bytes: the model hit its generation limit before finishing",
+			accumulated.Len())
+	}
+
+	return accumulated.String(), nil
 }
 
 // Model returns the model name used by this adapter.

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -1,0 +1,187 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ollamaTestServerWithCaps is ollamaTestServer with the model's advertised
+// capabilities made explicit. /api/show is answered like /api/tags — outside
+// the counter — because it is construction-time probing, not a completion: a
+// test asserting "exactly one retry" must not see the probe as an attempt.
+func ollamaTestServerWithCaps(t *testing.T, caps []string, chat http.HandlerFunc) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"models":[]}`))
+			return
+		case "/api/show":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": caps})
+			return
+		}
+		calls.Add(1)
+		chat(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("OLLAMA_HOST", srv.URL)
+	return srv, &calls
+}
+
+// captureOllamaRequest runs one completion against a server advertising caps
+// and returns the decoded /api/chat request body. The stream it replies with is
+// a single terminal chunk: these tests are about what we *send*.
+func captureOllamaRequest(t *testing.T, caps []string, opts CompletionOptions) map[string]any {
+	t.Helper()
+	var body map[string]any
+	ollamaTestServerWithCaps(t, caps, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		writeOllamaChunk(t, w, "ok", true)
+	})
+
+	adapter, err := NewOllamaAdapter(context.Background(), "test-model")
+	require.NoError(t, err)
+	_, err = adapter.Complete(context.Background(), "sys", []Message{{Role: "user", Content: "hi"}}, opts, nil)
+	require.NoError(t, err)
+	require.NotNil(t, body, "the adapter must have POSTed to /api/chat")
+	return body
+}
+
+// TestOllamaForceJSON_ThinkingModelOmitsFormat is the whole reason this change
+// exists. format:"json" is a grammar constraint the runner has to suspend across
+// the reasoning phase and resume afterwards, and on a reasoning model it is the
+// constraint itself that corrupts the answer: measured against gemma4:26b-mlx,
+// format:"json" with thinking on parsed 1/4, and dropping it parsed 4/4. So for
+// a model advertising the thinking capability, ForceJSON must be honoured by
+// asking for JSON in the prompt rather than by constraining the grammar.
+func TestOllamaForceJSON_ThinkingModelOmitsFormat(t *testing.T) {
+	body := captureOllamaRequest(t, []string{"completion", "thinking"}, CompletionOptions{ForceJSON: true})
+
+	require.NotContains(t, body, "format",
+		"a thinking model must not be sent the JSON grammar constraint — it is what breaks the output")
+	require.Equal(t, true, body["think"], "reasoning is the point of running this model; it stays on")
+}
+
+// TestOllamaForceJSON_ThinkingModelAsksForJSONInPrompt — dropping the grammar
+// constraint must not drop the requirement with it. ForceJSON means the caller
+// cannot use anything but JSON; when the constraint is unavailable the demand
+// has to move into the prompt, which is the only channel left to carry it.
+func TestOllamaForceJSON_ThinkingModelAsksForJSONInPrompt(t *testing.T) {
+	body := captureOllamaRequest(t, []string{"completion", "thinking"}, CompletionOptions{ForceJSON: true})
+
+	msgs, ok := body["messages"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, msgs)
+	sys, ok := msgs[0].(map[string]any)["content"].(string)
+	require.True(t, ok)
+	require.Contains(t, strings.ToLower(sys), "json",
+		"with no grammar to enforce it, the system prompt is the only place the JSON requirement can live")
+	require.Contains(t, sys, "sys", "the caller's own system prompt must survive")
+}
+
+// TestOllamaForceJSON_NonThinkingModelSendsFormat is the control. Without a
+// reasoning phase there is nothing for the grammar to be suspended across, and
+// format:"json" is a hard guarantee worth keeping — it measured 3/3 where the
+// prompt-only convention is merely very likely. Dropping it everywhere would
+// trade a guarantee for a convention on the models that never had the problem.
+func TestOllamaForceJSON_NonThinkingModelSendsFormat(t *testing.T) {
+	body := captureOllamaRequest(t, []string{"completion"}, CompletionOptions{ForceJSON: true})
+
+	require.Equal(t, "json", body["format"])
+	require.NotContains(t, body, "think",
+		"asking a model that cannot think to think is an error from ollama, not a no-op")
+}
+
+// TestOllamaComplete_OmitsFormatWhenJSONNotForced guards the field that used to
+// be sent unconditionally: `format` had no omitempty, so every ordinary
+// completion carried format:"" — accepted by ollama today, but a constraint
+// field is not something to send by accident.
+func TestOllamaComplete_OmitsFormatWhenJSONNotForced(t *testing.T) {
+	body := captureOllamaRequest(t, []string{"completion"}, CompletionOptions{})
+
+	require.NotContains(t, body, "format")
+}
+
+// TestOllamaComplete_DoesNotCapGeneration — reasoning tokens are generated
+// tokens: ollama counts them against num_predict before the caller sees them,
+// so a cap shared with the metered providers (defaultMaxTokens, sized to bound
+// spend) is spent on reasoning and the answer never gets written. Measured on
+// gemma4:26b-mlx, num_predict=2000 returned done_reason "length" with empty
+// content, while the same prompt uncapped answered correctly in 7565 tokens.
+// Locally there is no spend to bound, so there is nothing for the cap to buy.
+func TestOllamaComplete_DoesNotCapGeneration(t *testing.T) {
+	body := captureOllamaRequest(t, []string{"completion", "thinking"}, CompletionOptions{})
+
+	opts, ok := body["options"].(map[string]any)
+	require.True(t, ok, "options must still be sent")
+	require.Equal(t, float64(-1), opts["num_predict"],
+		"generation must run to a natural stop; the context window and the attempt timeout are the real bounds")
+}
+
+// TestOllamaComplete_TruncationIsAnError — the silent failure this change
+// closes. A truncated stream is a successful HTTP response: ollama sets
+// done_reason "length", the scanner sees done and stops, and Complete used to
+// return whatever it had accumulated with a nil error. With a reasoning model
+// that accumulation is routinely the empty string, because the budget went to
+// thinking — so the caller (internal/synthesize, which checks only err) parses
+// an empty response as though the model had answered.
+func TestOllamaComplete_TruncationIsAnError(t *testing.T) {
+	ollamaTestServerWithCaps(t, []string{"completion", "thinking"}, func(w http.ResponseWriter, r *http.Request) {
+		line, err := json.Marshal(ollamaStreamLine{
+			Message:    ollamaMessage{Role: "assistant", Content: ""},
+			Done:       true,
+			DoneReason: "length",
+		})
+		require.NoError(t, err)
+		_, _ = w.Write(append(line, '\n'))
+	})
+
+	adapter, err := NewOllamaAdapter(context.Background(), "test-model")
+	require.NoError(t, err)
+
+	_, err = adapter.Complete(context.Background(), "sys", []Message{{Role: "user", Content: "hi"}}, CompletionOptions{}, nil)
+	require.Error(t, err, "truncation must not reach the caller as a successful empty completion")
+	require.Contains(t, err.Error(), "truncated")
+}
+
+// TestOllamaComplete_SkipsThinkingTokens locks the demultiplexing half of the
+// contract. Ollama routes reasoning into message.thinking and the answer into
+// message.content; only content is the completion. This is what makes discarding
+// the reasoning chain safe, and it must hold for the streamed callback too — a
+// caller rendering deltas would otherwise splice the model's private reasoning
+// into the answer it displays.
+func TestOllamaComplete_SkipsThinkingTokens(t *testing.T) {
+	ollamaTestServerWithCaps(t, []string{"completion", "thinking"}, func(w http.ResponseWriter, r *http.Request) {
+		for _, l := range []ollamaStreamLine{
+			{Message: ollamaMessage{Role: "assistant", Thinking: "let me "}},
+			{Message: ollamaMessage{Role: "assistant", Thinking: "consider"}},
+			{Message: ollamaMessage{Role: "assistant", Content: "the "}},
+			{Message: ollamaMessage{Role: "assistant", Content: "answer"}, Done: true, DoneReason: "stop"},
+		} {
+			line, err := json.Marshal(l)
+			require.NoError(t, err)
+			_, _ = w.Write(append(line, '\n'))
+			w.(http.Flusher).Flush()
+		}
+	})
+
+	adapter, err := NewOllamaAdapter(context.Background(), "test-model")
+	require.NoError(t, err)
+
+	var chunks []string
+	out, err := adapter.Complete(context.Background(), "sys", []Message{{Role: "user", Content: "hi"}},
+		CompletionOptions{}, func(s string) { chunks = append(chunks, s) })
+	require.NoError(t, err)
+	require.Equal(t, "the answer", out, "the completion is the content channel, never the reasoning channel")
+	require.Equal(t, []string{"the ", "answer"}, chunks, "no reasoning delta may reach the caller's callback")
+}

--- a/internal/llm/resilience_test.go
+++ b/internal/llm/resilience_test.go
@@ -15,26 +15,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ollamaTestServer starts an httptest server that answers the health check
-// NewOllamaAdapter performs at construction and delegates /api/chat to chat.
-// It returns the server and a counter of /api/chat requests only — the health
-// check must never be mistaken for a completion attempt when a test asserts on
-// how many times the model was actually called.
+// ollamaTestServer starts an httptest server that answers both requests
+// NewOllamaAdapter makes at construction — the /api/tags health check and the
+// /api/show capability probe — and delegates /api/chat to chat. It returns the
+// server and a counter of /api/chat requests only: neither construction-time
+// request may be mistaken for a completion attempt when a test asserts on how
+// many times the model was actually called.
+//
+// The model is advertised as non-thinking, which is the right default for the
+// resilience tests — they exercise retry and timeout behaviour, where the
+// reasoning capability is irrelevant. Tests that care use
+// ollamaTestServerWithCaps directly.
 func ollamaTestServer(t *testing.T, chat http.HandlerFunc) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
-	var calls atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/tags" {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"models":[]}`))
-			return
-		}
-		calls.Add(1)
-		chat(w, r)
-	}))
-	t.Cleanup(srv.Close)
-	t.Setenv("OLLAMA_HOST", srv.URL)
-	return srv, &calls
+	return ollamaTestServerWithCaps(t, []string{"completion"}, chat)
 }
 
 // writeOllamaChunk writes one NDJSON line in the shape OllamaAdapter.Complete


### PR DESCRIPTION
## The bug

`internal/synthesize` asks for JSON with `ForceJSON: true`, which the ollama adapter turned into `format: "json"`. That flag is a decoding constraint the runner has to suspend for the reasoning phase and resume for the answer — and on a reasoning model, that seam is where the output breaks.

Measured against `gemma4:26b-mlx`, running each response through `internal/synthesize`'s own `extractJSON`:

| request | parses |
|---|---|
| `think:true` + `format:"json"` (**before**) | **1/4** |
| `think:true`, no `format` (**after**) | **4/4** |
| `think:true` + `format:<schema>` | 2/4 |

The failures were not fenced JSON, which `extractJSON` already handles. They were text it cannot recover: one response began with a bare literal `json` before the fence, another came back as YAML-ish key/value pairs. The flag whose job was to guarantee JSON was the reason there wasn't any.

## The fix

`ForceJSON` now states a requirement instead of naming a mechanism, and picks how to meet it from the capabilities `/api/show` reports at construction:

- **thinking model** → requirement moves into the prompt, no grammar constraint
- **non-thinking model** → keeps `format:"json"`, which is a hard guarantee where a prompt is only a strong convention, and which these models never had trouble with

A failed probe is not fatal. It only selects between two working strategies, so an unanswered one falls back to the grammar — the behaviour before this change.

## Two further failures, both routine only on a reasoning model

**`num_predict` was `defaultMaxTokens`** — a constant sized to bound spend on a metered API. Reasoning tokens are generated tokens, and ollama counts them against that budget before any reach us, so the budget went to thinking and the answer was never written. At `num_predict=2000`, gemma4 returned `done_reason: "length"` with **empty content**; the same prompt uncapped answered correctly in 7565 tokens. Nothing is metered locally, so the cap bought nothing and truncated real work.

**A truncated stream is a *successful* HTTP response**, and `done_reason` went unread. `Complete` returned whatever it had accumulated — with a reasoning model, routinely `""` — alongside a `nil` error, and `pipeline.go` checks only `err`. An empty string that reads as "the model said nothing" is worse than an error, because nothing downstream can tell it from a real answer. Truncation now returns one.

## Verification

- 7 new tests in `internal/llm/ollama_test.go`, each watched to fail first. Two are controls that must **not** change: the non-thinking model keeps its grammar constraint, and reasoning deltas never reach the caller's `onChunk`.
- End-to-end against a live ollama with `gemma4:26b-mlx`: probe correctly reports `thinking: true`, and `ForceJSON` completions returned parseable JSON 2/2 (24s, 11s).
- Full suite green (`go test ./...`, 0 failures).

## Notes for the reviewer

- `ollamaTestServer` in `resilience_test.go` now delegates to a capability-aware helper. Without it the new `/api/show` probe fell through to the chat handler and was counted as a completion attempt, breaking the retry-count assertions.
- `resilience.go:256` cites `input length … exceeds context window` as "the most common ollama 400". That is no longer true on ollama 0.32.5, which auto-sizes context — a 20k-token prompt returned 200 with `prompt_eval_count: 20023`. The anchored regex is still worth keeping as defence; only the comment's premise is stale. Left alone here to keep this diff to one concern.
- Not addressed, deliberately: `AttemptTimeout` for ollama. Uncapped reasoning makes the 5-minute per-attempt budget the binding constraint, and a hard prompt can approach it (266s measured on an adversarial riddle; 102–173s on realistic synthesis prompts). Worth a follow-up, along with whether a timed-out local reasoning call is worth retrying at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
