### PR TITLE
feat(web): connect remote becomes a sub-page of the repo, not a surface takeover

### DIFF
--- a/web/src/App.manage.test.tsx
+++ b/web/src/App.manage.test.tsx
@@ -41,6 +41,14 @@ vi.mock('./api', async (importOriginal) => {
   return {
     ...actual,
     fetchVersion: vi.fn().mockResolvedValue({ version: '0.0.0', commit: 'abc', full: '0.0.0.abc', readOnly: false }),
+    // The connect sub-page's backend. Only the commit-lock test drives these;
+    // everywhere else they exist so the wizard cannot reach the network.
+    createSession: vi.fn(),
+    streamTest: vi.fn(() => () => {}),
+    streamPreview: vi.fn(() => () => {}),
+    streamApply: vi.fn(),
+    streamCommit: vi.fn(),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
     api: {
       repos: vi.fn(), listLenses: vi.fn(), listArchived: vi.fn(), getAgentBranch: vi.fn(),
       status: vi.fn(), getOrigin: vi.fn(), getLens: vi.fn(), browse: vi.fn(), recent: vi.fn(),
@@ -216,5 +224,52 @@ describe('Manage as a mode', () => {
     // the thing on top is the whole window.
     await act(async () => { fireEvent.keyDown(window, { key: 'Escape' }); });
     await waitFor(() => expect(screen.queryByTestId('manage-surface')).not.toBeInTheDocument());
+  });
+
+  // ...with one exception of its own. Closing Manage unmounts the connect
+  // sub-page, and its commit stream has no abort and no undo: the store swap
+  // and index rebuild run on with nothing listening. The manager withholds its
+  // rail and the wizard withholds its crumb, but BOTH of the app's exits went
+  // straight past them — and Escape is precisely the reflex of a reader who has
+  // just found every visible control disabled.
+  it('holds Escape and the step-out while a connect commit is writing', async () => {
+    const mod = await import('./api');
+    const m = mod as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    m.createSession.mockResolvedValue({ session_id: 'sess-lock' });
+    m.streamTest.mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => {
+      queueMicrotask(() => onEvent({ phase: 'done', result: { branches: ['main'], agent_branches: [], default_branch: 'main', matched_agent: '', history: 'shared', remote_fact_count: 1, local_fact_count: 1 } }));
+      return () => {};
+    });
+    m.streamPreview.mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => {
+      queueMicrotask(() => onEvent({ phase: 'done', result: { local_only: 1, remote_only: 0, shared_path: 0, dead_refs_found: 0 } }));
+      return () => {};
+    });
+    m.streamApply.mockImplementation(async (_r: string, _s: string, _st: string, _b: string | undefined, onEvent: (e: unknown) => void) => {
+      onEvent({ phase: 'done', result: { total_facts: 0, from_local: 0, from_remote: 0, overwrites: 0 } });
+    });
+    // Never resolves — the commit is in flight for the rest of the test.
+    m.streamCommit.mockImplementation(() => new Promise(() => {}));
+
+    await mountApp();
+    await enterManage();
+    await act(async () => { fireEvent.click(screen.getByTestId('repomgr-item-alpha')); });
+    await act(async () => { fireEvent.click(await screen.findByTestId('remote-connect')); });
+    await act(async () => { fireEvent.change(await screen.findByTestId('wizard-url'), { target: { value: 'https://example.com/repo.git' } }); });
+    await act(async () => { fireEvent.click(screen.getByTestId('wizard-test')); });
+    await act(async () => { fireEvent.click(await screen.findByTestId('wizard-connect')); });
+    await waitFor(() => expect((screen.getByTestId('wizard-crumb-back') as HTMLButtonElement).disabled).toBe(true));
+
+    await act(async () => { fireEvent.keyDown(window, { key: 'Escape' }); });
+    expect(screen.getByTestId('manage-surface')).toBeInTheDocument();
+
+    // The step-out says so rather than silently swallowing the click: it stays
+    // where it was — a control that vanished would read as the window losing
+    // its way out rather than holding it — and carries the reason.
+    const gear = screen.getByTestId('toknomitr-manage-btn') as HTMLButtonElement;
+    expect(gear.disabled).toBe(true);
+    expect(gear.getAttribute('title')).toContain('leave it running');
+    await act(async () => { fireEvent.click(gear); });
+    expect(screen.getByTestId('manage-surface')).toBeInTheDocument();
+    expect(screen.getByTestId('remote-connect-wizard')).toBeInTheDocument();
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -250,6 +250,12 @@ export default function App() {
   // It is also not persisted: a reload landing in a settings screen is the wrong
   // default for a knowledge browser, and the gear is one click away.
   const [manageOpen, setManageOpen] = useState(false);
+  // Raised by Manage while a connect commit is in flight. Closing Manage
+  // unmounts the wizard, and the commit stream has no abort and no undo: the
+  // store swap and index rebuild run on with nothing listening for the result.
+  // The manager already withholds its rail; these are the app-level exits —
+  // Escape and the top bar's step-out — and they are this component's to hold.
+  const [manageBusy, setManageBusy] = useState(false);
 
   // Time-travel callbacks (scrub / hop / open-at / return-to-now), backed by
   // the reducer. RightPanel + LeftPanel + FilterBar all route their
@@ -676,9 +682,9 @@ export default function App() {
   // is exactly when TopBar's own `manageOpen` prop changes and it must re-render
   // anyway.
   const toggleRepoMgr = useCallback(() => {
-    if (manageOpen) closeRepoMgr();
+    if (manageOpen) { if (!manageBusy) closeRepoMgr(); }
     else openRepoMgr();
-  }, [manageOpen, openRepoMgr, closeRepoMgr]);
+  }, [manageOpen, manageBusy, openRepoMgr, closeRepoMgr]);
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -692,9 +698,13 @@ export default function App() {
       // after a rail click.
       //
       // Escape is the one key Manage answers, because dismissing the thing on
-      // top is unambiguous when the thing on top is the whole window.
+      // top is unambiguous when the thing on top is the whole window — except
+      // while Manage reports itself busy, which today means a connect commit
+      // writing to a repo. Escape is exactly the reflex of a reader who has
+      // just found every visible exit disabled, and it is the one exit that
+      // does not go through a control that could be greyed out to say so.
       if (manageOpen) {
-        if (e.key === 'Escape') { closeRepoMgr(); }
+        if (e.key === 'Escape' && !manageBusy) { closeRepoMgr(); }
         return;
       }
 
@@ -743,7 +753,7 @@ export default function App() {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [navigate, state, tt, manageOpen, closeRepoMgr]);
+  }, [navigate, state, tt, manageOpen, manageBusy, closeRepoMgr]);
 
   // A finished task is news for a moment, not for the session. Nothing used to
   // return a task to idle, so the footer kept the LAST terminal result forever
@@ -854,7 +864,7 @@ export default function App() {
             trail breadcrumb takes that job below, and there is no filtering
             while anchored. Manage passes nothing either: it does not list facts. */}
         <TopBar state={state} repos={repos} lenses={lenses} dispatch={dispatch}
-          onManageRepos={toggleRepoMgr} manageOpen={manageOpen} leftWidth={leftPanelWidth}
+          onManageRepos={toggleRepoMgr} manageOpen={manageOpen} manageBusy={manageBusy} leftWidth={leftPanelWidth}
           search={isLive(state) && !manageOpen ? (
             <ErrorBoundary variant="inline" label="Search hit an error">
               <FilterBar state={state} dispatch={dispatch} embedded />
@@ -927,6 +937,7 @@ export default function App() {
               hideRemoteConfig={state.serverReadOnly}
               onChanged={onRepoMgrChanged}
               onBrowse={onRepoMgrBrowse}
+              onBusyChange={setManageBusy}
             />
           </ErrorBoundary>
         ) : (

--- a/web/src/RemoteConnectWizard.test.tsx
+++ b/web/src/RemoteConnectWizard.test.tsx
@@ -9,7 +9,10 @@ vi.mock('./api', () => ({
   streamPreview: vi.fn(),
   streamApply: vi.fn(),
   streamCommit: vi.fn(),
-  deleteSession: vi.fn(),
+  // Resolved, not bare: every caller does `deleteSession(...).catch(...)`, so a
+  // stub returning undefined throws inside a click handler — and clearAllMocks
+  // clears calls, not implementations, so this survives beforeEach.
+  deleteSession: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { api, createSession, streamTest, streamPreview, streamApply, streamCommit } from './api';
@@ -114,6 +117,70 @@ describe('RemoteConnectWizard', () => {
 
     await waitFor(() => expect(streamApply).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(streamCommit).toHaveBeenCalledTimes(1));
+  });
+
+  // The session is the whole of step ①, so its failure is step ①'s only failure
+  // path. It used to strand the page: the catch asked `step === 'creating'`,
+  // which is the value captured when the button was clicked — always 'idle' —
+  // so nothing reset, every control stayed disabled by `busy`, and the error box
+  // (gated on 'idle') never rendered the reason either.
+  it('returns to the form, with the reason, when the session cannot be created', async () => {
+    (api.getOrigin as unknown as Fn).mockResolvedValueOnce(null);
+    (createSession as unknown as Fn).mockRejectedValueOnce(new Error('dial tcp: connection refused'));
+
+    render(<RemoteConnectWizard repo="knomit-kb" onCancel={() => {}} onDone={() => {}} />);
+    const url = await screen.findByTestId('wizard-url') as HTMLInputElement;
+    fireEvent.change(url, { target: { value: 'https://example.com/repo.git' } });
+    fireEvent.click(screen.getByTestId('wizard-test'));
+
+    expect(await screen.findByText('dial tcp: connection refused')).toBeInTheDocument();
+    // Back at step ① and usable: the fields take input and Test can run again.
+    expect(url.disabled).toBe(false);
+    expect((screen.getByTestId('wizard-test') as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.getByTestId('wizard-step-1')).toHaveAttribute('aria-current', 'step');
+    expect(screen.queryByText('Creating session…')).toBeNull();
+  });
+
+  // Leaving during the MERGE is allowed — nothing is written yet — but the
+  // shared-history path chains apply → commit, and a commit is a store swap on
+  // a session cancel() has already asked the server to delete.
+  it('does not chain into the commit when the reader leaves during the merge', async () => {
+    const onCancel = vi.fn();
+    let finishApply: () => void = () => {};
+    (api.getOrigin as unknown as Fn).mockResolvedValueOnce(null);
+    (createSession as unknown as Fn).mockResolvedValueOnce({ session_id: 'sess-leave' });
+    (streamTest as unknown as Fn).mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => {
+      queueMicrotask(() => onEvent({ phase: 'done', result: { branches: ['main'], agent_branches: [], default_branch: 'main', matched_agent: '', history: 'shared', remote_fact_count: 5, local_fact_count: 7 } }));
+      return () => {};
+    });
+    (streamPreview as unknown as Fn).mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => {
+      queueMicrotask(() => onEvent({ phase: 'done', result: { local_only: 2, remote_only: 1, shared_path: 4, dead_refs_found: 0 } }));
+      return () => {};
+    });
+    // Held open so the crumb can be clicked mid-merge, then completed.
+    (streamApply as unknown as Fn).mockImplementation((_r: string, _s: string, _strat: string, _b: string | undefined, onEvent: (e: unknown) => void) =>
+      new Promise<void>(resolve => {
+        finishApply = () => { onEvent({ phase: 'done', result: { total_facts: 0, from_local: 0, from_remote: 0, overwrites: 0 } }); resolve(); };
+      }));
+    (streamCommit as unknown as Fn).mockResolvedValue(undefined);
+
+    render(<RemoteConnectWizard repo="knomit-kb" onCancel={onCancel} onDone={() => {}} />);
+    fireEvent.change(await screen.findByTestId('wizard-url'), { target: { value: 'https://example.com/repo.git' } });
+    fireEvent.click(screen.getByTestId('wizard-test'));
+    fireEvent.click(await screen.findByTestId('wizard-connect'));
+
+    // The crumb is live during the merge — that is the point — and it is the
+    // one enabled control while the buttons below are disabled by `busy`.
+    await waitFor(() => expect(streamApply).toHaveBeenCalledTimes(1));
+    expect((screen.getByTestId('wizard-crumb-back') as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId('wizard-crumb-back'));
+    expect(onCancel).toHaveBeenCalled();
+
+    // Let the merge finish and the continuation after its await run.
+    finishApply();
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+    expect(streamCommit).not.toHaveBeenCalled();
   });
 
   const mockTestPreviewOK = () => {
@@ -247,6 +314,28 @@ describe('RemoteConnectWizard', () => {
       expect(onBusyChange.mock.calls.at(-1)?.[0]).toBe(false);
       expect(screen.getByTestId('wizard-step-3')).toHaveAttribute('aria-current', 'step');
       expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    });
+
+    // Retry lands on step ②, and shared history used to have nothing there: the
+    // Connect button excluded it, the Preview button excludes it by design, and
+    // what was left was "← Back", which deletes the session. So the one error
+    // the reader is most likely to want to retry was the one they could not.
+    it('offers the retry it lands on after a failed commit, for shared history too', async () => {
+      let fail = true;
+      await driveToCommit(async onEvent => {
+        if (fail) { fail = false; onEvent({ phase: 'error', message: 'swap failed: boom' }); return; }
+        onEvent({ phase: 'done' });
+      });
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+
+      const connect = await screen.findByTestId('wizard-connect');
+      fireEvent.click(connect);
+      await waitFor(() => expect(streamCommit).toHaveBeenCalledTimes(2));
+      // The retry re-runs the COMMIT only — the merge already happened, and
+      // replaying it would be a second write of the same reconciliation.
+      expect(streamApply).toHaveBeenCalledTimes(1);
+      expect(await screen.findByText('Remote connected successfully.')).toBeInTheDocument();
     });
 
     // onDone MOVES THE SELECTION. Left running past unmount, the success pause

--- a/web/src/RemoteConnectWizard.test.tsx
+++ b/web/src/RemoteConnectWizard.test.tsx
@@ -181,4 +181,86 @@ describe('RemoteConnectWizard', () => {
     expect(screen.getByTestId('wizard-auth-warning')).toBeTruthy();
     expect((screen.getByTestId('wizard-test') as HTMLButtonElement).disabled).toBe(false);
   });
+
+  // The commit is the one irreversible step: it swaps the store and rebuilds
+  // the index, streamCommit has no abort, and nothing in this component is
+  // registered to stop it. So "can the reader leave" is a claim these tests own
+  // — including the case where the page is no longer the whole surface and the
+  // manager's rail can unmount it.
+  describe('the commit lock', () => {
+    // Shared history connects in one click (apply chains into commit), so this
+    // reaches the commit with a single button press. `commit` is the stream
+    // implementation under test.
+    const driveToCommit = async (
+      commit: (onEvent: (e: unknown) => void) => Promise<void>,
+      props: Partial<React.ComponentProps<typeof RemoteConnectWizard>> = {},
+    ) => {
+      (api.getOrigin as unknown as Fn).mockResolvedValueOnce(null);
+      (createSession as unknown as Fn).mockResolvedValueOnce({ session_id: 'sess-commit' });
+      (streamTest as unknown as Fn).mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => {
+        queueMicrotask(() => onEvent({ phase: 'done', result: { branches: ['main'], agent_branches: [], default_branch: 'main', matched_agent: '', history: 'shared', remote_fact_count: 5, local_fact_count: 7 } }));
+        return () => {};
+      });
+      (streamPreview as unknown as Fn).mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => {
+        queueMicrotask(() => onEvent({ phase: 'done', result: { local_only: 2, remote_only: 1, shared_path: 4, dead_refs_found: 0 } }));
+        return () => {};
+      });
+      (streamApply as unknown as Fn).mockImplementation(async (_r: string, _s: string, _strat: string, _b: string | undefined, onEvent: (e: unknown) => void) => {
+        onEvent({ phase: 'done', result: { total_facts: 0, from_local: 0, from_remote: 0, overwrites: 0 } });
+      });
+      (streamCommit as unknown as Fn).mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => commit(onEvent));
+
+      const view = render(<RemoteConnectWizard repo="knomit-kb" onCancel={() => {}} onDone={() => {}} {...props} />);
+      const url = await screen.findByTestId('wizard-url') as HTMLInputElement;
+      fireEvent.change(url, { target: { value: 'https://example.com/repo.git' } });
+      fireEvent.click(screen.getByTestId('wizard-test'));
+      fireEvent.click(await screen.findByTestId('wizard-connect'));
+      return view;
+    };
+
+    const crumb = () => screen.getByTestId('wizard-crumb-back') as HTMLButtonElement;
+
+    it('holds the exit while the commit runs and releases it on unmount', async () => {
+      const onBusyChange = vi.fn();
+      // Never resolves: the commit is still in flight for the whole test.
+      const { unmount } = await driveToCommit(() => new Promise<void>(() => {}), { onBusyChange });
+
+      await waitFor(() => expect(crumb().disabled).toBe(true));
+      expect(onBusyChange.mock.calls.at(-1)?.[0]).toBe(true);
+
+      // The lock is published, not just enforced here — the manager's rail is
+      // the other exit, and it can only refuse what it has been told about.
+      unmount();
+      expect(onBusyChange.mock.calls.at(-1)?.[0]).toBe(false);
+    });
+
+    // A failed commit is NOT in flight: leaving it locked strands the reader on
+    // a page whose only exit is disabled, under a note telling them to wait for
+    // work that already died. The step stays 'committing' regardless — that is
+    // what keeps the Sync block, and with it the error, on screen.
+    it('reopens the exit when the commit fails, without losing the error', async () => {
+      const onBusyChange = vi.fn();
+      await driveToCommit(async onEvent => { onEvent({ phase: 'error', message: 'swap failed: boom' }); }, { onBusyChange });
+
+      expect(await screen.findByText('swap failed: boom')).toBeInTheDocument();
+      await waitFor(() => expect(crumb().disabled).toBe(false));
+      expect(onBusyChange.mock.calls.at(-1)?.[0]).toBe(false);
+      expect(screen.getByTestId('wizard-step-3')).toHaveAttribute('aria-current', 'step');
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    });
+
+    // onDone MOVES THE SELECTION. Left running past unmount, the success pause
+    // yanks a reader who navigated away back onto this repo's settings page.
+    it('cancels the success pause on unmount rather than navigating later', async () => {
+      const onDone = vi.fn();
+      const { unmount } = await driveToCommit(async onEvent => { onEvent({ phase: 'done' }); }, { onDone });
+
+      expect(await screen.findByText('Remote connected successfully.')).toBeInTheDocument();
+      expect(onDone).not.toHaveBeenCalled();   // the pause has started, not elapsed
+      unmount();
+
+      await new Promise(r => setTimeout(r, 1400));   // longer than the 1200ms pause
+      expect(onDone).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/web/src/RemoteConnectWizard.tsx
+++ b/web/src/RemoteConnectWizard.tsx
@@ -62,7 +62,16 @@ export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Pr
   // a reader who navigates away during the 1.2s window gets yanked back to this
   // repo's settings page a beat later, from wherever they went.
   const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Set once the reader has left — by the crumb, or by the page being unmounted
+  // out from under a running step. handleApply reads it before chaining into
+  // the commit, which is the one hand-off that would otherwise outlive the exit:
+  // the crumb stays enabled during 'applying' (nothing is written yet, so
+  // leaving is free), but the shared-history path chains apply → commit, and a
+  // commit is a store swap. Without this the reader backs out and the swap runs
+  // anyway, on a session cancel() has already asked the server to delete.
+  const leftRef = useRef(false);
   useEffect(() => () => {
+    leftRef.current = true;
     cleanupRef.current?.();
     if (doneTimerRef.current !== null) clearTimeout(doneTimerRef.current);
   }, []);
@@ -81,6 +90,7 @@ export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Pr
   }, [repo]);
 
   const cancel = useCallback(() => {
+    leftRef.current = true;
     cleanupRef.current?.(); cleanupRef.current = null;
     if (sessionId) deleteSession(repo, sessionId).catch(() => {});
     onCancel();
@@ -88,6 +98,13 @@ export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Pr
 
   const handleTest = async () => {
     setError(null); setStep('creating'); setProgress('Creating session…');
+    // Whether the session came up, tracked locally. The catch below used to ask
+    // `step === 'creating'` instead — the value captured at click time, which is
+    // always 'idle' — so the reset never ran: a rejected createSession (bad URL,
+    // server down) left the page at 'creating' forever, every control disabled
+    // by `busy`, and the error box is gated on 'idle' so the reason never
+    // showed either. The only way out was to leave and start over.
+    let created = false;
     try {
       const sess = await createSession(repo, {
         url,
@@ -96,6 +113,7 @@ export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Pr
         user: authMethod === 'basic' ? user : undefined,
         password: authMethod === 'basic' ? password : undefined,
       });
+      created = true;
       setSessionId(sess.session_id);
       setStep('testing'); setProgress('Connecting…');
       await new Promise<void>((resolve, reject) => {
@@ -114,8 +132,13 @@ export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Pr
         cleanupRef.current = close;
       });
     } catch (e) {
-      if (!error) setError({ section: 'creating', message: (e instanceof Error && e.message) || 'Failed to create session' });
-      if (step === 'creating') setStep('idle');
+      // Once the session exists, the only thing that rejects the promise above
+      // is the stream's own 'error' event — which has already recorded its
+      // message and returned the page to 'idle'. Overwriting it here would
+      // replace "auth failed" with a generic line.
+      if (created) return;
+      setError({ section: 'creating', message: (e instanceof Error && e.message) || 'Failed to create session' });
+      setStep('idle'); setProgress('');
     }
   };
 
@@ -193,7 +216,11 @@ export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Pr
     } catch (e) {
       ok = false; setError({ section: 'applying', message: (e instanceof Error && e.message) || 'Apply failed' }); setStep('applied');
     }
-    if (ok && thenCommit) await handleCommit();
+    // `leftRef` and not a state flag: this runs after an await, so a state read
+    // here would be the value captured when the click happened. Leaving during
+    // the merge is allowed — nothing is written yet — but it must not hand off
+    // to the step that writes.
+    if (ok && thenCommit && !leftRef.current) await handleCommit();
   };
 
   const handleRetry = () => {
@@ -393,7 +420,14 @@ export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Pr
                 {step === 'previewed' && isSharedHistory && (
                   <button type="button" data-testid="wizard-connect" style={btn(busy, 'primary')} disabled={busy} onClick={() => handleApply(true)}>Connect →</button>
                 )}
-                {step === 'applied' && !error && !isSharedHistory && (
+                {/* Shared history is included, and that is the whole exit from a
+                    failed commit: 'applied' is where Retry lands, and with the
+                    button excluded here the shared path arrived at a step with
+                    no Connect, no Preview and no Retry — only "← Back", which
+                    throws the session away. The shared flow reaches 'applied'
+                    only for an instant on its way into the commit it chains, so
+                    in practice this button belongs to the retry. */}
+                {step === 'applied' && !error && (
                   <button type="button" data-testid="wizard-connect" style={btn(false, 'primary')} onClick={handleCommit}>Connect →</button>
                 )}
                 {step === 'applied' && !error && !isSharedHistory && (

--- a/web/src/RemoteConnectWizard.tsx
+++ b/web/src/RemoteConnectWizard.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { api, createSession, streamTest, streamPreview, streamApply, streamCommit, deleteSession } from './api';
 import type { SSEEvent, TestResult, PreviewResult, ApplyResult } from './api';
+import { GlobeIcon } from './icons';
+import { btn, card } from './manageStyles';
+import { repoHue, repoHueBg, repoHueBorder, noMouseFocus } from './utils';
 
 type Step =
   | 'idle' | 'creating' | 'testing' | 'tested'
@@ -9,14 +12,26 @@ type Step =
 
 interface Props {
   repo: string;
-  onCancel: () => void;   // user backed out — return to the manager
-  onDone: () => void;     // remote connected — return to the manager
+  onCancel: () => void;   // user backed out — return to the repo's settings
+  onDone: () => void;     // remote connected — return to the repo's settings
 }
 
-// RemoteConnectWizard is the stepped connect/reconcile flow shown as the full
-// body of the Repo Manager dialog. It drives the session backend
-// (test → preview → apply → commit) and presents three steps:
+// RemoteConnectWizard is the stepped connect/reconcile flow. It drives the
+// session backend (test → preview → apply → commit) and presents three steps:
 //   ① Connect   ② Review   ③ Sync
+//
+// It is a SUB-PAGE of the repo it configures, not a surface of its own: the
+// manager's rail stays, and this renders in the detail column under a crumb
+// back to the repo. It used to replace the whole Manage surface with a 720px
+// column stretched to the window's full height, which left two form fields
+// floating above 600px of nothing with the actions pinned to the bottom edge —
+// dressed as a dialog (title bar, ✕, Cancel) with no dialog around it.
+//
+// So it borrows SettingsPage's grammar rather than inventing a third one: the
+// same column-plus-rail grid, the same block headings, and a rail in the slot
+// "On this page" occupies on the settings page you just came from. That rail is
+// the progress tracker — the only structural difference, and it earns the
+// difference because progress is genuinely what a reader wants there mid-flow.
 export function RemoteConnectWizard({ repo, onCancel, onDone }: Props) {
   const [url, setUrl] = useState('');
   // '' = auto-detect (backend infers SSH for git@/ssh:// URLs, else anonymous).
@@ -202,187 +217,296 @@ export function RemoteConnectWizard({ repo, onCancel, onDone }: Props) {
     && step !== 'committing' && step !== 'done';
   const activeStep: 1 | 2 | 3 = (step === 'committing' || step === 'done') ? 3 : onReview ? 2 : 1;
 
+  // Leaving is withheld once the commit is in flight: it swaps the store and
+  // rebuilds the index, and there is no "un-commit" to return the reader to.
+  const leavable = step !== 'committing' && step !== 'done';
+
   return (
-    <div data-testid="remote-connect-wizard" style={wrap}>
-      <header style={head}>
-        <h2 style={{ margin: 0, fontSize: 16 }}>Connect remote — {repo}</h2>
-        {step !== 'committing' && step !== 'done' && (
-          <button type="button" data-testid="wizard-close" style={iconBtn} onClick={cancel} aria-label="Cancel">✕</button>
-        )}
-      </header>
+    <div data-testid="remote-connect-wizard">
+      {/* The crumb is the way back, and the only one. It also states where you
+          are — a sub-page of a repository, not a mode — which is the thing the
+          old full-surface takeover could not say. */}
+      <nav style={crumb} aria-label="Breadcrumb">
+        <button type="button" data-testid="wizard-crumb-back" className="k-bare"
+          onMouseDown={noMouseFocus} style={crumbLink(!leavable)} disabled={!leavable} onClick={cancel}>
+          {repo}
+        </button>
+        <span style={crumbSep} aria-hidden="true">/</span>
+        <span>Connect remote</span>
+      </nav>
 
-      <div style={steps}>
-        {([[1, 'Connect'], [2, 'Review'], [3, 'Sync']] as const).map(([n, lbl]) => {
-          const state = activeStep === n ? 'active' : activeStep > n ? 'done' : 'todo';
-          return (
-            <div key={n} style={stepItem}>
-              <span style={stepDot(state)}>{state === 'done' ? '✓' : n}</span>
-              <span style={{ color: state === 'todo' ? '#666' : '#ddd', fontSize: 13 }}>{lbl}</span>
-              {n < 3 && <span style={stepBar(activeStep > n)} />}
-            </div>
-          );
-        })}
+      <div style={pageHead}>
+        <span style={iconBox(repo)}><GlobeIcon color={repoHue(repo)} size={16} /></span>
+        <div style={{ minWidth: 0 }}>
+          <h3 style={{ margin: 0, fontSize: 16 }}>Connect remote</h3>
+          <div style={{ fontSize: 12, color: '#777', marginTop: 1 }}>pull and push {repo} against an origin</div>
+        </div>
       </div>
 
-      <div style={bodyArea}>
-        {/* ── Step ① Connect ── */}
-        {activeStep === 1 && (
-          <>
-            <label style={label}>Remote URL</label>
-            <input data-testid="wizard-url" style={input} value={url} disabled={busy} placeholder="https://… · git@host:repo · /path/to/repo"
-              onChange={e => setUrl(e.target.value)} />
-            <label style={label}>Auth method</label>
-            <select style={input} value={authMethod} disabled={busy} onChange={e => setAuthMethod(e.target.value as typeof authMethod)}>
-              <option value="">Auto-detect</option>
-              <option value="none">None (anonymous)</option>
-              <option value="ssh">SSH (knomit key)</option>
-              <option value="token">Token</option>
-              <option value="basic">Basic (user / password)</option>
-            </select>
-            {authMethod === 'token' && (<>
-              <label style={label}>Token</label>
-              <input style={input} type="password" value={token} disabled={busy} placeholder="ghp_…" onChange={e => setToken(e.target.value)} />
-            </>)}
-            {authMethod === 'basic' && (<>
-              <label style={label}>Username</label>
-              <input style={input} value={user} disabled={busy} onChange={e => setUser(e.target.value)} />
-              <label style={label}>Password</label>
-              <input style={input} type="password" value={password} disabled={busy} onChange={e => setPassword(e.target.value)} />
-            </>)}
-            {authMismatch && <div style={errText}>{authMismatch}</div>}
-            {!authMismatch && authWarning && <div data-testid="wizard-auth-warning" style={warnText}>{authWarning}</div>}
-            {(step === 'creating' || step === 'testing') && <div style={progressText}>{progress}</div>}
-            {error && (step === 'idle') && (
-              <div style={errBox}><div style={{ color: '#f88' }}>{error.message}</div>
-                <button type="button" style={btn(false)} onClick={handleRetry}>Retry</button></div>
-            )}
-          </>
-        )}
-
-        {/* ── Step ② Review ── */}
-        {activeStep === 2 && testResult && (
-          <>
-            <div style={{ fontSize: 12, color: '#888', marginBottom: 12 }}>
-              {url} — {testResult.remote_fact_count} remote · {testResult.local_fact_count} local · {testResult.history} histories
-            </div>
-            <div style={{ display: 'flex', gap: 16, marginBottom: 12, fontSize: 13, alignItems: 'center' }}>
-              <span style={{ color: '#888' }}>Branch:</span>
-              <select value={selectedBranch} disabled={busy || (testResult.branches ?? []).length === 0} onChange={e => setSelectedBranch(e.target.value)}
-                style={{ background: '#1a1a1a', border: '1px solid #333', color: '#eee', padding: '2px 6px', borderRadius: 4, fontSize: 13 }}>
-                {(testResult.branches ?? []).length === 0
-                  ? <option value="">(no remote branches yet)</option>
-                  : (testResult.branches ?? []).map(b => <option key={b} value={b}>{b}</option>)}
-              </select>
-              {testResult.matched_agent && <span style={{ color: '#8af' }}>agent branch found — will replay on top</span>}
-            </div>
-
-            {step === 'previewing' && <div style={progressText}>{progress}</div>}
-            {previewResult && !error?.section?.startsWith('preview') && (
-              <div style={sectionBox}>
-                <div style={{ color: '#aaa' }}>
-                  {previewResult.local_only} local-only · {previewResult.remote_only} remote-only · {previewResult.shared_path} shared paths
-                </div>
-                {previewResult.dead_refs_found > 0 && <div style={{ color: '#888', marginTop: 4 }}>{previewResult.dead_refs_found} dead refs found</div>}
+      <div style={grid}>
+        <div style={column}>
+          {/* ── Step ① Connect ── */}
+          {activeStep === 1 && (
+            <section style={block}>
+              <div style={blockHead}>
+                <h4 style={blockTitle}>Origin</h4>
+                <span style={blockHint}>the git remote this repository syncs against</span>
               </div>
-            )}
-            {error && error.section === 'previewing' && (
-              <div style={errBox}><div style={{ color: '#f88' }}>{error.message}</div>
-                <button type="button" style={btn(false)} onClick={handleRetry}>Retry</button></div>
-            )}
-
-            {previewResult && !error?.section?.startsWith('preview') && (
-              <div style={sectionBox}>
-                {!isSharedHistory && (
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 10 }}>
-                    <span style={{ color: '#888', fontSize: 12 }}>Conflict strategy:</span>
-                    <label style={radio(busy)}><input type="radio" name="strategy" checked={strategy === 'local'} disabled={busy} onChange={() => setStrategy('local')} /> Local wins</label>
-                    <label style={radio(busy)}><input type="radio" name="strategy" checked={strategy === 'remote'} disabled={busy} onChange={() => setStrategy('remote')} /> Remote wins</label>
-                  </div>
+              <div>
+                <label style={label} htmlFor="wizard-url-input">Remote URL</label>
+                <input id="wizard-url-input" data-testid="wizard-url" style={input} value={url} disabled={busy}
+                  placeholder="https://… · git@host:repo · /path/to/repo"
+                  onChange={e => setUrl(e.target.value)} />
+                <label style={label} htmlFor="wizard-auth-select">Auth method</label>
+                <select id="wizard-auth-select" style={input} value={authMethod} disabled={busy}
+                  onChange={e => setAuthMethod(e.target.value as typeof authMethod)}>
+                  <option value="">Auto-detect</option>
+                  <option value="none">None (anonymous)</option>
+                  <option value="ssh">SSH (knomit key)</option>
+                  <option value="token">Token</option>
+                  <option value="basic">Basic (user / password)</option>
+                </select>
+                {authMethod === 'token' && (<>
+                  <label style={label} htmlFor="wizard-token">Token</label>
+                  <input id="wizard-token" style={input} type="password" value={token} disabled={busy} placeholder="ghp_…" onChange={e => setToken(e.target.value)} />
+                </>)}
+                {authMethod === 'basic' && (<>
+                  <label style={label} htmlFor="wizard-user">Username</label>
+                  <input id="wizard-user" style={input} value={user} disabled={busy} onChange={e => setUser(e.target.value)} />
+                  <label style={label} htmlFor="wizard-password">Password</label>
+                  <input id="wizard-password" style={input} type="password" value={password} disabled={busy} onChange={e => setPassword(e.target.value)} />
+                </>)}
+                {authMismatch && <div style={errText}>{authMismatch}</div>}
+                {!authMismatch && authWarning && <div data-testid="wizard-auth-warning" style={warnText}>{authWarning}</div>}
+                {(step === 'creating' || step === 'testing') && <div style={progressText}>{progress}</div>}
+                {error && (step === 'idle') && (
+                  <div style={errBox}><div style={{ color: '#f88' }}>{error.message}</div>
+                    <button type="button" style={{ ...btn(false), marginTop: 8 }} onClick={handleRetry}>Retry</button></div>
                 )}
-                {isSharedHistory && <div style={{ color: '#aaa', fontSize: 13 }}>Histories share an ancestor — sync reconciles local and remote on its next cycle. No merge preview needed.</div>}
-                {step === 'applying' && <div style={progressText}>{progress}</div>}
-                {step === 'applied' && applyResult && !error && !isSharedHistory && (
+              </div>
+              <div style={actions}>
+                <button type="button" data-testid="wizard-test" style={btn(!canTest, 'primary')} disabled={!canTest} onClick={handleTest}>Test connection →</button>
+                <button type="button" style={btn(busy)} disabled={busy} onClick={cancel}>Cancel</button>
+              </div>
+            </section>
+          )}
+
+          {/* ── Step ② Review ── */}
+          {activeStep === 2 && testResult && (
+            <section style={block}>
+              <div style={blockHead}>
+                <h4 style={blockTitle}>Review</h4>
+                <span style={blockHint}>what the two sides hold, and which of them wins</span>
+              </div>
+              <div style={{ fontSize: 12, color: '#888', wordBreak: 'break-all' }}>
+                {url} — {testResult.remote_fact_count} remote · {testResult.local_fact_count} local · {testResult.history} histories
+              </div>
+              <div style={{ display: 'flex', gap: 12, fontSize: 13, alignItems: 'center', flexWrap: 'wrap' }}>
+                <span style={{ color: '#888' }}>Branch:</span>
+                <select value={selectedBranch} disabled={busy || (testResult.branches ?? []).length === 0} onChange={e => setSelectedBranch(e.target.value)}
+                  aria-label="Remote branch"
+                  style={{ background: '#0c0c0c', border: '1px solid #333', color: '#eee', padding: '4px 7px', borderRadius: 4, fontSize: 13 }}>
+                  {(testResult.branches ?? []).length === 0
+                    ? <option value="">(no remote branches yet)</option>
+                    : (testResult.branches ?? []).map(b => <option key={b} value={b}>{b}</option>)}
+                </select>
+                {testResult.matched_agent && <span style={{ color: '#8af', fontSize: 12 }}>agent branch found — will replay on top</span>}
+              </div>
+
+              {step === 'previewing' && <div style={progressText}>{progress}</div>}
+              {previewResult && !error?.section?.startsWith('preview') && (
+                <div style={sectionBox}>
                   <div style={{ color: '#aaa' }}>
-                    <span style={{ color: '#4caf50' }}>Merge preview ready — </span>
-                    {applyResult.total_facts} facts: {applyResult.from_local} local, {applyResult.from_remote} remote{applyResult.overwrites > 0 && ` (${applyResult.overwrites} overwrites)`}
+                    {previewResult.local_only} local-only · {previewResult.remote_only} remote-only · {previewResult.shared_path} shared paths
                   </div>
+                  {previewResult.dead_refs_found > 0 && <div style={{ color: '#888', marginTop: 4 }}>{previewResult.dead_refs_found} dead refs found</div>}
+                </div>
+              )}
+              {error && error.section === 'previewing' && (
+                <div style={errBox}><div style={{ color: '#f88' }}>{error.message}</div>
+                  <button type="button" style={{ ...btn(false), marginTop: 8 }} onClick={handleRetry}>Retry</button></div>
+              )}
+
+              {previewResult && !error?.section?.startsWith('preview') && (
+                <div style={sectionBox}>
+                  {!isSharedHistory && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 10, flexWrap: 'wrap' }}>
+                      <span style={{ color: '#888', fontSize: 12 }}>Conflict strategy:</span>
+                      <label style={radio(busy)}><input type="radio" name="strategy" checked={strategy === 'local'} disabled={busy} onChange={() => setStrategy('local')} /> Local wins</label>
+                      <label style={radio(busy)}><input type="radio" name="strategy" checked={strategy === 'remote'} disabled={busy} onChange={() => setStrategy('remote')} /> Remote wins</label>
+                    </div>
+                  )}
+                  {isSharedHistory && <div style={{ color: '#aaa', fontSize: 13 }}>Histories share an ancestor — sync reconciles local and remote on its next cycle. No merge preview needed.</div>}
+                  {step === 'applying' && <div style={progressText}>{progress}</div>}
+                  {step === 'applied' && applyResult && !error && !isSharedHistory && (
+                    <div style={{ color: '#aaa' }}>
+                      <span style={{ color: '#4caf50' }}>Merge preview ready — </span>
+                      {applyResult.total_facts} facts: {applyResult.from_local} local, {applyResult.from_remote} remote{applyResult.overwrites > 0 && ` (${applyResult.overwrites} overwrites)`}
+                    </div>
+                  )}
+                  {error && error.section === 'applying' && (
+                    <div><div style={{ color: '#f88' }}>{error.message}</div>
+                      <button type="button" style={{ ...btn(false), marginTop: 8 }} onClick={handleRetry}>Retry</button></div>
+                  )}
+                </div>
+              )}
+
+              <div style={actions}>
+                {(step === 'previewed' || step === 'applying') && !isSharedHistory && (
+                  <button type="button" data-testid="wizard-preview" style={btn(busy || !previewResult, 'primary')} disabled={busy || !previewResult} onClick={() => handleApply(false)}>Preview merge →</button>
                 )}
-                {error && error.section === 'applying' && (
+                {step === 'previewed' && isSharedHistory && (
+                  <button type="button" data-testid="wizard-connect" style={btn(busy, 'primary')} disabled={busy} onClick={() => handleApply(true)}>Connect →</button>
+                )}
+                {step === 'applied' && !error && !isSharedHistory && (
+                  <button type="button" data-testid="wizard-connect" style={btn(false, 'primary')} onClick={handleCommit}>Connect →</button>
+                )}
+                {step === 'applied' && !error && !isSharedHistory && (
+                  <button type="button" style={btn(false)} onClick={() => { setApplyResult(null); setStep('previewed'); }}>Try different strategy</button>
+                )}
+                <button type="button" style={btn(busy)} disabled={busy} onClick={handleBack}>← Back</button>
+              </div>
+            </section>
+          )}
+
+          {/* ── Step ③ Sync ── */}
+          {activeStep === 3 && (
+            <section style={block}>
+              <div style={blockHead}>
+                <h4 style={blockTitle}>Sync</h4>
+                <span style={blockHint}>swapping the store and rebuilding the index</span>
+              </div>
+              <div style={sectionBox}>
+                {step === 'committing' && <div style={progressText}>{progress}</div>}
+                {step === 'done' && <div style={{ color: '#4caf50' }}>Remote connected successfully.</div>}
+                {error && error.section === 'committing' && (
                   <div><div style={{ color: '#f88' }}>{error.message}</div>
-                    <button type="button" style={btn(false)} onClick={handleRetry}>Retry</button></div>
+                    <button type="button" style={{ ...btn(false), marginTop: 8 }} onClick={handleRetry}>Retry</button></div>
                 )}
               </div>
-            )}
-          </>
-        )}
+            </section>
+          )}
+        </div>
 
-        {/* ── Step ③ Sync ── */}
-        {activeStep === 3 && (
-          <div style={sectionBox}>
-            {step === 'committing' && <div style={progressText}>{progress}</div>}
-            {step === 'done' && <div style={{ color: '#4caf50' }}>Remote connected successfully.</div>}
-            {error && error.section === 'committing' && (
-              <div><div style={{ color: '#f88' }}>{error.message}</div>
-                <button type="button" style={btn(false)} onClick={handleRetry}>Retry</button></div>
-            )}
-          </div>
-        )}
+        {/* The rail sits where SettingsPage's contents rail sits, so crossing
+            from the repo's settings into this page does not move it. It is a
+            tracker, not an index: the steps are not reachable out of order, so
+            they are text rather than buttons — an inert-looking row is the
+            honest rendering of a place you cannot click to. */}
+        <nav style={rail} aria-label="Progress">
+          <div style={railLabel}>Progress</div>
+          {([[1, 'Connect'], [2, 'Review'], [3, 'Sync']] as const).map(([n, lbl]) => {
+            const state = step === 'done' ? 'done' : activeStep === n ? 'active' : activeStep > n ? 'done' : 'todo';
+            return (
+              <div key={n} data-testid={`wizard-step-${n}`} aria-current={state === 'active' ? 'step' : undefined} style={railItem(state)}>
+                <span style={railMark(state)}>{state === 'done' ? '✓' : n}</span>
+                <span>{lbl}</span>
+              </div>
+            );
+          })}
+          <p style={railNote}>
+            {leavable
+              ? <>Nothing is written to <b style={{ color: '#8a8a8a', fontWeight: 600 }}>{repo}</b> until the last step runs.</>
+              : <>Writing to <b style={{ color: '#8a8a8a', fontWeight: 600 }}>{repo}</b> — leave this running.</>}
+          </p>
+        </nav>
       </div>
-
-      {/* ── Footer ── */}
-      {activeStep === 1 && (
-        <footer style={foot}>
-          <button type="button" style={btn(false, 'secondary')} onClick={cancel}>Cancel</button>
-          <button type="button" data-testid="wizard-test" style={btn(!canTest)} disabled={!canTest} onClick={handleTest}>Test connection →</button>
-        </footer>
-      )}
-      {activeStep === 2 && (
-        <footer style={foot}>
-          <button type="button" style={btn(busy, 'secondary')} disabled={busy} onClick={handleBack}>← Back</button>
-          <div style={{ display: 'flex', gap: 8 }}>
-            {step === 'applied' && !error && !isSharedHistory && (
-              <button type="button" style={btn(false, 'secondary')} onClick={() => { setApplyResult(null); setStep('previewed'); }}>Try different strategy</button>
-            )}
-            {(step === 'previewed' || step === 'applying') && !isSharedHistory && (
-              <button type="button" data-testid="wizard-preview" style={btn(busy || !previewResult)} disabled={busy || !previewResult} onClick={() => handleApply(false)}>Preview merge →</button>
-            )}
-            {step === 'previewed' && isSharedHistory && (
-              <button type="button" data-testid="wizard-connect" style={btn(busy)} disabled={busy} onClick={() => handleApply(true)}>Connect →</button>
-            )}
-            {step === 'applied' && !error && !isSharedHistory && (
-              <button type="button" data-testid="wizard-connect" style={btn(false)} onClick={handleCommit}>Connect →</button>
-            )}
-          </div>
-        </footer>
-      )}
     </div>
   );
 }
 
 // ── styles ──
-const wrap: React.CSSProperties = { display: 'flex', flexDirection: 'column', height: '100%', color: '#eee' };
-const head: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 18px', borderBottom: '1px solid #222' };
-const iconBtn: React.CSSProperties = { background: 'none', border: 'none', color: '#aaa', fontSize: 16, cursor: 'pointer' };
-const steps: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8, padding: '14px 18px 0' };
-const stepItem: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8 };
-const stepDot = (state: 'active' | 'done' | 'todo'): React.CSSProperties => ({
-  width: 22, height: 22, borderRadius: '50%', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-  fontSize: 12, fontWeight: 600,
-  background: state === 'active' ? '#1d4ed8' : state === 'done' ? '#14532d' : '#222',
-  color: state === 'todo' ? '#777' : '#fff', border: state === 'done' ? '1px solid #2e7d32' : '1px solid #333',
+//
+// Deliberately NOT a private button/input/card set: this page used to carry its
+// own btn(), input and sectionBox, which is why its controls did not match the
+// settings page one click away. `btn` and `card` come from manageStyles; what is
+// left here is the page's own structure, and the block/rail atoms mirror
+// SettingsPage's so the two pages read as one grammar.
+
+const crumb: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 7, fontSize: 12, color: '#888', marginBottom: 10,
+};
+const crumbLink = (disabled: boolean): React.CSSProperties => ({
+  background: 'none', border: 'none', padding: 0, fontSize: 12,
+  color: disabled ? '#555' : '#6ea8fe', cursor: disabled ? 'default' : 'pointer',
 });
-const stepBar = (done: boolean): React.CSSProperties => ({ width: 36, height: 2, background: done ? '#2e7d32' : '#333', marginLeft: 2 });
-const bodyArea: React.CSSProperties = { flex: 1, overflowY: 'auto', padding: 18 };
-const foot: React.CSSProperties = { display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 18px', borderTop: '1px solid #222' };
+const crumbSep: React.CSSProperties = { color: '#444' };
+
+const pageHead: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 };
+// Tinted in the repo's own hue rather than a generic accent — this page belongs
+// to that repository, and the icon box is where every other detail head says so.
+const iconBox = (repo: string): React.CSSProperties => ({
+  width: 30, height: 30, borderRadius: 7, flexShrink: 0,
+  background: repoHueBg(repo), border: '1px solid ' + repoHueBorder(repo),
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+});
+
+// Same two-column split as SettingsPage, to the pixel: the rail must not move
+// when you cross from the repo's settings into this page.
+const grid: React.CSSProperties = {
+  display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) 178px', gap: 26, alignItems: 'start',
+};
+// A form reads worse the wider it gets, so the column is measured inside its
+// grid cell rather than filling it.
+const column: React.CSSProperties = { maxWidth: 470 };
+
+const block: React.CSSProperties = {
+  borderTop: '1px solid #202020', paddingTop: 16, marginTop: 16,
+  display: 'flex', flexDirection: 'column', gap: 10,
+};
+const blockHead: React.CSSProperties = { display: 'flex', alignItems: 'baseline', gap: 10, flexWrap: 'wrap' };
+const blockTitle: React.CSSProperties = { margin: 0, fontSize: 13.5, fontWeight: 650, color: '#e6e6e6' };
+const blockHint: React.CSSProperties = { fontSize: 11.5, color: '#6e6e6e' };
+
+// Actions sit under the content they act on. The old footer was pinned to the
+// window's bottom edge, which put "Test connection" 600px below the field it
+// tests.
+const actions: React.CSSProperties = { display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', marginTop: 4 };
+
 const label: React.CSSProperties = { fontSize: 12, color: '#888', marginBottom: 4, marginTop: 10, display: 'block' };
-const input: React.CSSProperties = { width: '100%', boxSizing: 'border-box', background: '#1a1a1a', border: '1px solid #333', color: '#eee', padding: '6px 8px', borderRadius: 4, fontSize: 13 };
-const sectionBox: React.CSSProperties = { marginTop: 12, padding: 12, background: '#111', borderRadius: 4, fontSize: 13 };
-const errBox: React.CSSProperties = { marginTop: 12, padding: 12, background: '#1a1111', border: '1px solid #533', borderRadius: 4, fontSize: 13 };
+const input: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box', background: '#0c0c0c', border: '1px solid #333',
+  color: '#eee', padding: '6px 8px', borderRadius: 4, fontSize: 13,
+};
+const sectionBox: React.CSSProperties = { ...card, marginTop: 0, fontSize: 13 };
+const errBox: React.CSSProperties = { ...card, marginTop: 0, background: '#1a1111', borderColor: '#533', fontSize: 13 };
 const errText: React.CSSProperties = { color: '#f88', fontSize: 12, marginTop: 8 };
 const warnText: React.CSSProperties = { color: '#d2a24c', fontSize: 12, marginTop: 8 };
 const progressText: React.CSSProperties = { fontSize: 13, color: '#8af', marginTop: 8 };
 const radio = (busy: boolean): React.CSSProperties => ({ display: 'flex', alignItems: 'center', gap: 4, cursor: busy ? 'not-allowed' : 'pointer', color: '#ccc', fontSize: 13 });
-const btn = (disabled: boolean, variant: 'primary' | 'secondary' = 'primary'): React.CSSProperties => ({
-  padding: '7px 16px', borderRadius: 4, border: '1px solid #333', fontSize: 13, cursor: disabled ? 'not-allowed' : 'pointer',
-  background: disabled ? '#222' : variant === 'primary' ? '#1d4ed8' : '#2a2a2a', color: disabled ? '#666' : '#fff',
+
+// ── progress rail ──
+// Sticky, same slot and same type sizes as SettingsPage's contents rail. It
+// keeps that rail's single green accent rather than importing a second one:
+// green already means "here" in this column, and a step tracker that introduced
+// blue would be saying the same thing in a new colour.
+const rail: React.CSSProperties = {
+  position: 'sticky', top: 0, display: 'flex', flexDirection: 'column', gap: 2, marginTop: 16,
+};
+const railLabel: React.CSSProperties = {
+  fontSize: 9.5, letterSpacing: '0.13em', textTransform: 'uppercase', color: '#4e4e4e', padding: '0 8px 6px',
+};
+type StepState = 'active' | 'done' | 'todo';
+const railItem = (state: StepState): React.CSSProperties => ({
+  display: 'flex', alignItems: 'center', gap: 8, width: '100%',
+  padding: '4px 9px', borderRadius: 4, fontSize: 11.5, textAlign: 'left',
+  background: state === 'active' ? '#1a231d' : 'transparent',
+  color: state === 'active' ? '#dfe9e2' : state === 'done' ? '#7f9a89' : '#5e5e5e',
+  boxShadow: state === 'active' ? 'inset 2px 0 0 -0.5px #7c9' : 'none',
 });
+// A 15px disc so the numerals sit on the rail's own type scale — the old 22px
+// dots were dialog furniture and would tower over an 11.5px label.
+const railMark = (state: StepState): React.CSSProperties => ({
+  width: 15, height: 15, borderRadius: '50%', flexShrink: 0,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  fontSize: 9, fontWeight: 700,
+  background: state === 'active' ? '#24352b' : state === 'done' ? '#1c2a20' : '#1c1c1c',
+  border: '1px solid ' + (state === 'active' ? '#3e5c4a' : state === 'done' ? '#2e4636' : '#2c2c2c'),
+  color: state === 'todo' ? '#666' : state === 'done' ? '#7c9' : '#dfe9e2',
+});
+// The safety line the flow never stated. It is a whole-page fact rather than a
+// per-step one, so it lives under the tracker instead of beside a button.
+const railNote: React.CSSProperties = {
+  margin: '12px 9px 0', paddingTop: 10, borderTop: '1px solid #242424',
+  fontSize: 10.5, color: '#5e5e5e', lineHeight: 1.5,
+};

--- a/web/src/RemoteConnectWizard.tsx
+++ b/web/src/RemoteConnectWizard.tsx
@@ -14,6 +14,10 @@ interface Props {
   repo: string;
   onCancel: () => void;   // user backed out — return to the repo's settings
   onDone: () => void;     // remote connected — return to the repo's settings
+  // True while the commit is in flight (and through its brief success window).
+  // The parent MUST NOT unmount this component while it is true — see the
+  // `leavable` comment below for what unmounting costs.
+  onBusyChange?: (busy: boolean) => void;
 }
 
 // RemoteConnectWizard is the stepped connect/reconcile flow. It drives the
@@ -32,7 +36,7 @@ interface Props {
 // "On this page" occupies on the settings page you just came from. That rail is
 // the progress tracker — the only structural difference, and it earns the
 // difference because progress is genuinely what a reader wants there mid-flow.
-export function RemoteConnectWizard({ repo, onCancel, onDone }: Props) {
+export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Props) {
   const [url, setUrl] = useState('');
   // '' = auto-detect (backend infers SSH for git@/ssh:// URLs, else anonymous).
   // 'none' forces anonymous even for SSH-style URLs. handleTest sends '' as an
@@ -53,7 +57,15 @@ export function RemoteConnectWizard({ repo, onCancel, onDone }: Props) {
   const [error, setError] = useState<{ section: Step; message: string } | null>(null);
 
   const cleanupRef = useRef<(() => void) | null>(null);
-  useEffect(() => () => { cleanupRef.current?.(); }, []);
+  // The success pause before handing back to the parent. It has to be cancelled
+  // on unmount: it fires onDone(), and onDone MOVES THE SELECTION. Left running,
+  // a reader who navigates away during the 1.2s window gets yanked back to this
+  // repo's settings page a beat later, from wherever they went.
+  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    cleanupRef.current?.();
+    if (doneTimerRef.current !== null) clearTimeout(doneTimerRef.current);
+  }, []);
 
   // Prefill from the existing origin (reconnect/change case). The secret is
   // never returned by the API, so token/password start blank.
@@ -133,9 +145,13 @@ export function RemoteConnectWizard({ repo, onCancel, onDone }: Props) {
     try {
       await streamCommit(repo, sessionId, (ev: SSEEvent) => {
         if (ev.phase === 'done') {
-          setStep('done'); setProgress(''); setTimeout(() => onDone(), 1200);
+          setStep('done'); setProgress('');
+          doneTimerRef.current = setTimeout(() => onDone(), 1200);
         } else if (ev.phase === 'error') {
-          setError({ section: 'committing', message: ev.message });
+          // Keep step at 'committing' — it is what keeps the Sync block, and so
+          // this error and its Retry, on screen. `leavable` reads the error, not
+          // the step, to know the commit is no longer in flight.
+          setError({ section: 'committing', message: ev.message }); setProgress('');
         } else if (ev.phase === 'swapping') {
           setProgress('Swapping store…');
         } else if (ev.phase === 'configuring') {
@@ -147,6 +163,7 @@ export function RemoteConnectWizard({ repo, onCancel, onDone }: Props) {
       });
     } catch (e) {
       setError({ section: 'committing', message: (e instanceof Error && e.message) || 'Commit failed' });
+      setProgress('');
     }
   };
 
@@ -219,7 +236,25 @@ export function RemoteConnectWizard({ repo, onCancel, onDone }: Props) {
 
   // Leaving is withheld once the commit is in flight: it swaps the store and
   // rebuilds the index, and there is no "un-commit" to return the reader to.
-  const leavable = step !== 'committing' && step !== 'done';
+  //
+  // A FAILED commit is not in flight — the stream is over and the only moves
+  // left are Retry or leaving — but its step stays 'committing' so the Sync
+  // block keeps rendering the error. So "still running" is step AND no error;
+  // reading the step alone would strand the reader on a page whose only exit is
+  // disabled, under a rail note telling them to wait for work that already died.
+  const commitFailed = step === 'committing' && error?.section === 'committing';
+  const leavable = (step !== 'committing' || commitFailed) && step !== 'done';
+
+  // Published upward because the crumb is not the only exit any more: this page
+  // renders inside the manager, whose rail can unmount it out from under a live
+  // commit. streamCommit has no AbortController and is not registered in
+  // cleanupRef, so unmounting does not stop it — it strands a store swap whose
+  // completion the UI never hears, and leaves its temp dir open to being deleted
+  // by the next session the user starts.
+  useEffect(() => {
+    onBusyChange?.(!leavable);
+    return () => { onBusyChange?.(false); };
+  }, [leavable, onBusyChange]);
 
   return (
     <div data-testid="remote-connect-wizard">
@@ -405,9 +440,15 @@ export function RemoteConnectWizard({ repo, onCancel, onDone }: Props) {
             );
           })}
           <p style={railNote}>
-            {leavable
-              ? <>Nothing is written to <b style={{ color: '#8a8a8a', fontWeight: 600 }}>{repo}</b> until the last step runs.</>
-              : <>Writing to <b style={{ color: '#8a8a8a', fontWeight: 600 }}>{repo}</b> — leave this running.</>}
+            {/* Deliberately does NOT claim the repo is unchanged: it usually is
+                (every refusal aborts before the swap and says so in its own
+                message), but a failed swap — or a stream that dropped after the
+                server got past it — cannot promise that from here. */}
+            {commitFailed
+              ? <>The last step did not finish. Retry, or go back to <b style={{ color: '#8a8a8a', fontWeight: 600 }}>{repo}</b>.</>
+              : leavable
+                ? <>Nothing is written to <b style={{ color: '#8a8a8a', fontWeight: 600 }}>{repo}</b> until the last step runs.</>
+                : <>Writing to <b style={{ color: '#8a8a8a', fontWeight: 600 }}>{repo}</b> — leave this running.</>}
           </p>
         </nav>
       </div>

--- a/web/src/RemoteConnectWizard.tsx
+++ b/web/src/RemoteConnectWizard.tsx
@@ -69,11 +69,18 @@ export function RemoteConnectWizard({ repo, onCancel, onDone, onBusyChange }: Pr
   // leaving is free), but the shared-history path chains apply → commit, and a
   // commit is a store swap. Without this the reader backs out and the swap runs
   // anyway, on a session cancel() has already asked the server to delete.
+  // Cleared on setup, not just initialised at declaration: StrictMode mounts
+  // twice (setup → cleanup → setup), so a ref only ever set by the cleanup
+  // stays true for the whole life of the component in a dev build, and the
+  // chain below never fires.
   const leftRef = useRef(false);
-  useEffect(() => () => {
-    leftRef.current = true;
-    cleanupRef.current?.();
-    if (doneTimerRef.current !== null) clearTimeout(doneTimerRef.current);
+  useEffect(() => {
+    leftRef.current = false;
+    return () => {
+      leftRef.current = true;
+      cleanupRef.current?.();
+      if (doneTimerRef.current !== null) clearTimeout(doneTimerRef.current);
+    };
   }, []);
 
   // Prefill from the existing origin (reconnect/change case). The secret is

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -347,6 +347,62 @@ describe('RepoManager', () => {
     expect(within(block).getByTestId('remote-connect')).toBeInTheDocument();
   });
 
+  // The connect flow is a SUB-PAGE of the repo, not a surface of its own. It
+  // used to make RepoManager return early, which took the rail and every other
+  // way out of the pane with it — so these assert on what survives the click,
+  // not just on what appears.
+  describe('the connect sub-page', () => {
+    async function openConnect(name = 'core') {
+      render(<RepoManager {...baseProps} />);
+      await selectRepo(name);
+      fireEvent.click(await within(await screen.findByTestId('block-remote')).findByTestId('remote-connect'));
+      return screen.findByTestId('remote-connect-wizard');
+    }
+
+    it('keeps the rail, and leaves the repo it belongs to selected', async () => {
+      await openConnect();
+      expect(screen.getByTestId('repomgr-item-core')).toBeInTheDocument();
+      expect(screen.getByTestId('repomgr-item-work')).toBeInTheDocument();
+      expect(screen.getByTestId('repomgr-overview')).toBeInTheDocument();
+      // aria-current is not what the rail uses; the lit row is a style. Assert
+      // the thing a reader actually relies on instead: the crumb still names
+      // the repository whose page this is.
+      expect(screen.getByTestId('wizard-crumb-back').textContent).toBe('core');
+    });
+
+    it('replaces the settings page rather than stacking under it', async () => {
+      await openConnect();
+      expect(screen.queryByTestId('repo-settings')).not.toBeInTheDocument();
+    });
+
+    it('returns to the Remote block via the crumb', async () => {
+      await openConnect();
+      fireEvent.click(screen.getByTestId('wizard-crumb-back'));
+      await screen.findByTestId('repo-settings');
+      expect(screen.queryByTestId('remote-connect-wizard')).not.toBeInTheDocument();
+      // focus='remote' is what lands the reader back on the block they left
+      // from; SettingsPage marks the focused block current in its rail.
+      await waitFor(() => expect(screen.getByTestId('toc-remote')).toHaveAttribute('aria-current', 'true'));
+    });
+
+    it('switching repos in the rail leaves the flow', async () => {
+      await openConnect();
+      fireEvent.click(screen.getByTestId('repomgr-item-work'));
+      await screen.findByTestId('repo-settings');
+      expect(screen.queryByTestId('remote-connect-wizard')).not.toBeInTheDocument();
+    });
+
+    // Every step is either ahead of you or behind you, and none of them is a
+    // place you can click to — so the tracker is inert by construction.
+    it('shows a three-step tracker with Connect current', async () => {
+      const page = await openConnect();
+      expect(within(page).getByTestId('wizard-step-1')).toHaveAttribute('aria-current', 'step');
+      expect(within(page).getByTestId('wizard-step-2')).not.toHaveAttribute('aria-current');
+      expect(within(page).getByTestId('wizard-step-3')).not.toHaveAttribute('aria-current');
+      expect(within(page).queryByRole('button', { name: 'Review' })).toBeNull();
+    });
+  });
+
   it('shows the remote state when connected, and drops the Connect offer', async () => {
     (api.getOrigin as ReturnType<typeof vi.fn>).mockResolvedValue({
       name: 'origin', url: 'https://github.com/knomit/kb.git', branch: 'main', auth_method: 'token',

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -1,13 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { RepoManager } from './RepoManager';
-import { api, MAX_LENS_DESCRIPTION_BYTES, MAX_REPO_DESCRIPTION_BYTES } from './api';
+import { api, createSession, streamTest, streamPreview, streamApply, streamCommit, MAX_LENS_DESCRIPTION_BYTES, MAX_REPO_DESCRIPTION_BYTES } from './api';
 
-// Only `api` is stubbed. The module's other exports — the description byte
-// caps — pass through from the real module, so a test asserting on a cap is
-// asserting on the value the app actually ships.
+// `api` and the origin-session streams are stubbed; the module's other exports
+// — the description byte caps — pass through from the real module, so a test
+// asserting on a cap is asserting on the value the app actually ships.
 vi.mock('./api', async importOriginal => ({
   ...(await importOriginal<typeof import('./api')>()),
+  // The connect sub-page's backend. Only the commit-lock test drives these;
+  // everywhere else they exist so the wizard cannot reach the network.
+  createSession: vi.fn(),
+  streamTest: vi.fn(() => () => {}),
+  streamPreview: vi.fn(() => () => {}),
+  streamApply: vi.fn(),
+  streamCommit: vi.fn(),
+  deleteSession: vi.fn(),
   api: {
     listArchived: vi.fn().mockResolvedValue([
       { id: 'old.1', name: 'old', origin: '', archivedAt: '2026-06-01T00:00:00Z' },
@@ -390,6 +398,46 @@ describe('RepoManager', () => {
       fireEvent.click(screen.getByTestId('repomgr-item-work'));
       await screen.findByTestId('repo-settings');
       expect(screen.queryByTestId('remote-connect-wizard')).not.toBeInTheDocument();
+    });
+
+    // ...but NOT once the commit is in flight. Selecting anything unmounts the
+    // wizard, and the commit stream has no abort and no undo: the swap and
+    // rebuild would run on with nothing left listening, and the next session
+    // the user starts deletes the temp dir it is still reading from. The wizard
+    // withholds its own crumb; the rail is the other exit and this pane's to
+    // withhold.
+    it('the rail refuses to leave while the commit is in flight', async () => {
+      type Fn = ReturnType<typeof vi.fn>;
+      (createSession as unknown as Fn).mockResolvedValueOnce({ session_id: 'sess-lock' });
+      (streamTest as unknown as Fn).mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => {
+        queueMicrotask(() => onEvent({ phase: 'done', result: { branches: ['main'], agent_branches: [], default_branch: 'main', matched_agent: '', history: 'shared', remote_fact_count: 1, local_fact_count: 1 } }));
+        return () => {};
+      });
+      (streamPreview as unknown as Fn).mockImplementation((_r: string, _s: string, onEvent: (e: unknown) => void) => {
+        queueMicrotask(() => onEvent({ phase: 'done', result: { local_only: 1, remote_only: 0, shared_path: 0, dead_refs_found: 0 } }));
+        return () => {};
+      });
+      (streamApply as unknown as Fn).mockImplementation(async (_r: string, _s: string, _st: string, _b: string | undefined, onEvent: (e: unknown) => void) => {
+        onEvent({ phase: 'done', result: { total_facts: 0, from_local: 0, from_remote: 0, overwrites: 0 } });
+      });
+      // Never resolves — the commit is in flight for the rest of the test.
+      (streamCommit as unknown as Fn).mockImplementation(() => new Promise(() => {}));
+
+      await openConnect();
+      fireEvent.change(screen.getByTestId('wizard-url'), { target: { value: 'https://example.com/repo.git' } });
+      fireEvent.click(screen.getByTestId('wizard-test'));
+      fireEvent.click(await screen.findByTestId('wizard-connect'));
+
+      await waitFor(() => expect(screen.getByTestId('repomgr-item-work')).toBeDisabled());
+      expect(screen.getByTestId('repomgr-overview')).toBeDisabled();
+      expect(screen.getByTestId('repomgr-archived')).toBeDisabled();
+      expect(screen.getByTestId('repomgr-new')).toBeDisabled();
+      expect(screen.getByTestId('repomgr-new-lens')).toBeDisabled();
+      expect(screen.getByTestId('repomgr-lens-dev')).toBeDisabled();
+
+      // The rail is not merely styled as held — the click does nothing.
+      fireEvent.click(screen.getByTestId('repomgr-item-work'));
+      expect(screen.getByTestId('remote-connect-wizard')).toBeInTheDocument();
     });
 
     // Every step is either ahead of you or behind you, and none of them is a

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -15,7 +15,9 @@ vi.mock('./api', async importOriginal => ({
   streamPreview: vi.fn(() => () => {}),
   streamApply: vi.fn(),
   streamCommit: vi.fn(),
-  deleteSession: vi.fn(),
+  // Resolved, not bare: every caller does deleteSession(...).catch(...), so a
+  // bare vi.fn() fails inside a click handler rather than at an assertion.
+  deleteSession: vi.fn().mockResolvedValue(undefined),
   api: {
     listArchived: vi.fn().mockResolvedValue([
       { id: 'old.1', name: 'old', origin: '', archivedAt: '2026-06-01T00:00:00Z' },

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -38,6 +38,11 @@ type Selection =
   // focus names a settings block to land on, set when arriving from an Overview
   // cell so the thing you clicked is what you see.
   | { kind: 'repo'; name: string; focus?: string }
+  // A repo's connect flow is a SELECTION, not a surface. It used to be a piece
+  // of component state that made this whole pane return early, taking the rail
+  // and the repo with it; as a selection it is a sub-page of the repo, the rail
+  // survives, and the repo's own row stays lit while you are in it.
+  | { kind: 'connect'; name: string }
   | { kind: 'archived' }
   | { kind: 'new' }
   | { kind: 'lens'; name: string }
@@ -48,7 +53,6 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
   const [archived, setArchived] = useState<ArchivedRepo[]>([]);
   const [lenses, setLenses] = useState<Lens[]>([]);
   const [sel, setSel] = useState<Selection>(null);
-  const [connecting, setConnecting] = useState<string | null>(null);
   const [err, setErr] = useState('');
 
   // The detail column is the scrolling element, so switching entities has to
@@ -81,21 +85,6 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
   }, [open]);
 
   if (!open) return null;
-
-  // Connect wizard takes over the whole surface — its own header/footer.
-  if (connecting) {
-    return (
-      <div style={surface} data-testid="manage-surface">
-        <div style={wizardWrap}>
-          <RemoteConnectWizard
-            repo={connecting}
-            onCancel={() => setConnecting(null)}
-            onDone={() => { setConnecting(null); onChanged(); refresh(); }}
-          />
-        </div>
-      </div>
-    );
-  }
 
   // Manage lands on Overview: it is the only screen that answers "which of my
   // repositories needs something", and the repo you were browsing is one click
@@ -156,7 +145,10 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 type="button"
                 data-testid={`repomgr-item-${r.name}`}
                 onMouseDown={noMouseFocus}
-                style={listItem(view.kind === 'repo' && view.name === r.name)}
+                // Lit for the repo's connect sub-page too: the reader is still
+                // inside that repository, and a rail that went dark mid-flow
+                // would be the takeover's context loss in miniature.
+                style={listItem((view.kind === 'repo' || view.kind === 'connect') && view.name === r.name)}
                 onClick={() => setSel({ kind: 'repo', name: r.name })}
               >
                 {/* The repo's own deterministic hue, as in the top-bar switcher,
@@ -270,10 +262,24 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 readOnly={readOnly}
                 hideRemoteConfig={hideRemoteConfig}
                 onArchived={() => { onChanged(); refresh(); setSel(null); }}
-                onConnect={() => setConnecting(view.name)}
+                onConnect={() => setSel({ kind: 'connect', name: view.name })}
                 onChanged={onChanged}
                 onBrowse={onBrowse}
                 onError={setErr}
+              />
+            )}
+            {/* Both exits land back on the Remote block rather than at the top
+                of the settings page: it is the block you left from, and after a
+                successful connect it is the one carrying the new state. */}
+            {view.kind === 'connect' && (
+              <RemoteConnectWizard
+                key={view.name}
+                repo={view.name}
+                onCancel={() => setSel({ kind: 'repo', name: view.name, focus: 'remote' })}
+                onDone={() => {
+                  onChanged(); refresh();
+                  setSel({ kind: 'repo', name: view.name, focus: 'remote' });
+                }}
               />
             )}
             {view.kind === 'archived' && (
@@ -1478,12 +1484,6 @@ function ConnectBody({ kind, name, agentBranch }: { kind: 'repo' | 'lens'; name:
 const surface: React.CSSProperties = {
   flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column',
   background: '#141414', color: '#eee',
-};
-// The connect wizard still wants a measured column — it is a linear form, and
-// a full-window line length would be a worse read, not a better one.
-const wizardWrap: React.CSSProperties = {
-  flex: 1, minHeight: 0, overflowY: 'auto', padding: '20px 22px',
-  width: 'min(720px, 100%)', boxSizing: 'border-box',
 };
 const errBox: React.CSSProperties = { background: '#311', border: '1px solid #533', padding: 10, margin: '10px 18px 0', borderRadius: 4, fontSize: 13, flexShrink: 0 };
 const body: React.CSSProperties = { display: 'flex', flex: 1, minHeight: 0 };

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -31,6 +31,11 @@ interface Props {
   // surface has no chrome of its own to dismiss.
   onChanged: () => void;             // parent re-fetches the repo list
   onBrowse: (ctx: BrowseContext) => void;  // switch the app to browse a repo/lens
+  // True while a connect commit is in flight. Withholding the rail is not
+  // enough on its own: the app's own exits (Escape, the top bar's step-out)
+  // unmount this whole pane, and the wizard's contract is that nothing may
+  // unmount it mid-commit. The parent MUST NOT close Manage while it is true.
+  onBusyChange?: (busy: boolean) => void;
 }
 
 type Selection =
@@ -49,7 +54,7 @@ type Selection =
   | { kind: 'newLens' }
   | null;
 
-export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConfig, onChanged, onBrowse }: Props) {
+export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConfig, onChanged, onBrowse, onBusyChange }: Props) {
   const [archived, setArchived] = useState<ArchivedRepo[]>([]);
   const [lenses, setLenses] = useState<Lens[]>([]);
   const [sel, setSel] = useState<Selection>(null);
@@ -90,6 +95,15 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
   useEffect(() => {
     if (open) refresh();
   }, [open]);
+
+  // Republished upward unchanged. The cleanup matters as much as the call: if
+  // this pane goes away while the flag is up (the error boundary resetting, the
+  // app deciding it has no repos left), the parent must not be left holding a
+  // lock whose holder is gone.
+  useEffect(() => {
+    onBusyChange?.(connectBusy);
+    return () => { onBusyChange?.(false); };
+  }, [connectBusy, onBusyChange]);
 
   if (!open) return null;
 

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -55,6 +55,13 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
   const [sel, setSel] = useState<Selection>(null);
   const [err, setErr] = useState('');
 
+  // Set by the connect sub-page while its commit is in flight. Selecting
+  // anything unmounts that page, and the commit stream has no abort and no
+  // undo: the swap-and-rebuild would run on regardless, with nothing left
+  // listening for its result. The wizard already withholds its own crumb; the
+  // rail is the other exit, and it is this component's to withhold.
+  const [connectBusy, setConnectBusy] = useState(false);
+
   // The detail column is the scrolling element, so switching entities has to
   // reset it. The old boxed pane was rarely taller than its frame and nobody
   // noticed; a settings PAGE is, and without this you land halfway down the
@@ -106,7 +113,12 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
 
       <div style={body}>
           {/* ── Master list ── */}
-          <nav style={listCol}>
+          {/* Dimmed as a whole while a connect commit runs: every row below is
+              disabled, and a rail that looked live but refused every click
+              would read as a broken pane rather than a held one. The reason is
+              stated where the reader is looking — the connect page's own rail
+              note — not repeated here. */}
+          <nav style={connectBusy ? { ...listCol, opacity: 0.4 } : listCol}>
             {/* Overview is pinned above the lists it summarises, and is the only
                 rail row that is not an entity. Hidden with zero repos: there is
                 nothing to summarise, and the create form owns that screen. */}
@@ -117,6 +129,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                   data-testid="repomgr-overview"
                   onMouseDown={noMouseFocus}
                   style={listItem(view.kind === 'overview')}
+                  disabled={connectBusy}
                   onClick={() => setSel({ kind: 'overview' })}
                 >
                   <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -135,7 +148,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 title="New repository"
                 aria-label="New repository"
                 style={plusBtn(readOnly, view.kind === 'new')}
-                disabled={readOnly}
+                disabled={readOnly || connectBusy}
                 onClick={() => setSel({ kind: 'new' })}
               ><PlusIcon color="currentColor" size={14} /></button>
             </div>
@@ -149,6 +162,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 // inside that repository, and a rail that went dark mid-flow
                 // would be the takeover's context loss in miniature.
                 style={listItem((view.kind === 'repo' || view.kind === 'connect') && view.name === r.name)}
+                disabled={connectBusy}
                 onClick={() => setSel({ kind: 'repo', name: r.name })}
               >
                 {/* The repo's own deterministic hue, as in the top-bar switcher,
@@ -188,6 +202,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 data-testid="repomgr-archived"
                   onMouseDown={noMouseFocus}
                 style={archRow(view.kind === 'archived')}
+                disabled={connectBusy}
                 onClick={() => setSel({ kind: 'archived' })}
               >
                 <ArchiveIcon color={view.kind === 'archived' ? '#c8b89a' : '#7a6a5a'} size={12} />
@@ -206,7 +221,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 title="New lens"
                 aria-label="New lens"
                 style={plusBtn(readOnly, view.kind === 'newLens')}
-                disabled={readOnly}
+                disabled={readOnly || connectBusy}
                 onClick={() => setSel({ kind: 'newLens' })}
               ><PlusIcon color="currentColor" size={14} /></button>
             </div>
@@ -218,6 +233,7 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 data-testid={`repomgr-lens-${l.name}`}
                 onMouseDown={noMouseFocus}
                 style={listItem(view.kind === 'lens' && view.name === l.name)}
+                disabled={connectBusy}
                 onClick={() => setSel({ kind: 'lens', name: l.name })}
               >
                 <span style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
@@ -280,6 +296,10 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                   onChanged(); refresh();
                   setSel({ kind: 'repo', name: view.name, focus: 'remote' });
                 }}
+                // Passed as the raw setter, not a closure: this runs from an
+                // effect keyed on the value it sets, so an identity that
+                // changed every render would re-run it every render.
+                onBusyChange={setConnectBusy}
               />
             )}
             {view.kind === 'archived' && (

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -31,6 +31,12 @@ interface Props {
    *  no browse surface to return to. The toggle is then not rendered at all: a
    *  disabled exit is a control that answers "can I leave?" with noise. */
   manageLocked?: boolean;
+  /** True while Manage is doing something that must not be interrupted — today,
+   *  a connect commit swapping a repository's store. Unlike `manageLocked` the
+   *  exit stays RENDERED and merely refuses: this state is temporary, and a
+   *  control that vanished mid-flow would read as the window losing its way
+   *  out rather than holding it. The tooltip carries the reason. */
+  manageBusy?: boolean;
   /** Live width of the Library panel; the title-bar identity zone matches it
    *  so the divider lines up with the splitter below. */
   leftWidth: number;
@@ -44,7 +50,7 @@ interface Props {
 // The two that only reported — the commit, and the lens write target — moved to
 // the StatusFooter, which is the readout rail. What is left is the same shape in
 // both contexts: the switcher, then the scope picker, then search.
-export const TopBar = memo(function TopBar({ state, repos, lenses = [], dispatch, onManageRepos, manageOpen = false, manageLocked = false, leftWidth, search }: Props) {
+export const TopBar = memo(function TopBar({ state, repos, lenses = [], dispatch, onManageRepos, manageOpen = false, manageLocked = false, manageBusy = false, leftWidth, search }: Props) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuBtnRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -61,6 +67,10 @@ export const TopBar = memo(function TopBar({ state, repos, lenses = [], dispatch
   // the lens in a lens context and the repo otherwise. Named in the exit's
   // tooltip so the destination is one hover away without a label in the bar.
   const manageReturnTo = state.context.kind === 'lens' ? state.context.name : state.repo;
+  // "Held": in Manage, and Manage says it is mid-something uninterruptible.
+  // Only meaningful with manageOpen — busy is a state of the mode, not of a bar
+  // that is not showing it.
+  const held = manageOpen && manageBusy;
 
   useDismiss(menuOpen, () => setMenuOpen(false), [menuBtnRef, menuRef]);
 
@@ -292,14 +302,15 @@ export const TopBar = memo(function TopBar({ state, repos, lenses = [], dispatch
           onClick={onManageRepos}
           onMouseDown={noMouseFocus}
           aria-pressed={manageOpen}
-          title={manageOpen ? `Leave Manage — back to ${manageReturnTo}  (Esc)` : 'Manage repositories'}
-          aria-label={manageOpen ? `Leave Manage — back to ${manageReturnTo}` : 'Manage repositories'}
+          disabled={held}
+          title={held ? 'Manage is finishing something — leave it running' : manageOpen ? `Leave Manage — back to ${manageReturnTo}  (Esc)` : 'Manage repositories'}
+          aria-label={held ? 'Manage is finishing something — leave it running' : manageOpen ? `Leave Manage — back to ${manageReturnTo}` : 'Manage repositories'}
           // One control, one look: only the GLYPH changes between modes. A
           // tinted pill would make the way out read as a different kind of
           // thing from the way in, when it is the same button in the same pixel.
-          style={{ background: 'none', border: 'none', color: !manageOpen && remoteError ? '#f44336' : '#666', cursor: 'pointer', padding: 4, display: 'flex', alignItems: 'center', position: 'relative', flexShrink: 0, ...noDrag }}
-          onMouseEnter={e => { if (manageOpen || !remoteError) e.currentTarget.style.color = '#aaa'; }}
-          onMouseLeave={e => { e.currentTarget.style.color = !manageOpen && remoteError ? '#f44336' : '#666'; }}
+          style={{ background: 'none', border: 'none', color: held ? '#3d3d3d' : !manageOpen && remoteError ? '#f44336' : '#666', cursor: held ? 'default' : 'pointer', padding: 4, display: 'flex', alignItems: 'center', position: 'relative', flexShrink: 0, ...noDrag }}
+          onMouseEnter={e => { if (!held && (manageOpen || !remoteError)) e.currentTarget.style.color = '#aaa'; }}
+          onMouseLeave={e => { e.currentTarget.style.color = held ? '#3d3d3d' : !manageOpen && remoteError ? '#f44336' : '#666'; }}
         >
           {manageOpen ? <ExitIcon color="currentColor" size={15} /> : <GearIcon color="currentColor" size={15} />}
           {!manageOpen && remoteError && (


### PR DESCRIPTION
Re-targeted from #80, which was opened against `master` by mistake. Same four commits, unchanged; this repo lands work via `dev` → `master`.

Connect-remote moves from a full-dialog takeover to a sub-page of the repo, with the exit gated while a commit is in flight (a commit is a store swap and must not be abandoned mid-write).

Includes the fixes from review: `created`-flag stale-closure fix in `handleTest`, `doneTimerRef` cancellation on unmount, the `commitFailed`/`leavable` split, and a `leftRef` reset on effect setup so StrictMode cannot pin it true.

Known follow-ups, deliberately not in this PR:
- A commit stream that ends without a `done`/`error` event leaves the reader unable to exit Manage (no timeout, no escape hatch).
- Leaving the sub-page via the repo rail does not delete the server-side session, so a temp clone leaks until the 10-minute idle sweep.