### PR TITLE
perf(store): compute a commit's diff only when the commit is actually new

### DIFF
--- a/internal/store/branch_commit_log.go
+++ b/internal/store/branch_commit_log.go
@@ -34,27 +34,35 @@ func (rh *repoHandler) populateCommitLog(ctx context.Context, branch string) err
 	}
 	defer logIter.Close()
 
-	var count int
-	err = rh.gits.CommitLogSync(branch, func() (string, []string, []storegit.CommitLogEntry, error) {
+	// The payload is a thunk, not a value: changedFilesInCommit is an
+	// object.DiffTree costing ~300 object loads (~2 ms) per commit, and on a
+	// warm open every commit here is already recorded. CommitLogSync calls the
+	// thunk only for commits it will actually insert, so a no-op re-walk of a
+	// populated branch costs one indexed lookup per commit instead of a diff.
+	var count, computed int
+	err = rh.gits.CommitLogSync(branch, func() (string, storegit.CommitLogPayload, error) {
 		c, err := logIter.Next()
 		if err == io.EOF {
-			return "", nil, nil, nil
+			return "", nil, nil
 		}
 		if err != nil {
-			return "", nil, nil, err
+			return "", nil, err
 		}
 		count++
-		files, err := changedFilesInCommit(c)
-		if err != nil {
-			return "", nil, nil, err
-		}
-		return c.Hash.String(), parentHashes(c), commitEntries(c, files), nil
+		return c.Hash.String(), func() ([]string, []storegit.CommitLogEntry, error) {
+			computed++
+			files, err := changedFilesInCommit(c)
+			if err != nil {
+				return nil, nil, err
+			}
+			return parentHashes(c), commitEntries(c, files), nil
+		}, nil
 	})
 	if err != nil {
 		return fmt.Errorf("populateCommitLog: sync: %w", err)
 	}
 
-	log.Debug().Int("commits", count).Msg("commit_log: populated")
+	log.Debug().Int("commits", count).Int("computed", computed).Msg("commit_log: populated")
 	return nil
 }
 
@@ -102,23 +110,26 @@ func (rh *repoHandler) AppendCommitLog(ctx context.Context, branch, hashStr stri
 		return nil
 	}
 	hash := plumbing.NewHash(hashStr)
-	c, err := rh.repo.CommitObject(hash)
-	if err != nil {
-		return fmt.Errorf("AppendCommitLog: get commit %s: %w", hashStr, err)
-	}
-	files, err := changedFilesInCommit(c)
-	if err != nil {
-		return fmt.Errorf("AppendCommitLog: changed files %s: %w", hashStr, err)
-	}
 	done := false
-	entries := commitEntries(c, files)
-	parents := parentHashes(c)
-	if err := rh.gits.CommitLogSync(branch, func() (string, []string, []storegit.CommitLogEntry, error) {
+	// Same lazy-payload shape as populateCommitLog: reading the commit object
+	// and diffing it against its parent is skipped entirely when the commit is
+	// already recorded on this branch.
+	if err := rh.gits.CommitLogSync(branch, func() (string, storegit.CommitLogPayload, error) {
 		if done {
-			return "", nil, nil, nil
+			return "", nil, nil
 		}
 		done = true
-		return hash.String(), parents, entries, nil
+		return hash.String(), func() ([]string, []storegit.CommitLogEntry, error) {
+			c, err := rh.repo.CommitObject(hash)
+			if err != nil {
+				return nil, nil, fmt.Errorf("get commit %s: %w", hashStr, err)
+			}
+			files, err := changedFilesInCommit(c)
+			if err != nil {
+				return nil, nil, fmt.Errorf("changed files %s: %w", hashStr, err)
+			}
+			return parentHashes(c), commitEntries(c, files), nil
+		}, nil
 	}); err != nil {
 		return fmt.Errorf("AppendCommitLog: sync %s: %w", hashStr, err)
 	}

--- a/internal/store/commitlog_lazy_payload_test.go
+++ b/internal/store/commitlog_lazy_payload_test.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/require"
+
+	storegit "knomit/internal/store/git"
+)
+
+// newCommitLogService opens a fresh single-branch repo for commit-log tests.
+func newCommitLogService(t *testing.T) (*Service, string) {
+	t.Helper()
+	const branch = "main"
+	svc, err := Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+	return svc, branch
+}
+
+// syncSyntheticHashes feeds hashes to CommitLogSync and reports how many of
+// them had their payload thunk invoked.
+func syncSyntheticHashes(t *testing.T, s *Service, branch string, hashes []string) (payloads int) {
+	t.Helper()
+	var i int
+	err := s.rh.gits.CommitLogSync(branch, func() (string, storegit.CommitLogPayload, error) {
+		if i >= len(hashes) {
+			return "", nil, nil
+		}
+		h := hashes[i]
+		i++
+		return h, func() ([]string, []storegit.CommitLogEntry, error) {
+			payloads++
+			var parents []string
+			if i > 1 {
+				parents = []string{hashes[i-2]}
+			}
+			return parents, []storegit.CommitLogEntry{{
+				Hash: h, Path: fmt.Sprintf("kb/f%s.md", h), Message: "m",
+				Operation: "learn", AuthorName: "a", AuthorEmail: "a@b",
+				Action: "added", CommittedAt: 1000 + int64(i),
+			}}, nil
+		}, nil
+	})
+	require.NoError(t, err)
+	return payloads
+}
+
+// TestCommitLogSync_SkipsPayloadForKnownCommits is the regression anchor for
+// the warm-open cost. A commit already recorded on the branch must not cost a
+// payload computation: in production the payload is an object.DiffTree of ~300
+// SQLite object loads (~2 ms/commit), and it was previously computed for every
+// commit and then discarded by a dedup check that ran only afterwards. That
+// made a warm repo open cost ~2 ms per commit for rows it already had.
+func TestCommitLogSync_SkipsPayloadForKnownCommits(t *testing.T) {
+	svc, branch := newCommitLogService(t)
+	hashes := []string{
+		"1111111111111111111111111111111111111111",
+		"2222222222222222222222222222222222222222",
+		"3333333333333333333333333333333333333333",
+	}
+
+	require.Equal(t, 3, syncSyntheticHashes(t, svc, branch, hashes),
+		"first sync must compute every payload")
+
+	require.Equal(t, 0, syncSyntheticHashes(t, svc, branch, hashes),
+		"re-walk of fully-recorded commits must compute no payloads")
+
+	fresh := "4444444444444444444444444444444444444444"
+	require.Equal(t, 1, syncSyntheticHashes(t, svc, branch, append(append([]string{}, hashes...), fresh)),
+		"a new commit after known ones must still be computed")
+}
+
+// TestCommitLogSync_WalksPastDedupHits guards the DAG invariant that the lazy
+// payload must not weaken: a dedup hit mid-iteration skips-and-continues, it
+// never ends the walk. On a merge commit, a known commit on one parent's line
+// says nothing about the other parent's ancestry.
+func TestCommitLogSync_WalksPastDedupHits(t *testing.T) {
+	svc, branch := newCommitLogService(t)
+	a := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	b := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	c := "cccccccccccccccccccccccccccccccccccccccc"
+
+	syncSyntheticHashes(t, svc, branch, []string{b})
+
+	require.Equal(t, 2, syncSyntheticHashes(t, svc, branch, []string{a, b, c}),
+		"the walk must continue past the dedup hit on b and still compute c")
+
+	for _, h := range []string{a, b, c} {
+		var n int
+		require.NoError(t, svc.rh.db.QueryRow(
+			`SELECT COUNT(*) FROM branch_commits bc JOIN branches br ON br.id = bc.branch_id
+			 WHERE br.name = ? AND bc.commit_hash = ?`, branch, h).Scan(&n))
+		require.Equalf(t, 1, n, "branch_commits row for %s", h)
+	}
+
+	// The payload's rows still land: commit_log entries and commit_parents edges.
+	var edges int
+	require.NoError(t, svc.rh.db.QueryRow(
+		`SELECT COUNT(*) FROM commit_parents WHERE commit_hash = ? AND parent_hash = ?`,
+		c, b).Scan(&edges))
+	require.Equal(t, 1, edges, "commit_parents edge from the computed payload")
+}
+
+// TestPopulateCommitLog_NoTreeReadsForKnownCommits is the end-to-end anchor. It
+// deletes the tree objects of already-recorded commits, which makes any attempt
+// to diff them fail outright. A re-walk must still succeed, proving the diff is
+// never attempted for a commit the branch already has.
+func TestPopulateCommitLog_NoTreeReadsForKnownCommits(t *testing.T) {
+	svc, branch := newCommitLogService(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"a", "b", "c"} {
+		_, err := svc.Facts().WriteFact(ctx, branch, "kb/"+name+".md",
+			testFactBody(name, 0.9, nil), "learn "+name, "learn")
+		require.NoError(t, err)
+	}
+
+	// Collect every commit reachable from the tip, then drop its tree object.
+	head, err := svc.rh.resolveRef(ctx, branch)
+	require.NoError(t, err)
+	iter, err := svc.rh.repo.Log(&gogit.LogOptions{From: head, Order: gogit.LogOrderDefault})
+	require.NoError(t, err)
+	var trees []plumbing.Hash
+	require.NoError(t, iter.ForEach(func(c *object.Commit) error {
+		trees = append(trees, c.TreeHash)
+		return nil
+	}))
+	iter.Close()
+	require.NotEmpty(t, trees)
+
+	for _, h := range trees {
+		require.NoError(t, svc.rh.gits.DeleteObjectForTest(h))
+	}
+
+	// Every commit is already recorded, so no payload — and therefore no tree
+	// read — should be attempted. Before the lazy payload this errored with
+	// "changedFilesInCommit: tree: object not found".
+	require.NoError(t, svc.rh.populateCommitLog(ctx, branch),
+		"re-walk of a populated branch must not read commit trees")
+}

--- a/internal/store/git/commitlog.go
+++ b/internal/store/git/commitlog.go
@@ -68,21 +68,38 @@ func (s *Storer) commitLogTableExists() bool {
 	return true
 }
 
-// CommitLogSync is the core write method for commit_log.
-// It calls iter() repeatedly until it returns ("", nil, nil, nil) (sentinel for done).
-// For each non-empty hash: if the hash already exists in commit_log, iteration stops
-// (backfill dedup). All rows for a hash — commit_log entries, branch_commits
-// visibility, and commit_parents edges — are inserted in a single transaction.
-// The commitLog atomic is marked true once the table is confirmed to exist
-// and has been previously written to (either via a new insert or confirmed
-// via an existing indexed commit).
+// CommitLogPayload produces the rows for one commit: its ordered parent hashes
+// and its commit_log entries.
+//
+// It is deliberately a thunk rather than a value. CommitLogSync calls it ONLY
+// for a commit that is not yet recorded on the branch, because computing it is
+// expensive — in the production caller it is an object.DiffTree of the commit
+// against its first parent, ~300 SQLite object loads and ~2 ms per commit. A
+// warm repo open re-walks a fully-populated DAG, so nearly every commit is a
+// dedup hit; computing the payload eagerly made repo open cost ~2 ms per commit
+// (4.2 s for a 1831-commit repo) to produce rows that were immediately thrown
+// away. See CommitLogSync's dedup step.
 //
 // `parents` is the ordered list of parent commit hashes for this commit
 // (parents[0] is the first parent, etc.). Used by resolveActiveCommitForPath's
 // recursive-CTE walk and replaces the retired first_parent_chain virtual
 // table whose Go cursor callback could re-enter the *sql.DB pool mid-scan
 // and deadlock.
-func (s *Storer) CommitLogSync(branchName string, iter func() (hash string, parents []string, entries []CommitLogEntry, err error)) error {
+type CommitLogPayload func() (parents []string, entries []CommitLogEntry, err error)
+
+// CommitLogSync is the core write method for commit_log.
+// It calls iter() repeatedly until it returns ("", nil, nil) (sentinel for done).
+// For each non-empty hash: if the commit is already recorded as visible on this
+// branch it is skipped WITHOUT calling its payload, and the walk continues. All
+// rows for a hash — commit_log entries, branch_commits visibility, and
+// commit_parents edges — are inserted in a single transaction.
+// The commitLog atomic is marked true once the table is confirmed to exist
+// and has been previously written to (either via a new insert or confirmed
+// via an existing indexed commit).
+//
+// iter must return the hash cheaply; all per-commit work belongs in the
+// returned CommitLogPayload so the dedup check can gate it.
+func (s *Storer) CommitLogSync(branchName string, iter func() (hash string, payload CommitLogPayload, err error)) error {
 	if !s.CommitLogAvailable() {
 		return nil
 	}
@@ -98,7 +115,7 @@ func (s *Storer) CommitLogSync(branchName string, iter func() (hash string, pare
 	}
 
 	for {
-		hash, parents, entries, err := iter()
+		hash, payload, err := iter()
 		if err != nil {
 			return fmt.Errorf("CommitLogSync: iter: %w", err)
 		}
@@ -114,6 +131,9 @@ func (s *Storer) CommitLogSync(branchName string, iter func() (hash string, pare
 		// is walking a DAG — hitting a known commit on one parent's line says
 		// nothing about the other parent's ancestry. Skip this commit and
 		// continue walking rather than short-circuiting.
+		//
+		// This check runs BEFORE payload() so a known commit costs one indexed
+		// lookup instead of a full tree diff.
 		var cnt int
 		if err := s.db.QueryRow(
 			`SELECT COUNT(*) FROM branch_commits WHERE branch_id = ? AND commit_hash = ?`,
@@ -123,6 +143,14 @@ func (s *Storer) CommitLogSync(branchName string, iter func() (hash string, pare
 		if cnt > 0 {
 			s.commitLog.Store(true)
 			continue
+		}
+
+		var parents []string
+		var entries []CommitLogEntry
+		if payload != nil {
+			if parents, entries, err = payload(); err != nil {
+				return fmt.Errorf("CommitLogSync: payload for %s: %w", hash, err)
+			}
 		}
 
 		tx, err := s.db.Begin()


### PR DESCRIPTION
## The bug

`CommitLogSync`'s iterator returned `(hash, parents, entries)` together, so the caller had to compute the payload **before** the dedup check could reject it. In `populateCommitLog` that payload is an `object.DiffTree` of the commit against its first parent — ~307 SQLite object loads, ~2 ms per commit.

Every repo open re-walks a fully-populated DAG, so nearly every commit is a dedup hit. The cheap check was gating the expensive work, in the wrong order:

```
store.Open        =   4.0 ms
OpenRepo          = 4.187 s      <- 1831 diffs computed, all discarded
  iter.Next       =  12.5 ms  ( 0.3%)
  changedFiles    = 4.065 s   (99.5%)   <- object.DiffTree
  commitEntries   =  0.45 ms  ( 0.0%)
  dedup SELECT    =   8.9 ms  ( 0.2%)
```

## The fix

Make the payload a thunk:

```go
type CommitLogPayload func() (parents []string, entries []CommitLogEntry, err error)

func (s *Storer) CommitLogSync(branchName string,
    iter func() (hash string, payload CommitLogPayload, err error)) error
```

`CommitLogSync` calls `payload()` only after the `branch_commits` lookup misses. `AppendCommitLog` gets the same shape and now also skips reading the commit object when the commit is already recorded.

**The DAG invariant is untouched.** A dedup hit still skips-and-continues, never short-circuits — every commit is still visited and merge-parent lines are still followed. Only the per-commit *payload* became lazy. `TestCommitLogSync_WalksPastDedupHits` anchors this.

## Results

| | before | after |
|---|---:|---:|
| `OpenRepo` on core.db (1831 commits) | 4.187 s | **68.6 ms** |
| Boot, 24 repos (run 1) | 35.42 s | **3.02 s** |
| Boot, 24 repos (run 2) | 37.86 s | **1.85 s** |

Both binaries built from this same tree with the fix stashed for the "before" build. The baseline reproduces the previously-measured 35.34 s.

## Correctness

Verified identical output, not just faster. After booting all 24 repos on each binary, `branch_commits` / `commit_log` / `commit_parents` row counts and an md5 over every `(commit_hash, path, action)` row are **byte-identical** across all four repo shapes:

```
core-1                 5482 bc, 4904 cl, 1856 cp, md5=106b2bc7...  (both)
knomit-kb-1            1607 bc, 1652 cl,  783 cp, md5=0243f843...  (both)
agentic-engineering-1   552 bc,  523 cl,  187 cp, md5=6733ded7...  (both)
knomit-io-kb-1           20 bc,   12 cl,    8 cp, md5=e785b982...  (both)
```

Full `go test ./...` green. The new tests are non-vacuous — re-run with the eager ordering restored, both fail with `changedFilesInCommit: tree: object not found`. The end-to-end anchor deletes the tree objects of recorded commits, so any attempt to diff them fails outright; a re-walk succeeding proves the diff never happens.

## Two corrections to the earlier diagnosis

- **Not zlib, and not per-round-trip latency.** Objects are stored uncompressed (`storer.go` inserts the raw blob). Individual loads are 6.9 µs — SQLite is fine. The cost is the *number* of object loads.
- **Not `commits × branches`.** `OpenRepo` walks only the HEAD branch, and `healIndexBranches`' `SyncLocked` does not populate the commit log (only the `stale` path's `Rebuild` does). Cost is linear in **distinct commits on HEAD**. A repo used from five machines does not pay 5×.