### PR TITLE
Recall fires on your own conclusions, not just on user signals

### DIFF
--- a/.claude/skills/knomit-recall/SKILL.md
+++ b/.claude/skills/knomit-recall/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: knomit-recall
-description: Use BEFORE brainstorming sessions, implementation requests, or any non-trivial work in an area — surfaces invariants, design decisions, and anti-patterns from prior knowledge so they inform the work from the start
+description: Use BEFORE brainstorming sessions, implementation requests, non-trivial work in an area, or committing to an explanation of why something fails — surfaces invariants, design decisions, and anti-patterns from prior knowledge so they inform the work from the start
 ---
 
 # /knomit-recall <topic-or-text>
 
 ## When to use — trigger phrases
 
-Fire BEFORE acting on any of these user signals:
+Recall is a HABIT, not a phase. Two recalls at the top of a session do not
+cover the debugging you do an hour later. Most of the triggers below are user
+signals; the last group is not, and it is the one that gets missed.
 
 **Brainstorming / design exploration** — recall runs first so the brainstorm is informed by what already exists:
 
@@ -27,11 +29,33 @@ Fire BEFORE acting on any of these user signals:
 - "why does X work this way?" — existing-code rationale question
 - About to pick where new code goes
 
+**Your own conclusions — no user signal required.** These fire mid-task, when
+nobody has asked you anything:
+
+- About to state WHY something fails or misbehaves — "this test is flaky
+  because…", "the 500 comes from…", "that number is wrong because…"
+- About to act on a belief about a cause: writing the fix, reverting, changing
+  the retry strategy, declaring a failure pre-existing
+- About to brief a subagent on an area (see *Dispatching subagents* below)
+
+Why this group is the one you skip: recall fires when you notice a gap.
+Measuring your way to a confident answer removes the felt gap without removing
+the ignorance. The moment you have empirically settled something is precisely
+the moment you are least likely to ask whether it was already known — and
+therefore the moment a documented answer is most likely to be sitting unread.
+Reproducing a behaviour tells you THAT it happens; the corpus may already say
+WHY, and may say your reproduction supports the wrong cause.
+
 DON'T fire for:
 
 - Trivial edits in files you're actively iterating on
 - Questions answerable from the current file alone (lint fixes, typos)
-- After you've already recalled in this session for the SAME topic
+- Re-running a test to see whether it passes. Concluding what the failure
+  MEANS is a different act, and it does need recall.
+- After you've already recalled in this session for the SAME question. Same
+  *topic* is not enough: a design-time recall on an area does not cover a
+  later "why is this failing?" in that area — different question, different
+  facts.
 
 ## How
 
