### PR TITLE
fix(web,desktop): open external links in the OS browser

### DIFF
--- a/tools/desktop/app.go
+++ b/tools/desktop/app.go
@@ -444,6 +444,11 @@ const apiBaseWaitTimeout = 90 * time.Second
 // root and its SPA fallback.
 const desktopPrefix = "/desktop/"
 
+// wailsPrefix is the framework's reserved path space (/wails/runtime and
+// /wails/runtime.js). Wails answers it in middleware wrapping this handler;
+// see the guard in configInjectingHandler for why we refuse it anyway.
+const wailsPrefix = "/wails/"
+
 // configInjectingHandler serves /config.js with the live API base, serves the
 // embedded UI assets, falls back to index.html for client-side routes, and
 // serves the desktop-only bundle under /desktop/.
@@ -469,6 +474,19 @@ func configInjectingHandler(uiFS, desktopFS fs.FS, apiBase func(context.Context)
 		// the window showing the knowledge app — or, worse, nothing at all.
 		if desktopServer != nil && strings.HasPrefix(r.URL.Path, desktopPrefix) {
 			desktopServer.ServeHTTP(w, r)
+			return
+		}
+		// Wails' own endpoints (/wails/runtime, /wails/runtime.js) are answered
+		// by framework middleware that wraps this handler, so nothing under
+		// /wails/ should ever arrive here. If ordering ever changes so that it
+		// does, the SPA fallback below would answer a runtime call with
+		// index.html and a 200 — and the frontend, seeing an OK response, would
+		// believe the call succeeded. External links open through
+		// Browser.OpenURL over that endpoint (see web/src/externalLinks.ts);
+		// that failure would put them right back to doing nothing on click.
+		// 404 instead, so the breakage is visible.
+		if strings.HasPrefix(r.URL.Path, wailsPrefix) {
+			http.NotFound(w, r)
 			return
 		}
 		if r.URL.Path == "/config.js" {

--- a/tools/desktop/app_test.go
+++ b/tools/desktop/app_test.go
@@ -169,6 +169,24 @@ func TestConfigInjectingHandler_DesktopMissRejects(t *testing.T) {
 	}
 }
 
+// Wails' runtime endpoints are answered by middleware wrapping this handler, so
+// they must never reach it. If they ever do, the SPA fallback would return
+// index.html with a 200 and the frontend would read that as a successful
+// runtime call — which is how external links (Browser.OpenURL over
+// /wails/runtime, see web/src/externalLinks.ts) would silently go inert again.
+func TestConfigInjectingHandler_RefusesWailsRuntimePaths(t *testing.T) {
+	h := configInjectingHandler(testUIFS(), nil, staticBase("http://127.0.0.1:19278"))
+
+	for _, path := range []string{"/wails/runtime", "/wails/runtime.js"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, path, nil))
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s status = %d, want 404 (body %q)", path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
 // application.App.impl — what every Dialog, Quit and InvokeSync call
 // dereferences — is assigned INSIDE Run(). The boot watcher goroutine is
 // started ~45 lines earlier, so a fast bootKnomit failure (an unwritable

--- a/web/src/externalLinks.test.ts
+++ b/web/src/externalLinks.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { installExternalLinkHandler, openExternal } from './externalLinks';
+
+type DesktopWindow = Window & { __KNOMIT_DESKTOP__?: boolean };
+
+function setDesktop(on: boolean) {
+  if (on) (window as DesktopWindow).__KNOMIT_DESKTOP__ = true;
+  else delete (window as DesktopWindow).__KNOMIT_DESKTOP__;
+}
+
+/** Anchor in the document, so a dispatched click actually bubbles to it. */
+function anchor(html: string): HTMLAnchorElement {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  document.body.appendChild(host);
+  return host.querySelector('a')!;
+}
+
+function click(el: Element, init: MouseEventInit = {}): MouseEvent {
+  const e = new MouseEvent('click', { bubbles: true, cancelable: true, ...init });
+  el.dispatchEvent(e);
+  return e;
+}
+
+describe('installExternalLinkHandler', () => {
+  let uninstall: (() => void) | undefined;
+  let open: Mock<(url: string) => void>;
+
+  beforeEach(() => {
+    open = vi.fn<(url: string) => void>();
+  });
+
+  afterEach(() => {
+    uninstall?.();
+    uninstall = undefined;
+    document.body.innerHTML = '';
+    setDesktop(false);
+  });
+
+  it('does nothing outside the desktop shell, where target=_blank already works', () => {
+    setDesktop(false);
+    uninstall = installExternalLinkHandler({ open });
+
+    const a = anchor('<a href="https://example.com/x" target="_blank">x</a>');
+    const e = click(a);
+
+    expect(open).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it('hands an external link to the OS instead of the webview', () => {
+    setDesktop(true);
+    uninstall = installExternalLinkHandler({ open });
+
+    const a = anchor('<a href="https://example.com/x" target="_blank">x</a>');
+    const e = click(a);
+
+    expect(open).toHaveBeenCalledWith('https://example.com/x');
+    // Must be prevented: letting it through is what leaves the click inert.
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it('resolves the anchor from a click on a nested element', () => {
+    setDesktop(true);
+    uninstall = installExternalLinkHandler({ open });
+
+    const a = anchor('<a href="https://example.com/y"><span>go</span></a>');
+    click(a.querySelector('span')!);
+
+    expect(open).toHaveBeenCalledWith('https://example.com/y');
+  });
+
+  it('routes a modifier click externally too — the webview cannot open a tab either way', () => {
+    setDesktop(true);
+    uninstall = installExternalLinkHandler({ open });
+
+    const a = anchor('<a href="https://example.com/z">z</a>');
+    const e = click(a, { metaKey: true });
+
+    expect(open).toHaveBeenCalledWith('https://example.com/z');
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it.each([
+    ['a GFM footnote backref', '<a href="#user-content-fn-1">1</a>'],
+    ['an in-app relative link', '<a href="/facts/x">x</a>'],
+    ['a non-web scheme', '<a href="mailto:a@b.c">mail</a>'],
+    ['an anchor with no href', '<a>bare</a>'],
+  ])('leaves %s alone', (_label, html) => {
+    setDesktop(true);
+    uninstall = installExternalLinkHandler({ open });
+
+    const e = click(anchor(html));
+
+    expect(open).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it('yields to a handler that already prevented the click', () => {
+    setDesktop(true);
+    uninstall = installExternalLinkHandler({ open });
+
+    const a = anchor('<a href="https://example.com/x">x</a>');
+    a.addEventListener('click', (e) => e.preventDefault());
+    click(a);
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('stops intercepting once uninstalled', () => {
+    setDesktop(true);
+    const off = installExternalLinkHandler({ open });
+    off();
+
+    const e = click(anchor('<a href="https://example.com/x">x</a>'));
+
+    expect(open).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it('swallows a failure to reach the shell rather than rejecting into the click', async () => {
+    setDesktop(true);
+    const boom = vi.fn().mockRejectedValue(new Error('no runtime'));
+    const onError = vi.fn();
+    uninstall = installExternalLinkHandler({ open: boom, onError });
+
+    click(anchor('<a href="https://example.com/x">x</a>'));
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+  });
+});
+
+describe('openExternal', () => {
+  it('posts a Wails Browser.OpenURL runtime call', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+
+    await openExternal('https://example.com/x', fetchImpl);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    // Root-relative: the desktop window's origin is the custom wails:// scheme,
+    // for which location.origin is not a dependable base.
+    expect(url).toBe('/wails/runtime');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    // object 9 = Browser, method 0 = OpenURL. See the Wails v3 message processor.
+    expect(JSON.parse(init.body)).toEqual({
+      object: 9,
+      method: 0,
+      args: { url: 'https://example.com/x' },
+    });
+  });
+
+  it('rejects when the shell refuses the call, so the caller can log it', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('nope', { status: 400 }));
+
+    await expect(openExternal('https://example.com/x', fetchImpl)).rejects.toThrow(/nope/);
+  });
+});

--- a/web/src/externalLinks.ts
+++ b/web/src/externalLinks.ts
@@ -1,0 +1,128 @@
+// External links in the Wails desktop shell.
+//
+// Every outward-pointing link in the app renders as target="_blank" (see the
+// `a` override in markdown.tsx and the References rail in FactBody.tsx). In a
+// browser that opens a tab. In the desktop window the page runs inside a
+// WKWebView, and asking for a new window there routes through the WKUIDelegate
+// method `webView:createWebViewWithConfiguration:forNavigationAction:`. Wails
+// v3's macOS delegate does not implement it — its only WKUIDelegate method is
+// the file-input open panel — and WKWebView's documented behaviour when that
+// method is absent is to drop the request silently. So on desktop those links
+// were inert: click, nothing.
+//
+// Dropping target="_blank" is not the fix. Then the link navigates the webview
+// in place, and since the app has no router that is a full unload: app state
+// gone, and no chrome to get back with. The link has to leave the webview
+// entirely, which means handing the URL to the OS.
+//
+// Wails exposes exactly that as Browser.OpenURL, reachable over its runtime
+// transport — a POST to /wails/runtime, which the framework's HTTP
+// transport middleware answers ahead of knomit's own asset handler. Calling it
+// with a bare fetch (rather than importing @wailsio/runtime) keeps the Wails
+// dependency out of the shared browser bundle, the same trade TopBar.tsx makes
+// when it posts "wails:drag" by hand.
+
+/**
+ * Wails' runtime endpoint. Its HTTP transport middleware wraps the asset
+ * server, so this is answered before knomit's own handler ever sees the path.
+ */
+const RUNTIME_PATH = '/wails/runtime';
+/** Wails runtime object ID for Browser. See objectNames in the v3 runtime. */
+const BROWSER_OBJECT = 9;
+/** Wails Browser method ID for OpenURL. */
+const OPEN_URL_METHOD = 0;
+
+/**
+ * Ask the desktop shell to open `url` in the user's default browser.
+ *
+ * Rejects if the shell refuses the call, so callers can report it rather than
+ * leaving the user with a click that did nothing — the very failure this
+ * module exists to remove.
+ */
+export async function openExternal(url: string, fetchImpl: typeof fetch = fetch): Promise<void> {
+  // Root-relative, not origin-derived. The desktop window is served over the
+  // custom `wails://localhost` scheme, and `location.origin` is only
+  // well-defined for the URL spec's special schemes — a relative path resolves
+  // against the document regardless of how that stringifies.
+  const res = await fetchImpl(RUNTIME_PATH, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      object: BROWSER_OBJECT,
+      method: OPEN_URL_METHOD,
+      args: { url },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Browser.OpenURL failed (${res.status}): ${await res.text()}`);
+  }
+}
+
+export interface ExternalLinkOptions {
+  /** Where to listen. Defaults to the document. */
+  doc?: Document;
+  /** Hand-off to the shell. Injected by tests. */
+  open?: (url: string) => void | Promise<void>;
+  /** Called when the hand-off fails. Defaults to a console warning. */
+  onError?: (err: unknown, url: string) => void;
+}
+
+/** True only in the desktop shell, where config.js sets the flag. */
+function inDesktopShell(): boolean {
+  return typeof window !== 'undefined'
+    && Boolean((window as Window & { __KNOMIT_DESKTOP__?: boolean }).__KNOMIT_DESKTOP__);
+}
+
+/**
+ * Intercept clicks on http(s) links and route them to the OS browser.
+ *
+ * A single delegated listener rather than a per-link handler: the links this
+ * has to cover are generated — autolinked URLs inside arbitrary fact bodies,
+ * the References rail — so anything anchored to specific call sites goes stale
+ * the moment a new surface renders a link.
+ *
+ * No-op outside the desktop shell, where target="_blank" already does the
+ * right thing and intercepting would only replace a working tab with a
+ * runtime call that has nothing to answer it.
+ *
+ * Returns a function that removes the listener.
+ */
+export function installExternalLinkHandler(opts: ExternalLinkOptions = {}): () => void {
+  if (!inDesktopShell()) return () => {};
+
+  const doc = opts.doc ?? document;
+  const open = opts.open ?? ((url: string) => openExternal(url));
+  const onError = opts.onError
+    ?? ((err: unknown, url: string) => console.warn(`could not open ${url} externally:`, err));
+
+  const onClick = (e: MouseEvent) => {
+    // Bubble phase, and yield to anything that already handled the click: the
+    // app's own in-place navigations (ref hops, breadcrumbs) get first refusal.
+    if (e.defaultPrevented) return;
+    const target = e.target;
+    if (!(target instanceof Element)) return;
+    const a = target.closest('a[href]');
+    if (!a) return;
+    const href = a.getAttribute('href');
+    // Only http(s) leaves the app. Relative links, GFM footnote backrefs
+    // (#user-content-fn-1) and non-web schemes stay in the webview — the same
+    // boundary markdown.tsx uses to decide what gets target="_blank".
+    if (!href || !/^https?:\/\//i.test(href)) return;
+
+    e.preventDefault();
+    // Modifier clicks land here too. The webview cannot open a tab or a window
+    // for them either, so "open in the OS browser" is the only outcome that
+    // beats nothing at all.
+    try {
+      const r = open(href);
+      if (r && typeof (r as Promise<void>).catch === 'function') {
+        (r as Promise<void>).catch((err) => onError(err, href));
+      }
+    } catch (err) {
+      onError(err, href);
+    }
+  };
+
+  doc.addEventListener('click', onClick);
+  return () => doc.removeEventListener('click', onClick);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,6 +5,13 @@ import '@fontsource/jetbrains-mono/400.css'
 import '@fontsource/jetbrains-mono/500.css'
 import './index.css'
 import App from './App.tsx'
+import { installExternalLinkHandler } from './externalLinks'
+
+// Desktop only, and a no-op everywhere else: the Wails webview silently drops
+// target="_blank", so without this every external link in the app is inert.
+// Installed on the document rather than per-link because the links are
+// generated (autolinks in fact bodies, the References rail). See externalLinks.ts.
+installExternalLinkHandler()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/web/src/markdown.tsx
+++ b/web/src/markdown.tsx
@@ -77,7 +77,11 @@ export const markdownPlugins = [remarkGfm, remarkHttpsWww];
  * same contract the References rail in FactBody.tsx applies to its http refs.
  *
  * Only http(s) hrefs. GFM footnotes link within the document (`#user-content-fn-1`);
- * those must stay in-place or the backref opens a blank tab. */
+ * those must stay in-place or the backref opens a blank tab.
+ *
+ * target="_blank" is a browser answer. The desktop webview silently drops the
+ * new-window request, so externalLinks.ts intercepts these clicks there and
+ * hands the URL to the OS; the boundary it uses is this same http(s) test. */
 export const markdownComponents: Components = {
   a({ href, node, ...props }) {
     // react-markdown hands every override the hast node it rendered from. It is


### PR DESCRIPTION
Every outward-pointing link in the app renders as target="_blank" — the `a` override in markdown.tsx and the References rail in FactBody.tsx. In a browser that opens a tab. In the desktop window the page runs inside a WKWebView, where a new-window request routes through the WKUIDelegate method webView:createWebViewWithConfiguration:forNavigationAction:. Wails v3's macOS delegate does not implement it (its only WKUIDelegate method is the file-input open panel), and WKWebView drops the request silently when that method is absent. So on desktop every external link was inert: click, nothing.

Dropping target="_blank" is not the fix — the link would then navigate the webview in place, and with no router that is a full unload: app state gone and no chrome to get back with. The link has to leave the webview entirely.

Intercept the click instead and hand the URL to the OS via Wails' Browser.OpenURL, a POST to /wails/runtime. One delegated listener on the document rather than a per-link handler, because the links are generated (autolinked URLs inside arbitrary fact bodies, the References rail) and anything anchored to specific call sites goes stale the moment a new surface renders a link. A bare fetch rather than importing @wailsio/runtime keeps the Wails dependency out of the shared browser bundle — the same trade TopBar.tsx makes when it posts "wails:drag" by hand. The path is root-relative because the window is served over the custom wails://localhost scheme, for which location.origin is not a dependable base.

Installed only under __KNOMIT_DESKTOP__. In the browser build target="_blank" already works, and intercepting would trade a working tab for a runtime call with nothing to answer it.

configInjectingHandler now 404s anything under /wails/. Wails answers those in middleware wrapping this handler, so they should never arrive; if that ordering ever changed the SPA fallback would answer a runtime call with index.html and a 200, the frontend would read that as success, and external links would go silently inert again. Same reasoning as the existing /desktop/ guard.