### PR TITLE
feat: KB repo layout — README.md, LICENSE, and private dot-paths

### DIFF
--- a/internal/fact/private.go
+++ b/internal/fact/private.go
@@ -1,0 +1,27 @@
+package fact
+
+import "strings"
+
+// IsPrivatePath reports whether any segment of path begins with ".".
+//
+// A dot-prefixed directory or file is MACHINERY, not knowledge: .github/ holds
+// CI config, .domains/ holds the ontology definition. Private paths are
+// excluded from fact DISCOVERY everywhere — the search indexer, Verify, and the
+// OKF exporter all skip them, and the fact-creation paths refuse to allocate
+// one.
+//
+// Private means "not knowledge content", NOT "invisible to knomit". knomit
+// still reads specific known paths by name, which is precisely what lets it
+// load .domains/ontology.yaml. The rule governs walking, never opening.
+//
+// This is a LOCATION test, so it extends the ontology-root scope rule rather
+// than competing with it: membership is decided by where a file sits, never by
+// whether its bytes happen to parse.
+func IsPrivatePath(path string) bool {
+	for _, seg := range strings.Split(path, "/") {
+		if strings.HasPrefix(seg, ".") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/fact/private_test.go
+++ b/internal/fact/private_test.go
@@ -1,0 +1,31 @@
+package fact
+
+import "testing"
+
+func TestIsPrivatePath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"ordinary fact", "kb/architecture/store/a1b2c3d4.md", false},
+		{"leading segment", ".github/workflows/ci.yml", true},
+		{"ontology dir", ".domains/ontology.yaml", true},
+		{"middle segment", "kb/.drafts/a1b2c3d4.md", true},
+		{"filename segment", "kb/architecture/.wip.md", true},
+		{"deep middle segment", "kb/a/b/.c/d.md", true},
+		{"root manifest", "README.md", false},
+		{"licence", "LICENSE", false},
+		{"dot inside a segment", "kb/architecture/v1.2/a1b2c3d4.md", false},
+		{"parent traversal", "kb/../secrets.md", true},
+		{"current dir", "./kb/a/b/c.md", true},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPrivatePath(tc.path); got != tc.want {
+				t.Errorf("IsPrivatePath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -216,6 +216,13 @@ func validateAndBuildFacts(ontology *fact.Ontology, ontologyRoot string, inputs 
 		// Build path with server-generated UUID.
 		path := fact.BuildFactPath(ontologyRoot, fi.Topic, fi.Category)
 
+		// See handlers_fact_create.go: a private path is written and then
+		// ignored by every reader, so it is refused rather than accepted.
+		if fact.IsPrivatePath(path) {
+			return nil, nil, nil, nil, fmt.Errorf(
+				"fact %d: topic/category resolves to %s; a path segment beginning with '.' is private and cannot hold a fact", i, path)
+		}
+
 		domain := fi.Domain
 		if domain == nil {
 			domain = []string{}

--- a/internal/mcp/learn_paths_test.go
+++ b/internal/mcp/learn_paths_test.go
@@ -81,3 +81,27 @@ func TestMergeFacts_LineageRefUsesRawPath(t *testing.T) {
 	// Identity stays normalized — unchanged from the pre-refactor behaviour.
 	require.Equal(t, strings.ToLower(rawPath), merged.Path())
 }
+
+// knomit_learn must refuse exactly what the REST create path refuses: the two
+// share BuildFactPath, so they must share the rule that bounds its output.
+func TestValidateAndBuildFacts_RejectsPrivateTopic(t *testing.T) {
+	_, _, _, _, err := validateAndBuildFacts(nil, "kb", []learnFactInput{
+		{Topic: ".secret", Category: "x", Title: "T", Body: "B"},
+	})
+	if err == nil {
+		t.Fatal("a private topic must be rejected, not allocated")
+	}
+	if !strings.Contains(err.Error(), "private") {
+		t.Errorf("error should name the private-path rule, got %v", err)
+	}
+}
+
+// A private CATEGORY is the same hazard one segment deeper.
+func TestValidateAndBuildFacts_RejectsPrivateCategory(t *testing.T) {
+	_, _, _, _, err := validateAndBuildFacts(nil, "kb", []learnFactInput{
+		{Topic: "decisions", Category: ".wip", Title: "T", Body: "B"},
+	})
+	if err == nil {
+		t.Fatal("a private category must be rejected, not allocated")
+	}
+}

--- a/internal/mcp/update.go
+++ b/internal/mcp/update.go
@@ -95,6 +95,16 @@ func UpdateHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
 		file = factpkg.NormalizePath(ontologyRoot, file)
+		// knomit_learn refuses to ALLOCATE a private path; this refuses to
+		// write one that already exists. Same rule, both halves: a fact under
+		// a dot-prefixed segment is skipped by the indexer, Verify and the OKF
+		// exporter alike, so an update there would commit a revision no reader
+		// ever sees and report success for it. The file stays readable and
+		// deletable — private governs walking, not opening.
+		if factpkg.IsPrivatePath(file) {
+			return mcpgo.NewToolResultError(fmt.Sprintf(
+				"%s is private: a path segment beginning with '.' cannot hold a fact", file)), nil
+		}
 		momentName := req.GetString("moment_name", "")
 		if momentName == "" {
 			return mcpgo.NewToolResultError("moment_name is required"), nil

--- a/internal/mcp/update_test.go
+++ b/internal/mcp/update_test.go
@@ -173,3 +173,47 @@ func TestUpdateHandler_SourcesVerbatimAndOmittedUnchanged(t *testing.T) {
 	update(map[string]any{"sources": 0})
 	require.Equal(t, 0, readSources(), "an explicit 0 is legal (§2.2 requires only >= 0) and must survive")
 }
+
+// knomit_update must refuse a private path for the same reason knomit_learn
+// refuses to allocate one: a fact under a dot-prefixed segment is skipped by
+// the indexer, Verify and the OKF exporter alike, so a revision written there
+// is committed and then permanently invisible — reported as success.
+//
+// The fixture plants the fact by hand (nothing knomit offers CREATES one) and
+// the file therefore EXISTS, which is what makes this test able to fail:
+// without the guard the handler's FactExists check passes and the update
+// lands. The stored content is re-read afterwards to prove the refusal was a
+// refusal, not a write followed by an error.
+func TestUpdateHandler_RejectsPrivatePath(t *testing.T) {
+	svc, ctx, _ := newPrinciplesTestRepo(t)
+
+	const path = "kb/.drafts/aaaaaaaa.md"
+	f := fact.NewFact(path)
+	f.Title = "Hand-placed draft"
+	f.Body = "Parked in the private stash."
+	f.Type = fact.Observation
+	f.Domain = []string{"testing"}
+	f.Confidence = 0.8
+	f.Sources = 1
+	f.Entities = []string{}
+	content, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(ctx, "agent/test", path, content, "seed private draft", "")
+	require.NoError(t, err)
+
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"file":        path,
+		"moment_name": "touch-the-stash",
+		"updates":     map[string]any{"body": "rewritten"},
+	}
+	result, err := UpdateHandler()(ctx, req)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "a private path must be refused, not updated")
+	require.Contains(t, resultText(t, result), "private",
+		"the error must name the private-path rule")
+
+	res, err := svc.Facts().ReadFact(ctx, "agent/test", path, nil)
+	require.NoError(t, err)
+	require.Equal(t, content, res.Content, "the refused update must not have landed")
+}

--- a/internal/okf/source/facts.go
+++ b/internal/okf/source/facts.go
@@ -44,8 +44,9 @@ func okfReadFacts(st storer.EncodedObjectStorer, sourceSHA plumbing.Hash, hist o
 		}
 		parsed, err := fact.ParseFact(f.Name, content)
 		if err != nil {
-			// Non-fact markdown under kb/ (e.g. a stray README or the kb.md
-			// manifest) is skipped: it is simply not a fact to export.
+			// Non-fact markdown under kb/ (e.g. a stray README or the
+			// README.md manifest) is skipped: it is simply not a fact to
+			// export.
 			//
 			// A file that MEANT to be a fact is a different story — dropping it
 			// silently deletes knowledge from a published base — so it is

--- a/internal/okf/source/facts.go
+++ b/internal/okf/source/facts.go
@@ -38,6 +38,12 @@ func okfReadFacts(st storer.EncodedObjectStorer, sourceSHA plumbing.Hash, hist o
 		if !strings.HasPrefix(f.Name, okfOntologyRoot+"/") || !strings.HasSuffix(f.Name, ".md") {
 			return nil
 		}
+		// Private paths are machinery, not knowledge — and crucially they are
+		// skipped BEFORE the looksLikeFact check below, so a hand-placed draft
+		// is never reported as lost knowledge on every single export.
+		if fact.IsPrivatePath(f.Name) {
+			return nil
+		}
 		content, err := f.Contents()
 		if err != nil {
 			return fmt.Errorf("okf: read %s: %w", f.Name, err)

--- a/internal/okf/source/facts_test.go
+++ b/internal/okf/source/facts_test.go
@@ -1,0 +1,27 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The exporter must skip private paths — AND must not report them as
+// unparseable. looksLikeFact would otherwise flag every hand-placed draft as
+// lost knowledge on every single export: a permanent false alarm that trains
+// the reader to ignore a real one.
+func TestLoad_SkipsPrivatePathsWithoutWarning(t *testing.T) {
+	r := newFixtureRepo(t)
+	h := commitFiles(t, r, "seed", "a+learn@agents.knomit.io", map[string]string{
+		"kb/decisions/x/aaaaaaaa.md":      factBody("Alpha", 0.9),
+		"kb/.drafts/bbbbbbbb.md":          factBody("Draft", 0.9),
+		"kb/decisions/x/.wip/cccccccc.md": factBody("Wip", 0.9),
+	})
+
+	snap, err := Load(r.Storer, h)
+	require.NoError(t, err)
+	require.Len(t, snap.Facts, 1)
+	require.Equal(t, "kb/decisions/x/aaaaaaaa.md", snap.Facts[0].Fact.Path())
+	require.Empty(t, snap.Warnings,
+		"a private path is not lost knowledge and must not warn")
+}

--- a/internal/okf/source/facts_test.go
+++ b/internal/okf/source/facts_test.go
@@ -10,12 +10,22 @@ import (
 // unparseable. looksLikeFact would otherwise flag every hand-placed draft as
 // lost knowledge on every single export: a permanent false alarm that trains
 // the reader to ignore a real one.
+//
+// "kb/.drafts/dddddddd.md" is the case that actually pins the ORDER of the
+// guard relative to looksLikeFact: it opens with "---\n" (so looksLikeFact
+// would say yes) but is missing its closing frontmatter delimiter, so
+// fact.ParseFact fails on it. Every other fixture here parses cleanly and
+// therefore never reaches looksLikeFact at all regardless of where the
+// private-path skip sits — this one is what makes a wrong placement (skip
+// applied only after the looksLikeFact check, or not applied to the error
+// branch) visible as a non-empty snap.Warnings.
 func TestLoad_SkipsPrivatePathsWithoutWarning(t *testing.T) {
 	r := newFixtureRepo(t)
 	h := commitFiles(t, r, "seed", "a+learn@agents.knomit.io", map[string]string{
 		"kb/decisions/x/aaaaaaaa.md":      factBody("Alpha", 0.9),
 		"kb/.drafts/bbbbbbbb.md":          factBody("Draft", 0.9),
 		"kb/decisions/x/.wip/cccccccc.md": factBody("Wip", 0.9),
+		"kb/.drafts/dddddddd.md":          "---\nbroken: yes\n",
 	})
 
 	snap, err := Load(r.Storer, h)
@@ -23,5 +33,5 @@ func TestLoad_SkipsPrivatePathsWithoutWarning(t *testing.T) {
 	require.Len(t, snap.Facts, 1)
 	require.Equal(t, "kb/decisions/x/aaaaaaaa.md", snap.Facts[0].Fact.Path())
 	require.Empty(t, snap.Warnings,
-		"a private path is not lost knowledge and must not warn")
+		"a private path is not lost knowledge and must not warn, even one shaped enough to trip looksLikeFact")
 }

--- a/internal/okf/source/history.go
+++ b/internal/okf/source/history.go
@@ -452,6 +452,12 @@ func okfDeletionFromFile(name string, contents func() (string, error)) (okfDelet
 	if !strings.HasPrefix(name, okfOntologyRoot+"/") || !strings.HasSuffix(name, ".md") {
 		return okfDeletion{}, false
 	}
+	// Private paths are machinery, not knowledge — their removal is not the
+	// retirement of a published fact, so the authored-timestamp walk must
+	// agree with the fact walk and skip them the same way.
+	if fact.IsPrivatePath(name) {
+		return okfDeletion{}, false
+	}
 	content, err := contents()
 	if err != nil {
 		return okfDeletion{}, false
@@ -497,6 +503,12 @@ func unchangedInAnotherParent(c *object.Commit, path string, blob plumbing.Hash)
 // for a whole corpus would be pure waste.
 func okfChangeFromFile(name string, created bool, contents func() (string, error)) (okfChange, bool) {
 	if !strings.HasPrefix(name, okfOntologyRoot+"/") || !strings.HasSuffix(name, ".md") {
+		return okfChange{}, false
+	}
+	// Private paths are machinery, not knowledge — this walk feeds authored
+	// time and revision history, and must agree with the fact walk on which
+	// paths those apply to.
+	if fact.IsPrivatePath(name) {
 		return okfChange{}, false
 	}
 	ch := okfChange{path: name, created: created}

--- a/internal/okf/source/ontology.go
+++ b/internal/okf/source/ontology.go
@@ -13,10 +13,14 @@ import (
 
 const okfOntologyRoot = "kb"
 
-// okfOntologyFile is the ontology committed in the repo tree. Reading it at the
+// okfOntologyFile is the ontology committed in the repo tree; okfOntologyFileLegacy
+// is where it lived before moving into a private directory. Reading it at the
 // SOURCE COMMIT (rather than from the live repo instance) keeps the bundle a
 // pure function of that commit — the same determinism guarantee the facts get.
-const okfOntologyFile = "domains/ontology.yaml"
+const (
+	okfOntologyFile       = ".domains/ontology.yaml"
+	okfOntologyFileLegacy = "domains/ontology.yaml"
+)
 
 // okfOntologyDoc reads and flattens the authored ontology at sourceSHA. A
 // missing or unparseable ontology is not an error: the bundle is still fully
@@ -25,12 +29,16 @@ const okfOntologyFile = "domains/ontology.yaml"
 func okfOntologyDoc(st storer.EncodedObjectStorer, sourceSHA plumbing.Hash) (okf.OntologyDoc, []string) {
 	var warnings []string
 	// Mirror how the repo itself resolves its ontology (repos/builder.go):
-	// a committed domains/ontology.yaml wins, otherwise the embedded default,
-	// which is what the repo is actually being validated against. The default
-	// is compiled in, so it is stable for a given build.
+	// a committed ontology (canonical, then legacy) wins, otherwise the
+	// embedded default, which is what the repo is actually being validated
+	// against. The default is compiled in, so it is stable for a given build.
 	ont := fact.DefaultOntology()
 	if commit, err := object.GetCommit(st, sourceSHA); err == nil {
-		if f, err := commit.File(okfOntologyFile); err == nil {
+		f, ferr := commit.File(okfOntologyFile)
+		if ferr != nil {
+			f, ferr = commit.File(okfOntologyFileLegacy)
+		}
+		if ferr == nil {
 			if content, err := f.Contents(); err == nil {
 				parsed, perr := fact.ParseOntology([]byte(content))
 				if perr != nil {

--- a/internal/okf/source/ontology_test.go
+++ b/internal/okf/source/ontology_test.go
@@ -20,7 +20,23 @@ topics:
         description: The OKF export surface
 `
 
-func TestOntology_CommittedFileWins(t *testing.T) {
+// legacyOntologyYAML is testOntologyYAML with a different name:, so a test
+// committing both paths can tell which one was actually read.
+const legacyOntologyYAML = `id: source-code
+name: Legacy Source Code Knowledge
+description: Knowledge categories for AI agents working in a codebase.
+topics:
+  decisions:
+    description: Design choices with rationale
+    children:
+      okf:
+        description: The OKF export surface
+`
+
+// TestOntology_LegacyCommittedFileWins covers the read fallback for repos that
+// predate the move into .domains/: no migration is provided, so the legacy
+// path must still be honoured when it is the only one committed.
+func TestOntology_LegacyCommittedFileWins(t *testing.T) {
 	r := newFixtureRepo(t)
 	h := commitFiles(t, r, "seed", "a+learn@agents.knomit.io", map[string]string{
 		"domains/ontology.yaml":      testOntologyYAML,
@@ -36,6 +52,27 @@ func TestOntology_CommittedFileWins(t *testing.T) {
 	// of the bundle's directory tree.
 	require.Equal(t, "Design choices with rationale", snap.Ontology.Nodes["decisions"])
 	require.Equal(t, "The OKF export surface", snap.Ontology.Nodes["decisions/okf"])
+}
+
+// The canonical private path is preferred over the legacy one.
+//
+// This also exercises Task 5's interaction: .domains/ontology.yaml is a
+// private path, and the exporter must still read it by name while skipping it
+// during the fact walk. If Load returned the default ontology here, the
+// private check would have been wrongly applied to the ontology read.
+func TestOntology_DotDomainsWinsOverLegacy(t *testing.T) {
+	r := newFixtureRepo(t)
+	h := commitFiles(t, r, "seed", "a+learn@agents.knomit.io", map[string]string{
+		".domains/ontology.yaml":     testOntologyYAML,
+		"domains/ontology.yaml":      legacyOntologyYAML,
+		"kb/decisions/x/aaaaaaaa.md": factBody("Alpha", 0.9),
+	})
+
+	snap, err := Load(r.Storer, h)
+	require.NoError(t, err)
+	require.Empty(t, snap.Warnings)
+	require.Equal(t, "Source Code Knowledge", snap.Ontology.Name,
+		".domains/ must win when both are present")
 }
 
 // Absent ⇒ the embedded default, which is what the repo is actually validated

--- a/internal/okf/types.go
+++ b/internal/okf/types.go
@@ -86,7 +86,7 @@ type FactRef struct {
 }
 
 // OntologyDoc carries the knowledge scheme's own authored documentation, read
-// from domains/ontology.yaml in the source tree. Descriptions exist at every
+// from the ontology file in the source tree. Descriptions exist at every
 // level (the scheme itself, each topic, each category), which is exactly the
 // shape of the bundle's directory tree — so they become the `description` OKF
 // recommends for index entries, sourced from authored text rather than

--- a/internal/repos/builder.go
+++ b/internal/repos/builder.go
@@ -200,6 +200,7 @@ func (b *repoBuilder) loadOntology() {
 				log.Info().
 					Str("repo", b.name).
 					Str("preset_id", ont.ID).
+					Str("path", srcPath).
 					Msg("ontology refresh: stored is subset of embedded preset; upgrading to latest")
 				if _, werr := b.svc.Facts().WriteFact(
 					context.Background(),

--- a/internal/repos/builder.go
+++ b/internal/repos/builder.go
@@ -148,18 +148,33 @@ func (b *repoBuilder) rehydrateUpstreamMain() {
 	}
 }
 
-// loadOntology reads domains/ontology.yaml from the repo's agent branch.
-// Falls back to the default ontology if the file is absent or unparseable.
+// loadOntology reads the ontology from the repo's agent branch, preferring
+// OntologyPath and falling back to LegacyOntologyPath for repos that predate
+// the private-directory move (no migration is provided). Falls back to the
+// default ontology if neither file is present or the content is unparseable.
 func (b *repoBuilder) loadOntology() {
 	if b.svc == nil {
 		b.ontology = fact.DefaultOntology()
 		return
 	}
-	result, err := b.svc.Facts().ReadFact(context.Background(), b.agentBranch, "domains/ontology.yaml", nil)
+	// Track the source path: the refresh below writes BACK to it. Always
+	// writing the canonical path would leave a legacy repo holding two
+	// ontology files, the stale one indistinguishable from the live one.
+	srcPath := OntologyPath
+	result, err := b.svc.Facts().ReadFact(context.Background(), b.agentBranch, OntologyPath, nil)
 	if err != nil || result.Content == "" {
-		log.Warn().Str("repo", b.name).Msg("domains/ontology.yaml not found, using default ontology")
+		srcPath = LegacyOntologyPath
+		result, err = b.svc.Facts().ReadFact(context.Background(), b.agentBranch, LegacyOntologyPath, nil)
+	}
+	if err != nil || result.Content == "" {
+		log.Warn().Str("repo", b.name).
+			Msgf("no ontology at %s or %s, using default ontology", OntologyPath, LegacyOntologyPath)
 		b.ontology = fact.DefaultOntology()
 		return
+	}
+	if srcPath == LegacyOntologyPath {
+		log.Info().Str("repo", b.name).
+			Msgf("ontology loaded from the legacy path %s; rename it to %s", LegacyOntologyPath, OntologyPath)
 	}
 	ont, err := fact.ParseOntology([]byte(result.Content))
 	if err != nil {
@@ -189,7 +204,7 @@ func (b *repoBuilder) loadOntology() {
 				if _, werr := b.svc.Facts().WriteFact(
 					context.Background(),
 					b.agentBranch,
-					"domains/ontology.yaml",
+					srcPath,
 					string(presetY),
 					fmt.Sprintf("ontology: refresh to embedded %s preset", ont.ID),
 					"updated",
@@ -243,7 +258,7 @@ func (b *repoBuilder) initDefaultGit() error {
 		return fmt.Errorf("serialize ontology: %w", err)
 	}
 	seedFiles := map[string]string{
-		"domains/ontology.yaml": string(ontologyYAML),
+		OntologyPath: string(ontologyYAML),
 	}
 
 	if b.cfg.Git.Origin != "" {

--- a/internal/repos/builder_adopt_test.go
+++ b/internal/repos/builder_adopt_test.go
@@ -123,7 +123,7 @@ func TestEnsureBranch_AdoptsAgentBranchOnRestoredHome(t *testing.T) {
 }
 
 // TestOpenOne_EnsureBranchRunsBeforeLoadOntology pins the statement order in
-// Manager.openOne. loadOntology reads — and may rewrite — domains/ontology.yaml
+// Manager.openOne. loadOntology reads — and may rewrite — the ontology file
 // on the agent branch, so on a restored home it must run AFTER ensureBranch has
 // adopted that branch. Running it first fell back to the default ontology and
 // skipped the preset refresh on the first boot after a restore, self-correcting
@@ -144,8 +144,12 @@ topics:
     description: Load-bearing rules
 `
 	m1 := bootHome(t, dir, oldAgent)
+	// Overwrite at the canonical path: the initial boot already seeded a
+	// default ontology there, and the canonical path always wins over the
+	// legacy one when both exist, so writing to the legacy path here would be
+	// silently shadowed rather than exercising the restore scenario.
 	_, err := testService(t, m1.Get(config.DefaultRepoName)).Facts().WriteFact(
-		context.Background(), oldAgent, "domains/ontology.yaml", customOntologyYAML,
+		context.Background(), oldAgent, OntologyPath, customOntologyYAML,
 		"test: seed custom ontology", "updated")
 	require.NoError(t, err)
 	_ = m1.Close()

--- a/internal/repos/builder_ontology_test.go
+++ b/internal/repos/builder_ontology_test.go
@@ -8,6 +8,7 @@ import (
 
 	"knomit/internal/config"
 	"knomit/internal/fact"
+	"knomit/internal/store"
 )
 
 // TestLoadOntology_fallsBackToDefault verifies that a repo with no
@@ -22,12 +23,23 @@ func TestLoadOntology_fallsBackToDefault(t *testing.T) {
 	require.NotNil(t, b.ontology)
 }
 
-// bootKnomitWithStaleOntology starts a Manager once to bootstrap the default
-// repo, then overwrites domains/ontology.yaml on the agent branch with the
-// provided YAML, then closes the manager. The returned dir + agent branch
-// can be passed to a second New(...)/Start() pair to exercise loadOntology
-// against a stored ontology that lags the embedded preset.
-func bootKnomitWithStaleOntology(t *testing.T, staleYAML string) (dir, agentBranch string) {
+// staleCodeOntologyYAML is a minimal source-code ontology: same id as
+// CodeOntology but only one topic. CodeOntology has 8 topics (including
+// "incidents", checked below), so this is a strict subset — shared by every
+// test that needs a stored ontology lagging the embedded preset.
+const staleCodeOntologyYAML = `id: source-code
+name: Source Code Knowledge
+description: stale
+topics:
+  invariants:
+    description: Load-bearing rules
+`
+
+// bootKnomitWithStaleOntologyAt is bootKnomitWithStaleOntology with an explicit
+// ontology path, so a test can seed the canonical or the legacy location.
+// Body is identical to the original with ontologyPath substituted for the
+// hard-coded "domains/ontology.yaml" argument to WriteFact.
+func bootKnomitWithStaleOntologyAt(t *testing.T, ontologyPath, staleYAML string) (dir, agentBranch string) {
 	t.Helper()
 	dir = t.TempDir()
 	agentBranch = "agent/test-stale"
@@ -45,7 +57,7 @@ func bootKnomitWithStaleOntology(t *testing.T, staleYAML string) (dir, agentBran
 	_, err := testService(t, ri).Facts().WriteFact(
 		context.Background(),
 		agentBranch,
-		"domains/ontology.yaml",
+		ontologyPath,
 		staleYAML,
 		"test: seed stale ontology",
 		"updated",
@@ -56,22 +68,114 @@ func bootKnomitWithStaleOntology(t *testing.T, staleYAML string) (dir, agentBran
 	return dir, agentBranch
 }
 
+// bootKnomitWithLegacyOnlyOntology seeds the legacy path and REMOVES the
+// canonical one, reproducing an unmigrated repo exactly. Same body as
+// bootKnomitWithStaleOntologyAt(t, LegacyOntologyPath, staleYAML) plus, before
+// m.Close(), deleting the canonical file that the initial boot seeded — a
+// freshly-seeded repo always has a canonical ontology after Task 7's seed
+// change, so a legacy-only fixture must remove it or the fallback path this
+// helper exists to exercise is never actually hit.
+func bootKnomitWithLegacyOnlyOntology(t *testing.T, staleYAML string) (dir, agentBranch string) {
+	t.Helper()
+	dir = t.TempDir()
+	agentBranch = "agent/test-stale"
+
+	m := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: dir},
+		AgentBranch: agentBranch,
+	})
+	require.NoError(t, m.Start())
+
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	_, err := testService(t, ri).Facts().WriteFact(
+		context.Background(),
+		agentBranch,
+		LegacyOntologyPath,
+		staleYAML,
+		"test: seed stale ontology",
+		"updated",
+	)
+	require.NoError(t, err)
+
+	_, err = testService(t, ri).Facts().DeleteFact(
+		context.Background(), agentBranch, OntologyPath, "test: remove canonical ontology")
+	require.NoError(t, err)
+
+	require.NoError(t, m.Close())
+	return dir, agentBranch
+}
+
+// The canonical path wins when both exist.
+func TestLoadOntology_PrefersDotDomains(t *testing.T) {
+	dir, agentBranch := bootKnomitWithStaleOntologyAt(t, OntologyPath, staleCodeOntologyYAML)
+
+	m := New(context.Background(), Deps{
+		Cfg: config.Config{Home: dir}, AgentBranch: agentBranch,
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+	require.Equal(t, "source-code", ri.Ontology().ID)
+}
+
+// No migration is provided, so an unmigrated repo must keep validating
+// against ITS ontology. Falling through to DefaultOntology would silently
+// start accepting facts under topics this repo does not have.
+func TestLoadOntology_FallsBackToLegacyDomains(t *testing.T) {
+	dir, agentBranch := bootKnomitWithLegacyOnlyOntology(t, staleCodeOntologyYAML)
+
+	m := New(context.Background(), Deps{
+		Cfg: config.Config{Home: dir}, AgentBranch: agentBranch,
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+	require.Equal(t, "source-code", ri.Ontology().ID,
+		"the legacy ontology must be honoured, not replaced by the default")
+}
+
+// THE regression guard for this task. The stored ontology is a strict subset
+// of the embedded preset, so the boot-time refresh fires and rewrites it. If
+// that write went to the canonical path, a legacy repo would end up holding
+// TWO ontology files, the stale one indistinguishable from the live one.
+func TestLoadOntology_RefreshWritesBackToLegacyPath(t *testing.T) {
+	dir, agentBranch := bootKnomitWithLegacyOnlyOntology(t, staleCodeOntologyYAML)
+
+	m := New(context.Background(), Deps{
+		Cfg: config.Config{Home: dir}, AgentBranch: agentBranch,
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		legacy, rerr := svc.Facts().ReadFact(context.Background(), agentBranch, LegacyOntologyPath, nil)
+		require.NoError(t, rerr)
+		require.Contains(t, legacy.Content, "incidents",
+			"the refresh must land on the path it read from")
+
+		exists, eerr := svc.Facts().FactExists(context.Background(), agentBranch, OntologyPath)
+		require.NoError(t, eerr)
+		require.False(t, exists,
+			"a legacy repo must not grow a second ontology file")
+	}))
+}
+
 // TestLoadOntology_RefreshesPresetDerivedSubset seeds a repo with a stored
 // ontology that is a strict subset of the current CodeOntology embedded
 // preset, then re-opens the repo. loadOntology must detect the lag and
 // rewrite domains/ontology.yaml with the latest preset, and b.ontology must
 // reflect the upgraded version.
 func TestLoadOntology_RefreshesPresetDerivedSubset(t *testing.T) {
-	// A minimal source-code ontology: same id as CodeOntology but only one
-	// topic. CodeOntology has 8 topics, so this is a strict subset.
-	const staleYAML = `id: source-code
-name: Source Code Knowledge
-description: stale
-topics:
-  invariants:
-    description: Load-bearing rules
-`
-	dir, agentBranch := bootKnomitWithStaleOntology(t, staleYAML)
+	dir, agentBranch := bootKnomitWithStaleOntologyAt(t, OntologyPath, staleCodeOntologyYAML)
 
 	// Reopen against the same on-disk state — loadOntology should now run
 	// the refresh path and rewrite the stored ontology to match CodeOntology.
@@ -92,13 +196,13 @@ topics:
 		"refreshed ontology must include the principles topic from the latest preset")
 
 	// The on-branch file must match CodeOntology().Serialize().
-	result, err := testService(t, ri).Facts().ReadFact(context.Background(), agentBranch, "domains/ontology.yaml", nil)
+	result, err := testService(t, ri).Facts().ReadFact(context.Background(), agentBranch, OntologyPath, nil)
 	require.NoError(t, err)
 
 	expectedY, err := fact.CodeOntology().Serialize()
 	require.NoError(t, err)
 	require.Equal(t, string(expectedY), result.Content,
-		"domains/ontology.yaml on the agent branch must be rewritten to the embedded CodeOntology preset")
+		"the ontology on the agent branch must be rewritten to the embedded CodeOntology preset")
 }
 
 // TestLoadOntology_PreservesDivergedOntology seeds a repo with an ontology
@@ -118,7 +222,7 @@ topics:
   my-custom-topic:
     description: A user-only topic not in any embedded preset
 `
-	dir, agentBranch := bootKnomitWithStaleOntology(t, divergedYAML)
+	dir, agentBranch := bootKnomitWithStaleOntologyAt(t, OntologyPath, divergedYAML)
 
 	m := New(context.Background(), Deps{
 		Cfg:         config.Config{Home: dir},
@@ -139,8 +243,8 @@ topics:
 		"diverged ontology must NOT be refreshed; preset-only topics must NOT appear")
 
 	// The on-branch file must still match the diverged YAML.
-	result, err := testService(t, ri).Facts().ReadFact(context.Background(), agentBranch, "domains/ontology.yaml", nil)
+	result, err := testService(t, ri).Facts().ReadFact(context.Background(), agentBranch, OntologyPath, nil)
 	require.NoError(t, err)
 	require.Equal(t, divergedYAML, result.Content,
-		"domains/ontology.yaml on the agent branch must NOT be rewritten when the stored ontology has diverged from the preset")
+		"the ontology on the agent branch must NOT be rewritten when the stored ontology has diverged from the preset")
 }

--- a/internal/repos/builder_ontology_test.go
+++ b/internal/repos/builder_ontology_test.go
@@ -107,9 +107,67 @@ func bootKnomitWithLegacyOnlyOntology(t *testing.T, staleYAML string) (dir, agen
 	return dir, agentBranch
 }
 
-// The canonical path wins when both exist.
+// canonicalWinsYAML and legacyLosesYAML seed the two competing files in
+// TestLoadOntology_PrefersDotDomains with DIFFERENT ids — neither matching an
+// embedded preset — so (a) the assertion can tell which file was actually
+// read, mirroring the discrimination TestOntology_DotDomainsWinsOverLegacy
+// (internal/okf/source/ontology_test.go) applies to the exporter's own
+// ontology reader, and (b) EmbeddedPresetByID returns nil for both, keeping
+// the boot-time refresh (which rewrites srcPath when the stored ontology is a
+// preset subset) out of play — this test is purely about read preference.
+const canonicalWinsYAML = `id: canonical-wins
+name: Canonical Ontology
+description: seeded at .domains/ontology.yaml
+topics:
+  invariants:
+    description: Load-bearing rules
+`
+
+const legacyLosesYAML = `id: legacy-loses
+name: Legacy Ontology
+description: seeded at domains/ontology.yaml
+topics:
+  invariants:
+    description: Load-bearing rules
+`
+
+// bootKnomitWithBothOntologies seeds distinguishable ontologies at BOTH the
+// canonical and the legacy path, reproducing a repo that holds both (e.g.
+// mid hand-migration) — the only fixture that actually exercises "wins when
+// both exist"; bootKnomitWithStaleOntologyAt alone seeds just one path.
+func bootKnomitWithBothOntologies(t *testing.T, canonicalYAML, legacyYAML string) (dir, agentBranch string) {
+	t.Helper()
+	dir = t.TempDir()
+	agentBranch = "agent/test-stale"
+
+	m := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: dir},
+		AgentBranch: agentBranch,
+	})
+	require.NoError(t, m.Start())
+
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	_, err := testService(t, ri).Facts().WriteFact(
+		context.Background(), agentBranch, OntologyPath, canonicalYAML,
+		"test: seed canonical ontology", "updated")
+	require.NoError(t, err)
+
+	_, err = testService(t, ri).Facts().WriteFact(
+		context.Background(), agentBranch, LegacyOntologyPath, legacyYAML,
+		"test: seed legacy ontology alongside canonical", "updated")
+	require.NoError(t, err)
+
+	require.NoError(t, m.Close())
+	return dir, agentBranch
+}
+
+// The canonical path wins when both exist. Without bootKnomitWithBothOntologies
+// seeding the legacy file too, this test could not fail: there would be
+// nothing else for the canonical to "win" over.
 func TestLoadOntology_PrefersDotDomains(t *testing.T) {
-	dir, agentBranch := bootKnomitWithStaleOntologyAt(t, OntologyPath, staleCodeOntologyYAML)
+	dir, agentBranch := bootKnomitWithBothOntologies(t, canonicalWinsYAML, legacyLosesYAML)
 
 	m := New(context.Background(), Deps{
 		Cfg: config.Config{Home: dir}, AgentBranch: agentBranch,
@@ -119,7 +177,8 @@ func TestLoadOntology_PrefersDotDomains(t *testing.T) {
 
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
-	require.Equal(t, "source-code", ri.Ontology().ID)
+	require.Equal(t, "canonical-wins", ri.Ontology().ID,
+		"the canonical .domains/ontology.yaml must win when a legacy domains/ontology.yaml also exists")
 }
 
 // No migration is provided, so an unmigrated repo must keep validating

--- a/internal/repos/init_ontology_test.go
+++ b/internal/repos/init_ontology_test.go
@@ -25,7 +25,7 @@ func TestBoot_firstRunWritesOntologyToAgentBranch(t *testing.T) {
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
 
-	result, err := testService(t, ri).Facts().ReadFact(context.Background(), "agent/test-abc", "domains/ontology.yaml", nil)
+	result, err := testService(t, ri).Facts().ReadFact(context.Background(), "agent/test-abc", OntologyPath, nil)
 	require.NoError(t, err, "ontology must be readable from agent branch after init")
 	require.NotEmpty(t, result.Content, "ontology file must have content on agent branch")
 }
@@ -54,7 +54,7 @@ func TestBoot_firstRunWithEmptyRemoteWritesOntology(t *testing.T) {
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
 
-	result, err := testService(t, ri).Facts().ReadFact(context.Background(), "agent/test-abc", "domains/ontology.yaml", nil)
+	result, err := testService(t, ri).Facts().ReadFact(context.Background(), "agent/test-abc", OntologyPath, nil)
 	require.NoError(t, err, "ontology must be readable from agent branch after init from empty remote")
 	require.NotEmpty(t, result.Content, "ontology file must have content on agent branch")
 }

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -330,7 +330,7 @@ func (m *Manager) initLocal(ctx context.Context, spec CreateSpec, dbPath string,
 	svc.SetNetworkTimeout(m.deps.Cfg.Git.NetworkTimeout)
 	svc.SetOntologyRoot(m.deps.Cfg.OntologyRoot)
 	if err := svc.InitRepo(map[string]string{
-		"domains/ontology.yaml": string(y),
+		OntologyPath: string(y),
 	}, m.deps.AgentBranch); err != nil {
 		return fmt.Errorf("init git: %w", err)
 	}

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -683,7 +683,7 @@ func (m *Manager) openOne(name, dbPath string, isDefault bool) (*RepoInstance, e
 	}
 	// ensureBranch must run before loadOntology: on a restored/copied home the
 	// configured agent branch is absent until ensureBranch adopts it (issue
-	// #32), and loadOntology reads (and may rewrite) domains/ontology.yaml on
+	// #32), and loadOntology reads (and may rewrite) the ontology file on
 	// that branch. Running loadOntology first would fall back to the default
 	// ontology and skip the preset-refresh on the first boot after a restore.
 	b.ensureBranch()

--- a/internal/repos/manager_rescan_test.go
+++ b/internal/repos/manager_rescan_test.go
@@ -43,7 +43,7 @@ func initRepoFile(t *testing.T, home, name string) {
 	ontYAML, err := fact.DefaultOntology().Serialize()
 	require.NoError(t, err)
 	require.NoError(t, svc.InitRepo(map[string]string{
-		"domains/ontology.yaml": string(ontYAML),
+		repos.OntologyPath: string(ontYAML),
 	}, "machine/test"))
 }
 

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -9,37 +9,42 @@ import (
 )
 
 var (
-	// ErrRepoDescriptionTooLong is returned by WriteKBManifest when content
+	// ErrRepoDescriptionTooLong is returned by WriteReadme when content
 	// exceeds MaxRepoDescriptionBytes. Mirrors ErrLensDescriptionTooLong: the
 	// cap is a pure input check, enforced here rather than at the HTTP edge so
-	// every writer of kb.md is bound by it.
+	// every writer of README.md is bound by it.
 	ErrRepoDescriptionTooLong = errors.New("repo description too long")
 	// ErrAgentBranchUnset is returned when the repo has no agent branch yet, so
 	// there is no ref to read the manifest from or commit it to.
 	ErrAgentBranchUnset = errors.New("repo has no agent branch")
 )
 
-// MaxRepoDescriptionBytes caps the kb.md root manifest. Byte length, not rune
-// count: it bounds stored + wire size. Deliberately far larger than
+// MaxRepoDescriptionBytes caps the README.md root manifest. Byte length, not
+// rune count: it bounds stored + wire size. Deliberately far larger than
 // MaxLensDescriptionBytes — a lens description is a one-line note about a read
-// union, whereas kb.md is a repo's root manifest and routinely runs to several
-// pages of guidance for the agents reading it.
+// union, whereas README.md is a repo's root manifest and routinely runs to
+// several pages of guidance for the agents reading it.
 const MaxRepoDescriptionBytes = 64 * 1024
 
-// KBManifestPath is the repo's root manifest, at the root of the tree rather
-// than under the ontology root: it is not a fact. The search indexer skips it
-// as unparseable and the commits list filters to ontologyRoot, so writing it
-// moves the file and its commit-log row, never the fact index or the history UI.
-const KBManifestPath = "kb.md"
+// ReadmePath is the repo's root manifest, at the root of the tree rather than
+// under the ontology root: it is not a fact. The search indexer skips it (the
+// ontology-root location rule) and the commits list filters to ontologyRoot, so
+// writing it moves the file and its commit-log row, never the fact index or the
+// history UI.
+//
+// The name is not knomit's choice — every major git provider renders README.md
+// at the repo root as the repository description, which is exactly what this
+// file is. Case matters to that lookup, so writes go through WriteRootFile.
+const ReadmePath = "README.md"
 
-// kbManifestCommitMsg is the commit subject for every manifest edit, so the
-// git log reads uniformly regardless of which client made the change.
-const kbManifestCommitMsg = "docs: update kb.md root manifest"
+// readmeCommitMsg is the commit subject for every manifest edit, so the git log
+// reads uniformly regardless of which client made the change.
+const readmeCommitMsg = "docs: update README.md"
 
-// ReadKBManifest returns the verbatim content of kb.md at the tip of the repo's
-// agent branch. A missing manifest is not an error — it returns "" with a nil
-// error, because "this repo has no description" is an ordinary state.
-func (ri *RepoInstance) ReadKBManifest(ctx context.Context) (string, error) {
+// ReadReadme returns the verbatim content of README.md at the tip of the
+// repo's agent branch. A missing manifest is not an error — it returns "" with
+// a nil error, because "this repo has no description" is an ordinary state.
+func (ri *RepoInstance) ReadReadme(ctx context.Context) (string, error) {
 	branch := ri.agentBranch
 	if branch == "" {
 		return "", ErrAgentBranchUnset
@@ -48,7 +53,7 @@ func (ri *RepoInstance) ReadKBManifest(ctx context.Context) (string, error) {
 	// WithRead's contract: fn does not run unless a live service is available,
 	// and the error says why — so there is no nil svc to guard against here.
 	err := ri.WithRead(func(svc *store.Service) {
-		res, rerr := svc.Facts().ReadFact(ctx, branch, KBManifestPath, nil)
+		res, rerr := svc.Facts().ReadFact(ctx, branch, ReadmePath, nil)
 		if rerr != nil {
 			return // absent (or unreadable) — no description to report
 		}
@@ -57,17 +62,17 @@ func (ri *RepoInstance) ReadKBManifest(ctx context.Context) (string, error) {
 	return content, err
 }
 
-// WriteKBManifest commits content to kb.md on the repo's agent branch — the
-// exact file and branch ReadKBManifest reads, so an edit round-trips. It
-// reports whether a commit was made: a byte-identical manifest is skipped,
-// because the store's write path always builds a fresh commit object and
-// re-saving unchanged text would otherwise append an empty commit to the agent
-// branch (and push it to the remote).
+// WriteReadme commits content to README.md on the repo's agent branch — the
+// exact file and branch ReadReadme reads, so an edit round-trips. It reports
+// whether a commit was made: a byte-identical manifest is skipped, because the
+// store's write path always builds a fresh commit object and re-saving
+// unchanged text would otherwise append an empty commit to the agent branch
+// (and push it to the remote).
 //
 // The read-compare-write is not atomic. That is the same last-write-wins
 // contract the fact-write path already has: a racing writer can turn this call
 // into a no-op, and the loser's content is what a subsequent read returns.
-func (ri *RepoInstance) WriteKBManifest(ctx context.Context, content string) (committed bool, err error) {
+func (ri *RepoInstance) WriteReadme(ctx context.Context, content string) (committed bool, err error) {
 	if len(content) > MaxRepoDescriptionBytes {
 		return false, fmt.Errorf("%w: %d bytes exceeds the maximum of %d",
 			ErrRepoDescriptionTooLong, len(content), MaxRepoDescriptionBytes)
@@ -81,11 +86,11 @@ func (ri *RepoInstance) WriteKBManifest(ctx context.Context, content string) (co
 	// store, in which case fn never ran at all. Dropping it would turn "the
 	// write never happened" into a silent success.
 	acquireErr := ri.WithRead(func(svc *store.Service) {
-		if cur, rerr := svc.Facts().ReadFact(ctx, branch, KBManifestPath, nil); rerr == nil && cur.Content == content {
+		if cur, rerr := svc.Facts().ReadFact(ctx, branch, ReadmePath, nil); rerr == nil && cur.Content == content {
 			return
 		}
-		if _, werr := svc.Facts().WriteFact(ctx, branch, KBManifestPath,
-			content, kbManifestCommitMsg, "update"); werr != nil {
+		if _, werr := svc.Facts().WriteRootFile(ctx, branch, ReadmePath,
+			content, readmeCommitMsg, "update"); werr != nil {
 			writeErr = werr
 			return
 		}

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -122,6 +122,12 @@ const LegacyOntologyPath = "domains/ontology.yaml"
 //
 // Read-only by design: a licence is authored by whoever owns the repo, and
 // knomit reports it rather than offering to write one.
+//
+// Deliberately one filename only: ReadLicense below resolves it through
+// ReadFact, which matches case-insensitively (so "license" is found), but it
+// tries no alternate names — "LICENSE.md", "LICENSE.txt" and "COPYING" are
+// not found. A known limit, not an oversight; widening it is a real feature
+// and out of scope here.
 const LicensePath = "LICENSE"
 
 // ReadLicense returns the verbatim content of LICENSE at the tip of the repo's

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -123,11 +123,11 @@ const LegacyOntologyPath = "domains/ontology.yaml"
 // Read-only by design: a licence is authored by whoever owns the repo, and
 // knomit reports it rather than offering to write one.
 //
-// Deliberately one filename only: ReadLicense below resolves it through
-// ReadFact, which matches case-insensitively (so "license" is found), but it
-// tries no alternate names — "LICENSE.md", "LICENSE.txt" and "COPYING" are
-// not found. A known limit, not an oversight; widening it is a real feature
-// and out of scope here.
+// Deliberately this one spelling only. ReadLicense below resolves it through
+// ReadFact, which bottoms out in go-git's Tree.FindEntry — an EXACT tree-entry
+// lookup, not a case-insensitive one. So "license" and "License" are not found
+// either, nor are "LICENSE.md", "LICENSE.txt" and "COPYING". A known limit, not
+// an oversight; widening it is a real feature and out of scope here.
 const LicensePath = "LICENSE"
 
 // ReadLicense returns the verbatim content of LICENSE at the tip of the repo's

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
+
 	"knomit/internal/store"
 )
 
@@ -100,4 +102,40 @@ func (ri *RepoInstance) WriteReadme(ctx context.Context, content string) (commit
 		return false, acquireErr
 	}
 	return committed, writeErr
+}
+
+// LicensePath is the terms under which the KB's content is published, at the
+// tree root beside README.md. Like the manifest it is not a fact, and like the
+// manifest git providers look for it by this exact name.
+//
+// Read-only by design: a licence is authored by whoever owns the repo, and
+// knomit reports it rather than offering to write one.
+const LicensePath = "LICENSE"
+
+// ReadLicense returns the verbatim content of LICENSE at the tip of the repo's
+// agent branch. A missing licence is not an error — it returns "" with a nil
+// error, because "this KB states no terms" is an ordinary state.
+//
+// Content over MaxRepoDescriptionBytes is reported as absent: this is a
+// RESPONSE guard (there is no write path to reject on), and GPL-3 at ~35KB
+// leaves ample headroom, so nothing legitimate trips it.
+func (ri *RepoInstance) ReadLicense(ctx context.Context) (string, error) {
+	branch := ri.agentBranch
+	if branch == "" {
+		return "", ErrAgentBranchUnset
+	}
+	var content string
+	err := ri.WithRead(func(svc *store.Service) {
+		res, rerr := svc.Facts().ReadFact(ctx, branch, LicensePath, nil)
+		if rerr != nil {
+			return // absent (or unreadable) — no terms to report
+		}
+		if len(res.Content) > MaxRepoDescriptionBytes {
+			log.Warn().Str("repo", ri.Name()).Int("bytes", len(res.Content)).
+				Msg("LICENSE exceeds the read guard; reporting no licence")
+			return
+		}
+		content = res.Content
+	})
+	return content, err
 }

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -104,6 +104,18 @@ func (ri *RepoInstance) WriteReadme(ctx context.Context, content string) (commit
 	return committed, writeErr
 }
 
+// OntologyPath is the ontology definition, in a PRIVATE directory: it is
+// configuration, not knowledge, so it sits outside fact discovery entirely
+// (see fact.IsPrivatePath). knomit reads it by name, which the private rule
+// explicitly permits.
+const OntologyPath = ".domains/ontology.yaml"
+
+// LegacyOntologyPath is where the ontology lived before it moved into a
+// private directory. Read-only and read-second: no migration is provided, so
+// an unmigrated repo must keep validating against ITS ontology rather than
+// silently falling back to the embedded default.
+const LegacyOntologyPath = "domains/ontology.yaml"
+
 // LicensePath is the terms under which the KB's content is published, at the
 // tree root beside README.md. Like the manifest it is not a fact, and like the
 // manifest git providers look for it by this exact name.

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -8,66 +8,104 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/config"
+	"knomit/internal/store"
 )
+
+// The file must land at README.md with its case intact — a git provider looks
+// for that exact name, and case-preservation is the whole point of the rename.
+func TestWriteReadme_LandsAtExactPath(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	committed, err := ri.WriteReadme(context.Background(), "# my kb")
+	require.NoError(t, err)
+	require.True(t, committed)
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		paths, lerr := svc.Facts().ListAll(context.Background(), ri.AgentBranch())
+		require.NoError(t, lerr)
+		require.Contains(t, paths, "README.md")
+		require.NotContains(t, paths, "readme.md")
+	}))
+}
+
+// Clean break: kb.md is not read. A repo that still has one reports no
+// description, which is the ordinary "no manifest" state.
+func TestReadReadme_IgnoresLegacyKBMd(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteFact(context.Background(), ri.AgentBranch(),
+			"kb.md", "# legacy manifest", "seed legacy", "update")
+		require.NoError(t, werr)
+	}))
+
+	got, err := ri.ReadReadme(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
 
 // A write to a torn-down instance must report the failure. WithRead does not
 // invoke fn when no store is reachable, so an implementation that only captures
 // errors set inside the closure returns nil — reporting success for a write
 // that never happened.
-func TestWriteKBManifest_ClosedInstance_ReportsError(t *testing.T) {
+func TestWriteReadme_ClosedInstance_ReportsError(t *testing.T) {
 	m := newLifetimeTestManager(t)
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
 
 	ri.shutdown()
 
-	committed, err := ri.WriteKBManifest(context.Background(), "# after close")
+	committed, err := ri.WriteReadme(context.Background(), "# after close")
 	require.ErrorIs(t, err, ErrRepoClosed)
 	require.False(t, committed)
 }
 
-// The cap is enforced in the domain, so every writer of kb.md is bound by it —
-// not only the HTTP handler.
-func TestWriteKBManifest_EnforcesCap(t *testing.T) {
+// The cap is enforced in the domain, so every writer of README.md is bound by
+// it — not only the HTTP handler.
+func TestWriteReadme_EnforcesCap(t *testing.T) {
 	m := newLifetimeTestManager(t)
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
 
-	_, err := ri.WriteKBManifest(context.Background(), strings.Repeat("x", MaxRepoDescriptionBytes+1))
+	_, err := ri.WriteReadme(context.Background(), strings.Repeat("x", MaxRepoDescriptionBytes+1))
 	require.ErrorIs(t, err, ErrRepoDescriptionTooLong)
 
 	// The rejected write must not have landed.
-	got, err := ri.ReadKBManifest(context.Background())
+	got, err := ri.ReadReadme(context.Background())
 	require.NoError(t, err)
 	require.NotContains(t, got, strings.Repeat("x", 64))
 
-	committed, err := ri.WriteKBManifest(context.Background(), strings.Repeat("x", MaxRepoDescriptionBytes))
+	committed, err := ri.WriteReadme(context.Background(), strings.Repeat("x", MaxRepoDescriptionBytes))
 	require.NoError(t, err)
 	require.True(t, committed, "an at-cap description is accepted")
 }
 
 // Round-trip plus the unchanged-content skip: re-writing identical bytes
 // reports committed=false and leaves the content in place.
-func TestWriteKBManifest_RoundTripsAndSkipsUnchanged(t *testing.T) {
+func TestWriteReadme_RoundTripsAndSkipsUnchanged(t *testing.T) {
 	m := newLifetimeTestManager(t)
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
 	ctx := context.Background()
 
 	const md = "# Core\n\n| a | b |\n|---|---|\n| 1 | 2 |\n"
-	committed, err := ri.WriteKBManifest(ctx, md)
+	committed, err := ri.WriteReadme(ctx, md)
 	require.NoError(t, err)
 	require.True(t, committed)
 
-	got, err := ri.ReadKBManifest(ctx)
+	got, err := ri.ReadReadme(ctx)
 	require.NoError(t, err)
 	require.Equal(t, md, got, "stored byte-for-byte")
 
-	committed, err = ri.WriteKBManifest(ctx, md)
+	committed, err = ri.WriteReadme(ctx, md)
 	require.NoError(t, err)
 	require.False(t, committed, "identical content must not produce a commit")
 
-	got, err = ri.ReadKBManifest(ctx)
+	got, err = ri.ReadReadme(ctx)
 	require.NoError(t, err)
 	require.Equal(t, md, got, "a skipped write leaves the manifest intact")
 }

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -30,22 +30,28 @@ func TestWriteReadme_LandsAtExactPath(t *testing.T) {
 	}))
 }
 
-// Clean break: kb.md is not read. A repo that still has one reports no
-// description, which is the ordinary "no manifest" state.
+// Clean break: kb.md is never read, even when a real README.md exists right
+// alongside it (InitRepo seeds one). Plant a kb.md with distinctive content
+// and assert ReadReadme returns the seeded README.md and never the legacy
+// content — stronger than merely checking for emptiness, since it proves the
+// legacy file is ignored rather than merely that no manifest happens to be
+// found.
 func TestReadReadme_IgnoresLegacyKBMd(t *testing.T) {
 	m := newLifetimeTestManager(t)
 	ri := m.Get(config.DefaultRepoName)
 	require.NotNil(t, ri)
 
+	const legacy = "# legacy manifest, must never surface"
 	require.NoError(t, ri.WithRead(func(svc *store.Service) {
 		_, werr := svc.Facts().WriteFact(context.Background(), ri.AgentBranch(),
-			"kb.md", "# legacy manifest", "seed legacy", "update")
+			"kb.md", legacy, "seed legacy", "update")
 		require.NoError(t, werr)
 	}))
 
 	got, err := ri.ReadReadme(context.Background())
 	require.NoError(t, err)
-	require.Empty(t, got)
+	require.NotContains(t, got, legacy, "the legacy kb.md must never be read")
+	require.Contains(t, got, "Root manifest.", "ReadReadme must still return the README.md seeded at init")
 }
 
 // A write to a torn-down instance must report the failure. WithRead does not

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -163,3 +163,26 @@ func TestWriteReadme_RoundTripsAndSkipsUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, md, got, "a skipped write leaves the manifest intact")
 }
+
+// The one spelling is LICENSE, exactly. ReadFact bottoms out in go-git's
+// Tree.FindEntry — an exact tree-entry lookup, not a case-insensitive one — so
+// a repo carrying "license" or "License" reports no terms. That is the
+// documented limit on LicensePath; this pins it so the doc cannot drift back
+// into claiming a case-insensitive resolution the read path does not do.
+func TestReadLicense_IsCaseSensitive(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		for _, name := range []string{"license", "License"} {
+			_, werr := svc.Facts().WriteRootFile(context.Background(), ri.AgentBranch(),
+				name, "MIT License\n", "docs: add "+name, "update")
+			require.NoError(t, werr)
+		}
+	}))
+
+	got, err := ri.ReadLicense(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, got, "only the exact name LICENSE is resolved")
+}

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -90,6 +90,54 @@ func TestWriteReadme_EnforcesCap(t *testing.T) {
 	require.True(t, committed, "an at-cap description is accepted")
 }
 
+// An unlicensed KB is an ordinary state, not an error.
+func TestReadLicense_AbsentIsNotAnError(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	got, err := ri.ReadLicense(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// Verbatim: a licence is a legal text, and reformatting it is not knomit's
+// call. Round-trip the exact bytes, newlines included.
+func TestReadLicense_ReturnsVerbatim(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	const mit = "MIT License\n\nPermission is hereby granted, free of charge,\nto any person obtaining a copy...\n"
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteRootFile(context.Background(), ri.AgentBranch(),
+			"LICENSE", mit, "docs: add LICENSE", "update")
+		require.NoError(t, werr)
+	}))
+
+	got, err := ri.ReadLicense(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, mit, got)
+}
+
+// The read guard bounds the wire response. There is no write path to reject
+// on, so an oversized file degrades to "no licence" rather than streaming.
+func TestReadLicense_OverCapIsOmitted(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(config.DefaultRepoName)
+	require.NotNil(t, ri)
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteRootFile(context.Background(), ri.AgentBranch(),
+			"LICENSE", strings.Repeat("x", MaxRepoDescriptionBytes+1), "docs: add LICENSE", "update")
+		require.NoError(t, werr)
+	}))
+
+	got, err := ri.ReadLicense(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
 // Round-trip plus the unchanged-content skip: re-writing identical bytes
 // reports committed=false and leaves the content in place.
 func TestWriteReadme_RoundTripsAndSkipsUnchanged(t *testing.T) {

--- a/internal/store/fact_history.go
+++ b/internal/store/fact_history.go
@@ -73,7 +73,7 @@ func commitEntries(c *object.Commit, files []changedFileEntry) []storegit.Commit
 // changedFilesInCommit returns every file added/modified/deleted in c.
 // Historically this filtered to .md files only, but that left commit_log
 // sparse for any commit that touched non-.md files (e.g. the InitRepo
-// commit that seeds domains/ontology.yaml). The Verify tool's commit-log
+// commit that seeds .domains/ontology.yaml). The Verify tool's commit-log
 // parity check (Task 1.3) requires every reachable commit to have at least
 // one commit_log row, so the filter was removed in 2026-04-08. Callers
 // that need a .md-only view must filter themselves.

--- a/internal/store/fact_write.go
+++ b/internal/store/fact_write.go
@@ -24,10 +24,19 @@ func validatePath(path string) error {
 	return nil
 }
 
-// writeFile writes content to path in a new commit with message on branch.
-// Returns the commit hash and the blob hash of the written file.
+// writeFile writes content to path in a new commit with message on branch,
+// normalizing case first. Returns the commit hash and the blob hash.
+//
+// The lowercasing keeps FACT paths free of case-duplicate topics ("AI" vs
+// "ai") — see fact.NormalizePath. It is a fact-path rule, not a storage rule,
+// so writeFileExact is the door for files that are not facts.
 func (fi *factIndex) writeFile(ctx context.Context, branch, path, content, message, operation string) (commitHash string, blobHash string, err error) {
-	path = strings.ToLower(path)
+	return fi.writeFileExact(ctx, branch, strings.ToLower(path), content, message, operation)
+}
+
+// writeFileExact is writeFile without case normalization. Callers own the
+// exact bytes of the path they pass.
+func (fi *factIndex) writeFileExact(ctx context.Context, branch, path, content, message, operation string) (commitHash string, blobHash string, err error) {
 	if err := validatePath(path); err != nil {
 		return "", "", fmt.Errorf("store: WriteFile: %w", err)
 	}
@@ -287,6 +296,20 @@ func (fi *factIndex) batchWriteLocked(ctx context.Context, branch string, files 
 // via rh.notifyCommit — no redundant fi.im.Sync call here.
 func (fi *factIndex) WriteFact(ctx context.Context, branch, path, content, message, operation string) (WriteFactResult, error) {
 	commitHash, blobHash, err := fi.writeFile(ctx, branch, path, content, message, operation)
+	if err != nil {
+		return WriteFactResult{}, err
+	}
+	return WriteFactResult{CommitHash: commitHash, BlobHash: blobHash}, nil
+}
+
+// WriteRootFile writes a root-level, non-fact file (README.md, and any future
+// sibling) preserving the case of path. Root-level only: a nested path would
+// otherwise be a way around fact-path normalization.
+func (fi *factIndex) WriteRootFile(ctx context.Context, branch, path, content, message, operation string) (WriteFactResult, error) {
+	if strings.Contains(path, "/") {
+		return WriteFactResult{}, fmt.Errorf("store: WriteRootFile: %q is not root-level", path)
+	}
+	commitHash, blobHash, err := fi.writeFileExact(ctx, branch, path, content, message, operation)
 	if err != nil {
 		return WriteFactResult{}, err
 	}

--- a/internal/store/fact_write_test.go
+++ b/internal/store/fact_write_test.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A root file's name is chosen for an EXTERNAL reader — git providers look for
+// README.md. writeFile lowercases to keep fact topics free of case duplicates;
+// that rule must not reach a file that is not a fact.
+func TestWriteRootFile_PreservesCase(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
+	fi := svc.Facts()
+
+	_, err = fi.WriteRootFile(context.Background(), "main",
+		"README.md", "# hello", "docs: update README.md", "update")
+	require.NoError(t, err)
+
+	paths, err := fi.ListAll(context.Background(), "main")
+	require.NoError(t, err)
+	require.Contains(t, paths, "README.md")
+	require.NotContains(t, paths, "readme.md")
+}
+
+// The case-preserving door is for ROOT files only. Letting it take a nested
+// path would hand callers a way to bypass fact-path normalization entirely.
+func TestWriteRootFile_RejectsNestedPath(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
+
+	_, err = svc.Facts().WriteRootFile(context.Background(), "main",
+		"kb/Architecture/X.md", "# x", "msg", "update")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "root-level")
+}
+
+// The existing fact path must still normalize — this is the regression guard
+// for the split.
+func TestWriteFact_StillLowercasesPath(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
+	fi := svc.Facts()
+
+	_, err = fi.WriteFact(context.Background(), "main",
+		"kb/Technology/Software/AbCdEf12.md", testFactBody("AbCdEf12", 0.9, nil), "msg", "learn")
+	require.NoError(t, err)
+
+	paths, err := fi.ListAll(context.Background(), "main")
+	require.NoError(t, err)
+	require.Contains(t, paths, "kb/technology/software/abcdef12.md")
+}

--- a/internal/store/factpath.go
+++ b/internal/store/factpath.go
@@ -23,8 +23,8 @@ func (rh *repoHandler) ontologyRoot() string {
 // parse. Those are not the same test: fact.ParseFact accepts any file that
 // opens with YAML frontmatter and an H1 heading, which is the ordinary shape of
 // a markdown document — so a parse-based rule hands index membership to whoever
-// authored the file. That became live when the repo description (kb.md, at the
-// tree root) turned into a user-editable field: a manifest written with
+// authored the file. That became live when the repo description (README.md, at
+// the tree root) turned into a user-editable field: a manifest written with
 // frontmatter would parse, index as a fact, and then be reported by Verify as a
 // ghost branch_facts row, because checkFactsCoherence builds its expected set
 // from the ontology root alone. Location is the rule Verify already enforces;

--- a/internal/store/factpath.go
+++ b/internal/store/factpath.go
@@ -1,6 +1,10 @@
 package store
 
-import "strings"
+import (
+	"strings"
+
+	"knomit/internal/fact"
+)
 
 // defaultOntologyRoot mirrors config.Defaults().OntologyRoot. The store cannot
 // import internal/config (config is the outer layer), so the default lives here
@@ -32,6 +36,14 @@ func (rh *repoHandler) ontologyRoot() string {
 //
 // Callers still keep their parse-failure skips: this bounds WHERE a fact can
 // live, parsing decides whether a file in that place is a well-formed one.
+//
+// Dot-prefixed segments are excluded at any depth. A directory or file whose
+// name begins with "." is machinery, not knowledge — see fact.IsPrivatePath.
+// This is the same LOCATION rule, applied one level finer: a well-formed fact
+// hand-placed at kb/.drafts/x.md is deliberately not indexed, so the directory
+// works as a private stash.
 func (rh *repoHandler) isFactPath(path string) bool {
-	return strings.HasPrefix(path, rh.ontologyRoot()+"/") && strings.HasSuffix(path, ".md")
+	return strings.HasPrefix(path, rh.ontologyRoot()+"/") &&
+		strings.HasSuffix(path, ".md") &&
+		!fact.IsPrivatePath(path)
 }

--- a/internal/store/index_scope_test.go
+++ b/internal/store/index_scope_test.go
@@ -28,10 +28,10 @@ func indexedPaths(t *testing.T, svc *Service, branch string) []string {
 }
 
 // A .md file OUTSIDE the ontology root is not a fact, however well-formed its
-// contents happen to be. kb.md is the live case: it is the repo's root manifest
-// and its content is user-editable through PATCH /repos/{repo}, so "does this
-// parse as a fact" is an attacker-/user-controlled question and cannot be what
-// decides index membership.
+// contents happen to be. README.md is the live case: it is the repo's root
+// manifest and its content is user-editable through PATCH /repos/{repo}, so
+// "does this parse as a fact" is an attacker-/user-controlled question and
+// cannot be what decides index membership.
 //
 // Verify already encodes the rule this test pins (checkFactsCoherence builds
 // its expected set from kb/ only), so an indexed stray is not merely noise —
@@ -44,9 +44,12 @@ func TestIndex_SkipsFilesOutsideOntologyRoot(t *testing.T) {
 	ctx := context.Background()
 
 	// Frontmatter + an H1 — the ordinary shape of a markdown document, and
-	// enough for fact.ParseFact to accept it.
+	// enough for fact.ParseFact to accept it. Written via WriteRootFile (not
+	// WriteFact) so the path lands as README.md rather than being lowercased to
+	// readme.md — the case a git provider actually looks for, and the same case
+	// this test needs to prove location (not case) decides index membership.
 	const manifest = "---\ntitle: Core manifest\n---\n\n# Core\n\nGuidance for agents.\n"
-	_, err = svc.Facts().WriteFact(ctx, "agent/a", "kb.md", manifest, "docs: manifest", "update")
+	_, err = svc.Facts().WriteRootFile(ctx, "agent/a", "README.md", manifest, "docs: manifest", "update")
 	require.NoError(t, err)
 	_, err = svc.Facts().WriteFact(ctx, "agent/a", "kb/obs/real.md", testFactBody("Real", 0.9, nil), "add", "")
 	require.NoError(t, err)

--- a/internal/store/index_scope_test.go
+++ b/internal/store/index_scope_test.go
@@ -123,3 +123,40 @@ func TestIndex_HonoursConfiguredOntologyRoot(t *testing.T) {
 
 	require.Equal(t, []string{"knowledge/obs/a.md"}, indexedPaths(t, svc, "agent/a"))
 }
+
+// A dot-directory UNDER the ontology root is a private stash. The file below
+// parses perfectly as a fact — that is the point: parsing is not what decides
+// membership, location is, and a dot-prefixed segment puts it out of scope.
+//
+// Verify must agree, or the stash surfaces as a ghost branch_facts row on the
+// next integrity run — the same failure mode the ontology-root rule fixed.
+func TestIndex_SkipsPrivatePathsUnderOntologyRoot(t *testing.T) {
+	svc, err := Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/a"))
+	ctx := context.Background()
+
+	_, err = svc.Facts().WriteFact(ctx, "agent/a", "kb/.drafts/draft.md",
+		testFactBody("Draft", 0.9, nil), "add", "")
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(ctx, "agent/a", "kb/obs/real.md",
+		testFactBody("Real", 0.9, nil), "add", "")
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"kb/obs/real.md"}, indexedPaths(t, svc, "agent/a"),
+		"a dot-prefixed segment is private, however well-formed the file")
+
+	// A rebuild must reach the same set — and must EVICT a private path an
+	// earlier build admitted, not merely stop adding new ones.
+	require.NoError(t, svc.IndexManager().Rebuild(ctx, "agent/a", nil))
+	require.Equal(t, []string{"kb/obs/real.md"}, indexedPaths(t, svc, "agent/a"),
+		"rebuild must not re-admit a private path")
+
+	report, err := svc.Verify(ctx, VerifyOpts{Deep: true})
+	require.NoError(t, err)
+	for _, iss := range report.Issues {
+		require.NotEqual(t, CategoryFactsCoherence, iss.Category,
+			"a private path must be invisible to Verify, not a ghost: %+v", iss)
+	}
+}

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -13,6 +13,10 @@ import (
 type FactIndex interface {
 	ReadFact(ctx context.Context, branch, path string, opts *ReadFactOpts) (ReadFactResult, error)
 	WriteFact(ctx context.Context, branch, path, content, message, operation string) (WriteFactResult, error)
+	// WriteRootFile writes a root-level non-fact file (e.g. README.md)
+	// PRESERVING CASE. WriteFact lowercases, which is correct for fact paths
+	// and wrong for a filename an external reader looks for by exact name.
+	WriteRootFile(ctx context.Context, branch, path, content, message, operation string) (WriteFactResult, error)
 	// BatchWriteFacts applies writes and deletions as ONE commit. Pass deletes
 	// to retract facts atomically with the writes that supersede them — a
 	// separate DeleteFact call would be a second commit that can land without

--- a/internal/store/replay_suspend_index_test.go
+++ b/internal/store/replay_suspend_index_test.go
@@ -64,7 +64,7 @@ func TestReplay_SkipIndexSync(t *testing.T) {
 	}
 
 	// wantIndexed is the number of indexable facts the replay materializes:
-	// the two real facts (kb/a.md, kb/b.md). The InitRepo seed (kb.md) is a
+	// the two real facts (kb/a.md, kb/b.md). The InitRepo seed (README.md) is a
 	// non-indexable placeholder — it sits in the git tree but never produces a
 	// branch_facts row — so it does not count here.
 	const wantIndexed = 2

--- a/internal/store/repo.go
+++ b/internal/store/repo.go
@@ -145,7 +145,7 @@ func (s *Service) InitRepoWithUpstream(initFiles map[string]string, upstreamMain
 	// for why two machines can silently diverge and why a real fix needs
 	// init-time cross-machine coordination rather than weakening the nonce.
 	initMsg := fmt.Sprintf("init: create knowledge base\n\nknomit-repo-nonce: %s", uuid.New().String())
-	lastCommit, _, err := writeFileToStore(s.rh.gits, plumbing.ZeroHash, "kb.md", rootManifest, initMsg, initSig, initSig)
+	lastCommit, _, err := writeFileToStore(s.rh.gits, plumbing.ZeroHash, "README.md", rootManifest, initMsg, initSig, initSig)
 	if err != nil {
 		return fmt.Errorf("InitRepo: initial commit: %w", err)
 	}
@@ -524,7 +524,7 @@ func (s *Service) initFromEmptyRemote(repo *gogit.Repository, originURL string, 
 	// first-writer-wins lock on origin), NOT automatic reconciliation after the
 	// fact.
 	initMsg := fmt.Sprintf("init: create knowledge base\n\nknomit-repo-nonce: %s", uuid.New().String())
-	lastCommit, _, writeErr := writeFileToStore(s.rh.gits, plumbing.ZeroHash, "kb.md", rootManifest, initMsg, initSig, initSig)
+	lastCommit, _, writeErr := writeFileToStore(s.rh.gits, plumbing.ZeroHash, "README.md", rootManifest, initMsg, initSig, initSig)
 	if writeErr != nil {
 		return fmt.Errorf("InitFromRemote: empty remote fallback: %w", writeErr)
 	}

--- a/internal/store/repo_test.go
+++ b/internal/store/repo_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"errors"
 	"os"
 	"os/exec"
@@ -9,6 +10,24 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// InitRepo seeds the root manifest through writeFileToStore — the low-level
+// git writer, not writeFile/WriteFact — so the fact-path lowercasing rule
+// (which exists to stop case-duplicate ontology topics) never touches it.
+// Assert the case explicitly rather than assuming it: a future refactor that
+// routed this seed through the fact-write path would silently regress it to
+// readme.md, and a git provider looks for the exact name README.md.
+func TestInitRepo_SeedsReadmeWithExactCase(t *testing.T) {
+	svc, err := Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
+
+	paths, err := svc.Facts().ListAll(context.Background(), "main")
+	require.NoError(t, err)
+	require.Contains(t, paths, "README.md")
+	require.NotContains(t, paths, "readme.md")
+}
 
 // TestCloneFrom_EmptyRemoteReturnsErrEmptyRemote verifies that CloneFrom
 // returns the typed sentinel ErrEmptyRemote when the remote repository

--- a/internal/store/search_index.go
+++ b/internal/store/search_index.go
@@ -516,7 +516,7 @@ func (si *searchIndex) Rebuild(ctx context.Context, branch string, progress Rebu
 }
 
 // indexFile reads a single file from git, parses it as a fact, and upserts
-// it into the index. Files that fail to parse (e.g. kb.md manifest) are
+// it into the index. Files that fail to parse (e.g. README.md manifest) are
 // silently skipped.
 //
 // commitHash is the fallback; if commit_log has a more specific last-touch
@@ -538,7 +538,7 @@ func (si *searchIndex) indexFile(ctx context.Context, branch, path, commitHash s
 
 	rec, err := parseFact(path, content)
 	if err != nil {
-		return nil, nil // not a fact file (e.g. kb.md manifest, ontology.yaml)
+		return nil, nil // not a fact file (e.g. README.md manifest, ontology.yaml)
 	}
 	rec.BlobHash = blobHash
 	rec.SourceCommit = commitHash

--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -41,6 +41,13 @@ func validateOutputPath(path, ontologyRoot string) error {
 	if !strings.HasPrefix(strings.ToLower(path), prefix) {
 		return fmt.Errorf("path %q is outside ontology root %q", path, ontologyRoot)
 	}
+	// A dot-prefixed segment is private: it would be written and then skipped
+	// by the indexer, Verify and the exporter alike, so it is refused here
+	// rather than silently discarded. Both of this function's callers land on
+	// this one rule.
+	if fact.IsPrivatePath(path) {
+		return fmt.Errorf("%s is private: a path segment beginning with '.' cannot hold a fact", path)
+	}
 	return nil
 }
 

--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -43,8 +43,9 @@ func validateOutputPath(path, ontologyRoot string) error {
 	}
 	// A dot-prefixed segment is private: it would be written and then skipped
 	// by the indexer, Verify and the exporter alike, so it is refused here
-	// rather than silently discarded. All three of this function's callers
-	// (merge, distill, propose) land on this one rule.
+	// rather than silently discarded. All four of this function's callers
+	// (merge, distill, propose, and discovery's emergent-fact write) land on
+	// this one rule.
 	if fact.IsPrivatePath(path) {
 		return fmt.Errorf("%s is private: a path segment beginning with '.' cannot hold a fact", path)
 	}

--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -43,8 +43,8 @@ func validateOutputPath(path, ontologyRoot string) error {
 	}
 	// A dot-prefixed segment is private: it would be written and then skipped
 	// by the indexer, Verify and the exporter alike, so it is refused here
-	// rather than silently discarded. Both of this function's callers land on
-	// this one rule.
+	// rather than silently discarded. All three of this function's callers
+	// (merge, distill, propose) land on this one rule.
 	if fact.IsPrivatePath(path) {
 		return fmt.Errorf("%s is private: a path segment beginning with '.' cannot hold a fact", path)
 	}

--- a/internal/synthesize/decision_test.go
+++ b/internal/synthesize/decision_test.go
@@ -31,6 +31,12 @@ func TestValidateOutputPath_RejectsOutsideOntologyRoot(t *testing.T) {
 		// is rejected.
 		{"trailing slash on root", "kb/foo.md", "kb/", false, ""},
 		{"multiple trailing slashes", "kb/foo.md", "kb//", false, ""},
+		// A dot-prefixed segment is private machinery, not knowledge (Task 4/5):
+		// the search indexer, Verify, and the OKF exporter all skip it. Writing
+		// one here would be silent knowledge loss, so validateOutputPath must
+		// reject it same as an out-of-root path.
+		{"private directory segment", "kb/.secret/x.md", "kb", true, "private"},
+		{"private filename segment", "kb/decisions/.wip.md", "kb", true, "private"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/web/handlers_fact_create.go
+++ b/internal/web/handlers_fact_create.go
@@ -73,6 +73,16 @@ func handleFactCreate(b hal.URLBuilder, ontologyRoot string, writer FactWriter) 
 
 		path := knomitfact.BuildFactPath(ontologyRoot, topic, category)
 
+		// A dot-prefixed segment is private: it would be written and then
+		// skipped by the indexer, Verify and the exporter alike. Returning 201
+		// for a fact no reader will ever see is the worst available answer.
+		if knomitfact.IsPrivatePath(path) {
+			hal.WriteProblem(w, http.StatusBadRequest, "Private path",
+				"domain resolves to "+path+"; a path segment beginning with '.' is private and cannot hold a fact",
+				r.URL.Path)
+			return
+		}
+
 		// Resolve kind and leaf type. SerializeFact validates the (kind,
 		// type) pair below, so we don't pre-validate here — that lets a
 		// single rule reject mismatched values (e.g. pragmatic kind with

--- a/internal/web/handlers_fact_create_test.go
+++ b/internal/web/handlers_fact_create_test.go
@@ -300,3 +300,30 @@ func TestHandleFactCreate_ExplicitZeroSourcesSurvives(t *testing.T) {
 		t.Errorf("explicit 0 confidence: got %v, want 0 preserved", view.Confidence)
 	}
 }
+
+// The create path derives the fact's location from caller-supplied domain, so
+// a caller can steer it into a private directory. Accepting that returns 201
+// for a fact the indexer, Verify and the exporter all skip — silent loss.
+func TestHandleFactCreate_RejectsPrivateDomain(t *testing.T) {
+	s := &Server{
+		Manager:      newTestManagerWithRepos(t, "alpha"),
+		OntologyRoot: "know",
+		providers: storeProviders{
+			factWriter: stubFactWriterForCreate{},
+		},
+	}
+	r := s.NewAPIRouter()
+
+	body := `{"title":"My Fact","body":"some body","type":"observation","domain":[".secret"],"confidence":0.9,"sources":1}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/repos/alpha/branches/main/facts", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "private") {
+		t.Errorf("problem body should name the private-path rule, got %s", rec.Body.String())
+	}
+}

--- a/internal/web/handlers_fact_write.go
+++ b/internal/web/handlers_fact_write.go
@@ -153,6 +153,17 @@ func handleFactUpdate(b hal.URLBuilder, writer FactWriter) http.HandlerFunc {
 			return
 		}
 
+		// Unlike the create paths, which derive their target from topic/category
+		// and guard the path they construct, this handler receives the path
+		// verbatim from the caller — it is also how a fresh path gets created
+		// (PriorRefs returns nil for one), so a private segment here would be
+		// indexed nowhere but still committed to git, permanently invisible.
+		if knomitfact.IsPrivatePath(path) {
+			hal.WriteProblem(w, http.StatusBadRequest, "Private path",
+				path+": a path segment beginning with '.' is private and cannot hold a fact", r.URL.Path)
+			return
+		}
+
 		var body struct {
 			Content string `json:"content"`
 		}

--- a/internal/web/handlers_fact_write_test.go
+++ b/internal/web/handlers_fact_write_test.go
@@ -130,6 +130,41 @@ func TestHandleFactUpdate_WriteError_Returns500(t *testing.T) {
 	}
 }
 
+// Unlike the create handlers, which derive their target path from
+// topic/category, PUT receives the path verbatim from the caller: the path is
+// the one thing the client fully controls, and this is a create too — see
+// PriorRefs' "no prior version" comment — so a private segment here would
+// commit a fact to git that every reader (indexer, Verify, the OKF exporter)
+// then permanently skips.
+func TestHandleFactUpdate_RejectsPrivatePath(t *testing.T) {
+	writer := &stubFactWriter{writeHash: "abc123"}
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			factWriter: writer,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	body := `{"content":"` + testFactContent + `"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut,
+		"/repos/alpha/branches/agent:test/facts/kb/.drafts/test.md",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "private") {
+		t.Errorf("problem body should name the private-path rule, got %s", rec.Body.String())
+	}
+	if writer.writeCalls != 0 {
+		t.Errorf("writer.Write called %d times for a private path; it must never reach git", writer.writeCalls)
+	}
+}
+
 func TestHandleFactDelete_Returns204(t *testing.T) {
 	writer := &stubFactWriter{}
 	s := &Server{

--- a/internal/web/handlers_lenses_topics.go
+++ b/internal/web/handlers_lenses_topics.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	knomitfact "knomit/internal/fact"
 	"knomit/internal/federate"
 	"knomit/internal/repos"
 	"knomit/internal/store"
@@ -103,6 +104,15 @@ func handleHALLensTopics(lister TopicLister, ontologyRoot string) http.HandlerFu
 			}
 			var leafEntries []store.DirEntry
 			for _, e := range entries {
+				// Private paths are excluded from discovery everywhere else
+				// (indexer, Verify, the OKF exporter, the repo topicHandler
+				// above) — the lens union tree is a reader too, and checking
+				// the full path (not just e.Name) also covers a private
+				// dirPath itself, since every child then inherits its
+				// parent's private segment.
+				if knomitfact.IsPrivatePath(dirPath + "/" + e.Name) {
+					continue
+				}
 				if e.IsDir {
 					if !dirSeen[e.Name] {
 						dirSeen[e.Name] = true

--- a/internal/web/handlers_lenses_topics_test.go
+++ b/internal/web/handlers_lenses_topics_test.go
@@ -327,6 +327,38 @@ func TestLensTopics_EmptyLevel(t *testing.T) {
 	}
 }
 
+// TestLensTopics_HidesPrivateDirectory pins spec/mbekg.md §3.8 for the lens
+// union tree, the same rule the plain repo topicHandler enforces: a
+// dot-prefixed directory is machinery, and the lens tree — knomit's own
+// reader — must not surface it either, on any mount, dir or leaf alike.
+func TestLensTopics_HidesPrivateDirectory(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensTopicsStub{
+		dirsByRepo: map[string][]store.DirEntry{
+			"alpha": {{Name: "gotchas", IsDir: true}, {Name: ".drafts", IsDir: true}},
+			"beta":  {{Name: ".hidden.md", IsDir: false}, {Name: "b.md", IsDir: false}},
+		},
+	}
+	s := &Server{Manager: m, OntologyRoot: "kb", providers: storeProviders{topicLister: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensTopics(t, getLensFacts(t, r, "/lenses/eng/topics"))
+	names := make([]string, len(body.Children))
+	for i, c := range body.Children {
+		names[i] = c.Name
+	}
+	want := []string{"gotchas", "b.md"}
+	if len(names) != len(want) {
+		t.Fatalf("children: got %v, want %v (private entries excluded)", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("children: got %v, want %v", names, want)
+		}
+	}
+}
+
 // An unknown lens is 404 (from LensMiddleware, before the handler runs).
 func TestLensTopics_UnknownLens404(t *testing.T) {
 	m, _ := newTestLensManager(t, "alpha")

--- a/internal/web/handlers_repos_hal.go
+++ b/internal/web/handlers_repos_hal.go
@@ -55,12 +55,12 @@ func handleHALRepos(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
 	}
 }
 
-// readKBManifest returns the verbatim content of kb.md at the root of the
+// readReadme returns the verbatim content of README.md at the root of the
 // repo's git store, read at HEAD (the agent branch tip). It returns "" if the
-// store is not yet open, the branch is unknown, or kb.md does not exist — all
-// non-fatal for a view: the repo simply has no description to surface.
-func readKBManifest(r *http.Request, ri *repos.RepoInstance) string {
-	content, err := ri.ReadKBManifest(r.Context())
+// store is not yet open, the branch is unknown, or README.md does not exist —
+// all non-fatal for a view: the repo simply has no description to surface.
+func readReadme(r *http.Request, ri *repos.RepoInstance) string {
+	content, err := ri.ReadReadme(r.Context())
 	if err != nil {
 		return ""
 	}
@@ -119,7 +119,7 @@ func handleHALReposRescan(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
 // reconcile two shapes for the same resource.
 func repoView(b hal.URLBuilder, r *http.Request, name string, ri *repos.RepoInstance) map[string]any {
 	// Read the branch from the instance so the advertised agent_branch and
-	// the branch readKBManifest reads kb.md from can never drift apart.
+	// the branch readReadme reads README.md from can never drift apart.
 	branch := ri.AgentBranch()
 	a := hal.Anchor{Branch: branch}
 	body := map[string]any{
@@ -132,11 +132,11 @@ func repoView(b hal.URLBuilder, r *http.Request, name string, ri *repos.RepoInst
 			"mcp":      {Href: b.Branch(name, a) + "/mcp{?profile}", Templated: true},
 		},
 	}
-	// description is the verbatim kb.md root manifest read at HEAD (the
+	// description is the verbatim README.md root manifest read at HEAD (the
 	// repo's agent branch tip — HEAD points there). Omitted when the
-	// store is unreadable or kb.md is absent, so the UI shows it only
+	// store is unreadable or README.md is absent, so the UI shows it only
 	// when available.
-	if desc := readKBManifest(r, ri); desc != "" {
+	if desc := readReadme(r, ri); desc != "" {
 		body["description"] = desc
 	}
 	return body
@@ -167,9 +167,9 @@ type patchRepoRequest struct {
 const maxRepoPatchBodyBytes = 8 * repos.MaxRepoDescriptionBytes
 
 // handleHALRepoPatch serves PATCH /api/v1/repos/{repo}. It edits the repo's
-// description by committing kb.md on the agent branch, then returns the same
-// view GET does — re-read from git, so the response reflects what was actually
-// persisted rather than what was requested.
+// description by committing README.md on the agent branch, then returns the
+// same view GET does — re-read from git, so the response reflects what was
+// actually persisted rather than what was requested.
 func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := chi.URLParam(r, "repo")
@@ -193,9 +193,9 @@ func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 			return
 		}
 		// The cap, the branch check and the unchanged-content skip all live in
-		// WriteKBManifest, so every writer of kb.md gets them; this maps its
+		// WriteReadme, so every writer of README.md gets them; this maps its
 		// errors onto status codes.
-		if _, err := ri.WriteKBManifest(r.Context(), *req.Description); err != nil {
+		if _, err := ri.WriteReadme(r.Context(), *req.Description); err != nil {
 			switch {
 			case errors.Is(err, repos.ErrRepoDescriptionTooLong):
 				hal.WriteProblem(w, http.StatusUnprocessableEntity, "Repo description too long",
@@ -204,11 +204,11 @@ func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 				hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
 					"the repo has no agent branch yet", r.URL.Path)
 			case errors.Is(err, repos.ErrRepoClosed), errors.Is(err, repos.ErrStoreUnavailable):
-				log.Warn().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write kb.md: store not available")
+				log.Warn().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write README.md: store not available")
 				hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
 					"the repo's store is not available; try again", r.URL.Path)
 			default:
-				log.Error().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write kb.md failed")
+				log.Error().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write README.md failed")
 				hal.WriteProblem(w, http.StatusInternalServerError, "Update failed",
 					"could not write the repo description", r.URL.Path)
 			}

--- a/internal/web/handlers_repos_hal.go
+++ b/internal/web/handlers_repos_hal.go
@@ -67,6 +67,16 @@ func readReadme(r *http.Request, ri *repos.RepoInstance) string {
 	return content
 }
 
+// readLicense returns the verbatim LICENSE at the repo's agent-branch tip, or
+// "" when there is none — non-fatal for a view, exactly like readReadme.
+func readLicense(r *http.Request, ri *repos.RepoInstance) string {
+	content, err := ri.ReadLicense(r.Context())
+	if err != nil {
+		return ""
+	}
+	return content
+}
+
 // rescanErrorView is the JSON shape for a per-repo failure entry in a
 // rescan response.
 type rescanErrorView struct {
@@ -138,6 +148,12 @@ func repoView(b hal.URLBuilder, r *http.Request, name string, ri *repos.RepoInst
 	// when available.
 	if desc := readReadme(r, ri); desc != "" {
 		body["description"] = desc
+	}
+	// license is the verbatim LICENSE read at HEAD. Single-repo GET only, the
+	// same scoping description has — the repo LIST stays a cheap index and must
+	// not grow a second per-repo git read.
+	if lic := readLicense(r, ri); lic != "" {
+		body["license"] = lic
 	}
 	return body
 }

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -113,10 +113,12 @@ func TestHandleHALRepo_ReturnsRepoWithBranchesLink(t *testing.T) {
 	}
 }
 
-// TestHandleHALRepo_IncludesDescriptionFromKBMd verifies the single-repo
-// response carries the full kb.md content as "description". The default
-// kb.md root manifest is "# Knowledge Base\n\nRoot manifest.\n".
-func TestHandleHALRepo_IncludesDescriptionFromKBMd(t *testing.T) {
+// TestHandleHALRepo_IncludesDescriptionFromReadme verifies the single-repo
+// response carries the full README.md content as "description". InitRepo does
+// not seed README.md (the clean break: only README.md is ever read, and there
+// is no migration writing one), so this test writes it itself via PATCH — the
+// same path a real client uses — before asserting on GET.
+func TestHandleHALRepo_IncludesDescriptionFromReadme(t *testing.T) {
 	home := t.TempDir()
 	m := repos.New(context.Background(), repos.Deps{
 		Cfg: config.Config{
@@ -139,6 +141,11 @@ func TestHandleHALRepo_IncludesDescriptionFromKBMd(t *testing.T) {
 	s := &Server{Manager: m, AgentBranch: "machine/test"}
 	r := s.NewAPIRouter()
 
+	const md = "# Knowledge Base\n\nRoot manifest.\n"
+	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": md})); rec.Code != http.StatusOK {
+		t.Fatalf("seed PATCH status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/repos/work", nil)
 	r.ServeHTTP(rec, req)
@@ -157,10 +164,10 @@ func TestHandleHALRepo_IncludesDescriptionFromKBMd(t *testing.T) {
 		t.Errorf("name: got %q, want %q", body.Name, "work")
 	}
 	if !strings.Contains(body.Description, "Root manifest.") {
-		t.Errorf("description: got %q, want it to contain the kb.md body", body.Description)
+		t.Errorf("description: got %q, want it to contain the README.md body", body.Description)
 	}
 	if !strings.Contains(body.Description, "# Knowledge Base") {
-		t.Errorf("description should be the whole kb.md file (incl. heading); got %q", body.Description)
+		t.Errorf("description should be the whole README.md file (incl. heading); got %q", body.Description)
 	}
 }
 
@@ -178,7 +185,7 @@ func TestHandleHALRepo_OmitsDescriptionWhenNoStore(t *testing.T) {
 		t.Fatalf("status: %d", rec.Code)
 	}
 	if strings.Contains(rec.Body.String(), `"description"`) {
-		t.Errorf("description must be omitted when no kb.md is readable; body=%s", rec.Body.String())
+		t.Errorf("description must be omitted when no README.md is readable; body=%s", rec.Body.String())
 	}
 }
 
@@ -486,7 +493,7 @@ func TestHandleHALRepos_IncludesRescanLink(t *testing.T) {
 }
 
 // newRepoPatchServer boots a real manager with one on-disk repo ("work") whose
-// kb.md holds the default root manifest, and returns its API router.
+// README.md holds the default root manifest, and returns its API router.
 func newRepoPatchServer(t *testing.T) http.Handler {
 	t.Helper()
 	r, _ := newRepoPatchServerWithManager(t)
@@ -496,7 +503,7 @@ func newRepoPatchServer(t *testing.T) http.Handler {
 // newRepoPatchServerWithManager is newRepoPatchServer for tests that must also
 // reach past HTTP — asserting on the git ref itself, which no read endpoint
 // exposes unfiltered (the commits list is scoped to the ontology root, so a
-// root-level kb.md commit never appears there).
+// root-level README.md commit never appears there).
 func newRepoPatchServerWithManager(t *testing.T) (http.Handler, *repos.Manager) {
 	t.Helper()
 	home := t.TempDir()
@@ -542,10 +549,10 @@ func repoDescription(t *testing.T, r http.Handler, repo string) string {
 	return body.Description
 }
 
-// A PATCHed description is committed to kb.md and is visible to the very next
+// A PATCHed description is committed to README.md and is visible to the very next
 // GET — the write and the read must agree on file AND branch, or the edit
 // silently disappears.
-func TestHandleHALRepoPatch_WritesKBMdAndRoundTrips(t *testing.T) {
+func TestHandleHALRepoPatch_WritesReadmeAndRoundTrips(t *testing.T) {
 	r := newRepoPatchServer(t)
 
 	const md = "# Work\n\nA **markdown** manifest.\n\n- one\n- two\n"
@@ -587,9 +594,17 @@ func TestHandleHALRepoPatch_StoresMarkdownVerbatim(t *testing.T) {
 // An omitted description is a no-op, not a clear — PATCH is a merge.
 func TestHandleHALRepoPatch_OmittedDescriptionKeepsCurrent(t *testing.T) {
 	r := newRepoPatchServer(t)
+	// InitRepo does not seed README.md (the clean break means only README.md
+	// is ever read, and there is no migration writing one), so this test seeds
+	// its own description via PATCH rather than relying on the repo's initial
+	// content.
+	const seed = "# Work\n\nSeeded description.\n"
+	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": seed})); rec.Code != http.StatusOK {
+		t.Fatalf("seed PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
 	before := repoDescription(t, r, "work")
-	if before == "" {
-		t.Fatal("precondition: seeded repo should have a kb.md description")
+	if before != seed {
+		t.Fatalf("precondition: seeded description did not round-trip: got %q, want %q", before, seed)
 	}
 	if rec := patchRepo(t, r, "work", `{}`); rec.Code != http.StatusOK {
 		t.Fatalf("PATCH status: %d; body=%s", rec.Code, rec.Body.String())
@@ -600,7 +615,7 @@ func TestHandleHALRepoPatch_OmittedDescriptionKeepsCurrent(t *testing.T) {
 }
 
 // An explicit empty string clears the manifest — the description then drops out
-// of the GET body entirely (readKBManifest treats "" as absent).
+// of the GET body entirely (readReadme treats "" as absent).
 func TestHandleHALRepoPatch_EmptyDescriptionClears(t *testing.T) {
 	r := newRepoPatchServer(t)
 	if rec := patchRepo(t, r, "work", `{"description":""}`); rec.Code != http.StatusOK {

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"knomit/internal/config"
 	"knomit/internal/fact"
 	"knomit/internal/repos"
@@ -180,6 +182,125 @@ func TestHandleHALRepo_OmitsDescriptionWhenNoStore(t *testing.T) {
 	}
 	if strings.Contains(rec.Body.String(), `"description"`) {
 		t.Errorf("description must be omitted when no README.md is readable; body=%s", rec.Body.String())
+	}
+}
+
+// TestHandleHALRepo_IncludesLicenseWhenPresent verifies the single-repo
+// response carries a root LICENSE as "license", verbatim. InitRepo does not
+// seed one, so this writes it directly through the fact store the same way
+// the manifest package's own tests do.
+func TestHandleHALRepo_IncludesLicenseWhenPresent(t *testing.T) {
+	home := t.TempDir()
+	m := repos.New(context.Background(), repos.Deps{
+		Cfg: config.Config{
+			Home:         home,
+			ClusterCache: config.ClusterCacheConfig{},
+		},
+		AgentBranch:           "machine/test",
+		DisableBackgroundSync: true,
+	})
+	if err := m.Start(); err != nil {
+		t.Fatalf("manager start: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+
+	initRepoFile(t, home, "work")
+	if _, err := m.Rescan(); err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+
+	ri := m.Get("work")
+	require.NotNil(t, ri)
+	const mit = "MIT License\n\nPermission is hereby granted, free of charge...\n"
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteRootFile(context.Background(), ri.AgentBranch(),
+			"LICENSE", mit, "docs: add LICENSE", "update")
+		require.NoError(t, werr)
+	}))
+
+	s := &Server{Manager: m, AgentBranch: "machine/test"}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/repos/work", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		License string `json:"license"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.License != mit {
+		t.Errorf("license: got %q, want %q", body.License, mit)
+	}
+}
+
+// TestHandleHALRepo_OmitsLicenseWhenNoStore verifies a stub instance with no
+// store does not panic and simply omits the license, exactly like
+// TestHandleHALRepo_OmitsDescriptionWhenNoStore does for description.
+func TestHandleHALRepo_OmitsLicenseWhenNoStore(t *testing.T) {
+	s := &Server{Manager: newTestManagerWithRepos(t, "alpha")}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/repos/alpha", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), `"license"`) {
+		t.Errorf("license must be omitted when no LICENSE is readable; body=%s", rec.Body.String())
+	}
+}
+
+// TestHandleHALRepos_OmitsLicenseFromList verifies the repo LIST never carries
+// a "license" field, even when the repo has one — the collection must stay a
+// cheap index and not grow a second per-repo git read.
+func TestHandleHALRepos_OmitsLicenseFromList(t *testing.T) {
+	home := t.TempDir()
+	m := repos.New(context.Background(), repos.Deps{
+		Cfg: config.Config{
+			Home:         home,
+			ClusterCache: config.ClusterCacheConfig{},
+		},
+		AgentBranch:           "machine/test",
+		DisableBackgroundSync: true,
+	})
+	if err := m.Start(); err != nil {
+		t.Fatalf("manager start: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+
+	initRepoFile(t, home, "work")
+	if _, err := m.Rescan(); err != nil {
+		t.Fatalf("rescan: %v", err)
+	}
+
+	ri := m.Get("work")
+	require.NotNil(t, ri)
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteRootFile(context.Background(), ri.AgentBranch(),
+			"LICENSE", "MIT License\n", "docs: add LICENSE", "update")
+		require.NoError(t, werr)
+	}))
+
+	s := &Server{Manager: m, AgentBranch: "machine/test"}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/repos", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), `"license"`) {
+		t.Errorf("license must never appear in the repo LIST; body=%s", rec.Body.String())
 	}
 }
 

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -468,7 +468,7 @@ func initRepoFile(t *testing.T, home, name string) {
 		t.Fatalf("serialize ontology: %v", err)
 	}
 	if err := svc.InitRepo(map[string]string{
-		"domains/ontology.yaml": string(ontologyYAML),
+		repos.OntologyPath: string(ontologyYAML),
 	}, "machine/test"); err != nil {
 		t.Fatalf("svc.InitRepo: %v", err)
 	}

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -114,10 +114,9 @@ func TestHandleHALRepo_ReturnsRepoWithBranchesLink(t *testing.T) {
 }
 
 // TestHandleHALRepo_IncludesDescriptionFromReadme verifies the single-repo
-// response carries the full README.md content as "description". InitRepo does
-// not seed README.md (the clean break: only README.md is ever read, and there
-// is no migration writing one), so this test writes it itself via PATCH — the
-// same path a real client uses — before asserting on GET.
+// response carries the full README.md content as "description". InitRepo
+// seeds README.md, so a freshly rescanned repo already has one — no PATCH
+// needed to seed it.
 func TestHandleHALRepo_IncludesDescriptionFromReadme(t *testing.T) {
 	home := t.TempDir()
 	m := repos.New(context.Background(), repos.Deps{
@@ -140,11 +139,6 @@ func TestHandleHALRepo_IncludesDescriptionFromReadme(t *testing.T) {
 
 	s := &Server{Manager: m, AgentBranch: "machine/test"}
 	r := s.NewAPIRouter()
-
-	const md = "# Knowledge Base\n\nRoot manifest.\n"
-	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": md})); rec.Code != http.StatusOK {
-		t.Fatalf("seed PATCH status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
-	}
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/repos/work", nil)
@@ -594,17 +588,9 @@ func TestHandleHALRepoPatch_StoresMarkdownVerbatim(t *testing.T) {
 // An omitted description is a no-op, not a clear — PATCH is a merge.
 func TestHandleHALRepoPatch_OmittedDescriptionKeepsCurrent(t *testing.T) {
 	r := newRepoPatchServer(t)
-	// InitRepo does not seed README.md (the clean break means only README.md
-	// is ever read, and there is no migration writing one), so this test seeds
-	// its own description via PATCH rather than relying on the repo's initial
-	// content.
-	const seed = "# Work\n\nSeeded description.\n"
-	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"description": seed})); rec.Code != http.StatusOK {
-		t.Fatalf("seed PATCH status: %d; body=%s", rec.Code, rec.Body.String())
-	}
 	before := repoDescription(t, r, "work")
-	if before != seed {
-		t.Fatalf("precondition: seeded description did not round-trip: got %q, want %q", before, seed)
+	if before == "" {
+		t.Fatal("precondition: seeded repo should have a README.md description")
 	}
 	if rec := patchRepo(t, r, "work", `{}`); rec.Code != http.StatusOK {
 		t.Fatalf("PATCH status: %d; body=%s", rec.Code, rec.Body.String())

--- a/internal/web/handlers_topics.go
+++ b/internal/web/handlers_topics.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog/log"
 
+	knomitfact "knomit/internal/fact"
 	"knomit/internal/repos"
 	"knomit/internal/store"
 	"knomit/internal/web/hal"
@@ -123,6 +124,15 @@ func handleTopicFacts(b hal.URLBuilder, ontologyRoot string, lister TopicLister,
 				continue
 			}
 			fullPath := ontologyRoot + "/" + topicPath + "/" + e.Name
+			// Private paths (a dot-prefixed segment anywhere, including in
+			// topicPath itself when a private directory is browsed directly)
+			// are excluded from fact discovery — the same rule the indexer,
+			// Verify and the OKF exporter already enforce. Without this, GET
+			// .../topics/.drafts/facts would list the stash's contents with
+			// live self links, contradicting spec/mbekg.md §3.8.
+			if knomitfact.IsPrivatePath(fullPath) {
+				continue
+			}
 			item := factSummary{Name: e.Name}
 			if fb, gerr := lister.GetByPath(r.Context(), ri, branch, fullPath); gerr == nil && fb != nil {
 				item.Type = fb.Type
@@ -240,6 +250,17 @@ func topicHandler(b hal.URLBuilder, ontologyRoot string, lister TopicLister, nod
 
 		items := make([]topicEntry, 0, len(entries))
 		for _, e := range entries {
+			// checkPath mirrors the fullPath/childURL construction below: the
+			// ontology-relative path this entry would sit at. Checking it
+			// (not just e.Name) also catches the case where nodePath itself
+			// is already private, so every entry under it is skipped too.
+			checkPath := e.Name
+			if nodePath != "" {
+				checkPath = nodePath + "/" + e.Name
+			}
+			if knomitfact.IsPrivatePath(checkPath) {
+				continue
+			}
 			entry := topicEntry{
 				Name:  e.Name,
 				IsDir: e.IsDir,

--- a/internal/web/handlers_topics_sub_test.go
+++ b/internal/web/handlers_topics_sub_test.go
@@ -190,6 +190,53 @@ func TestHandleTopicStats_EmptyHighlightsSerializeAsArrayNotNull(t *testing.T) {
 	}
 }
 
+// TestHandleTopicFacts_HidesPrivateTopic pins spec/mbekg.md §3.8 for the
+// direct-navigation case the reviewer called out: GET .../topics/.drafts/facts
+// must not list the stash's contents just because the caller names it
+// directly — private governs discovery "including under the ontology root",
+// not just whether a parent listing exposes it.
+func TestHandleTopicFacts_HidesPrivateTopic(t *testing.T) {
+	lister := &stubTopicLister{
+		dirs: []store.DirEntry{
+			{Name: "secret.md", IsDir: false},
+		},
+		byPath: map[string]*store.FactWithBody{
+			"ontology/.drafts/secret.md": {FactRecord: store.FactRecord{Title: "Secret", Type: "observation"}},
+		},
+	}
+	s := &Server{
+		Manager:      newTestManagerWithRepos(t, "alpha"),
+		OntologyRoot: "ontology",
+		providers: storeProviders{
+			topicLister: lister,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/repos/alpha/branches/main/topics/.drafts/facts", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Count    int `json:"count"`
+		Embedded struct {
+			Facts []struct {
+				Name string `json:"name"`
+			} `json:"facts"`
+		} `json:"_embedded"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Count != 0 {
+		t.Fatalf("count: %d, want 0 — a private topic's facts must not be listed", body.Count)
+	}
+}
+
 // TestHandleTopicNode_StillWorksAfterDispatch ensures the existing topic-node
 // behaviour is unaffected when no sub-resource suffix is present.
 func TestHandleTopicNode_StillWorksAfterDispatch(t *testing.T) {

--- a/internal/web/handlers_topics_test.go
+++ b/internal/web/handlers_topics_test.go
@@ -199,6 +199,58 @@ func TestHandleTopicNode_ReturnsChildren(t *testing.T) {
 	}
 }
 
+// TestHandleTopics_HidesPrivateDirectory pins spec/mbekg.md §3.8: a
+// dot-prefixed directory under the ontology root is machinery, not a topic,
+// and readers MUST skip it during discovery. ListDir (a raw git tree walk)
+// returns it unfiltered, so this is the handler's own responsibility, not
+// the store's — the same call site the reviewer flagged as listing
+// ".drafts" as an ordinary topic.
+func TestHandleTopics_HidesPrivateDirectory(t *testing.T) {
+	lister := &stubTopicLister{
+		dirs: []store.DirEntry{
+			{Name: "ai", IsDir: true},
+			{Name: ".drafts", IsDir: true},
+		},
+	}
+	s := &Server{
+		Manager:      newTestManagerWithRepos(t, "alpha"),
+		OntologyRoot: "ontology",
+		providers: storeProviders{
+			topicLister: lister,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/repos/alpha/branches/agent:test/topics", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Count    int `json:"count"`
+		Embedded struct {
+			Topics []struct {
+				Name string `json:"name"`
+			} `json:"topics"`
+		} `json:"_embedded"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if body.Count != 1 {
+		t.Fatalf("count: %d, want 1 (the private dir must be hidden)", body.Count)
+	}
+	for _, topic := range body.Embedded.Topics {
+		if topic.Name == ".drafts" {
+			t.Errorf("private directory %q appeared in the topics listing", topic.Name)
+		}
+	}
+}
+
 func TestHandleTopics_UnknownRepo_Returns404(t *testing.T) {
 	s := &Server{
 		Manager:      newTestManagerWithRepos(t),

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -151,13 +151,13 @@ paths:
       summary: Update repository description
       description: |
         Edits the repo's description, which is the verbatim content of the
-        `kb.md` root manifest. The new content is committed to `kb.md` on the
-        repo's agent branch, so the change is part of the repo's git history
-        and syncs with it.
+        `README.md` root manifest. The new content is committed to `README.md`
+        on the repo's agent branch, so the change is part of the repo's git
+        history and syncs with it.
 
         `description` is markdown and is stored byte-for-byte — no
         normalization. Omitting the field leaves the manifest unchanged; an
-        explicit empty string empties `kb.md` (the file stays, and
+        explicit empty string empties `README.md` (the file stays, and
         `description` is then absent from the response). The maximum size is
         65536 bytes; a larger request body is refused with 413 before it is
         read, and an over-cap description with 422.
@@ -176,7 +176,7 @@ paths:
               properties:
                 description:
                   type: string
-                  description: Markdown content for kb.md; omit to keep the current manifest.
+                  description: Markdown content for README.md; omit to keep the current manifest.
                   maxLength: 65536
       responses:
         "200":
@@ -1650,8 +1650,8 @@ components:
         description:
           type: string
           description: |
-            Verbatim content of the repo's kb.md root manifest, read at HEAD.
-            Omitted when the repo has no readable kb.md.
+            Verbatim content of the repo's README.md root manifest, read at HEAD.
+            Omitted when the repo has no readable README.md.
         _links: { $ref: "#/components/schemas/LinkMap" }
 
     BranchSummary:

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -1652,6 +1652,12 @@ components:
           description: |
             Verbatim content of the repo's README.md root manifest, read at HEAD.
             Omitted when the repo has no readable README.md.
+        license:
+          type: string
+          description: >
+            Verbatim contents of LICENSE at the repository root, read at the
+            agent-branch tip. Absent when the repository has no LICENSE or the
+            file exceeds 65536 bytes. Read-only — there is no write path.
         _links: { $ref: "#/components/schemas/LinkMap" }
 
     BranchSummary:

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -1654,6 +1654,7 @@ components:
             Omitted when the repo has no readable README.md.
         license:
           type: string
+          readOnly: true
           description: >
             Verbatim contents of LICENSE at the repository root, read at the
             agent-branch tip. Absent when the repository has no LICENSE or the

--- a/spec/mbekg.md
+++ b/spec/mbekg.md
@@ -568,8 +568,8 @@ top-level directory is machinery and holds no facts (§3.8). Roots other than
 Three non-fact files exist by convention: `README.md` — the root manifest, a
 plain markdown file with no frontmatter, describing the knowledge base;
 `LICENSE` — the terms under which the content is published; and
-`.domains/ontology.yaml` (§3.2). All three sit at the repository root, outside
-the ontology root.
+`.domains/ontology.yaml` (§3.2). All three sit at or directly under the
+repository root, outside the ontology root.
 
 **Exclusion is location-based.** A fact is a file that
 

--- a/spec/mbekg.md
+++ b/spec/mbekg.md
@@ -62,11 +62,12 @@ A client MUST NOT depend on their existence.
 To read a knowledge base:
 
 1. Clone the repository and check out the branch of interest (§4.4).
-2. Read `domains/ontology.yaml` for the taxonomy (§3.2). If absent, assume
-   an embedded default (§3.3).
-3. Walk the ontology root (default `kb/`) for `.md` files. Skip `kb.md` and
-   any file that does not parse as a fact; treat every file that does parse
-   as a fact, wherever it sits (§3.8).
+2. Read `.domains/ontology.yaml` for the taxonomy (§3.2). If absent, check the
+   legacy location `domains/ontology.yaml`; if neither exists, assume an
+   embedded default (§3.3).
+3. Walk the ontology root (default `kb/`) for `.md` files. Skip any path with a
+   dot-prefixed segment (§3.8) and any file that does not parse as a fact;
+   treat every remaining file that parses as a fact (§3.8).
 4. For each fact, parse the YAML frontmatter and the title heading per §2.
 5. Resolve `refs` — local paths, external URLs, or cross-repo `kb://`
    pointers — per §2.9.
@@ -381,8 +382,9 @@ Facts live in a two-level hierarchy — **topic** → **category** → fact file
 under the ontology root (default `kb/`):
 
 ```
+README.md                            ← root manifest (not a fact; §3.8)
+LICENSE                              ← terms for the KB content (§3.8)
 kb/
-  kb.md                              ← root manifest (not a fact; §3.8)
   people/
     individuals/
       a1b2c3d4.md                    ← fact file (8-char UUID filename)
@@ -392,15 +394,18 @@ kb/
   technology/
     software/
       m3n4o5p6.md
-domains/
-  ontology.yaml                      ← ontology definition (outside the root; §3.2)
+.domains/
+  ontology.yaml                      ← ontology definition (private; §3.2)
 ```
 
 ### 3.2 The Definition File
 
-The ontology is defined in **`domains/ontology.yaml`** — at the top level of
-the repository tree, **outside the ontology root**. The location is fixed;
-it does not move if the ontology root differs from `kb`.
+The ontology is defined in **`.domains/ontology.yaml`** — at the top level of
+the repository tree, **outside the ontology root**, in a private directory
+(§3.8). The location is fixed; it does not move if the ontology root differs
+from `kb`. Repositories written before the private-directory convention carry
+it at `domains/ontology.yaml`; a reader SHOULD accept either, preferring
+`.domains/`.
 
 ```yaml
 id: general
@@ -435,7 +440,8 @@ applies (§3.3). The copy on the branch being read is the one in force.
 
 Two taxonomies are conventional, identified by the `id` field. A client will
 encounter one of these — possibly extended — in most repositories, but MUST
-NOT assume either: always read `domains/ontology.yaml`.
+NOT assume either: always read `.domains/ontology.yaml` (or its legacy
+location).
 
 **`general`** (id `general`) — 13 topics, no validation rules. The default
 for new general-purpose repositories:
@@ -550,22 +556,39 @@ applicable validation rules before committing.
 
 ### 3.7 The Ontology Root
 
-Default `kb`. The root is a server-side configuration and is **not recorded
-in the repository**; a reader identifies it as the top-level directory
-containing topic directories of fact files (alongside `domains/` and any
-top-level manifest). Roots other than `kb` are possible but uncommon.
+Default `kb`. The root is a server-side configuration and is **not recorded in
+the repository**; a reader identifies it as the top-level directory containing
+topic directories of fact files (alongside `.domains/`, `README.md`, and
+`LICENSE`). The ontology root is never a private directory — a dot-prefixed
+top-level directory is machinery and holds no facts (§3.8). Roots other than
+`kb` are possible but uncommon.
 
 ### 3.8 Non-Fact Files
 
-Two non-fact files exist by convention: `kb.md` — the root manifest, a plain
-markdown file with no frontmatter, describing the knowledge base; it is part
-of the repository's root commit — and `domains/ontology.yaml`.
+Three non-fact files exist by convention: `README.md` — the root manifest, a
+plain markdown file with no frontmatter, describing the knowledge base;
+`LICENSE` — the terms under which the content is published; and
+`.domains/ontology.yaml` (§3.2). All three sit at the repository root, outside
+the ontology root.
 
-**Exclusion is parse-failure-based, not path-based.** There is no list of
-excluded paths; any file that fails fact parsing (§2.1) is simply not a
-fact. The consequence cuts both ways: a stray file that *does* carry valid
-frontmatter and a title heading is a fact wherever it sits, under any
-filename, and readers MUST treat it as one.
+**Exclusion is location-based.** A fact is a file that
+
+1. sits under the ontology root (§3.7),
+2. has no path segment beginning with `.`, at any depth, and
+3. ends in `.md`.
+
+Parsing (§2.1) then decides whether a file in such a location is a *well-formed*
+fact. The two tests are separate and both must pass: location bounds where a
+fact may live, parsing decides whether what lives there is valid.
+
+**Dot-prefixed segments are private.** A directory or file whose name begins
+with `.` is machinery rather than knowledge — `.github/` for CI, `.domains/`
+for the ontology — and readers MUST skip it during discovery, including under
+the ontology root. `kb/.drafts/` is therefore a usable private stash: a
+well-formed fact placed there is deliberately not part of the knowledge base.
+
+Private governs *walking*, not *opening*: an implementation still reads known
+paths such as `.domains/ontology.yaml` by name.
 
 ## 4. Git Conventions
 
@@ -972,8 +995,9 @@ wins unless it has strictly fewer sources.
 ### 6.1 Repository State
 
 ```
+README.md
+LICENSE
 kb/
-  kb.md
   people/
     individuals/
       a1b2c3d4.md          ← "Alice likes rock music"
@@ -982,7 +1006,7 @@ kb/
   geography/
     urban/
       i9j0k1l2.md          ← "London rain in April"
-domains/
+.domains/
   ontology.yaml
 ```
 

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -206,6 +206,31 @@ describe('RepoManager', () => {
     expect(desc.querySelector('.k-prose')).not.toBeNull();
   });
 
+  // A licence rendered through the markdown pipeline loses every single
+  // newline — markdown reflows them. This asserts the raw text survives
+  // byte-for-byte, which is the one thing that distinguishes a correct
+  // implementation from a plausible-looking one.
+  it('renders LICENSE as preformatted text, preserving line breaks', async () => {
+    const mit = 'MIT License\n\nPermission is hereby granted, free of charge,\nto any person obtaining a copy';
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'core', license: mit,
+    });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
+
+    fireEvent.click(await screen.findByTestId('repo-license-toggle'));
+    expect(screen.getByTestId('repo-license-text').textContent).toBe(mit);
+  });
+
+  // No LICENSE ⇒ no card at all. Unlike the description there is nothing to
+  // write, so an empty card would offer an action that does not exist.
+  it('omits the license card when the repo has no LICENSE', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core' });
+    render(<RepoManager {...baseProps} />);
+    await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
+    expect(screen.queryByTestId('repo-license-toggle')).toBeNull();
+  });
+
   // With no README.md the card is still offered so a description can be
   // written — but only when the user could actually write one.
   it('offers an empty description card when the repo has no README.md', async () => {

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -179,7 +179,7 @@ describe('RepoManager', () => {
     expect(screen.queryByTestId('repo-archive')).not.toBeInTheDocument();
   });
 
-  it('renders the kb.md description in the detail pane', async () => {
+  it('renders the README.md description in the detail pane', async () => {
     (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({
       name: 'core', description: '# Knowledge Base\n\nRoot manifest.',
     });
@@ -189,7 +189,7 @@ describe('RepoManager', () => {
     expect(screen.getByTestId('repo-description')).toHaveTextContent('Root manifest.');
   });
 
-  it('renders GFM in the kb.md description — a table, not literal pipe text', async () => {
+  it('renders GFM in the README.md description — a table, not literal pipe text', async () => {
     (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({
       name: 'core',
       description: '# KB\n\n| Topic | Meaning |\n|---|---|\n| invariants | violate this and it breaks |',
@@ -206,9 +206,9 @@ describe('RepoManager', () => {
     expect(desc.querySelector('.k-prose')).not.toBeNull();
   });
 
-  // With no kb.md the card is still offered so a description can be written —
-  // but only when the user could actually write one.
-  it('offers an empty description card when the repo has no kb.md', async () => {
+  // With no README.md the card is still offered so a description can be
+  // written — but only when the user could actually write one.
+  it('offers an empty description card when the repo has no README.md', async () => {
     (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core' });
     render(<RepoManager {...baseProps} />);
     await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
@@ -226,9 +226,9 @@ describe('RepoManager', () => {
     expect(screen.queryByTestId('repo-description-toggle')).not.toBeInTheDocument();
   });
 
-  // Editing a repo description writes kb.md through PATCH /repos/{repo}, and
-  // the pane adopts the SERVER's re-read value, not the local draft.
-  it('edits a repo description and saves it to kb.md', async () => {
+  // Editing a repo description writes README.md through PATCH /repos/{repo},
+  // and the pane adopts the SERVER's re-read value, not the local draft.
+  it('edits a repo description and saves it to README.md', async () => {
     (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '# Old' });
     (api.updateRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '# New\n\nBody.' });
     render(<RepoManager {...baseProps} />);

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -231,6 +231,8 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
 }) {
   const [agentBranch, setAgentBranch] = useState('');
   const [description, setDescription] = useState('');
+  // license is read-only: set once from the GET response, never written back.
+  const [license, setLicense] = useState('');
   const [rebuilding, setRebuilding] = useState(false);
   const [rebuildMsg, setRebuildMsg] = useState('');
   const [busy, setBusy] = useState(false);
@@ -243,7 +245,12 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
     let cancelled = false;
     api.getAgentBranch(name).then(b => { if (!cancelled) setAgentBranch(b); }).catch(() => {});
     setDescription('');
-    api.getRepo(name).then(r => { if (!cancelled) setDescription(r.description ?? ''); }).catch(() => {});
+    setLicense('');
+    api.getRepo(name).then(r => {
+      if (cancelled) return;
+      setDescription(r.description ?? '');
+      setLicense(r.license ?? '');
+    }).catch(() => {});
     return () => { cancelled = true; };
   }, [name]);
 
@@ -381,6 +388,14 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
             setDescription(updated.description ?? '');
           }}
         />
+      )}
+
+      {license && (
+        <Disclosure label="License" hint="LICENSE at the repo root" testid="repo-license-toggle" bodyTestid="repo-license">
+          {/* Preformatted, NOT markdown: a licence's single newlines are
+              meaningful, and a markdown renderer reflows them away. */}
+          <pre style={licenseText} data-testid="repo-license-text">{license}</pre>
+        </Disclosure>
       )}
 
       <ConnectPanel kind="repo" name={name} agentBranch={agentBranch} />
@@ -1045,6 +1060,13 @@ const descTextarea: React.CSSProperties = {
 const disclosureHead: React.CSSProperties = {
   display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%',
   background: 'none', border: 'none', padding: 0, cursor: 'pointer', textAlign: 'left',
+};
+// licenseText renders LICENSE preformatted, not as markdown — a licence's
+// single newlines are meaningful, and a markdown renderer reflows them away.
+const licenseText: React.CSSProperties = {
+  margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+  fontFamily: 'var(--k-font-mono)', fontSize: 11.5, lineHeight: 1.6,
+  color: '#a0a0a8', maxHeight: 320, overflowY: 'auto',
 };
 const menuTrigger = (open: boolean): React.CSSProperties => ({
   display: 'inline-flex', alignItems: 'center', justifyContent: 'center',

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -373,7 +373,7 @@ function RepoDetail({ name, canArchive, readOnly, hideRemoteConfig, onArchived, 
         <DescriptionCard
           markdown={description}
           readOnly={readOnly}
-          saveHint="committed to kb.md on the agent branch"
+          saveHint="committed to README.md on the agent branch"
           maxBytes={MAX_REPO_DESCRIPTION_BYTES}
           onSave={async md => {
             const updated = await api.updateRepo(name, { description: md });
@@ -453,8 +453,8 @@ function Disclosure({ label, hint, testid, bodyTestid, action, open: openProp, o
 // (no rich-text layer that could rewrite what gets committed).
 function DescriptionCard({ markdown, readOnly, saveHint, maxBytes, onSave }: {
   markdown: string; readOnly: boolean; saveHint: string;
-  // Byte cap the server enforces for THIS destination — a repo's kb.md and a
-  // lens's note share this editor but not their limits.
+  // Byte cap the server enforces for THIS destination — a repo's README.md and
+  // a lens's note share this editor but not their limits.
   maxBytes: number;
   onSave: (md: string) => Promise<void>;
 }) {
@@ -1035,7 +1035,7 @@ const plusBtn = (disabled: boolean, active: boolean): React.CSSProperties => ({
 // Browse, then the ⋯ overflow. It never wraps under the title.
 const headActions: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 };
 // descTextarea edits raw markdown, so it is monospaced and generously tall —
-// a repo's kb.md is a document, not a caption.
+// a repo's README.md is a document, not a caption.
 const descTextarea: React.CSSProperties = {
   width: '100%', boxSizing: 'border-box', minHeight: 240, resize: 'vertical',
   background: '#0c0c0c', border: '1px solid #333', borderRadius: 5, color: '#ddd',

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -67,30 +67,32 @@ function branchBase(repo: string, branch: string): string {
 // repo's root commit and will never match anything here.
 export interface RepoInfo { name: string; id?: string }
 
-// RepoDetails is the single-repo GET shape. description is the verbatim kb.md
-// root manifest read at HEAD; absent when the repo has no readable kb.md.
+// RepoDetails is the single-repo GET shape. description is the verbatim
+// README.md root manifest read at HEAD; absent when the repo has no readable
+// README.md.
 export interface RepoDetails { name: string; agent_branch?: string; description?: string }
 
-// getRepo fetches GET /api/v1/repos/{repo} — name, agent branch, and the kb.md
-// description when available.
+// getRepo fetches GET /api/v1/repos/{repo} — name, agent branch, and the
+// README.md description when available.
 async function getRepo(repo: string): Promise<RepoDetails> {
   return fetchJSON<RepoDetails>(repoBase(repo));
 }
 
 /* Description caps, in BYTES (not characters) — mirrors of the server-side
- * limits, kept here beside the calls they bound. A repo's kb.md is a manifest
- * that runs to pages; a lens description is a note about a read union, and its
- * cap is more than an order of magnitude smaller. An editor shared by both must
- * say which one it is holding, or the difference only surfaces as a 422.
+ * limits, kept here beside the calls they bound. A repo's README.md is a
+ * manifest that runs to pages; a lens description is a note about a read union,
+ * and its cap is more than an order of magnitude smaller. An editor shared by
+ * both must say which one it is holding, or the difference only surfaces as a
+ * 422.
  *   repos.MaxRepoDescriptionBytes — internal/repos/manifest.go
  *   repos.MaxLensDescriptionBytes — internal/repos/lens.go */
 export const MAX_REPO_DESCRIPTION_BYTES = 64 * 1024;
 export const MAX_LENS_DESCRIPTION_BYTES = 4096;
 
 // updateRepo PATCHes /api/v1/repos/{repo}. The only editable field is
-// description, which the server commits to the repo's kb.md root manifest on
-// the agent branch — so editing it here writes a real commit into the repo's
-// history. Returns the re-read repo view (same shape as getRepo).
+// description, which the server commits to the repo's README.md root manifest
+// on the agent branch — so editing it here writes a real commit into the
+// repo's history. Returns the re-read repo view (same shape as getRepo).
 async function updateRepo(repo: string, body: { description?: string }): Promise<RepoDetails> {
   return fetchJSON<RepoDetails>(repoBase(repo), {
     method: 'PATCH',

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -68,9 +68,9 @@ function branchBase(repo: string, branch: string): string {
 export interface RepoInfo { name: string; id?: string }
 
 // RepoDetails is the single-repo GET shape. description is the verbatim
-// README.md root manifest read at HEAD; absent when the repo has no readable
-// README.md.
-export interface RepoDetails { name: string; agent_branch?: string; description?: string }
+// README.md root manifest read at HEAD; license is the verbatim LICENSE. Both
+// are absent when the repo has no readable copy.
+export interface RepoDetails { name: string; agent_branch?: string; description?: string; license?: string }
 
 // getRepo fetches GET /api/v1/repos/{repo} — name, agent branch, and the
 // README.md description when available.


### PR DESCRIPTION
Reshapes a KB repo's on-disk layout so it reads as an ordinary git repository to an ordinary git host.

**There is no migration — existing KB repos are renamed by hand.** Each change below states what an unmigrated repo does.

## Changes

**`kb.md` → `README.md`** — every major git provider already renders `README.md` at a repo root as the repository description, which is exactly what this file is. Clean break: nothing reads `kb.md`. An unmigrated repo shows an empty description card until the file is renamed.

**`LICENSE` at the repo root** — read and exposed on the single-repo GET, rendered as preformatted text (a markdown renderer reflows a licence's newlines away). Read-only by design: no write path, no seeding, no OKF export.

**Dot-prefixed segments are private** — `fact.IsPrivatePath` excludes them from fact *discovery* at any depth, including under the ontology root, and the fact-creation paths refuse to allocate one. `kb/.drafts/` is therefore a usable private stash.

Private governs **walking, not opening** — knomit still reads `.domains/ontology.yaml` by name. That is why the check is deliberately *not* in `store.validatePath`, which also guards `README.md` and the ontology write.

**`domains/` → `.domains/`** — the ontology is configuration, not knowledge. Unlike the README this *does* keep a legacy read fallback, because the cost of a miss differs: a missing README costs a description, a missing ontology falls back to `DefaultOntology()` and would silently validate new facts against the wrong taxonomy. `loadOntology` remembers which path it read and the preset refresh writes back to that same path — otherwise a legacy repo grows a second ontology file with the stale one left as a decoy.

**`spec/mbekg.md`** — §3.8 asserted "Exclusion is parse-failure-based, not path-based. There is no list of excluded paths." That is now false, and had already drifted from `isFactPath` before this work. Rewritten to the location-based contract, and its corollary that a stray file with valid frontmatter is a fact *wherever it sits* is deleted — that is the exact misreading this change eliminates. Also fixes a pre-existing error in the §3.1 diagram, which placed the root manifest inside `kb/` rather than at the tree root.

## Note on `WriteRootFile`

`factIndex.writeFile` lowercases every path — a fact-path rule that prevents case-duplicate topics (`AI` vs `ai`). It never mattered for `kb.md`, but would have committed `readme.md`. `store.WriteRootFile` is the case-preserving door for non-fact root files, restricted to root level so it cannot become a bypass of fact-path normalization.

## Review

Eight tasks, each independently reviewed, plus a whole-branch review. Six defects were caught and fixed before merge, including two that this branch itself introduced:

- A **fourth** fact-creation site — the `PUT .../facts/{path...}` endpoint, which takes a fully caller-supplied path. This branch had silently changed it from "accepted and indexed" to "committed and permanently invisible, returns 200".
- Three ListDir-backed topic browsers that listed `.drafts` as an ordinary topic, contradicting the §3.8 MUST shipped in this same PR.

Three of the six were tests that passed under a broken implementation; each was replaced with one demonstrated to fail against the specific regression it guards.

## Verification

- `CGO_ENABLED=1 go test ./...` — 43 packages, 0 failures
- `CGO_ENABLED=1 go vet ./...` — clean
- `cd web && npm run build` — clean (the real `tsc -b`; `npx tsc --noEmit` type-checks zero files in this repo)
- `cd web && npx vitest run` — 718/718

🤖 Generated with [Claude Code](https://claude.com/claude-code)