@@ -66,6 +90,21 @@ Pick the 3–5 facts whose specific claims (thresholds, ordering, struct shapes,
   the failure modes the blob form removes.
 - If it has only external (`https://`) refs: sanity-check via the actual source file before relying.
 - If it has no refs at all: lower your trust accordingly; prefer reading the relevant code directly.
+
+## Dispatching subagents
+
+A controller that stops recalling gives its subagents no reason to recall
+either, so a whole fan-out can re-derive what one fact already records. Before
+dispatching implementers, reviewers, or explorers into an area, do one of:
+
+- Recall on their behalf and put the findings in the brief — preferred when the
+  area has invariants they could violate without knowing it.
+- Tell them explicitly to run `/knomit-recall <area>` before concluding
+  anything.
+
+Their reports are subject to the same rule: a subagent that hands back a cause
+("the failure is a parallelism bug") has asserted a WHY, and that assertion is
+worth checking against the corpus before you act on it.
 
 ## Interpreting refs in returned facts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,14 @@ wrap knomit's MCP tools. Use them in these moments:
 - Picking where new code goes
 - Implementing a pattern that may already exist
 - Answering "why does X work this way?"
+- Committing to an explanation of a failure — before you name the cause,
+  not after. Reproducing a bug tells you THAT it happens; the corpus may
+  already say WHY, and may say your reproduction points at the wrong cause.
+- Briefing a subagent on an area — recall for them and put it in the brief,
+  or tell them to recall.
+
+Recall is a habit, not a phase: two recalls at the start of a session do
+not cover the debugging you do an hour later.
 
 After recall returns, VERIFY load-bearing claims (3–5 facts your work
 depends on) against HEAD before building on them. See the skill for the
@@ -62,4 +70,6 @@ time, with a real upcoming work driver.
 load-bearing; re-read before touching the area they cover. Facts can be
 stale; `/knomit-why` and `/knomit-update`/`/knomit-retract` are how you
 keep the corpus from rotting. When uncertain, `/knomit-recall` — also cheap.
+When you have just measured your way to a confident cause, recall then too:
+that is when the felt gap is gone but the ignorance isn't.
 <!-- /knomit:integration -->

--- a/tools/bridge/claude/templates/CLAUDE-md-block.txt
+++ b/tools/bridge/claude/templates/CLAUDE-md-block.txt
@@ -9,6 +9,14 @@ wrap knomit's MCP tools. Use them in these moments:
 - Picking where new code goes
 - Implementing a pattern that may already exist
 - Answering "why does X work this way?"
+- Committing to an explanation of a failure — before you name the cause,
+  not after. Reproducing a bug tells you THAT it happens; the corpus may
+  already say WHY, and may say your reproduction points at the wrong cause.
+- Briefing a subagent on an area — recall for them and put it in the brief,
+  or tell them to recall.
+
+Recall is a habit, not a phase: two recalls at the start of a session do
+not cover the debugging you do an hour later.
 
 After recall returns, VERIFY load-bearing claims (3–5 facts your work
 depends on) against HEAD before building on them. See the skill for the
@@ -55,4 +63,6 @@ time, with a real upcoming work driver.
 load-bearing; re-read before touching the area they cover. Facts can be
 stale; `/knomit-why` and `/knomit-update`/`/knomit-retract` are how you
 keep the corpus from rotting. When uncertain, `/knomit-recall` — also cheap.
+When you have just measured your way to a confident cause, recall then too:
+that is when the felt gap is gone but the ignorance isn't.
 <!-- /knomit:integration -->

--- a/tools/bridge/claude/templates/skills/knomit-recall/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-recall/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: knomit-recall
-description: Use BEFORE brainstorming sessions, implementation requests, or any non-trivial work in an area — surfaces invariants, design decisions, and anti-patterns from prior knowledge so they inform the work from the start
+description: Use BEFORE brainstorming sessions, implementation requests, non-trivial work in an area, or committing to an explanation of why something fails — surfaces invariants, design decisions, and anti-patterns from prior knowledge so they inform the work from the start
 ---
 
 # /knomit-recall <topic-or-text>
 
 ## When to use — trigger phrases
 
-Fire BEFORE acting on any of these user signals:
+Recall is a HABIT, not a phase. Two recalls at the top of a session do not
+cover the debugging you do an hour later. Most of the triggers below are user
+signals; the last group is not, and it is the one that gets missed.
 
 **Brainstorming / design exploration** — recall runs first so the brainstorm is informed by what already exists:
 
@@ -27,11 +29,33 @@ Fire BEFORE acting on any of these user signals:
 - "why does X work this way?" — existing-code rationale question
 - About to pick where new code goes
 
+**Your own conclusions — no user signal required.** These fire mid-task, when
+nobody has asked you anything:
+
+- About to state WHY something fails or misbehaves — "this test is flaky
+  because…", "the 500 comes from…", "that number is wrong because…"
+- About to act on a belief about a cause: writing the fix, reverting, changing
+  the retry strategy, declaring a failure pre-existing
+- About to brief a subagent on an area (see *Dispatching subagents* below)
+
+Why this group is the one you skip: recall fires when you notice a gap.
+Measuring your way to a confident answer removes the felt gap without removing
+the ignorance. The moment you have empirically settled something is precisely
+the moment you are least likely to ask whether it was already known — and
+therefore the moment a documented answer is most likely to be sitting unread.
+Reproducing a behaviour tells you THAT it happens; the corpus may already say
+WHY, and may say your reproduction supports the wrong cause.
+
 DON'T fire for:
 
 - Trivial edits in files you're actively iterating on
 - Questions answerable from the current file alone (lint fixes, typos)
-- After you've already recalled in this session for the SAME topic
+- Re-running a test to see whether it passes. Concluding what the failure
+  MEANS is a different act, and it does need recall.
+- After you've already recalled in this session for the SAME question. Same
+  *topic* is not enough: a design-time recall on an area does not cover a
+  later "why is this failing?" in that area — different question, different
+  facts.
 
 ## How
 
@@ -66,6 +90,21 @@ Pick the 3–5 facts whose specific claims (thresholds, ordering, struct shapes,
   the failure modes the blob form removes.
 - If it has only external (`https://`) refs: sanity-check via the actual source file before relying.
 - If it has no refs at all: lower your trust accordingly; prefer reading the relevant code directly.
+
+## Dispatching subagents
+
+A controller that stops recalling gives its subagents no reason to recall
+either, so a whole fan-out can re-derive what one fact already records. Before
+dispatching implementers, reviewers, or explorers into an area, do one of:
+
+- Recall on their behalf and put the findings in the brief — preferred when the
+  area has invariants they could violate without knowing it.
+- Tell them explicitly to run `/knomit-recall <area>` before concluding
+  anything.
+
+Their reports are subject to the same rule: a subagent that hands back a cause
+("the failure is a parallelism bug") has asserted a WHY, and that assertion is
+worth checking against the corpus before you act on it.
 
 ## Interpreting refs in returned facts
 


### PR DESCRIPTION
## Why

`kb/meta/methodology/recall-discipline/7672fa0e.md` records a failure mode observed during the PR #62 execution loop: an agent recalled twice at the start of the session, then ran an entire multi-task loop — debugging, diagnosing, concluding — without consulting the corpus again. Six test runs established that two `Library.sort.test.tsx` failures were pre-existing and reported the cause as "timing-sensitive under parallel workers". `kb/gotchas/web/testing/vitest-parallel-flakiness/806a17af.md` already named that exact file and states the opposite: the flakes are effect/`waitFor` races, not a parallelism bug. The empirical work did not merely duplicate a fact — it produced the specific misdiagnosis that fact exists to prevent.

Reviewing the bridge integration against that fact turned up three holes.

## What was wrong

**The trigger list is keyed entirely to user utterances.** `knomit-recall/SKILL.md` opened with "Fire BEFORE acting on any of these user signals", and all three groups were phrasings a user might type. An agent that has just concluded a cause matches none of them — nobody asked it anything. `"why does X work this way?"` was listed, but as a question the user asks, not as a belief you are about to form.

**The "already recalled" exemption licensed the failure.** `DON'T fire for: after you've already recalled in this session for the SAME topic` — a design-time recall on `web/testing` and a later "why is this test flaky" are the same topic and different questions. As written, the second was explicitly waved off.

**Nothing anywhere covered dispatch.** `grep -i "subagent|dispatch|fan-out"` across all eleven skill templates and the CLAUDE.md block returned zero hits, so the fact's second consequence — a controller that stops recalling propagates the blind spot to every agent it spawns — had no home.

The CLAUDE.md block had the same shape: all four recall bullets were design-time, and Philosophy said "when uncertain, `/knomit-recall`" — the wrong condition, since the failure happens while you feel certain.

## Changes

`tools/bridge/claude/templates/skills/knomit-recall/SKILL.md`

- New trigger group, *Your own conclusions — no user signal required*: about to state why something fails, about to act on a belief about a cause, about to brief a subagent.
- The suppression mechanism stated outright, not paraphrased into a bullet: recall fires when you notice a gap; measuring your way to a confident answer removes the felt gap without removing the ignorance.
- `DON'T fire` narrowed from same *topic* to same *question*, plus the boundary from the fact — re-running a test needs no recall, concluding what the failure means does.
- New `## Dispatching subagents` section, including that a subagent's returned cause is itself an assertion worth checking.
- Frontmatter `description` extended so the trigger is visible where the harness advertises the skill.

`tools/bridge/claude/templates/CLAUDE-md-block.txt`

- Two bullets under "Before non-trivial work" (concluding why something fails; briefing a subagent) and a "recall is a habit, not a phase" line.
- Philosophy inverted to name the certain case.

Installed copies (`.claude/skills/knomit-recall/SKILL.md`, `CLAUDE.md`) regenerated from the templates and verified byte-identical to them — `.claude/skills/` is overwritten by `knomit-bridge init` (`isOwnedByIntegration`), and `CLAUDE.md` is merge-required, so a hand-edit that skipped the template would have been silently reverted on the next init.

## Verification

- `go test ./tools/bridge/...` — passing, baseline was green before the change.
- Block and skill diffed against their templates after regeneration: both in sync.

Only these two files carry recall triggers; the other ten skills needed no change.
