### PR TITLE
feat: fact version timestamps, repo & lens rename, LICENSE write path

### DIFF
--- a/cmd/migrate_registry.go
+++ b/cmd/migrate_registry.go
@@ -221,6 +221,11 @@ type skippedFile struct {
 
 // lensPlan is one lens, already translated to uids.
 type lensPlan struct {
+	// UID is the lens's own registry identity (lenses.uid) it will land with.
+	// Carried across unchanged when the source row already has one (a re-run
+	// against a control.db this same tool already re-keyed); minted fresh
+	// otherwise.
+	UID         string
 	Name        string
 	WriteUID    string
 	Description string
@@ -1082,6 +1087,21 @@ func planLenses(plan *migrationPlan, opts migrateOpts) error {
 		writeCol, readCol = "write_uid", "repo_uid"
 	}
 
+	// A control.db this same tool already re-keyed (write_uid present) may or
+	// may not already carry the lens's OWN uid too — that column was added
+	// alongside OpenLensRegistry's self-upgrade, so an already-uid-keyed home
+	// this tool has not yet touched under the new version does not have it
+	// yet. Read it when present so a --force re-run does not mint a second,
+	// different identity for a lens that already has one; mint fresh below
+	// when it is absent.
+	hasOwnUID := false
+	if newShape {
+		hasOwnUID, err = rawColumnExists(db, "lenses", "uid")
+		if err != nil {
+			return err
+		}
+	}
+
 	// name -> uid for ACTIVE repos, with archived names as a fallback. The old
 	// archive guard refused to archive a lens member, so a lens should only
 	// ever name an active repo; the fallback covers a home where that guard was
@@ -1108,22 +1128,31 @@ func planLenses(plan *migrationPlan, opts migrateOpts) error {
 		return uid, ok
 	}
 
-	rows, err := db.Query(
-		`SELECT name, ` + writeCol + `, description, created_at, updated_at FROM lenses ORDER BY name`)
+	lensSelectCols := "name, " + writeCol + ", description, created_at, updated_at"
+	if hasOwnUID {
+		lensSelectCols = "uid, " + lensSelectCols
+	}
+	rows, err := db.Query(`SELECT ` + lensSelectCols + ` FROM lenses ORDER BY name`)
 	if err != nil {
 		return fmt.Errorf("read legacy lenses: %w", err)
 	}
 	var lenses []lensPlan
 	type rawLens struct {
-		name, write, desc string
-		created, updated  int64
+		uid, name, write, desc string
+		created, updated       int64
 	}
 	var raws []rawLens
 	for rows.Next() {
 		var rl rawLens
-		if err := rows.Scan(&rl.name, &rl.write, &rl.desc, &rl.created, &rl.updated); err != nil {
+		var scanErr error
+		if hasOwnUID {
+			scanErr = rows.Scan(&rl.uid, &rl.name, &rl.write, &rl.desc, &rl.created, &rl.updated)
+		} else {
+			scanErr = rows.Scan(&rl.name, &rl.write, &rl.desc, &rl.created, &rl.updated)
+		}
+		if scanErr != nil {
 			rows.Close()
-			return fmt.Errorf("read legacy lenses: %w", err)
+			return fmt.Errorf("read legacy lenses: %w", scanErr)
 		}
 		raws = append(raws, rl)
 	}
@@ -1140,7 +1169,12 @@ func planLenses(plan *migrationPlan, opts migrateOpts) error {
 		return err
 	}
 	for _, rl := range raws {
+		uid := rl.uid
+		if uid == "" {
+			uid = ksuid.New().String()
+		}
 		lp := lensPlan{
+			UID:         uid,
 			Name:        rl.name,
 			Description: rl.desc,
 			CreatedAt:   rl.created,
@@ -1156,9 +1190,16 @@ func planLenses(plan *migrationPlan, opts migrateOpts) error {
 		lp.WriteUID = writeUID
 
 		if readsExist {
+			// lens_reads.lens_uid replaces .lens_name in the exact same DDL
+			// change that adds lenses.uid, so the two probes share hasOwnUID:
+			// when the lens's own uid is already there, so is its child's.
+			readsKeyCol, readsKeyVal := "lens_name", rl.name
+			if hasOwnUID {
+				readsKeyCol, readsKeyVal = "lens_uid", rl.uid
+			}
 			rrows, qerr := db.Query(
-				`SELECT `+readCol+`, branch, COALESCE(source, '') FROM lens_reads WHERE lens_name = ? ORDER BY `+readCol,
-				rl.name)
+				`SELECT `+readCol+`, branch, COALESCE(source, '') FROM lens_reads WHERE `+readsKeyCol+` = ? ORDER BY `+readCol,
+				readsKeyVal)
 			if qerr != nil {
 				return fmt.Errorf("read legacy lens reads: %w", qerr)
 			}
@@ -1409,9 +1450,9 @@ func applyControlDB(plan *migrationPlan) error {
 	}
 	for _, lp := range plan.Lenses {
 		if _, err := tx.Exec(
-			`INSERT INTO lenses (name, write_uid, description, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?)`,
-			lp.Name, lp.WriteUID, lp.Description, lp.CreatedAt, lp.UpdatedAt,
+			`INSERT INTO lenses (uid, name, write_uid, description, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			lp.UID, lp.Name, lp.WriteUID, lp.Description, lp.CreatedAt, lp.UpdatedAt,
 		); err != nil {
 			return fmt.Errorf("rewrite lens %q: %w", lp.Name, err)
 		}
@@ -1421,8 +1462,8 @@ func applyControlDB(plan *migrationPlan) error {
 				source = r.Source
 			}
 			if _, err := tx.Exec(
-				`INSERT INTO lens_reads (lens_name, repo_uid, branch, source) VALUES (?, ?, ?, ?)`,
-				lp.Name, r.RepoUID, r.Branch, source,
+				`INSERT INTO lens_reads (lens_uid, repo_uid, branch, source) VALUES (?, ?, ?, ?)`,
+				lp.UID, r.RepoUID, r.Branch, source,
 			); err != nil {
 				return fmt.Errorf("rewrite lens %q read mount: %w", lp.Name, err)
 			}

--- a/cmd/migrate_registry.go
+++ b/cmd/migrate_registry.go
@@ -252,9 +252,15 @@ type migrationPlan struct {
 	ArchiveDir  string
 	Repos       []repoPlan
 	Lenses      []lensPlan
-	// LensesAlreadyKeyedByUID is true when control.db's lens tables were found
-	// in the new shape (a re-run); rows are then carried across unchanged.
-	LensesAlreadyKeyedByUID bool
+	// LensMembersKeyedByUID is true when control.db's lens tables were found in
+	// the new shape (a re-run) — i.e. the lens MEMBER references (write_uid /
+	// repo_uid) are already keyed by repo uid rather than repo name. Probed
+	// from the write_uid column. This says nothing about whether the lens ROW
+	// ITSELF has its own uid — that is the separate hasOwnUID probe (the
+	// "uid" column), added later alongside OpenLensRegistry's self-upgrade;
+	// a home can have this true and hasOwnUID false. When this is true, rows
+	// are carried across unchanged.
+	LensMembersKeyedByUID bool
 	// ControlDBExists is false for a home that never had a control.db, in which
 	// case there is nothing to back up.
 	ControlDBExists bool
@@ -1081,7 +1087,7 @@ func planLenses(plan *migrationPlan, opts migrateOpts) error {
 	if err != nil {
 		return err
 	}
-	plan.LensesAlreadyKeyedByUID = newShape
+	plan.LensMembersKeyedByUID = newShape
 	writeCol, readCol := "write_repo", "repo"
 	if newShape {
 		writeCol, readCol = "write_uid", "repo_uid"
@@ -1679,7 +1685,7 @@ func printPlan(out io.Writer, plan *migrationPlan) {
 	if plan.ForceResetRows {
 		fmt.Fprintln(out, "--force: the existing repos rows will be rebuilt from what is on disk")
 	}
-	if plan.LensesAlreadyKeyedByUID {
+	if plan.LensMembersKeyedByUID {
 		fmt.Fprintln(out, "lens tables are already uid-keyed; their rows are carried across unchanged")
 	}
 	if len(plan.Repos) == 0 {

--- a/cmd/migrate_registry_test.go
+++ b/cmd/migrate_registry_test.go
@@ -711,6 +711,18 @@ func TestMigrateRegistry_ForceResumesAfterAnInterruptedRun(t *testing.T) {
 	require.NoError(t, applyControlDB(plan))
 	require.FileExists(t, filepath.Join(home, "repos", "alpha.db"), "the crash was before the renames")
 
+	// The lens's own uid must be just as stable across the resume as the repo
+	// uid asserted below: Task 4d pins the MCP cursor on this id, and a
+	// re-mint here would silently invalidate every pinned cursor and any
+	// stored reference to it.
+	firstLensReg, err := repos.OpenLensRegistry(filepath.Join(home, "control.db"))
+	require.NoError(t, err)
+	firstLens, ok, err := firstLensReg.Get("workspace")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotEmpty(t, firstLens.UID)
+	require.NoError(t, firstLensReg.Close())
+
 	// Without --force the re-run refuses, because the registry has rows.
 	rerr := runMigrateRegistry(home, quietOpts(migrateOpts{}))
 	require.Error(t, rerr)
@@ -734,6 +746,7 @@ func TestMigrateRegistry_ForceResumesAfterAnInterruptedRun(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, active[0].UID, lens.WriteUID, "lens membership still resolves")
+	require.Equal(t, firstLens.UID, lens.UID, "the re-run reuses the lens's own uid, not just the repo uid it points at")
 }
 
 // The entire ordering invariant rests on this: a legacy repo database can be

--- a/internal/mcp/binding_pin_test.go
+++ b/internal/mcp/binding_pin_test.go
@@ -2,12 +2,16 @@ package mcp
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/config"
+	"knomit/internal/fact"
 	"knomit/internal/repos"
+	"knomit/internal/store"
 )
 
 // newRenameTestRepo stands up a started Manager with one registered repo
@@ -61,4 +65,57 @@ func TestQueryResume_SurvivesRepoRename(t *testing.T) {
 	second := runQuery(t, ctx, map[string]any{"cursor": *first.Cursor})
 	require.Equal(t, n-defaultPageSize, len(second.Facts), "resumed page must survive the rename")
 	require.False(t, second.HasMore, "no more results after the last page")
+}
+
+// newUidlessTestRepo builds a bare RepoInstance with NO uid set, deliberately
+// — unlike every other fixture in this package (see nextTestRepoUID in
+// learn_test.go), which now always sets one. This is the one fixture meant to
+// exercise the case pinOf/PinID fail closed on: a registry row that never got
+// a live instance can't reach a Binding constructor in production (four
+// independent barriers per the binding.go doc), but the failure-closed
+// behavior itself still needs a direct test.
+func newUidlessTestRepo(t *testing.T) (*repos.RepoInstance, context.Context) {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:         "uidless",
+		AgentBranch:  "agent/test",
+		Svc:          svc,
+		Ontology:     fact.CodeOntology(),
+		OntologyRoot: "kb",
+	})
+	require.Empty(t, ri.UID(), "fixture must be uid-less for this test to mean anything")
+	return ri, repos.WithRepoInstance(context.Background(), ri)
+}
+
+// TestQueryResume_RejectsUidlessBindingMint pins the Important finding from
+// round 1 review: pinOf fails closed to "" on an empty uid, so a session
+// minted by a uid-less binding (PinID() == "") can never resume — even
+// against the SAME binding that minted it. Without the resume-side "" guard
+// (query.go), a stored "" and a computed "" compare equal and this resume
+// would wrongly succeed; WITH it, the rejection is byte-identical to real
+// expiry, exactly like every other §7.3 rejection.
+func TestQueryResume_RejectsUidlessBindingMint(t *testing.T) {
+	ri, ctx := newUidlessTestRepo(t)
+	const n = 25 // > defaultPageSize (20) so a cursor is returned
+	seedFedMany(t, ctx, n, "Alpha", "alpha body ", "store")
+
+	b := repos.NewBindingOfRepo(ri, "")
+	require.Empty(t, b.PinID(), "sanity: the binding under test really is uid-less")
+
+	first := runQuery(t, ctx, map[string]any{"type": []any{"policy"}})
+	require.NotNil(t, first.Cursor, "mint is unguarded — a uid-less binding can still mint a cursor")
+
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{"cursor": *first.Cursor}
+	result, err := QueryHandler()(ctx, req)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "a session minted by a uid-less binding must never resume, even against itself")
+	require.Contains(t, resultText(t, result), "session expired or not found",
+		"the rejection must be byte-identical to real expiry")
 }

--- a/internal/mcp/binding_pin_test.go
+++ b/internal/mcp/binding_pin_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/config"
+	"knomit/internal/repos"
+)
+
+// newRenameTestRepo stands up a started Manager with one registered repo
+// ("alpha") so the test can drive Manager.RenameRepo — the production rename
+// path (internal/repos/lifecycle.go) — rather than faking a rename by hand.
+// Mirrors newLensE2E's single-repo half; a lens is unnecessary here since the
+// property under test (cursor survives a repo rename) only needs a
+// lens-of-one binding.
+func newRenameTestRepo(t *testing.T) (m *repos.Manager, ri *repos.RepoInstance, ctx context.Context) {
+	t.Helper()
+
+	dir := t.TempDir()
+	m = repos.New(context.Background(), repos.Deps{
+		Cfg:         config.Config{Home: dir},
+		AgentBranch: "agent/test",
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+
+	ri = newE2ERepo(t, m, "alpha")
+	m.Set("alpha", ri)
+
+	return m, ri, repos.WithRepoInstance(context.Background(), ri)
+}
+
+// TestQueryResume_SurvivesRepoRename pins the fix this task exists for: before
+// the cursor pin moved onto ids (repo:<uid> / lens:<uid>), the resume check
+// compared Binding.Name() against the stored name, so a repo rename between
+// mint and resume changed Name() and silently orphaned every in-flight
+// cursor. Renaming the repo mid-walk must no longer affect an outstanding
+// cursor — resume must still serve the frozen page.
+func TestQueryResume_SurvivesRepoRename(t *testing.T) {
+	m, ri, ctx := newRenameTestRepo(t)
+	const n = 25 // > defaultPageSize (20) so a cursor is returned
+	seedFedMany(t, ctx, n, "Alpha", "alpha body ", "store")
+
+	// Mint the cursor while the repo is still named "alpha".
+	first := runQuery(t, ctx, map[string]any{"type": []any{"policy"}})
+	require.NotNil(t, first.Cursor, "multi-page query must return a cursor")
+	require.Len(t, first.Facts, defaultPageSize, "first page must be full")
+
+	// Rename through the real production path. RenameRepo updates ri in
+	// place (same *RepoInstance, new name) — ctx still refers to it, so the
+	// next handler call rebuilds a Binding from the SAME instance, now under
+	// its new name, exactly as a live server would after a rename lands.
+	require.NoError(t, m.RenameRepo("alpha", "alpha-renamed"))
+	require.Equal(t, "alpha-renamed", ri.Name(), "rename must update the instance in place")
+
+	// Resume: the rebuilt binding's Name() differs from the one at mint time,
+	// but its PinID() (repo:<uid>) does not — the resume must succeed.
+	second := runQuery(t, ctx, map[string]any{"cursor": *first.Cursor})
+	require.Equal(t, n-defaultPageSize, len(second.Facts), "resumed page must survive the rename")
+	require.False(t, second.HasMore, "no more results after the last page")
+}

--- a/internal/mcp/explain.go
+++ b/internal/mcp/explain.go
@@ -419,7 +419,7 @@ func explainFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, fi
 		queueItems = append(queueItems, store.QueueItem{Path: wire(e.Path), CommitHash: e.Commit, SortKey: 1})
 	}
 
-	session, err := sWrite.toolSession.CreateToolSession(ctx, "explain", b.WriteMountBranch(), rel, b.Name(), federate.ReadSetFingerprint(b))
+	session, err := sWrite.toolSession.CreateToolSession(ctx, "explain", b.WriteMountBranch(), rel, b.PinID(), federate.ReadSetFingerprint(b))
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("create session error: %v", err)), nil
 	}
@@ -463,8 +463,11 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 	}
 	// A cursor is a frozen view of ONE binding's read set (lenses RFC §7.3).
 	// A different binding — even one sharing the write repo — must not see it;
-	// the error is indistinguishable from expiry by design.
-	if session.Binding != b.Name() {
+	// the error is indistinguishable from expiry by design. session.Binding
+	// holds PinID(), the binding's stable id (repo:<uid> / lens:<uid>), not
+	// Name() — a repo or lens rename changes Name but never moves the pin, so
+	// a rename cannot orphan an in-flight cursor.
+	if session.Binding != b.PinID() {
 		return mcpgo.NewToolResultError("session expired or not found — omit cursor to start a new session"), nil
 	}
 	// A cursor is a frozen view of the binding's READ SET at mint time — and the

--- a/internal/mcp/explain.go
+++ b/internal/mcp/explain.go
@@ -467,7 +467,13 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 	// holds PinID(), the binding's stable id (repo:<uid> / lens:<uid>), not
 	// Name() — a repo or lens rename changes Name but never moves the pin, so
 	// a rename cannot orphan an in-flight cursor.
-	if session.Binding != b.PinID() {
+	//
+	// PinID() (via pinOf) fails CLOSED on an empty uid: it returns "", never a
+	// bare "repo:"/"lens:" prefix. "" must never match here even though a
+	// stored "" and a computed "" are byte-equal — a uid-less binding must be
+	// able to MINT a session but never RESUME one, or two uid-less bindings
+	// would positively match instead of merely colliding on a shared prefix.
+	if session.Binding == "" || session.Binding != b.PinID() {
 		return mcpgo.NewToolResultError("session expired or not found — omit cursor to start a new session"), nil
 	}
 	// A cursor is a frozen view of the binding's READ SET at mint time — and the

--- a/internal/mcp/explain_test.go
+++ b/internal/mcp/explain_test.go
@@ -439,6 +439,7 @@ func TestExplainResume_RejectsForeignBinding(t *testing.T) {
 	// Resume under a DIFFERENT binding backed by the same store and branch.
 	foreignRI := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
 		Name:         "other-lens",
+		UID:          nextTestRepoUID(),
 		AgentBranch:  explainTestBranch,
 		Svc:          svc,
 		Ontology:     fact.CodeOntology(),

--- a/internal/mcp/learn_test.go
+++ b/internal/mcp/learn_test.go
@@ -3,7 +3,9 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -15,6 +17,20 @@ import (
 	"knomit/internal/repos"
 	"knomit/internal/store"
 )
+
+// testRepoUIDSeq backs nextTestRepoUID.
+var testRepoUIDSeq atomic.Int64
+
+// nextTestRepoUID returns a fresh, globally-unique uid for a test
+// RepoInstance fixture. Binding.PinID() (repo:<uid>) is the MCP
+// cursor-pinning identity (lenses RFC §7.3); two fixtures that are meant to
+// be different bindings must never share a uid, or a foreign-binding
+// rejection test would pass for the wrong reason (or not at all). Fixtures
+// that don't otherwise care about uid (most of them) get one anyway — it's
+// free and removes a whole class of accidental collision.
+func nextTestRepoUID() string {
+	return fmt.Sprintf("test-repo-%d", testRepoUIDSeq.Add(1))
+}
 
 // newLenEmbedder returns a mock BatchEmbedder whose 768-dim vectors depend
 // only on text length, so any two equal-length strings embed identically
@@ -80,6 +96,7 @@ func newLearnTestRepo(t *testing.T, ontology *fact.Ontology) *repos.RepoInstance
 
 	return repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
 		Name:         "test",
+		UID:          nextTestRepoUID(),
 		AgentBranch:  "agent/test",
 		Svc:          svc,
 		Ontology:     ontology,
@@ -197,6 +214,7 @@ func newPrinciplesTestRepo(t *testing.T) (*store.Service, context.Context, store
 
 	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
 		Name:         "test",
+		UID:          nextTestRepoUID(),
 		AgentBranch:  "agent/test",
 		Svc:          svc,
 		Ontology:     fact.CodeOntology(),

--- a/internal/mcp/query.go
+++ b/internal/mcp/query.go
@@ -319,7 +319,7 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 	// through the shared resume path, so body hydration + paging match relevance
 	// mode. Each row's WIRE path (bare for the write mount, kb://-qualified for a
 	// foreign mount — RFC §6.2 uniformity) carries the mount identity on resume.
-	sess, err := sWrite.toolSession.CreateToolSession(ctx, "query", b.WriteMountBranch(), "", b.Name(), federate.ReadSetFingerprint(b))
+	sess, err := sWrite.toolSession.CreateToolSession(ctx, "query", b.WriteMountBranch(), "", b.PinID(), federate.ReadSetFingerprint(b))
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("session error: %v", err)), nil
 	}
@@ -464,7 +464,7 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 
 	// Snapshot the remainder ([pageSize:]) into the write repo's session DB; the
 	// first page is rendered directly (full bodies available, no re-fetch).
-	sess, err := sWrite.toolSession.CreateToolSession(ctx, "query", b.WriteMountBranch(), "", b.Name(), federate.ReadSetFingerprint(b))
+	sess, err := sWrite.toolSession.CreateToolSession(ctx, "query", b.WriteMountBranch(), "", b.PinID(), federate.ReadSetFingerprint(b))
 	if err != nil {
 		return mcpgo.NewToolResultError(fmt.Sprintf("session error: %v", err)), nil
 	}
@@ -547,8 +547,16 @@ func queryResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, cursor 
 	}
 	// A cursor is a frozen view of ONE binding's read set (lenses RFC §7.3).
 	// A different binding — even one sharing the write repo — must not see it;
-	// the error is indistinguishable from expiry by design.
-	if sess.Binding != b.Name() {
+	// the error is indistinguishable from expiry by design. sess.Binding holds
+	// PinID(), the binding's stable id (repo:<uid> / lens:<uid>), not Name() —
+	// a repo or lens rename changes Name but never moves the pin, so a rename
+	// cannot orphan an in-flight cursor.
+	//
+	// Sessions minted before the pin moved onto ids hold a bare name and will
+	// not match, so they read as expired. That is deliberate and needs no
+	// migration: "expired" is already the designed-safe answer here, and tool
+	// sessions idle out after defaultToolIdleTTL (15 minutes).
+	if sess.Binding != b.PinID() {
 		return mcpgo.NewToolResultError("session expired or not found — omit cursor to start a new query"), nil
 	}
 	// A cursor is a frozen view of the binding's READ SET at mint time — and the

--- a/internal/mcp/query.go
+++ b/internal/mcp/query.go
@@ -556,7 +556,15 @@ func queryResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, cursor 
 	// not match, so they read as expired. That is deliberate and needs no
 	// migration: "expired" is already the designed-safe answer here, and tool
 	// sessions idle out after defaultToolIdleTTL (15 minutes).
-	if sess.Binding != b.PinID() {
+	//
+	// PinID() (via pinOf) fails CLOSED on an empty uid: it returns "", never a
+	// bare "repo:"/"lens:" prefix. "" must never match here even though a
+	// stored "" and a computed "" are byte-equal — a uid-less binding must be
+	// able to MINT a session (that half is unguarded) but never RESUME one, or
+	// two uid-less bindings would positively match instead of merely
+	// colliding on a shared prefix. Reject an empty sess.Binding outright,
+	// before the equality check gets the chance to agree with itself.
+	if sess.Binding == "" || sess.Binding != b.PinID() {
 		return mcpgo.NewToolResultError("session expired or not found — omit cursor to start a new query"), nil
 	}
 	// A cursor is a frozen view of the binding's READ SET at mint time — and the

--- a/internal/mcp/query_federation_test.go
+++ b/internal/mcp/query_federation_test.go
@@ -621,6 +621,7 @@ func rankedFedRepo(t *testing.T) (*repos.RepoInstance, context.Context) {
 	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
 	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
 		Name:         "test",
+		UID:          nextTestRepoUID(),
 		AgentBranch:  "agent/test",
 		Svc:          svc,
 		Ontology:     fact.CodeOntology(),

--- a/internal/mcp/query_paging_test.go
+++ b/internal/mcp/query_paging_test.go
@@ -184,6 +184,7 @@ func TestQueryResume_RejectsForeignBinding(t *testing.T) {
 	// binding check can fire — the branch is identical.
 	foreignRI := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
 		Name:         "other-lens",
+		UID:          nextTestRepoUID(),
 		AgentBranch:  "agent/test",
 		Svc:          svc,
 		Ontology:     fact.CodeOntology(),

--- a/internal/mcp/query_readset_test.go
+++ b/internal/mcp/query_readset_test.go
@@ -152,7 +152,7 @@ func TestQueryResume_RetriesPastUnreadableWindow(t *testing.T) {
 	var sessID string
 	repoA.WithRead(func(svc *store.Service) {
 		ts := svc.ToolSession()
-		sess, cerr := ts.CreateToolSession(context.Background(), "query", b.WriteMountBranch(), "", b.Name(), federate.ReadSetFingerprint(b))
+		sess, cerr := ts.CreateToolSession(context.Background(), "query", b.WriteMountBranch(), "", b.PinID(), federate.ReadSetFingerprint(b))
 		require.NoError(t, cerr)
 		sessID = sess.ID
 		require.NoError(t, ts.EnqueuePaths(context.Background(), sess.ID, []store.QueueItem{

--- a/internal/repos/binding.go
+++ b/internal/repos/binding.go
@@ -68,6 +68,25 @@ func (b *Binding) Name() string { return b.name }
 // prefix removes the question instead of arguing about probabilities.
 func (b *Binding) PinID() string { return b.pinID }
 
+// pinOf builds a PinID value, failing CLOSED on an empty uid: it returns ""
+// rather than a bare "repo:"/"lens:" prefix. Four independent barriers make
+// an empty uid unreachable today (Registry.Insert rejects it; migrate-registry
+// mints one; every live instance's uid comes from a registry row; a corrupted
+// row can't open, so it never reaches a constructor) — but every other
+// empty-uid site in this package guards explicitly (registry.go, swapstore.go,
+// manager.go), and this is the one that guards a security check, so it does
+// too. "" is deliberately not a valid PinID: the resume comparisons
+// (query.go, explain.go) additionally reject a stored/computed "" outright,
+// so a uid-less binding can mint a session but can never resume one — a
+// bare-prefix collision between two uid-less bindings never gets the chance
+// to matter.
+func pinOf(prefix, uid string) string {
+	if uid == "" {
+		return ""
+	}
+	return prefix + uid
+}
+
 // IsLens reports whether this binding federates across more than its own
 // write repo — i.e. at least one read mount is a different repo. A lens-of-one
 // (the /repos/{repo}/… path) is not a lens: its only read mount is the write
@@ -111,7 +130,7 @@ func NewBindingOfRepo(ri *RepoInstance, branch string) *Binding {
 		write:   ri,
 		writeOK: ri.WritableBranch(branch),
 		name:    ri.Name(),
-		pinID:   "repo:" + ri.UID(),
+		pinID:   pinOf("repo:", ri.UID()),
 		reads:   []ReadTarget{{RI: ri, Branch: branch}},
 	}
 }
@@ -126,7 +145,7 @@ func NewBindingForTest(write *RepoInstance, reads ...ReadTarget) *Binding {
 		write:   write,
 		writeOK: true,
 		name:    write.Name(),
-		pinID:   "repo:" + write.UID(),
+		pinID:   pinOf("repo:", write.UID()),
 		reads:   reads,
 	}
 }
@@ -165,7 +184,7 @@ func NewBindingOfLens(m *Manager, l Lens) (*Binding, error) {
 		write:   write,
 		writeOK: true, // lens writes always target the write repo's agent branch
 		name:    l.Name,
-		pinID:   "lens:" + l.UID,
+		pinID:   pinOf("lens:", l.UID),
 		reads:   reads,
 	}, nil
 }

--- a/internal/repos/binding.go
+++ b/internal/repos/binding.go
@@ -25,7 +25,9 @@ type Binding struct {
 	write   *RepoInstance
 	writeOK bool
 	name    string
-	reads   []ReadTarget
+	// pinID is the binding's STABLE identity — see PinID for the contract.
+	pinID string
+	reads []ReadTarget
 }
 
 // Write returns the single write repo.
@@ -50,8 +52,21 @@ func (b *Binding) WriteMountBranch() string {
 	return b.write.AgentBranch()
 }
 
-// Name returns the lens name, or the repo name for a lens-of-one.
+// Name returns the lens name, or the repo name for a lens-of-one. Human-
+// readable; used in error messages and logs. Can change under a rename — use
+// PinID, never Name, for any comparison that must survive one.
 func (b *Binding) Name() string { return b.name }
+
+// PinID returns the binding's STABLE identity, used to pin MCP tool-session
+// cursors (lenses RFC §7.3): repo:<uid> for a lens-of-one, lens:<uid> for a
+// lens. Distinct from Name, which is for humans and can change — use PinID,
+// never Name, for any comparison that must survive a rename.
+//
+// Prefixed deliberately. Once one side stops being a name the two value
+// spaces are no longer self-evidently disjoint, and a legal repo name can
+// parse as a ksuid (see the migrate-registry ksuid-shaped-name gotcha). The
+// prefix removes the question instead of arguing about probabilities.
+func (b *Binding) PinID() string { return b.pinID }
 
 // IsLens reports whether this binding federates across more than its own
 // write repo — i.e. at least one read mount is a different repo. A lens-of-one
@@ -96,6 +111,7 @@ func NewBindingOfRepo(ri *RepoInstance, branch string) *Binding {
 		write:   ri,
 		writeOK: ri.WritableBranch(branch),
 		name:    ri.Name(),
+		pinID:   "repo:" + ri.UID(),
 		reads:   []ReadTarget{{RI: ri, Branch: branch}},
 	}
 }
@@ -110,6 +126,7 @@ func NewBindingForTest(write *RepoInstance, reads ...ReadTarget) *Binding {
 		write:   write,
 		writeOK: true,
 		name:    write.Name(),
+		pinID:   "repo:" + write.UID(),
 		reads:   reads,
 	}
 }
@@ -148,6 +165,7 @@ func NewBindingOfLens(m *Manager, l Lens) (*Binding, error) {
 		write:   write,
 		writeOK: true, // lens writes always target the write repo's agent branch
 		name:    l.Name,
+		pinID:   "lens:" + l.UID,
 		reads:   reads,
 	}, nil
 }

--- a/internal/repos/binding_test.go
+++ b/internal/repos/binding_test.go
@@ -23,6 +23,36 @@ func TestNewBindingOfRepo(t *testing.T) {
 	require.Equal(t, "main", ro.Reads()[0].Branch)
 }
 
+// TestBinding_PinID_FailsClosedOnEmptyUID pins pinOf's fail-closed contract: a
+// uid-less RepoInstance (TestInstanceConfig.UID left at its zero value, as
+// most test fixtures across the codebase do) must never produce a bare
+// "repo:"/"lens:" prefix as its PinID — that would let two DIFFERENT
+// uid-less bindings collide on a shared, non-empty pin. Two independently
+// built, uid-less bindings over two DIFFERENT repos end up with neither
+// having a real PinID to share: both come back empty. (What then keeps an
+// empty PinID from letting a minted session resume under a different
+// uid-less binding is the resume-side guard in internal/mcp/query.go and
+// explain.go — sess.Binding == "" is rejected outright — which is exercised
+// at the MCP layer, not here.)
+func TestBinding_PinID_FailsClosedOnEmptyUID(t *testing.T) {
+	riA := NewTestInstanceWithDeps(TestInstanceConfig{Name: "alpha", AgentBranch: "agent/test"})
+	riB := NewTestInstanceWithDeps(TestInstanceConfig{Name: "beta", AgentBranch: "agent/test"})
+	require.Empty(t, riA.UID(), "fixture must be uid-less for this test to mean anything")
+	require.Empty(t, riB.UID())
+
+	bA := NewBindingOfRepo(riA, "")
+	bB := NewBindingOfRepo(riB, "")
+
+	require.NotEqual(t, bA.Name(), bB.Name(), "sanity: these are genuinely different bindings")
+	require.Empty(t, bA.PinID(), "an empty uid must never produce a bare \"repo:\" prefix")
+	require.Empty(t, bB.PinID(), "same for a second, independently uid-less binding")
+
+	// NewBindingForTest and NewBindingOfLens share the same pinOf helper, so
+	// the fail-closed contract holds for every constructor, not just
+	// NewBindingOfRepo.
+	require.Empty(t, NewBindingForTest(riA).PinID())
+}
+
 func TestBinding_IsLens(t *testing.T) {
 	ri := NewTestInstanceWithDeps(TestInstanceConfig{Name: "solo"})
 	require.False(t, NewBindingOfRepo(ri, "").IsLens(), "lens-of-one is not a lens")

--- a/internal/repos/builder.go
+++ b/internal/repos/builder.go
@@ -471,7 +471,6 @@ func (b *repoBuilder) build() *RepoInstance {
 	// Allocate ri first — the observer and closures capture the pointer so
 	// they follow SwapStore field replacements via the read lock.
 	ri := &RepoInstance{
-		name:                          b.name,
 		uid:                           b.uid,
 		dbPath:                        b.dbPath,
 		agentBranch:                   b.agentBranch,
@@ -494,6 +493,7 @@ func (b *repoBuilder) build() *RepoInstance {
 		handle:                        newStoreHandle(b.svc),
 		hub:                           hub,
 	}
+	ri.setName(b.name)
 
 	// Observer: sync index + push SSE on every git commit.
 	//

--- a/internal/repos/instance.go
+++ b/internal/repos/instance.go
@@ -59,8 +59,12 @@ const (
 
 // RepoInstance holds all runtime state for a single repository.
 type RepoInstance struct {
-	mu          sync.RWMutex
-	name        string
+	mu sync.RWMutex
+	// name is the repo's DISPLAY name — the only one of its three identifiers
+	// that is mutable (uid is membership, the root-commit id is fact
+	// addressing). Atomic because RenameRepo writes it on a live instance while
+	// unsynchronised readers — mostly log statements — are reading it.
+	name        atomic.Pointer[string]
 	dbPath      string
 	agentBranch string
 	// uid is the registry identity: stable for the repo's whole life, minted at
@@ -229,8 +233,19 @@ func (ri *RepoInstance) attachStore(svc *store.Service) bool {
 	return true
 }
 
-// Name returns the repository name.
-func (ri *RepoInstance) Name() string { return ri.name }
+// Name returns the repository's display name.
+func (ri *RepoInstance) Name() string {
+	if p := ri.name.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// setName publishes a new display name. Package-private: the only legitimate
+// caller is Manager.RenameRepo, which re-keys m.repos in the same operation.
+// Setting one without the other leaves the manager's map disagreeing with the
+// instance about what this repo is called.
+func (ri *RepoInstance) setName(s string) { ri.name.Store(&s) }
 
 // UID returns the repo's registry identity — the control.db primary key and
 // the .db filename stem. Never empty for a registered repo.
@@ -259,7 +274,7 @@ func (ri *RepoInstance) ID() string {
 		}
 		root, err := svc.RootCommit(context.Background(), ri.agentBranch)
 		if err != nil {
-			log.Warn().Err(err).Str("repo", ri.name).Msg("repo id: root commit unresolved")
+			log.Warn().Err(err).Str("repo", ri.Name()).Msg("repo id: root commit unresolved")
 			return
 		}
 		ri.id = root
@@ -453,11 +468,11 @@ func (ri *RepoInstance) shutdown() {
 func (ri *RepoInstance) Verify(ctx context.Context, opts store.VerifyOpts) (store.IntegrityReport, error) {
 	svc, release, err := ri.Acquire()
 	if err != nil {
-		return store.IntegrityReport{Repo: ri.name}, err
+		return store.IntegrityReport{Repo: ri.Name()}, err
 	}
 	defer release()
 	report, err := svc.Verify(ctx, opts)
-	report.Repo = ri.name
+	report.Repo = ri.Name()
 	return report, err
 }
 
@@ -465,13 +480,14 @@ func (ri *RepoInstance) Verify(ctx context.Context, opts store.VerifyOpts) (stor
 // exercise Manager operations (Set, Get, Replace, ForEach, Names, context).
 // Production code must use Manager.openOne instead.
 func NewTestInstance(name string) *RepoInstance {
-	return &RepoInstance{
-		name:        name,
+	ri := &RepoInstance{
 		syncCancel:  func() {},
 		syncWg:      &sync.WaitGroup{},
 		indexCancel: func() {},
 		indexWg:     &sync.WaitGroup{},
 	}
+	ri.setName(name)
+	return ri
 }
 
 // TestInstanceConfig holds optional fields for NewTestInstanceWithDeps.
@@ -497,8 +513,7 @@ type TestInstanceConfig struct {
 // dependencies. Intended for handler/integration tests in sibling packages.
 // Production code must use Manager.openOne instead.
 func NewTestInstanceWithDeps(cfg TestInstanceConfig) *RepoInstance {
-	return &RepoInstance{
-		name:                cfg.Name,
+	ri := &RepoInstance{
 		uid:                 cfg.UID,
 		agentBranch:         cfg.AgentBranch,
 		handle:              newStoreHandle(cfg.Svc),
@@ -520,4 +535,6 @@ func NewTestInstanceWithDeps(cfg TestInstanceConfig) *RepoInstance {
 		indexCancel:                   func() {},
 		indexWg:                       &sync.WaitGroup{},
 	}
+	ri.setName(cfg.Name)
+	return ri
 }

--- a/internal/repos/instance.go
+++ b/internal/repos/instance.go
@@ -497,7 +497,15 @@ type TestInstanceConfig struct {
 	// UID is the instance's control.db identity. Leave empty for a bare
 	// instance that no registry row backs; set it (to the uid of a row the
 	// test inserted) when the code under test writes through Manager.Repos()
-	// or Manager.Origins(), both of which key on it.
+	// or Manager.Origins(), both of which key on it. It is ALSO
+	// Binding.PinID()'s source (repo:<uid>) — the MCP cursor-pinning identity,
+	// RFC §7.3 — so two fixtures left at the zero value collapse onto the same
+	// pin ("" in, "" back out: PinID fails closed rather than a bare "repo:").
+	// A resume against that pin is rejected either way (empty never matches),
+	// but a test whose whole point is that two DIFFERENT bindings behave
+	// differently needs distinct, non-empty uids to exercise that at all — set
+	// one whenever a test builds more than one instance and compares them as
+	// bindings.
 	UID                 string
 	AgentBranch         string
 	Svc                 *store.Service

--- a/internal/repos/lens.go
+++ b/internal/repos/lens.go
@@ -30,6 +30,7 @@ import (
 	// Registers the stock "sqlite3" driver. The registry deliberately does
 	// not use the custom "sqlite3_knomit" driver — no vec extension needed.
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/segmentio/ksuid"
 )
 
 var (
@@ -67,6 +68,11 @@ type LensRead struct {
 // decision 19), so there is no write-branch field. Reads always include the
 // write repo after normalize.
 type Lens struct {
+	// UID is the lens's own registry identity (lenses.uid), minted once at
+	// Create and never reused — the same three-identifier model repos already
+	// have. It is what makes a lens nameable-twice-over: renaming Name never
+	// touches a lens_reads row, because membership does not reference Name.
+	UID         string
 	Name        string
 	WriteUID    string
 	Description string // free markdown text, display-only; ignored by normalize
@@ -104,30 +110,41 @@ func (l Lens) normalize() Lens {
 // the repo registry immediately after, both before any lens write.
 const lensSchema = `
 CREATE TABLE IF NOT EXISTS lenses (
-    name        TEXT PRIMARY KEY,
+    uid         TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
     write_uid   TEXT NOT NULL REFERENCES repos(uid),
     description TEXT NOT NULL DEFAULT '',
     created_at  INTEGER NOT NULL,
     updated_at  INTEGER NOT NULL
 );
+CREATE UNIQUE INDEX IF NOT EXISTS lenses_name ON lenses(name);
 CREATE TABLE IF NOT EXISTS lens_reads (
-    lens_name TEXT NOT NULL REFERENCES lenses(name) ON DELETE CASCADE,
+    lens_uid  TEXT NOT NULL REFERENCES lenses(uid) ON DELETE CASCADE,
     repo_uid  TEXT NOT NULL REFERENCES repos(uid),
     branch    TEXT NOT NULL DEFAULT '',
     source    TEXT,
-    PRIMARY KEY (lens_name, repo_uid)
+    PRIMARY KEY (lens_uid, repo_uid)
 );
 `
 
 // LensSchemaSQL exposes the uid-keyed lens DDL to `knomit migrate-registry`.
 //
-// That tool OWNS the lens schema upgrade. OpenLensRegistry cannot perform it:
-// its CREATE TABLE IF NOT EXISTS is a no-op against a legacy control.db, whose
-// `lenses` table already exists carrying the old NAME-keyed columns
-// (write_repo / repo). Such a table would survive the open unchanged and every
-// query against write_uid would fail at runtime. migrate-registry therefore
-// DROPS the legacy tables and recreates them from this constant, carrying the
-// rows across with names translated to uids.
+// Two upgrade mechanisms exist, for two different starting shapes, and this
+// constant is the target shape of both:
+//
+//   - A genuinely pre-registry control.db (`lenses.write_repo`, member
+//     references by NAME) is only ever seen by `migrate-registry`.
+//     Manager.Start's boot guard (HasLegacyLensSchema) refuses to boot such a
+//     home at all, so OpenLensRegistry never runs against it in practice.
+//     migrate-registry DROPS those legacy tables and recreates them from this
+//     constant, translating member references from names to uids as it goes.
+//   - A control.db that has already been through migrate-registry once
+//     (`lenses.write_uid` present — membership already uid-keyed) but predates
+//     this lenses.uid column is exactly the shape OpenLensRegistry's own
+//     upgradeLensSchema (lens_migrate.go) re-keys in place, via an explicit
+//     column probe rather than CREATE TABLE IF NOT EXISTS — which is a no-op
+//     against either existing shape above and would otherwise leave the table
+//     unchanged while every query against the new column fails at runtime.
 const LensSchemaSQL = lensSchema
 
 // LensRegistry persists lens definitions in the control-plane database.
@@ -145,6 +162,15 @@ func OpenLensRegistry(path string) (*LensRegistry, error) {
 		return nil, fmt.Errorf("open lens registry: %w", err)
 	}
 	db.SetMaxOpenConns(1)
+	// The upgrade MUST run before lensSchema's CREATE TABLE IF NOT EXISTS: IF
+	// NOT EXISTS is a no-op against a `lenses` table that already exists in the
+	// pre-uid shape, so it would never see the legacy table if this ran second.
+	// upgradeLensSchema's own column probe is what makes it able to see (and
+	// re-key) that table where CREATE TABLE IF NOT EXISTS cannot.
+	if err := upgradeLensSchema(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("lens registry upgrade: %w", err)
+	}
 	if _, err := db.Exec(lensSchema); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("lens registry schema: %w", err)
@@ -159,7 +185,7 @@ func (r *LensRegistry) Close() error {
 
 // List returns all lenses sorted by name.
 func (r *LensRegistry) List() ([]Lens, error) {
-	rows, err := r.db.Query(`SELECT name, write_uid, description, created_at, updated_at FROM lenses ORDER BY name`)
+	rows, err := r.db.Query(`SELECT uid, name, write_uid, description, created_at, updated_at FROM lenses ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("list lenses: %w", err)
 	}
@@ -167,7 +193,7 @@ func (r *LensRegistry) List() ([]Lens, error) {
 	var out []Lens
 	for rows.Next() {
 		var l Lens
-		if err := rows.Scan(&l.Name, &l.WriteUID, &l.Description, &l.CreatedAt, &l.UpdatedAt); err != nil {
+		if err := rows.Scan(&l.UID, &l.Name, &l.WriteUID, &l.Description, &l.CreatedAt, &l.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("list lenses: %w", err)
 		}
 		out = append(out, l)
@@ -176,7 +202,7 @@ func (r *LensRegistry) List() ([]Lens, error) {
 		return nil, fmt.Errorf("list lenses: %w", err)
 	}
 	for i := range out {
-		reads, err := r.readsOf(out[i].Name)
+		reads, err := r.readsOf(out[i].UID)
 		if err != nil {
 			return nil, err
 		}
@@ -185,9 +211,10 @@ func (r *LensRegistry) List() ([]Lens, error) {
 	return out, nil
 }
 
-// readsOf loads the read mounts for one lens, sorted by repo uid.
-func (r *LensRegistry) readsOf(name string) ([]LensRead, error) {
-	rows, err := r.db.Query(`SELECT repo_uid, branch, COALESCE(source, '') FROM lens_reads WHERE lens_name = ? ORDER BY repo_uid`, name)
+// readsOf loads the read mounts for one lens, keyed by the lens's own uid
+// (lens_reads.lens_uid), sorted by repo uid.
+func (r *LensRegistry) readsOf(lensUID string) ([]LensRead, error) {
+	rows, err := r.db.Query(`SELECT repo_uid, branch, COALESCE(source, '') FROM lens_reads WHERE lens_uid = ? ORDER BY repo_uid`, lensUID)
 	if err != nil {
 		return nil, fmt.Errorf("lens reads: %w", err)
 	}
@@ -213,6 +240,7 @@ func (r *LensRegistry) Create(l Lens) (Lens, error) {
 		return Lens{}, ErrLensWriteEmpty
 	}
 	l = l.normalize()
+	l.UID = ksuid.New().String()
 
 	tx, err := r.db.Begin()
 	if err != nil {
@@ -221,8 +249,8 @@ func (r *LensRegistry) Create(l Lens) (Lens, error) {
 	defer tx.Rollback()
 
 	if _, err := tx.Exec(
-		`INSERT INTO lenses (name, write_uid, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
-		l.Name, l.WriteUID, l.Description, l.CreatedAt, l.UpdatedAt,
+		`INSERT INTO lenses (uid, name, write_uid, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		l.UID, l.Name, l.WriteUID, l.Description, l.CreatedAt, l.UpdatedAt,
 	); err != nil {
 		if isUniqueViolation(err) {
 			return Lens{}, fmt.Errorf("%w: %q", ErrLensExists, l.Name)
@@ -235,8 +263,8 @@ func (r *LensRegistry) Create(l Lens) (Lens, error) {
 			source = lr.Source
 		}
 		if _, err := tx.Exec(
-			`INSERT INTO lens_reads (lens_name, repo_uid, branch, source) VALUES (?, ?, ?, ?)`,
-			l.Name, lr.RepoUID, lr.Branch, source,
+			`INSERT INTO lens_reads (lens_uid, repo_uid, branch, source) VALUES (?, ?, ?, ?)`,
+			l.UID, lr.RepoUID, lr.Branch, source,
 		); err != nil {
 			return Lens{}, fmt.Errorf("create lens reads: %w", err)
 		}
@@ -268,22 +296,26 @@ func (r *LensRegistry) Update(l Lens) (Lens, error) {
 	}
 	defer tx.Rollback()
 
-	res, err := tx.Exec(
-		`UPDATE lenses SET write_uid = ?, description = ?, updated_at = ? WHERE name = ?`,
-		l.WriteUID, l.Description, l.UpdatedAt, l.Name,
-	)
-	if err != nil {
-		return Lens{}, fmt.Errorf("update lens: %w", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return Lens{}, fmt.Errorf("update lens: %w", err)
-	}
-	if n == 0 {
+	// lens_reads is keyed by the lens's own uid, not its name, so the uid must
+	// be resolved before the read mounts can be replaced.
+	var uid string
+	err = tx.QueryRow(`SELECT uid FROM lenses WHERE name = ?`, l.Name).Scan(&uid)
+	if errors.Is(err, sql.ErrNoRows) {
 		return Lens{}, fmt.Errorf("%w: %q", ErrLensNotFound, l.Name)
 	}
+	if err != nil {
+		return Lens{}, fmt.Errorf("update lens: %w", err)
+	}
+	l.UID = uid
+
+	if _, err := tx.Exec(
+		`UPDATE lenses SET write_uid = ?, description = ?, updated_at = ? WHERE uid = ?`,
+		l.WriteUID, l.Description, l.UpdatedAt, uid,
+	); err != nil {
+		return Lens{}, fmt.Errorf("update lens: %w", err)
+	}
 	// Wholesale replace the read mounts: drop all rows, reinsert the new set.
-	if _, err := tx.Exec(`DELETE FROM lens_reads WHERE lens_name = ?`, l.Name); err != nil {
+	if _, err := tx.Exec(`DELETE FROM lens_reads WHERE lens_uid = ?`, uid); err != nil {
 		return Lens{}, fmt.Errorf("update lens reads: %w", err)
 	}
 	for _, lr := range l.Reads {
@@ -292,8 +324,8 @@ func (r *LensRegistry) Update(l Lens) (Lens, error) {
 			source = lr.Source
 		}
 		if _, err := tx.Exec(
-			`INSERT INTO lens_reads (lens_name, repo_uid, branch, source) VALUES (?, ?, ?, ?)`,
-			l.Name, lr.RepoUID, lr.Branch, source,
+			`INSERT INTO lens_reads (lens_uid, repo_uid, branch, source) VALUES (?, ?, ?, ?)`,
+			uid, lr.RepoUID, lr.Branch, source,
 		); err != nil {
 			return Lens{}, fmt.Errorf("update lens reads: %w", err)
 		}
@@ -308,15 +340,15 @@ func (r *LensRegistry) Update(l Lens) (Lens, error) {
 func (r *LensRegistry) Get(name string) (Lens, bool, error) {
 	var l Lens
 	err := r.db.QueryRow(
-		`SELECT name, write_uid, description, created_at, updated_at FROM lenses WHERE name = ?`, name,
-	).Scan(&l.Name, &l.WriteUID, &l.Description, &l.CreatedAt, &l.UpdatedAt)
+		`SELECT uid, name, write_uid, description, created_at, updated_at FROM lenses WHERE name = ?`, name,
+	).Scan(&l.UID, &l.Name, &l.WriteUID, &l.Description, &l.CreatedAt, &l.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Lens{}, false, nil
 	}
 	if err != nil {
 		return Lens{}, false, fmt.Errorf("get lens: %w", err)
 	}
-	reads, err := r.readsOf(name)
+	reads, err := r.readsOf(l.UID)
 	if err != nil {
 		return Lens{}, false, fmt.Errorf("get lens: %w", err)
 	}
@@ -345,10 +377,12 @@ func (r *LensRegistry) Delete(name string) error {
 // mirrors the write repo into lens_reads, but this stays correct if a future
 // path ever stores a write without mirroring.
 func (r *LensRegistry) RefsRepo(uid string) ([]string, error) {
+	// lens_reads no longer carries the lens's name (only its uid), so the read
+	// side of the UNION joins back to lenses to recover it.
 	rows, err := r.db.Query(
 		`SELECT name FROM lenses WHERE write_uid = ?
 		 UNION
-		 SELECT lens_name FROM lens_reads WHERE repo_uid = ?
+		 SELECT l.name FROM lens_reads lr JOIN lenses l ON l.uid = lr.lens_uid WHERE lr.repo_uid = ?
 		 ORDER BY 1`, uid, uid)
 	if err != nil {
 		return nil, fmt.Errorf("refs repo: %w", err)

--- a/internal/repos/lens.go
+++ b/internal/repos/lens.go
@@ -365,6 +365,48 @@ func (r *LensRegistry) Delete(name string) error {
 	return nil
 }
 
+// Rename changes a lens's display name, touching only the lenses row: lens_reads
+// references lens_uid (never a name), so a rename never rewrites a read mount —
+// the whole reason membership was moved off names in the first place.
+//
+// This is deliberately NOT Update, which resolves its target by NAME and would
+// therefore silently ignore a renamed target — a caller trying to implement
+// rename via Update("newName", ...) gets "lens not found" instead of a rename,
+// because Update's `WHERE name = ?` never matches the OLD name once the caller
+// has already put the NEW one in the row it hands in.
+//
+// It is also deliberately a compare-and-swap on `from` (`WHERE uid = ? AND name
+// = ?`), not a plain `UPDATE ... WHERE uid = ?`. RenameRepo (lifecycle.go)
+// shipped exactly the bug a plain UPDATE invites: two concurrent renames of the
+// same row can both durably succeed with a plain UPDATE, with whichever commits
+// last winning regardless of which one goes on to win any in-memory book-keeping
+// — the registry and any caller-side state can end up disagreeing about the
+// name. Manager.RenameLens happens to fully serialize its callers under m.mu
+// today (there is no in-memory lens map to race, unlike m.repos), so that
+// specific race is not currently reachable through it — but the CAS form is
+// the correct shape for this primitive regardless of today's one caller, and
+// costs nothing: changed reports whether `from` still named uid at the time of
+// the write, which RenameLens uses to detect a lost race rather than silently
+// doing nothing.
+//
+// A collision with another lens's name trips the lenses_name UNIQUE index;
+// that is mapped to ErrLensExists here, the same sentinel Create returns for a
+// duplicate name.
+func (r *LensRegistry) Rename(uid, from, to string) (bool, error) {
+	res, err := r.db.Exec(`UPDATE lenses SET name = ? WHERE uid = ? AND name = ?`, to, uid, from)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return false, fmt.Errorf("%w: %q", ErrLensExists, to)
+		}
+		return false, fmt.Errorf("rename lens: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("rename lens: %w", err)
+	}
+	return n > 0, nil
+}
+
 // RefsRepo returns the names of all lenses referencing the repo with this
 // registry UID as their write repo or as a read mount, deduped and sorted.
 //

--- a/internal/repos/lens.go
+++ b/internal/repos/lens.go
@@ -110,7 +110,7 @@ func (l Lens) normalize() Lens {
 // the repo registry immediately after, both before any lens write.
 const lensSchema = `
 CREATE TABLE IF NOT EXISTS lenses (
-    uid         TEXT PRIMARY KEY,
+    uid         TEXT PRIMARY KEY NOT NULL,
     name        TEXT NOT NULL,
     write_uid   TEXT NOT NULL REFERENCES repos(uid),
     description TEXT NOT NULL DEFAULT '',

--- a/internal/repos/lens.go
+++ b/internal/repos/lens.go
@@ -40,9 +40,14 @@ var (
 	ErrLensNameEmpty = errors.New("lens name required")
 	// ErrLensWriteEmpty is returned by Create when the write repo is empty.
 	ErrLensWriteEmpty = errors.New("lens write repo required")
-	// ErrLensNotFound is returned by Update when the lens name does not exist.
-	// Delete stays idempotent (no such error); Update needs a not-found signal
-	// because it mutates a row that must already be there.
+	// ErrLensNotFound is returned by the paths that address an existing lens by
+	// name and must mutate a row that is already there: LensRegistry.Update,
+	// and Manager.RenameLens — the latter both when the old name resolves to
+	// nothing and when LensRegistry.Rename's CAS reports it matched no row (the
+	// two are why the web layer maps this sentinel to 404, not 409; see
+	// lensRenameErrStatus). LensRegistry.Rename itself does NOT return it; it
+	// reports a missed CAS as (false, nil) and leaves the attribution to its
+	// caller. Delete stays idempotent and never returns it either.
 	ErrLensNotFound = errors.New("lens not found")
 	// ErrLensDescriptionTooLong is returned when a lens description exceeds
 	// MaxLensDescriptionBytes. Description is display-only metadata, so the cap

--- a/internal/repos/lens_migrate.go
+++ b/internal/repos/lens_migrate.go
@@ -145,6 +145,38 @@ func upgradeLensSchema(db *sql.DB) (err error) {
 		}
 	}
 
+	// Account for the read mounts BEFORE dropping the old table. The copy above
+	// is driven by uidByName, so a lens_reads_old row whose lens_name matches no
+	// row in lenses is silently left behind and then destroyed by the DROP.
+	//
+	// Discarding it is correct — the new lens_reads has a FK to lenses(uid), so
+	// there is no uid to give it and the constraint would reject it anyway — but
+	// discarding it SILENTLY is not. Such a row is reachable: the old schema's
+	// FK is only enforced when foreign_keys is ON, and the sqlite3 CLI defaults
+	// it OFF, so anyone who has ever poked at control.db by hand could have left
+	// one. Losing read mounts with no trace is the kind of thing an operator
+	// discovers months later as "that lens used to see more repos".
+	//
+	// Counted, logged, and never fatal: a failed count must not abort a
+	// migration that has otherwise succeeded, so a count error degrades to a
+	// warning of its own.
+	var oldReads, newReads int
+	countErr := tx.QueryRow(`SELECT COUNT(*) FROM lens_reads_old`).Scan(&oldReads)
+	if countErr == nil {
+		countErr = tx.QueryRow(`SELECT COUNT(*) FROM lens_reads`).Scan(&newReads)
+	}
+	switch {
+	case countErr != nil:
+		log.Warn().Err(countErr).
+			Msg("lens registry: could not account for read mounts across the re-key; orphaned rows (if any) were dropped uncounted")
+	case oldReads > newReads:
+		log.Warn().
+			Int("discarded", oldReads-newReads).
+			Int("before", oldReads).
+			Int("after", newReads).
+			Msg("lens registry: dropped read mounts whose lens_name matched no lens; they cannot be re-keyed onto a lens uid and the new lens_reads foreign key would reject them")
+	}
+
 	for _, s := range []string{`DROP TABLE lens_reads_old`, `DROP TABLE lenses_old`} {
 		if _, err := tx.Exec(s); err != nil {
 			return fmt.Errorf("lens upgrade: %q: %w", s, err)

--- a/internal/repos/lens_migrate.go
+++ b/internal/repos/lens_migrate.go
@@ -1,0 +1,155 @@
+package repos
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/segmentio/ksuid"
+)
+
+// upgradeLensSchema re-keys a name-keyed `lenses`/`lens_reads` pair onto uids.
+//
+// Guarded by an explicit column probe rather than CREATE TABLE IF NOT EXISTS,
+// which is a NO-OP against an existing table — that is exactly how the previous
+// lens re-keying could not be done on the open path (see LensSchemaSQL). The
+// probe is what makes this work where that would not.
+//
+// The starting shape this expects is "membership already uid-keyed, lens row
+// itself still name-keyed": `lenses.write_uid` / `lens_reads.repo_uid` already
+// point at repos(uid) (every home that has ever run `migrate-registry`), but
+// `lenses` itself is still keyed by name with no `uid` column of its own. A
+// genuinely pre-registry home (`lenses.write_repo`) never reaches here at all:
+// Manager.Start's boot guard refuses it before OpenLensRegistry runs, and only
+// `migrate-registry` converts that shape.
+//
+// Runs on every open and is idempotent: a database already carrying lenses.uid
+// returns immediately, so uids are never re-minted.
+//
+// SQLite cannot change a PRIMARY KEY in place, so both tables are rebuilt.
+// foreign_keys is disabled for the duration — lens_reads references lenses(name)
+// until the swap completes, and the rebuild would trip the constraint mid-flight.
+// The PRAGMA is a no-op inside a transaction, so it is issued outside one and
+// restored in a defer.
+func upgradeLensSchema(db *sql.DB) error {
+	hasLenses, err := lensTableExists(db)
+	if err != nil {
+		return fmt.Errorf("lens upgrade: probe table: %w", err)
+	}
+	if !hasLenses {
+		return nil // fresh database: lensSchema creates the new shape directly
+	}
+	hasUID, err := lensColumnExists(db, "lenses", "uid")
+	if err != nil {
+		return fmt.Errorf("lens upgrade: probe column: %w", err)
+	}
+	if hasUID {
+		return nil // already migrated
+	}
+
+	if _, err := db.Exec(`PRAGMA foreign_keys=off`); err != nil {
+		return fmt.Errorf("lens upgrade: disable fks: %w", err)
+	}
+	defer func() {
+		if _, derr := db.Exec(`PRAGMA foreign_keys=on`); derr != nil {
+			log.Error().Err(derr).Msg("lens upgrade: could not restore foreign_keys")
+		}
+	}()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("lens upgrade: begin: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after a successful Commit
+
+	// Mint a uid per existing lens, in Go rather than SQL — ksuid is how repo
+	// uids are minted and the two must be indistinguishable in shape.
+	rows, err := tx.Query(`SELECT name FROM lenses`)
+	if err != nil {
+		return fmt.Errorf("lens upgrade: read names: %w", err)
+	}
+	uidByName := map[string]string{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			rows.Close()
+			return fmt.Errorf("lens upgrade: scan name: %w", err)
+		}
+		uidByName[name] = ksuid.New().String()
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("lens upgrade: rows: %w", err)
+	}
+	rows.Close()
+
+	stmts := []string{
+		`ALTER TABLE lenses RENAME TO lenses_old`,
+		`ALTER TABLE lens_reads RENAME TO lens_reads_old`,
+		`CREATE TABLE lenses (
+		    uid TEXT PRIMARY KEY, name TEXT NOT NULL,
+		    write_uid TEXT NOT NULL REFERENCES repos(uid),
+		    description TEXT NOT NULL DEFAULT '',
+		    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+		`CREATE UNIQUE INDEX lenses_name ON lenses(name)`,
+		`CREATE TABLE lens_reads (
+		    lens_uid TEXT NOT NULL REFERENCES lenses(uid) ON DELETE CASCADE,
+		    repo_uid TEXT NOT NULL REFERENCES repos(uid),
+		    branch TEXT NOT NULL DEFAULT '', source TEXT,
+		    PRIMARY KEY (lens_uid, repo_uid))`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.Exec(s); err != nil {
+			return fmt.Errorf("lens upgrade: %q: %w", s, err)
+		}
+	}
+
+	for name, uid := range uidByName {
+		if _, err := tx.Exec(
+			`INSERT INTO lenses (uid, name, write_uid, description, created_at, updated_at)
+			 SELECT ?, name, write_uid, description, created_at, updated_at
+			   FROM lenses_old WHERE name = ?`, uid, name); err != nil {
+			return fmt.Errorf("lens upgrade: copy lens %q: %w", name, err)
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO lens_reads (lens_uid, repo_uid, branch, source)
+			 SELECT ?, repo_uid, branch, source
+			   FROM lens_reads_old WHERE lens_name = ?`, uid, name); err != nil {
+			return fmt.Errorf("lens upgrade: copy reads for %q: %w", name, err)
+		}
+	}
+
+	for _, s := range []string{`DROP TABLE lens_reads_old`, `DROP TABLE lenses_old`} {
+		if _, err := tx.Exec(s); err != nil {
+			return fmt.Errorf("lens upgrade: %q: %w", s, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("lens upgrade: commit: %w", err)
+	}
+	log.Info().Int("lenses", len(uidByName)).Msg("lens registry: re-keyed onto uids")
+	return nil
+}
+
+// lensTableExists / lensColumnExists mirror migrate-registry's rawTableExists /
+// rawColumnExists (cmd/migrate_registry.go:1761,1770) — same sqlite_master /
+// PRAGMA table_info shapes. Duplicated rather than shared because cmd/ ->
+// internal/ is the only legal import direction; internal/repos cannot import
+// cmd's helpers.
+func lensTableExists(db *sql.DB) (bool, error) {
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'lenses'`).Scan(&n); err != nil {
+		return false, fmt.Errorf("look for table %q: %w", "lenses", err)
+	}
+	return n > 0, nil
+}
+
+func lensColumnExists(db *sql.DB, table, column string) (bool, error) {
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`, table, column).Scan(&n); err != nil {
+		return false, fmt.Errorf("look for %s.%s: %w", table, column, err)
+	}
+	return n > 0, nil
+}

--- a/internal/repos/lens_migrate.go
+++ b/internal/repos/lens_migrate.go
@@ -31,7 +31,15 @@ import (
 // until the swap completes, and the rebuild would trip the constraint mid-flight.
 // The PRAGMA is a no-op inside a transaction, so it is issued outside one and
 // restored in a defer.
-func upgradeLensSchema(db *sql.DB) error {
+//
+// The restore is verified, not just attempted: this connection is the single
+// connection OpenLensRegistry hands out for the rest of the process's life
+// (SetMaxOpenConns(1)), so a restore that silently failed would leave every
+// later Delete's `ON DELETE CASCADE` disarmed for good — lens_reads rows would
+// outlive the lens they belonged to, with nothing after the one log line to
+// say so. A migration that leaves the handle in that state must not report
+// success.
+func upgradeLensSchema(db *sql.DB) (err error) {
 	hasLenses, err := lensTableExists(db)
 	if err != nil {
 		return fmt.Errorf("lens upgrade: probe table: %w", err)
@@ -53,6 +61,24 @@ func upgradeLensSchema(db *sql.DB) error {
 	defer func() {
 		if _, derr := db.Exec(`PRAGMA foreign_keys=on`); derr != nil {
 			log.Error().Err(derr).Msg("lens upgrade: could not restore foreign_keys")
+			if err == nil {
+				err = fmt.Errorf("lens upgrade: could not restore foreign_keys: %w", derr)
+			}
+			return
+		}
+		var fk int
+		if qerr := db.QueryRow(`PRAGMA foreign_keys`).Scan(&fk); qerr != nil {
+			log.Error().Err(qerr).Msg("lens upgrade: could not verify foreign_keys restored")
+			if err == nil {
+				err = fmt.Errorf("lens upgrade: could not verify foreign_keys restored: %w", qerr)
+			}
+			return
+		}
+		if fk != 1 {
+			log.Error().Int("foreign_keys", fk).Msg("lens upgrade: foreign_keys did not re-enable")
+			if err == nil {
+				err = fmt.Errorf("lens upgrade: foreign_keys did not re-enable (pragma reports %d)", fk)
+			}
 		}
 	}()
 
@@ -87,7 +113,7 @@ func upgradeLensSchema(db *sql.DB) error {
 		`ALTER TABLE lenses RENAME TO lenses_old`,
 		`ALTER TABLE lens_reads RENAME TO lens_reads_old`,
 		`CREATE TABLE lenses (
-		    uid TEXT PRIMARY KEY, name TEXT NOT NULL,
+		    uid TEXT PRIMARY KEY NOT NULL, name TEXT NOT NULL,
 		    write_uid TEXT NOT NULL REFERENCES repos(uid),
 		    description TEXT NOT NULL DEFAULT '',
 		    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,

--- a/internal/repos/lens_migrate_test.go
+++ b/internal/repos/lens_migrate_test.go
@@ -1,10 +1,13 @@
 package repos
 
 import (
+	"bytes"
 	"database/sql"
 	"path/filepath"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,6 +135,78 @@ func TestOpenLensRegistry_UpgradesLegacyNameKeyedSchema(t *testing.T) {
 	require.NotEqual(t, eng.UID, ops.UID, "uids are distinct per lens")
 	require.Len(t, ops.Reads, 1)
 	require.Equal(t, "repoB", ops.Reads[0].RepoUID)
+}
+
+// A lens_reads row whose lens_name matches no lens cannot be carried across:
+// the copy is driven by the lens list, and the new lens_reads has a foreign key
+// to lenses(uid) that would reject it anyway. Dropping it is correct. Dropping
+// it SILENTLY is not — read mounts vanishing with no trace is what an operator
+// finds months later as "that lens used to see more repos".
+//
+// The orphan is seeded with foreign_keys OFF because that is exactly how a real
+// one gets there: the legacy schema's FK is only enforced when the pragma is
+// on, and the sqlite3 CLI defaults it off.
+func TestOpenLensRegistry_UpgradeLogsDiscardedOrphanReads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "control.db")
+	seedLegacyLenses(t, path, []legacyLens{
+		{name: "eng", writeUID: "repoA", reads: []legacyRead{plainRead("repoA")}},
+	})
+
+	// Two orphans, so the assertion is on the COUNT and not merely on the
+	// warning firing at all.
+	db, err := sql.Open("sqlite3", path+"?_foreign_keys=off&_busy_timeout=5000&_journal_mode=WAL")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	_, err = db.Exec(
+		`INSERT INTO lens_reads (lens_name, repo_uid, branch, source) VALUES
+		   ('ghost', 'repoA', '', NULL),
+		   ('ghost', 'repoB', '', NULL)`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(zerolog.SyncWriter(&buf)).Level(zerolog.WarnLevel)
+	t.Cleanup(func() { log.Logger = orig })
+
+	r, err := OpenLensRegistry(path)
+	require.NoError(t, err, "an orphan must not fail the migration")
+	defer r.Close()
+
+	// The surviving lens is untouched.
+	eng, ok, err := r.Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, eng.Reads, 1)
+
+	logged := buf.String()
+	require.Contains(t, logged, `"discarded":2`,
+		"the WARN must name how many read mounts were discarded; got %s", logged)
+	require.Contains(t, logged, "dropped read mounts",
+		"the WARN must say what happened; got %s", logged)
+}
+
+// The mirror of the test above: a clean migration must NOT cry wolf. A count
+// comparison that was off by one — or that fired unconditionally — would train
+// operators to ignore the one warning that matters.
+func TestOpenLensRegistry_UpgradeIsSilentWithNoOrphans(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "control.db")
+	seedLegacyLenses(t, path, []legacyLens{
+		{name: "eng", writeUID: "repoA", reads: []legacyRead{plainRead("repoA"), plainRead("repoB")}},
+		{name: "ops", writeUID: "repoB", reads: []legacyRead{plainRead("repoB")}},
+	})
+
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(zerolog.SyncWriter(&buf)).Level(zerolog.WarnLevel)
+	t.Cleanup(func() { log.Logger = orig })
+
+	r, err := OpenLensRegistry(path)
+	require.NoError(t, err)
+	defer r.Close()
+
+	require.NotContains(t, buf.String(), "dropped read mounts",
+		"a migration that discarded nothing must warn about nothing")
 }
 
 // The upgrade must be idempotent — Start opens this registry on every boot.

--- a/internal/repos/lens_migrate_test.go
+++ b/internal/repos/lens_migrate_test.go
@@ -1,0 +1,147 @@
+package repos
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// legacyLensDDL is the shape every home has after running `migrate-registry`
+// but before this change: lens MEMBERSHIP is already uid-keyed (write_uid /
+// repo_uid point at repos(uid)), but the `lenses` row itself is still keyed by
+// name, with no uid column of its own.
+//
+// Pasted literally rather than referencing lensSchema: if it referenced the
+// constant, this test would stop testing the migration the instant the
+// constant changed — which is exactly the regression this whole file guards
+// against.
+const legacyLensDDL = `
+CREATE TABLE lenses (
+    name        TEXT PRIMARY KEY,
+    write_uid   TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL
+);
+CREATE TABLE lens_reads (
+    lens_name TEXT NOT NULL REFERENCES lenses(name) ON DELETE CASCADE,
+    repo_uid  TEXT NOT NULL,
+    branch    TEXT NOT NULL DEFAULT '',
+    source    TEXT,
+    PRIMARY KEY (lens_name, repo_uid)
+);`
+
+// legacyLens is one row (plus its read mounts) to seed into a control.db built
+// in the legacy shape.
+type legacyLens struct {
+	name     string
+	writeUID string
+	reads    []string // repo uids mounted as reads; writeUID is not implied here
+}
+
+// seedLegacyLenses opens path with the same DSN OpenLensRegistry uses, execs
+// legacyLensDDL literally, and inserts the given rows. It does NOT go through
+// OpenLensRegistry, so nothing upgrades the shape before the test does.
+func seedLegacyLenses(t *testing.T, path string, lenses []legacyLens) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", path+"?_foreign_keys=on&_busy_timeout=5000&_journal_mode=WAL")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+
+	_, err = db.Exec(legacyLensDDL)
+	require.NoError(t, err)
+
+	for _, l := range lenses {
+		_, err := db.Exec(
+			`INSERT INTO lenses (name, write_uid, description, created_at, updated_at) VALUES (?, ?, '', 1, 1)`,
+			l.name, l.writeUID)
+		require.NoError(t, err)
+		for _, repoUID := range l.reads {
+			_, err := db.Exec(
+				`INSERT INTO lens_reads (lens_name, repo_uid, branch, source) VALUES (?, ?, '', NULL)`,
+				l.name, repoUID)
+			require.NoError(t, err)
+		}
+	}
+}
+
+// A legacy control.db must come out of OpenLensRegistry in the new shape with
+// every lens and every read mount intact. This is the case that silently
+// no-ops if the upgrade is attempted with CREATE TABLE IF NOT EXISTS.
+func TestOpenLensRegistry_UpgradesLegacyNameKeyedSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "control.db")
+	seedLegacyLenses(t, path, []legacyLens{
+		{name: "eng", writeUID: "repoA", reads: []string{"repoA", "repoB"}},
+		{name: "ops", writeUID: "repoB", reads: []string{"repoB"}},
+	})
+
+	r, err := OpenLensRegistry(path)
+	require.NoError(t, err)
+	defer r.Close()
+
+	eng, ok, err := r.Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok, "the lens must survive the upgrade")
+	require.NotEmpty(t, eng.UID, "every migrated lens gets a uid")
+	require.Equal(t, "repoA", eng.WriteUID)
+	require.Len(t, eng.Reads, 2, "read mounts must be carried across")
+
+	// The read mounts themselves, not just their count: this is the case a
+	// migration that carried lenses across but dropped lens_reads would still
+	// pass a careless "does the lens exist" check.
+	gotRepoUIDs := map[string]bool{}
+	for _, rd := range eng.Reads {
+		gotRepoUIDs[rd.RepoUID] = true
+	}
+	require.True(t, gotRepoUIDs["repoA"], "eng's read mount on repoA must survive")
+	require.True(t, gotRepoUIDs["repoB"], "eng's read mount on repoB must survive")
+
+	ops, ok, err := r.Get("ops")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotEqual(t, eng.UID, ops.UID, "uids are distinct per lens")
+	require.Len(t, ops.Reads, 1)
+	require.Equal(t, "repoB", ops.Reads[0].RepoUID)
+}
+
+// The upgrade must be idempotent — Start opens this registry on every boot.
+func TestOpenLensRegistry_UpgradeIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "control.db")
+	seedLegacyLenses(t, path, []legacyLens{{name: "eng", writeUID: "repoA", reads: []string{"repoA"}}})
+
+	r1, err := OpenLensRegistry(path)
+	require.NoError(t, err)
+	first, ok, err := r1.Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, r1.Close())
+
+	r2, err := OpenLensRegistry(path)
+	require.NoError(t, err)
+	defer r2.Close()
+	second, ok, err := r2.Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, first.UID, second.UID, "a second open must not re-mint the uid")
+	require.Len(t, second.Reads, 1, "read mounts survive a second open too")
+}
+
+// A fresh database goes straight to the new shape with no upgrade step.
+func TestOpenLensRegistry_FreshDBIsAlreadyNewShape(t *testing.T) {
+	r, repoReg := openTestRegistry(t)
+	repoUID := seedMember(t, repoReg, "repoA")
+
+	got, err := r.Create(Lens{Name: "eng", WriteUID: repoUID,
+		CreatedAt: 1, UpdatedAt: 1,
+		Reads: []LensRead{{RepoUID: repoUID}}})
+	require.NoError(t, err)
+	require.NotEmpty(t, got.UID)
+
+	fetched, ok, err := r.Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, got.UID, fetched.UID)
+}

--- a/internal/repos/lens_migrate_test.go
+++ b/internal/repos/lens_migrate_test.go
@@ -33,12 +33,26 @@ CREATE TABLE lens_reads (
     PRIMARY KEY (lens_name, repo_uid)
 );`
 
+// legacyRead is one read mount to seed, with its branch/source carried
+// through explicitly rather than always defaulting empty — a migration whose
+// copy `SELECT` list silently dropped `branch` or `source` would still pass a
+// test where every seeded mount has empty/NULL values for both.
+type legacyRead struct {
+	repoUID string
+	branch  string
+	source  string // "" seeds NULL, matching how LensRead.Source round-trips elsewhere
+}
+
+// plainRead is a read mount with no non-default branch/source, for the common
+// case where only the repo uid matters to the test.
+func plainRead(repoUID string) legacyRead { return legacyRead{repoUID: repoUID} }
+
 // legacyLens is one row (plus its read mounts) to seed into a control.db built
 // in the legacy shape.
 type legacyLens struct {
 	name     string
 	writeUID string
-	reads    []string // repo uids mounted as reads; writeUID is not implied here
+	reads    []legacyRead
 }
 
 // seedLegacyLenses opens path with the same DSN OpenLensRegistry uses, execs
@@ -59,10 +73,14 @@ func seedLegacyLenses(t *testing.T, path string, lenses []legacyLens) {
 			`INSERT INTO lenses (name, write_uid, description, created_at, updated_at) VALUES (?, ?, '', 1, 1)`,
 			l.name, l.writeUID)
 		require.NoError(t, err)
-		for _, repoUID := range l.reads {
+		for _, rd := range l.reads {
+			var source any
+			if rd.source != "" {
+				source = rd.source
+			}
 			_, err := db.Exec(
-				`INSERT INTO lens_reads (lens_name, repo_uid, branch, source) VALUES (?, ?, '', NULL)`,
-				l.name, repoUID)
+				`INSERT INTO lens_reads (lens_name, repo_uid, branch, source) VALUES (?, ?, ?, ?)`,
+				l.name, rd.repoUID, rd.branch, source)
 			require.NoError(t, err)
 		}
 	}
@@ -74,8 +92,11 @@ func seedLegacyLenses(t *testing.T, path string, lenses []legacyLens) {
 func TestOpenLensRegistry_UpgradesLegacyNameKeyedSchema(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "control.db")
 	seedLegacyLenses(t, path, []legacyLens{
-		{name: "eng", writeUID: "repoA", reads: []string{"repoA", "repoB"}},
-		{name: "ops", writeUID: "repoB", reads: []string{"repoB"}},
+		{name: "eng", writeUID: "repoA", reads: []legacyRead{
+			{repoUID: "repoA", branch: "feature/eng", source: "src://eng"},
+			plainRead("repoB"),
+		}},
+		{name: "ops", writeUID: "repoB", reads: []legacyRead{plainRead("repoB")}},
 	})
 
 	r, err := OpenLensRegistry(path)
@@ -92,12 +113,18 @@ func TestOpenLensRegistry_UpgradesLegacyNameKeyedSchema(t *testing.T) {
 	// The read mounts themselves, not just their count: this is the case a
 	// migration that carried lenses across but dropped lens_reads would still
 	// pass a careless "does the lens exist" check.
-	gotRepoUIDs := map[string]bool{}
+	byRepoUID := map[string]LensRead{}
 	for _, rd := range eng.Reads {
-		gotRepoUIDs[rd.RepoUID] = true
+		byRepoUID[rd.RepoUID] = rd
 	}
-	require.True(t, gotRepoUIDs["repoA"], "eng's read mount on repoA must survive")
-	require.True(t, gotRepoUIDs["repoB"], "eng's read mount on repoB must survive")
+	repoA, ok := byRepoUID["repoA"]
+	require.True(t, ok, "eng's read mount on repoA must survive")
+	require.Equal(t, "feature/eng", repoA.Branch, "a non-empty branch must survive the copy")
+	require.Equal(t, "src://eng", repoA.Source, "a non-NULL source must survive the copy")
+	repoB, ok := byRepoUID["repoB"]
+	require.True(t, ok, "eng's read mount on repoB must survive")
+	require.Equal(t, "", repoB.Branch)
+	require.Equal(t, "", repoB.Source)
 
 	ops, ok, err := r.Get("ops")
 	require.NoError(t, err)
@@ -110,7 +137,7 @@ func TestOpenLensRegistry_UpgradesLegacyNameKeyedSchema(t *testing.T) {
 // The upgrade must be idempotent — Start opens this registry on every boot.
 func TestOpenLensRegistry_UpgradeIsIdempotent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "control.db")
-	seedLegacyLenses(t, path, []legacyLens{{name: "eng", writeUID: "repoA", reads: []string{"repoA"}}})
+	seedLegacyLenses(t, path, []legacyLens{{name: "eng", writeUID: "repoA", reads: []legacyRead{plainRead("repoA")}}})
 
 	r1, err := OpenLensRegistry(path)
 	require.NoError(t, err)

--- a/internal/repos/lens_rename_test.go
+++ b/internal/repos/lens_rename_test.go
@@ -1,0 +1,161 @@
+package repos
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/config"
+)
+
+// TestRenameLens_RekeysWithoutDeleteAndRecreate is the whole point of giving
+// lenses a uid: renaming a lens must be a display-string UPDATE, never a
+// delete-and-recreate, because an in-flight MCP cursor is pinned to
+// lens:<uid> (Binding.PinID(), RFC §7.3) and would be orphaned by anything
+// that mints a fresh uid. The uid-unchanged assertion below is what actually
+// proves that — a rename that silently deleted and recreated the row would
+// pass every other assertion in this file but fail this one.
+func TestRenameLens_RekeysWithoutDeleteAndRecreate(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+	beta := makeLensRepo(t, m, "beta")
+
+	stored, err := m.CreateLens(context.Background(), Lens{
+		Name: "eng", WriteUID: alpha.UID(), Reads: []LensRead{{RepoUID: beta.UID()}},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, m.RenameLens("eng", "engineering"))
+
+	_, ok, err := m.LensRegistry().Get("eng")
+	require.NoError(t, err)
+	require.False(t, ok, "the old name must no longer resolve")
+
+	got, ok, err := m.LensRegistry().Get("engineering")
+	require.NoError(t, err)
+	require.True(t, ok, "the new name must resolve")
+	require.Equal(t, stored.UID, got.UID, "uid is identity and must never change across a rename")
+	require.Equal(t, "engineering", got.Name)
+	require.Equal(t, stored.WriteUID, got.WriteUID)
+	// Read mounts are untouched: lens_reads references lens_uid, which the
+	// rename never rewrites (Task 4b's whole point).
+	require.Equal(t, stored.Reads, got.Reads, "read mounts must survive a rename unchanged")
+}
+
+func TestRenameLens_RejectsInvalidName(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+	_, err := m.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, m.RenameLens("eng", "Has Capitals"), ErrInvalidLensName)
+	require.ErrorIs(t, m.RenameLens("eng", ""), ErrInvalidLensName)
+
+	_, ok, err := m.LensRegistry().Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok, "a rejected rename leaves the lens alone")
+}
+
+func TestRenameLens_RejectsNameHeldByAnotherLens(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+
+	_, err := m.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+	_, err = m.CreateLens(context.Background(), Lens{Name: "sales", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, m.RenameLens("eng", "sales"), ErrLensExists)
+
+	_, ok, err := m.LensRegistry().Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok, "a rejected rename leaves the source lens alone")
+	_, ok, err = m.LensRegistry().Get("sales")
+	require.NoError(t, err)
+	require.True(t, ok, "the colliding lens is untouched")
+}
+
+// A repo may hold newName even though no lens does — repos and lenses share
+// one namespace (gotcha M-1). Same guard CreateLens/UpdateLens run via
+// validateLensLocked; RenameLens must run it too.
+func TestRenameLens_RejectsNameHeldByRepo(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+	makeLensRepo(t, m, "gamma") // an active repo named "gamma"
+
+	_, err := m.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, m.RenameLens("eng", "gamma"), ErrLensNameConflictsRepo)
+
+	_, ok, err := m.LensRegistry().Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok, "a rejected rename leaves the lens alone")
+}
+
+func TestRenameLens_UnknownLens(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+	_, err := m.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, m.RenameLens("ghost", "engineering"), ErrLensNotFound)
+}
+
+// Renaming to the current name is a successful no-op, not a self-collision
+// against the lens's own row.
+func TestRenameLens_SameNameIsNoOp(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+	stored, err := m.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+
+	require.NoError(t, m.RenameLens("eng", "eng"))
+
+	got, ok, err := m.LensRegistry().Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, stored.UID, got.UID)
+}
+
+// TestRenameLens_PersistsAcrossRestart pins the durable half: the UPDATE to
+// control.db, not just a read served from a connection that never left
+// memory. An implementation that renamed only some in-memory copy — or that
+// (per the landmine this task was warned about) routed the rename through
+// LensRegistry.Update, which resolves its target by NAME and would silently
+// no-op or misbehave against a changed name — would need a fresh process
+// re-reading the registry from disk to be caught; a same-process check alone
+// is not enough, because a stale connection could still serve the old value
+// from a cache the driver never invalidated.
+func TestRenameLens_PersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	boot := func() *Manager {
+		m := New(context.Background(), Deps{
+			Cfg:                   config.Config{Home: dir},
+			AgentBranch:           "machine/test",
+			DisableBackgroundSync: true,
+		})
+		require.NoError(t, m.Start())
+		return m
+	}
+
+	m1 := boot()
+	alpha := makeLensRepo(t, m1, "alpha")
+	_, err := m1.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+	require.NoError(t, m1.RenameLens("eng", "engineering"))
+	require.NoError(t, m1.Close())
+
+	m2 := boot()
+	t.Cleanup(func() { _ = m2.Close() })
+
+	_, ok, err := m2.LensRegistry().Get("eng")
+	require.NoError(t, err)
+	require.False(t, ok, "the old name must not resurrect on reboot")
+
+	got, ok, err := m2.LensRegistry().Get("engineering")
+	require.NoError(t, err)
+	require.True(t, ok, "the rename must have reached the registry row, not only an in-memory read")
+	require.Equal(t, alpha.UID(), got.WriteUID)
+}

--- a/internal/repos/lens_rename_test.go
+++ b/internal/repos/lens_rename_test.go
@@ -94,6 +94,55 @@ func TestRenameLens_RejectsNameHeldByRepo(t *testing.T) {
 	require.True(t, ok, "a rejected rename leaves the lens alone")
 }
 
+// A concurrent Create/Restore already bringing newName into the active map
+// must block RenameLens from claiming it too — and m.mu cannot see that
+// operation, because Create does its slow work (git init, a network clone)
+// OUTSIDE m.mu and calls m.Add only at the end. For that whole window
+// m.repos[newName] is nil, so RenameLens's in-lock repo check reports "free"
+// about a name that is actively being taken; reserveNameAndOrigin is the only
+// gate that overlaps the window. Without the reservation this test fails and
+// the machine can end up with a repo and a lens sharing one name, durably.
+// Mirrors TestRenameRepo_RejectsWhenTargetNameInFlight, holding the
+// reservation directly to stand in for the concurrent operation.
+func TestRenameLens_RejectsWhenTargetNameInFlight(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+	_, err := m.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+
+	release, err := m.reserveNameAndOrigin("engineering", "")
+	require.NoError(t, err)
+	defer release()
+
+	require.ErrorIs(t, m.RenameLens("eng", "engineering"), ErrCreateInFlight)
+
+	_, ok, err := m.LensRegistry().Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok, "a rejected rename leaves the lens alone")
+	_, ok, err = m.LensRegistry().Get("engineering")
+	require.NoError(t, err)
+	require.False(t, ok, "the reserved name must not have been claimed")
+}
+
+// The reservation must be RELEASED on every exit path, including the happy
+// one: a rename that leaked its m.creating entry would leave the new name
+// permanently unclaimable by any later create, restore or rename. Renaming
+// straight back is the cheapest probe — it can only succeed if the first call
+// released "engineering", and the second must itself release "eng".
+func TestRenameLens_ReleasesTheReservation(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+	_, err := m.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+
+	require.NoError(t, m.RenameLens("eng", "engineering"))
+	require.NoError(t, m.RenameLens("engineering", "eng"))
+
+	release, err := m.reserveNameAndOrigin("engineering", "")
+	require.NoError(t, err, "the target name must be free again after a successful rename")
+	release()
+}
+
 func TestRenameLens_UnknownLens(t *testing.T) {
 	m := newLifecycleManager(t)
 	alpha := makeLensRepo(t, m, "alpha")

--- a/internal/repos/lens_rename_test.go
+++ b/internal/repos/lens_rename_test.go
@@ -94,6 +94,34 @@ func TestRenameLens_RejectsNameHeldByRepo(t *testing.T) {
 	require.True(t, ok, "a rejected rename leaves the lens alone")
 }
 
+// A repo whose .db file is missing or unopenable at boot never reaches
+// m.repos — it lives in m.unavailable instead (markUnavailable), keyed by
+// uid, not name — but its registry row still holds the name. RenameLens must
+// reject a target name held by such a repo exactly as it rejects one held by
+// a live repo (TestRenameLens_RejectsNameHeldByRepo above): repos and lenses
+// share one namespace (gotcha M-1) regardless of whether the repo is
+// currently live.
+func TestRenameLens_RejectsNameHeldByUnavailableRepo(t *testing.T) {
+	m := newLifecycleManager(t)
+	alpha := makeLensRepo(t, m, "alpha")
+
+	_, err := m.CreateLens(context.Background(), Lens{Name: "eng", WriteUID: alpha.UID()})
+	require.NoError(t, err)
+
+	// Simulate the state openRegistered leaves behind for a boot-time
+	// failure: an active registry row named "acme" that never became a live
+	// instance, so it is flagged unavailable rather than added to m.repos.
+	m.markUnavailable(RepoRecord{
+		UID: "acme-uid", Name: "acme", State: StateActive, Profile: ProfileCode, CreatedAt: 1,
+	}, "missing", "database file not found")
+
+	require.ErrorIs(t, m.RenameLens("eng", "acme"), ErrLensNameConflictsRepo)
+
+	_, ok, err := m.LensRegistry().Get("eng")
+	require.NoError(t, err)
+	require.True(t, ok, "a rejected rename leaves the lens alone")
+}
+
 // A concurrent Create/Restore already bringing newName into the active map
 // must block RenameLens from claiming it too — and m.mu cannot see that
 // operation, because Create does its slow work (git init, a network clone)

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -84,10 +84,19 @@ func (m *Manager) controlHandles() (*Registry, *Origins, error) {
 // a lens in the registry, enforcing the reverse direction of the lens/repo
 // name-disjointness invariant (gotcha M-1). It returns nil when the registry is
 // not yet open (before Start), matching how Archive skips its lens check on a
-// nil registry: fail soft at startup, fail loud at creation. Callers are the
-// user-facing name-introducing paths (CreatePreflight, Create, Restore) that do
-// NOT hold m.mu at their call sites, so the Registry() accessor (which takes
-// m.mu.RLock) is safe here — no self-deadlock as in Archive's direct-field read.
+// nil registry: fail soft at startup, fail loud at creation.
+//
+// Callers are the user-facing paths that introduce a repo name — CreatePreflight,
+// Create, Restore and RenameRepo — every one of which does NOT hold m.mu at its
+// call site, so the LensRegistry() accessor (which takes m.mu.RLock) is safe
+// here; no self-deadlock as in Archive's direct-field read. Keep it that way:
+// calling this from under m.mu deadlocks.
+//
+// RenameLens enforces the SAME disjointness invariant but is deliberately not a
+// caller. It runs entirely under m.mu (so this function would self-deadlock),
+// and it needs the opposite direction anyway — "does a REPO hold this name",
+// which it reads straight off m.repos. Between the two, both directions of
+// gotcha M-1 are covered.
 func (m *Manager) lensNameConflict(name string) error {
 	reg := m.LensRegistry()
 	if reg == nil {
@@ -896,14 +905,19 @@ func (m *Manager) Purge(uid string) error {
 // with whichever instance actually kept the name in memory.
 //
 // Two separate mechanisms close these, both built on the same conditional
-// primitive (RenameIfNamed) rather than the unconditional Rename Restore uses
-// at lifecycle.go:764/773/804:
+// primitive (RenameIfNamed) rather than the unconditional Registry.Rename that
+// Restore still uses for its forward write and its compensations (grep
+// `reg.Rename(` in this file — deliberately not cited by line number, which has
+// already drifted twice):
 //
 //  1. The forward write is itself a CAS — RenameIfNamed(oldName, newName) —
 //     not a bare Rename. SQLite serializes concurrent writers, so of two
 //     RenameRepo calls racing FROM the same oldName, at most one CAS can see
-//     oldName still there and succeed; the other learns it lost right here,
-//     before either has touched the map, and never reaches the code below.
+//     oldName still there and succeed. The loser learns it lost right here, at
+//     its own forward write, and never reaches the code below — so IT has
+//     certainly touched no map. (The winner may already have swapped the map by
+//     then; the point is not that both are still pre-map, it is that the loser
+//     stops before writing anything and therefore has nothing to compensate.)
 //     This is what actually resolves two-different-targets races — the
 //     revalidate step alone cannot, because by the time a loser would reach
 //     it, an unconditional forward write from EITHER call could already have
@@ -971,8 +985,10 @@ func (m *Manager) RenameRepo(oldName, newName string) error {
 	// RenameIfNamed(oldName, newName) commits only if the row still holds
 	// oldName, and SQLite serializes concurrent writers, so of two renames
 	// racing FROM the same oldName at most one forward commit can ever
-	// succeed — the loser learns it lost right here, before either one has
-	// touched the map, and never gets far enough to need compensating.
+	// succeed — the loser learns it lost right here, at its own forward write,
+	// and never gets far enough to touch the map or to need compensating. (The
+	// WINNER may already have swapped the map by then; what matters is that the
+	// loser wrote nothing.)
 	changed, err := reg.RenameIfNamed(ri.UID(), oldName, newName)
 	if err != nil {
 		return err // ErrRepoExists when an active repo raced us to the name
@@ -1027,33 +1043,55 @@ func (m *Manager) RenameRepo(oldName, newName string) error {
 // lenses row and touches no read mount — that uid-keying is the whole point of
 // moving lens membership off names.
 //
-// This is materially simpler than RenameRepo above, and for a reason worth
-// spelling out rather than assuming: Manager holds NO in-memory map of lenses
-// analogous to m.repos/m.byUID. A lens is resolved from LensRegistry per
-// request (LensRegistry(), CreateLens, UpdateLens all go straight to
-// m.registry), so there is nothing to re-key, no second copy of the name that
-// could disagree with the registry row, and therefore none of RenameRepo's
-// out-of-lock-CAS-then-revalidate-under-the-lock structure is needed here: the
-// registry row IS the only place a lens's name lives, so checking it and
-// writing it in the same m.mu.Lock() critical section is enough.
+// The in-memory half is materially simpler than RenameRepo above, and for a
+// reason worth spelling out rather than assuming: Manager holds NO in-memory
+// map of lenses analogous to m.repos/m.byUID. A lens is resolved from
+// LensRegistry per request (LensRegistry(), CreateLens, UpdateLens all go
+// straight to m.registry), so there is nothing to re-key, no second copy of the
+// name that could disagree with the registry row, and therefore none of
+// RenameRepo's revalidate-under-the-lock-then-compensate structure is needed
+// here: the registry row IS the only place a lens's name lives, so checking it
+// and writing it in the same m.mu.Lock() critical section is enough.
 //
-// That single critical section is also why the race RenameRepo's comment
-// documents at length cannot presently reach this function: every lens
-// mutation (CreateLens, UpdateLens, and this) holds m.mu for its entire
-// duration, so two concurrent RenameLens calls (or a RenameLens racing a
-// CreateLens for the same target name) are fully serialized by Go's mutex
-// before either touches the registry. LensRegistry.Rename is still the CAS
-// form (WHERE uid = ? AND name = ?), not a plain UPDATE, on the same
+// That single critical section serializes this against every OTHER lens
+// mutation (CreateLens, UpdateLens, and a second RenameLens all hold m.mu for
+// their whole duration), and LensRegistry.Rename is still the CAS form
+// (WHERE uid = ? AND name = ?) rather than a plain UPDATE, on the same
 // reasoning RenameRepo's doc comment gives: a plain UPDATE is the shape that
 // let two concurrent repo renames both durably succeed with the last writer
 // winning, and there is no reason the lens registry should be one direct call
 // away from the identical failure mode should a future caller ever reach it
 // outside Manager's lock.
 //
+// m.mu ALONE IS NOT ENOUGH, and the reservation below is not optional.
+// Repo Create/Restore do their slow work — git init, a network clone — WITHOUT
+// holding m.mu, and only call m.Add(name) at the very END. So a
+// Create("foo") that has already taken its reservation and cleared
+// lensNameConflict leaves m.repos["foo"] == nil for the entire clone, and an
+// in-lock `m.repos[newName] != nil` check is therefore not evidence that no
+// repo is claiming newName — it is only evidence that none has FINISHED
+// claiming it. Left unreserved, RenameLens("eng" → "foo") sails through that
+// check mid-clone and commits, and the machine ends up with a repo foo AND a
+// lens foo, durably, with nothing repairing it at the next boot. The same hole
+// is open against Restore and against a concurrent RenameRepo(_ → "foo").
+// Reserving newName in the SAME in-flight set (m.creating, via
+// reserveNameAndOrigin) closes it exactly as it does for CreateLens (P2, see
+// manager.go) and for RenameRepo: whichever side reserves first wins, the other
+// gets ErrCreateInFlight, and because the winner releases only after persisting,
+// the loser's post-reservation re-check observes it. The `m.repos[newName]`
+// read below is that re-check, not the primary guard.
+//
+// ORDERING: reserveNameAndOrigin must be called BEFORE m.mu.Lock(), never
+// while holding it — it can call ActiveRepoWithOrigin, which takes m.mu, and
+// sync.RWMutex is not reentrant. The deferred release then runs strictly after
+// the deferred m.mu.Unlock() (defers are LIFO), which is the overlap CreateLens
+// depends on: reserved while also persisted.
+//
 // Guards mirror RenameRepo's: newName must pass the shared name grammar
-// (ErrInvalidLensName), must not be held by an ACTIVE repo
-// (ErrLensNameConflictsRepo — repos and lenses share one namespace, gotcha
-// M-1; checked against m.repos directly, the same in-lock read
+// (ErrInvalidLensName), must not be being claimed by an in-flight
+// Create/Restore/CreateLens/rename (ErrCreateInFlight), must not be held by an
+// ACTIVE repo (ErrLensNameConflictsRepo — repos and lenses share one namespace,
+// gotcha M-1; checked against m.repos directly, the same in-lock read
 // validateLensLocked uses), and must not be held by another lens (ErrLensExists,
 // via LensRegistry.Rename's CAS hitting the lenses_name UNIQUE index).
 // oldName must resolve to an existing lens (ErrLensNotFound). Renaming to the
@@ -1067,6 +1105,18 @@ func (m *Manager) RenameLens(oldName, newName string) error {
 	if !isValidRepoName(newName) {
 		return fmt.Errorf("%w: %q", ErrInvalidLensName, newName)
 	}
+
+	// Hold the target name for the whole check → commit window, so a Create or
+	// Restore that is mid-clone — reservation taken, m.Add not yet reached, and
+	// therefore INVISIBLE to the m.repos read below — cannot end up sharing the
+	// name with this lens. Before m.mu.Lock(): reserveNameAndOrigin may take m.mu
+	// itself and RWMutex is not reentrant. The deferred release runs after the
+	// deferred Unlock (LIFO), so the reservation outlives the persist.
+	release, err := m.reserveNameAndOrigin(newName, "")
+	if err != nil {
+		return err // ErrCreateInFlight when another operation already holds this name
+	}
+	defer release()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1088,6 +1138,11 @@ func (m *Manager) RenameLens(oldName, newName string) error {
 	// one namespace (gotcha M-1). Direct field read: we already hold m.mu, so
 	// the Get accessor's RLock would deadlock — the same reasoning Archive's
 	// direct m.repos/m.registry reads document above.
+	//
+	// This is the RE-CHECK, exactly as in RenameRepo: it catches a Create or
+	// Restore that finished (m.Add landed) before this call reserved the name.
+	// It cannot catch one still in flight — that is what the reservation above
+	// is for, and why removing it would reopen the repo/lens name collision.
 	if m.repos[newName] != nil {
 		return fmt.Errorf("%w: %q", ErrLensNameConflictsRepo, newName)
 	}

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -1146,6 +1146,20 @@ func (m *Manager) RenameLens(oldName, newName string) error {
 	if m.repos[newName] != nil {
 		return fmt.Errorf("%w: %q", ErrLensNameConflictsRepo, newName)
 	}
+	// A repo whose .db file is missing or unopenable at boot has no live
+	// instance — it never reaches m.repos, it lives in m.unavailable instead
+	// (markUnavailable, manager.go) — but its registry row still holds the
+	// name, and nothing joins the lenses table to repo names. Without this
+	// scan, restoring that file later resurrects a repo sharing a name with
+	// this lens, violating gotcha M-1 durably. m.unavailable is keyed by uid,
+	// not name, so this must be a linear scan; direct field read for the same
+	// reason as m.repos above — we already hold m.mu, and the Unavailable()
+	// accessor's RLock would deadlock.
+	for _, u := range m.unavailable {
+		if u.Record.Name == newName {
+			return fmt.Errorf("%w: %q", ErrLensNameConflictsRepo, newName)
+		}
+	}
 
 	changed, err := m.registry.Rename(l.UID, oldName, newName)
 	if err != nil {

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -876,12 +876,12 @@ func (m *Manager) Purge(uid string) error {
 // ri.shutdown(), closing the store, dropping SSE subscribers and forcing an
 // index re-warm, all to change a string.
 //
-// A rename is not free of consequences, though: Binding.Name() is also the
-// MCP cursor-pinning identity (lenses RFC §7.3), persisted into
-// tool_sessions.binding, so renaming a repo orphans any in-flight
-// knomit_query/knomit_explain session that pinned its cursor to the old name.
-// A follow-up task moves that pin onto the repo's stable id instead; until
-// then, a rename is expected to break live cursors bound to the old name.
+// A rename used to have a consequence here: the MCP cursor-pinning identity
+// (lenses RFC §7.3), persisted into tool_sessions.binding, was Binding.Name()
+// — so renaming a repo orphaned any in-flight knomit_query/knomit_explain
+// session pinned to the old name. That pin is now Binding.PinID()
+// (repo:<uid>), which this call never touches, so an in-flight cursor
+// survives a rename.
 //
 // Rejects a name that is invalid, held by another ACTIVE repo, or held by a
 // lens. Renaming to the current name is a successful no-op.

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -891,13 +891,38 @@ func (m *Manager) Purge(uid string) error {
 // Archive or Remove (neither consults it, or the old name, at all), and it
 // does not exclude a second concurrent RenameRepo of this SAME oldName to a
 // DIFFERENT newName (the two reservations don't collide because the target
-// names differ). Registry.Rename also has no state predicate, so left
-// unguarded either race would durably rename an archived row or resurrect a
-// shut-down instance into the active map. The revalidate-under-the-lock step
-// below, with a compensating UPDATE when it fails, is what catches both —
-// the same style Restore already uses to unwind its own durable half
-// (lifecycle.go's `_ = reg.Rename(uid, rec.Name)` calls) when a later step
-// fails.
+// names differ). An unconditional Registry.Rename has no state predicate, so
+// left unguarded either race would durably rename an archived row or resurrect
+// a shut-down instance into the active map — or leave the registry disagreeing
+// with whichever instance actually kept the name in memory.
+//
+// Two separate mechanisms close these, both built on the same conditional
+// primitive (RenameIfNamed) rather than the unconditional Rename Restore uses
+// at lifecycle.go:764/773/804:
+//
+//  1. The forward write is itself a CAS — RenameIfNamed(oldName, newName) —
+//     not a bare Rename. SQLite serializes concurrent writers, so of two
+//     RenameRepo calls racing FROM the same oldName, at most one CAS can see
+//     oldName still there and succeed; the other learns it lost right here,
+//     before either has touched the map, and never reaches the code below.
+//     This is what actually resolves two-different-targets races — the
+//     revalidate step alone cannot, because by the time a loser would reach
+//     it, an unconditional forward write from EITHER call could already have
+//     overwritten the other's, independent of which one goes on to win the
+//     in-memory map.
+//  2. The revalidate-under-the-lock step below catches what the forward CAS
+//     cannot see: Archive/Remove drop oldName from the map WITHOUT touching
+//     its registry row's name column, so this call's own forward CAS can
+//     still succeed against an oldName that Archive/Remove pulled out of
+//     m.repos moments earlier. When that happens the map is left untouched
+//     and this call's own durable write is undone with
+//     RenameIfNamed(newName, oldName) — conditional again, so it only ever
+//     undoes THIS call's write and can't clobber a legitimate concurrent
+//     rename of the same uid. A revert that reports no row changed means a
+//     racer legitimately holds the name now, which is correct, not an error;
+//     a revert that fails outright leaves the registry disagreeing with the
+//     map until the next boot, which is why that case is logged rather than
+//     discarded.
 func (m *Manager) RenameRepo(oldName, newName string) error {
 	if !isValidRepoName(newName) {
 		return ErrInvalidName
@@ -934,22 +959,53 @@ func (m *Manager) RenameRepo(oldName, newName string) error {
 		return err
 	}
 
-	if err := reg.Rename(ri.UID(), newName); err != nil {
+	// Conditional, not unconditional: an unconditional forward write here is
+	// racy against a second concurrent RenameRepo of this SAME oldName to a
+	// DIFFERENT target. Both calls would otherwise write the row in turn with
+	// no ordering relative to which one goes on to win the in-memory map swap
+	// below, so the registry could end up holding EITHER target's name
+	// regardless of which one actually keeps the map entry — an unconditional
+	// write plus a merely-conditional compensation (an earlier version of this
+	// fix) is not enough, because the compensation only ever undoes a call's
+	// OWN write; it does nothing about a straggling forward write from the
+	// call that loses the map race landing chronologically AFTER the winner's.
+	// RenameIfNamed(oldName, newName) commits only if the row still holds
+	// oldName, and SQLite serializes concurrent writers, so of two renames
+	// racing FROM the same oldName at most one forward commit can ever
+	// succeed — the loser learns it lost right here, before either one has
+	// touched the map, and never gets far enough to need compensating.
+	changed, err := reg.RenameIfNamed(ri.UID(), oldName, newName)
+	if err != nil {
 		return err // ErrRepoExists when an active repo raced us to the name
 	}
+	if !changed {
+		// oldName moved before this call's write landed — a racing rename won,
+		// or oldName was already stale. Nothing durable was written by this
+		// call, so there is nothing to undo.
+		return fmt.Errorf("%w: %q", ErrRepoNotFound, oldName)
+	}
 
-	// Revalidate under the SAME lock that performs the swap. Everything above
-	// ran without m.mu held, so an Archive/Remove of oldName — or a second
-	// RenameRepo of oldName to a different target — can land in the gap
-	// between the UPDATE above and this point. If oldName no longer maps to
-	// this exact instance (or newName has since been taken), the durable
-	// rename is undone rather than left to disagree with the map, and the map
-	// itself is left untouched: whichever caller loses this race gets a clean
-	// ErrRepoNotFound instead of corrupting shared state.
+	// Revalidate under the SAME lock that performs the swap. The forward CAS
+	// above closes the same-oldName race, but it says nothing about Archive or
+	// Remove, which drop oldName from the map WITHOUT touching its registry
+	// row's name column — so this call's forward CAS can still succeed against
+	// an oldName that Archive/Remove pulled out of m.repos moments earlier. If
+	// oldName no longer maps to this exact instance (or newName has since been
+	// taken), the map itself is left untouched, and the durable rename this
+	// call just wrote is undone with RenameIfNamed(newName, oldName) — the
+	// conditional revert, not an unconditional one, so it only ever undoes
+	// THIS call's own write and can never clobber a legitimate concurrent
+	// rename of the same uid.
 	m.mu.Lock()
 	if m.repos[oldName] != ri || m.repos[newName] != nil {
 		m.mu.Unlock()
-		_ = reg.Rename(ri.UID(), oldName) // undo the durable half
+		if reverted, cerr := reg.RenameIfNamed(ri.UID(), newName, oldName); cerr != nil {
+			log.Error().Err(cerr).Str("uid", ri.UID()).Str("from", newName).Str("to", oldName).
+				Msg("rename: could not revert the registry after a lost race; registry and live map may disagree until restart")
+		} else if !reverted {
+			log.Info().Str("uid", ri.UID()).Str("held", newName).
+				Msg("rename: revert skipped — another operation already changed this repo's name")
+		}
 		return fmt.Errorf("%w: %q", ErrRepoNotFound, oldName)
 	}
 	m.repos[newName] = ri

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -876,8 +876,28 @@ func (m *Manager) Purge(uid string) error {
 // ri.shutdown(), closing the store, dropping SSE subscribers and forcing an
 // index re-warm, all to change a string.
 //
+// A rename is not free of consequences, though: Binding.Name() is also the
+// MCP cursor-pinning identity (lenses RFC §7.3), persisted into
+// tool_sessions.binding, so renaming a repo orphans any in-flight
+// knomit_query/knomit_explain session that pinned its cursor to the old name.
+// A follow-up task moves that pin onto the repo's stable id instead; until
+// then, a rename is expected to break live cursors bound to the old name.
+//
 // Rejects a name that is invalid, held by another ACTIVE repo, or held by a
 // lens. Renaming to the current name is a successful no-op.
+//
+// reserveNameAndOrigin excludes this from Create/Restore/CreateLens racing the
+// SAME newName, but it reserves only the new name — it does not exclude
+// Archive or Remove (neither consults it, or the old name, at all), and it
+// does not exclude a second concurrent RenameRepo of this SAME oldName to a
+// DIFFERENT newName (the two reservations don't collide because the target
+// names differ). Registry.Rename also has no state predicate, so left
+// unguarded either race would durably rename an archived row or resurrect a
+// shut-down instance into the active map. The revalidate-under-the-lock step
+// below, with a compensating UPDATE when it fails, is what catches both —
+// the same style Restore already uses to unwind its own durable half
+// (lifecycle.go's `_ = reg.Rename(uid, rec.Name)` calls) when a later step
+// fails.
 func (m *Manager) RenameRepo(oldName, newName string) error {
 	if !isValidRepoName(newName) {
 		return ErrInvalidName
@@ -918,14 +938,30 @@ func (m *Manager) RenameRepo(oldName, newName string) error {
 		return err // ErrRepoExists when an active repo raced us to the name
 	}
 
+	// Revalidate under the SAME lock that performs the swap. Everything above
+	// ran without m.mu held, so an Archive/Remove of oldName — or a second
+	// RenameRepo of oldName to a different target — can land in the gap
+	// between the UPDATE above and this point. If oldName no longer maps to
+	// this exact instance (or newName has since been taken), the durable
+	// rename is undone rather than left to disagree with the map, and the map
+	// itself is left untouched: whichever caller loses this race gets a clean
+	// ErrRepoNotFound instead of corrupting shared state.
 	m.mu.Lock()
+	if m.repos[oldName] != ri || m.repos[newName] != nil {
+		m.mu.Unlock()
+		_ = reg.Rename(ri.UID(), oldName) // undo the durable half
+		return fmt.Errorf("%w: %q", ErrRepoNotFound, oldName)
+	}
 	m.repos[newName] = ri
 	delete(m.repos, oldName)
-	m.mu.Unlock()
-	// After the map move, so a reader that resolved the instance under either
-	// key never sees a name belonging to neither. byUID is untouched — the uid
-	// did not change.
+	// setName INSIDE this same critical section, not after: Get/Names/ForEach
+	// all take m.mu.RLock, so a reader that resolves ri between an out-of-lock
+	// setName and the map swap (or vice versa) would observe an instance whose
+	// Name() names neither key it is reachable under. setName is a lock-free
+	// atomic Store — cheap, and it cannot block or deadlock — so there is no
+	// cost to closing that window by publishing the name before releasing mu.
 	ri.setName(newName)
+	m.mu.Unlock()
 
 	log.Info().Str("uid", ri.UID()).Str("from", oldName).Str("to", newName).Msg("renamed repo")
 	return nil

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -1021,3 +1021,90 @@ func (m *Manager) RenameRepo(oldName, newName string) error {
 	log.Info().Str("uid", ri.UID()).Str("from", oldName).Str("to", newName).Msg("renamed repo")
 	return nil
 }
+
+// RenameLens changes a lens's display name. lens_reads references lens_uid
+// (Task 4b), never a name, so this is a single control.db UPDATE of the
+// lenses row and touches no read mount — that uid-keying is the whole point of
+// moving lens membership off names.
+//
+// This is materially simpler than RenameRepo above, and for a reason worth
+// spelling out rather than assuming: Manager holds NO in-memory map of lenses
+// analogous to m.repos/m.byUID. A lens is resolved from LensRegistry per
+// request (LensRegistry(), CreateLens, UpdateLens all go straight to
+// m.registry), so there is nothing to re-key, no second copy of the name that
+// could disagree with the registry row, and therefore none of RenameRepo's
+// out-of-lock-CAS-then-revalidate-under-the-lock structure is needed here: the
+// registry row IS the only place a lens's name lives, so checking it and
+// writing it in the same m.mu.Lock() critical section is enough.
+//
+// That single critical section is also why the race RenameRepo's comment
+// documents at length cannot presently reach this function: every lens
+// mutation (CreateLens, UpdateLens, and this) holds m.mu for its entire
+// duration, so two concurrent RenameLens calls (or a RenameLens racing a
+// CreateLens for the same target name) are fully serialized by Go's mutex
+// before either touches the registry. LensRegistry.Rename is still the CAS
+// form (WHERE uid = ? AND name = ?), not a plain UPDATE, on the same
+// reasoning RenameRepo's doc comment gives: a plain UPDATE is the shape that
+// let two concurrent repo renames both durably succeed with the last writer
+// winning, and there is no reason the lens registry should be one direct call
+// away from the identical failure mode should a future caller ever reach it
+// outside Manager's lock.
+//
+// Guards mirror RenameRepo's: newName must pass the shared name grammar
+// (ErrInvalidLensName), must not be held by an ACTIVE repo
+// (ErrLensNameConflictsRepo — repos and lenses share one namespace, gotcha
+// M-1; checked against m.repos directly, the same in-lock read
+// validateLensLocked uses), and must not be held by another lens (ErrLensExists,
+// via LensRegistry.Rename's CAS hitting the lenses_name UNIQUE index).
+// oldName must resolve to an existing lens (ErrLensNotFound). Renaming to the
+// current name is a successful no-op.
+//
+// A rename has no cursor-pinning consequence: the MCP binding pin is
+// lens:<uid> (Binding.PinID(), RFC §7.3), never the name, so an in-flight
+// knomit_query/knomit_explain session pinned to this lens survives a rename
+// exactly as an in-flight repo session survives RenameRepo.
+func (m *Manager) RenameLens(oldName, newName string) error {
+	if !isValidRepoName(newName) {
+		return fmt.Errorf("%w: %q", ErrInvalidLensName, newName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.registry == nil {
+		return fmt.Errorf("lens registry not open")
+	}
+
+	l, ok, err := m.registry.Get(oldName)
+	if err != nil {
+		return fmt.Errorf("lens registry: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrLensNotFound, oldName)
+	}
+	if oldName == newName {
+		return nil
+	}
+	// A repo may hold newName even though no lens does — repos and lenses share
+	// one namespace (gotcha M-1). Direct field read: we already hold m.mu, so
+	// the Get accessor's RLock would deadlock — the same reasoning Archive's
+	// direct m.repos/m.registry reads document above.
+	if m.repos[newName] != nil {
+		return fmt.Errorf("%w: %q", ErrLensNameConflictsRepo, newName)
+	}
+
+	changed, err := m.registry.Rename(l.UID, oldName, newName)
+	if err != nil {
+		return err // ErrLensExists when another lens already holds newName
+	}
+	if !changed {
+		// Unreachable today (this whole function runs under one m.mu.Lock(), so
+		// nothing else can have moved oldName in between) but Rename's CAS
+		// reports it rather than silently doing nothing, so a future caller that
+		// reaches LensRegistry.Rename outside this lock is told honestly, not
+		// left believing a rename happened when it didn't.
+		return fmt.Errorf("%w: %q", ErrLensNotFound, oldName)
+	}
+
+	log.Info().Str("uid", l.UID).Str("from", oldName).Str("to", newName).Msg("renamed lens")
+	return nil
+}

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -868,3 +868,65 @@ func (m *Manager) Purge(uid string) error {
 	log.Info().Str("uid", uid).Str("repo", rec.Name).Msg("purged repo")
 	return nil
 }
+
+// RenameRepo changes a repo's display name. The store is NOT closed: a name is
+// display-only (the .db is <home>/repos/<uid>.db, lens membership is uid-keyed,
+// and the lens wire format derives its name field), so this is a control.db
+// UPDATE plus a map-key move. Remove+Add — what Restore does — would call
+// ri.shutdown(), closing the store, dropping SSE subscribers and forcing an
+// index re-warm, all to change a string.
+//
+// Rejects a name that is invalid, held by another ACTIVE repo, or held by a
+// lens. Renaming to the current name is a successful no-op.
+func (m *Manager) RenameRepo(oldName, newName string) error {
+	if !isValidRepoName(newName) {
+		return ErrInvalidName
+	}
+	// Snapshot the control handles BEFORE taking m.mu: controlHandles takes
+	// m.mu.RLock and RWMutex is not reentrant. Same ordering as Archive.
+	reg, _, err := m.controlHandles()
+	if err != nil {
+		return err
+	}
+
+	ri := m.Get(oldName)
+	if ri == nil {
+		return fmt.Errorf("%w: %q", ErrRepoNotFound, oldName)
+	}
+	if oldName == newName {
+		return nil
+	}
+
+	// Hold the target name for the whole check → commit window so a concurrent
+	// Create or Restore cannot claim it between the checks and the UPDATE.
+	release, err := m.reserveNameAndOrigin(newName, "")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	if m.Get(newName) != nil {
+		return fmt.Errorf("%w: %q", ErrRepoExists, newName)
+	}
+	// A lens may hold the name even though no repo does; repos and lenses share
+	// one namespace. Same guard Create and Restore run.
+	if err := m.lensNameConflict(newName); err != nil {
+		return err
+	}
+
+	if err := reg.Rename(ri.UID(), newName); err != nil {
+		return err // ErrRepoExists when an active repo raced us to the name
+	}
+
+	m.mu.Lock()
+	m.repos[newName] = ri
+	delete(m.repos, oldName)
+	m.mu.Unlock()
+	// After the map move, so a reader that resolved the instance under either
+	// key never sees a name belonging to neither. byUID is untouched — the uid
+	// did not change.
+	ri.setName(newName)
+
+	log.Info().Str("uid", ri.UID()).Str("from", oldName).Str("to", newName).Msg("renamed repo")
+	return nil
+}

--- a/internal/repos/lifecycle.go
+++ b/internal/repos/lifecycle.go
@@ -36,11 +36,10 @@ var (
 	ErrRepoNotFound = errors.New("repo not found")
 	// ErrRepoNameConflictsLens rejects creating or restoring a repo whose name
 	// equals an existing lens name. It is the reverse-direction twin of
-	// ErrLensNameConflictsRepo: a lens and a lens-of-one repo both surface
-	// Binding.Name() as their cursor-pinning identity (RFC §7.3). A same-name
-	// cursor cross-resume is ALSO blocked physically — sessions live in the
-	// write repo's own session DB, and a lens can never be named after its own
-	// write repo — so this guard is defense-in-depth for the name check plus
+	// ErrLensNameConflictsRepo. The cursor-pinning identity (RFC §7.3) is now
+	// Binding.PinID() — repo:<uid> / lens:<uid> — which cannot collide between
+	// a lens and a repo even if they share a name, so this guard is no longer
+	// what keeps a same-name cursor cross-resume closed; it survives as
 	// namespace legibility (one name must never serve two endpoints).
 	// ValidateLens closes the direction where the lens is created second; this
 	// closes the direction where the repo is created (or restored) second, so

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -169,12 +169,15 @@ func (m *Manager) ValidateLens(ctx context.Context, l Lens) error {
 // while m.mu is held.
 //
 // Members resolve by registry uid; only the lens NAME is checked against repo
-// names, because names (not uids) share the Binding.Name() cursor-pinning
-// namespace.
+// names. The cursor-pinning identity (RFC §7.3) is Binding.PinID() now —
+// repo:<uid> / lens:<uid> — which cannot collide between a lens and a repo
+// even if they share a name, so this check is no longer what keeps cursor
+// namespaces disjoint; it survives as a UX nicety (one name must never serve
+// two endpoints).
 func (m *Manager) validateLensLocked(ctx context.Context, l Lens) error {
 	// Name checks fail fast, before any member resolution: a lens name must be a
-	// valid repo-grammar name and must not collide with an existing repo name,
-	// so lens and repo cursor-binding namespaces stay disjoint (gotcha M-1).
+	// valid repo-grammar name and must not collide with an existing repo name
+	// (namespace legibility — one name must never serve two endpoints; gotcha M-1).
 	if !isValidRepoName(l.Name) {
 		return fmt.Errorf("%w: %q", ErrInvalidLensName, l.Name)
 	}

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -354,10 +354,16 @@ func (m *Manager) CreateLens(ctx context.Context, l Lens) (Lens, error) {
 // persists first (Archive's RefsRepo then sees the new mount → ErrRepoInUseByLens).
 // A member can never be archived between the membership check and the persist.
 //
-// Unlike CreateLens it does NOT reserve the name in m.creating: the lens already
-// exists and its name is immutable, so there is no new repo/lens name to race
-// (P2). A repo Create for the lens's name still loses to the existing lens via
-// its own registry re-check, independent of this call.
+// Unlike CreateLens — and unlike RenameLens, which DOES reserve — this does not
+// reserve the name in m.creating, and the reason is narrow: UpdateLens never
+// CHANGES the name. Lens names became mutable on this branch, so "the name is
+// immutable" is no longer why this is safe; what makes it safe is that the only
+// name in play here is one the lens already durably holds. There is no new name
+// being introduced into the shared repo/lens namespace, so there is nothing for
+// P2's mutual exclusion to protect: a repo Create for that name still loses to
+// the existing lens via its own lensNameConflict re-check, independent of this
+// call. Any future edit that lets this method rewrite l.Name must add the
+// reservation (see RenameLens for the shape and for what goes wrong without it).
 //
 // The write repo and description are pure input, checked up front. The name is
 // re-validated (grammar) but never changed — the caller passes the existing name.

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -141,11 +141,13 @@ var ErrLensBranchUnknown = errors.New("lens pins an unknown branch")
 var ErrInvalidLensName = errors.New("invalid lens name")
 
 // ErrLensNameConflictsRepo rejects a lens whose name equals an existing repo
-// name. A lens and a lens-of-one repo both surface Binding.Name() as their
-// cursor-pinning identity (RFC §7.3); if a lens and a repo shared a name a
-// cursor minted on one endpoint could resume on the other. Disjoint names
-// keep the binding pin sound (closes ledger gotcha M-1 /
-// kb/gotchas/lens/cursor-binding-pin).
+// name. The cursor-pinning identity (RFC §7.3) is Binding.PinID() now —
+// repo:<uid> / lens:<uid> — which cannot collide between a lens and a repo
+// even if they share a name, so this guard is no longer what keeps the
+// binding pin sound. It survives as a UX nicety: a lens and a lens-of-one
+// repo share one display-name and endpoint-path namespace, and letting them
+// collide would make "which one did I mean" ambiguous in URLs, error
+// messages, and logs (closes ledger gotcha M-1 / kb/gotchas/lens/cursor-binding-pin).
 var ErrLensNameConflictsRepo = errors.New("lens name conflicts with an existing repo name")
 
 // ValidateLens checks a lens definition against the live repo set: every

--- a/internal/repos/manager_test.go
+++ b/internal/repos/manager_test.go
@@ -41,11 +41,13 @@ func TestStart_freshHomeHasNoRepos(t *testing.T) {
 func TestManager_Set_EvictsStaleUID(t *testing.T) {
 	m := New(context.Background(), Deps{})
 
-	first := &RepoInstance{name: "core", uid: "uid-1", syncCancel: func() {}, syncWg: &sync.WaitGroup{}, indexCancel: func() {}, indexWg: &sync.WaitGroup{}}
+	first := &RepoInstance{uid: "uid-1", syncCancel: func() {}, syncWg: &sync.WaitGroup{}, indexCancel: func() {}, indexWg: &sync.WaitGroup{}}
+	first.setName("core")
 	m.Set("core", first)
 	require.Same(t, first, m.GetByUID("uid-1"))
 
-	second := &RepoInstance{name: "core", uid: "uid-2", syncCancel: func() {}, syncWg: &sync.WaitGroup{}, indexCancel: func() {}, indexWg: &sync.WaitGroup{}}
+	second := &RepoInstance{uid: "uid-2", syncCancel: func() {}, syncWg: &sync.WaitGroup{}, indexCancel: func() {}, indexWg: &sync.WaitGroup{}}
+	second.setName("core")
 	m.Set("core", second)
 
 	require.Nil(t, m.GetByUID("uid-1"), "stale uid must be evicted from byUID")
@@ -88,10 +90,10 @@ func TestShutdown_concurrentSyncCancelUpdate(t *testing.T) {
 
 	m := New(ctx, Deps{})
 	ri := &RepoInstance{
-		name:       "test",
 		syncWg:     &sync.WaitGroup{},
 		syncCancel: func() {},
 	}
+	ri.setName("test")
 	m.Set("test", ri)
 
 	const n = 500

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -177,6 +177,17 @@ const licenseCommitMsg = "docs: update LICENSE"
 //
 // The read-compare-write is not atomic — the same last-write-wins contract
 // WriteReadme and the fact-write path already have.
+//
+// An empty content is skipped too, but only when LICENSE does not already
+// exist: ReadFact then errors, and the byte-identical check above never
+// fires, so without this a blank "Add license" draft would commit an empty
+// file — one that ReadLicense reads back as "" and the UI treats as no
+// licence at all, i.e. a junk commit for a file that appears not to exist.
+// Saving "" over an EXISTING licence is the legitimate "clear it" action and
+// must still write, so the distinguishing signal is whether ReadFact
+// succeeded, not the content by itself — a licence file that is merely
+// unreadable (e.g. over the size cap) also errors here and is treated the
+// same as absent, matching ReadLicense's own "absent (or unreadable)" stance.
 func (ri *RepoInstance) WriteLicense(ctx context.Context, content string) (committed bool, err error) {
 	if len(content) > MaxRepoDescriptionBytes {
 		return false, fmt.Errorf("%w: %d bytes exceeds the maximum of %d",
@@ -191,8 +202,12 @@ func (ri *RepoInstance) WriteLicense(ctx context.Context, content string) (commi
 	// store, in which case fn never ran at all. Dropping it would turn "the
 	// write never happened" into a silent success.
 	acquireErr := ri.WithRead(func(svc *store.Service) {
-		if cur, rerr := svc.Facts().ReadFact(ctx, branch, LicensePath, nil); rerr == nil && cur.Content == content {
-			return
+		cur, rerr := svc.Facts().ReadFact(ctx, branch, LicensePath, nil)
+		if rerr == nil && cur.Content == content {
+			return // byte-identical to what is already there
+		}
+		if rerr != nil && content == "" {
+			return // nothing to clear: no licence exists, and none is being added
 		}
 		if _, werr := svc.Facts().WriteRootFile(ctx, branch, LicensePath,
 			content, licenseCommitMsg, "update"); werr != nil {

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -120,8 +120,9 @@ const LegacyOntologyPath = "domains/ontology.yaml"
 // tree root beside README.md. Like the manifest it is not a fact, and like the
 // manifest git providers look for it by this exact name.
 //
-// Read-only by design: a licence is authored by whoever owns the repo, and
-// knomit reports it rather than offering to write one.
+// Readable AND writable, but never GENERATED: knomit round-trips whatever terms
+// the repo owner supplies and offers no template picker, so it stays out of the
+// business of producing legal text. The editor starts blank by design.
 //
 // Deliberately this one spelling only. ReadLicense below resolves it through
 // ReadFact, which bottoms out in go-git's Tree.FindEntry — an EXACT tree-entry
@@ -134,9 +135,9 @@ const LicensePath = "LICENSE"
 // agent branch. A missing licence is not an error — it returns "" with a nil
 // error, because "this KB states no terms" is an ordinary state.
 //
-// Content over MaxRepoDescriptionBytes is reported as absent: this is a
-// RESPONSE guard (there is no write path to reject on), and GPL-3 at ~35KB
-// leaves ample headroom, so nothing legitimate trips it.
+// Content over MaxRepoDescriptionBytes is reported as absent. WriteLicense now
+// rejects oversized input at the door, so this guard only catches a LICENSE
+// that arrived some other way — a clone, or a hand-edited working tree.
 func (ri *RepoInstance) ReadLicense(ctx context.Context) (string, error) {
 	branch := ri.agentBranch
 	if branch == "" {
@@ -156,4 +157,52 @@ func (ri *RepoInstance) ReadLicense(ctx context.Context) (string, error) {
 		content = res.Content
 	})
 	return content, err
+}
+
+// licenseCommitMsg is the commit subject for every licence edit, so the git log
+// reads uniformly regardless of which client made the change.
+const licenseCommitMsg = "docs: update LICENSE"
+
+// WriteLicense commits content to LICENSE on the repo's agent branch — the
+// exact file and branch ReadLicense reads, so an edit round-trips. It reports
+// whether a commit was made: a byte-identical licence is skipped, because the
+// store's write path always builds a fresh commit object and re-saving
+// unchanged text would otherwise append an empty commit to the agent branch
+// (and push it to the remote).
+//
+// Reuses MaxRepoDescriptionBytes and ErrRepoDescriptionTooLong rather than
+// minting licence-specific twins: it is the same cap on the same kind of root
+// manifest, and a second sentinel would need a second mapping arm at the HTTP
+// edge saying exactly the same thing. GPL-3 is ~35KB against a 64KB cap.
+//
+// The read-compare-write is not atomic — the same last-write-wins contract
+// WriteReadme and the fact-write path already have.
+func (ri *RepoInstance) WriteLicense(ctx context.Context, content string) (committed bool, err error) {
+	if len(content) > MaxRepoDescriptionBytes {
+		return false, fmt.Errorf("%w: %d bytes exceeds the maximum of %d",
+			ErrRepoDescriptionTooLong, len(content), MaxRepoDescriptionBytes)
+	}
+	branch := ri.agentBranch
+	if branch == "" {
+		return false, ErrAgentBranchUnset
+	}
+	var writeErr error
+	// Capture WithRead's own error separately: it reports a closed or detached
+	// store, in which case fn never ran at all. Dropping it would turn "the
+	// write never happened" into a silent success.
+	acquireErr := ri.WithRead(func(svc *store.Service) {
+		if cur, rerr := svc.Facts().ReadFact(ctx, branch, LicensePath, nil); rerr == nil && cur.Content == content {
+			return
+		}
+		if _, werr := svc.Facts().WriteRootFile(ctx, branch, LicensePath,
+			content, licenseCommitMsg, "update"); werr != nil {
+			writeErr = werr
+			return
+		}
+		committed = true
+	})
+	if acquireErr != nil {
+		return false, acquireErr
+	}
+	return committed, writeErr
 }

--- a/internal/repos/manifest.go
+++ b/internal/repos/manifest.go
@@ -19,6 +19,15 @@ var (
 	// ErrAgentBranchUnset is returned when the repo has no agent branch yet, so
 	// there is no ref to read the manifest from or commit it to.
 	ErrAgentBranchUnset = errors.New("repo has no agent branch")
+	// ErrLicenseTooLargeToReplace is returned by WriteLicense when the LICENSE
+	// already on the agent branch exceeds MaxRepoDescriptionBytes. ReadFact has
+	// no size cap of its own, so that read succeeds; without this guard
+	// WriteLicense would treat "exists but too large to show" as ordinary
+	// content, and a blank "Add license" draft (offered because the UI could
+	// not display the oversize file and looked empty) would silently commit
+	// over it. Refusing beats guessing: there is no safe rewrite of a file this
+	// call never actually read.
+	ErrLicenseTooLargeToReplace = errors.New("existing LICENSE exceeds the size cap; refusing to replace it blindly")
 )
 
 // MaxRepoDescriptionBytes caps the README.md root manifest. Byte length, not
@@ -132,31 +141,36 @@ const LegacyOntologyPath = "domains/ontology.yaml"
 const LicensePath = "LICENSE"
 
 // ReadLicense returns the verbatim content of LICENSE at the tip of the repo's
-// agent branch. A missing licence is not an error — it returns "" with a nil
+// agent branch. A missing licence is not an error — it returns "", false, nil
 // error, because "this KB states no terms" is an ordinary state.
 //
-// Content over MaxRepoDescriptionBytes is reported as absent. WriteLicense now
-// rejects oversized input at the door, so this guard only catches a LICENSE
-// that arrived some other way — a clone, or a hand-edited working tree.
-func (ri *RepoInstance) ReadLicense(ctx context.Context) (string, error) {
+// oversize reports whether a LICENSE exists but exceeds MaxRepoDescriptionBytes
+// — content is "" in that case too, but a caller MUST be able to tell "no
+// LICENSE" from "a LICENSE that is too large to show": those are different
+// states with different safe UIs. Treating the second as the first is exactly
+// the bug this return value closes — see WriteLicense's ErrLicenseTooLargeToReplace
+// guard for the write-side half. WriteLicense rejects oversized input at the
+// door, so an oversize LICENSE here only arrives some other way — a clone, or
+// a hand-edited working tree.
+func (ri *RepoInstance) ReadLicense(ctx context.Context) (content string, oversize bool, err error) {
 	branch := ri.agentBranch
 	if branch == "" {
-		return "", ErrAgentBranchUnset
+		return "", false, ErrAgentBranchUnset
 	}
-	var content string
-	err := ri.WithRead(func(svc *store.Service) {
+	err = ri.WithRead(func(svc *store.Service) {
 		res, rerr := svc.Facts().ReadFact(ctx, branch, LicensePath, nil)
 		if rerr != nil {
 			return // absent (or unreadable) — no terms to report
 		}
 		if len(res.Content) > MaxRepoDescriptionBytes {
 			log.Warn().Str("repo", ri.Name()).Int("bytes", len(res.Content)).
-				Msg("LICENSE exceeds the read guard; reporting no licence")
+				Msg("LICENSE exceeds the read guard; reporting oversize rather than content")
+			oversize = true
 			return
 		}
 		content = res.Content
 	})
-	return content, err
+	return content, oversize, err
 }
 
 // licenseCommitMsg is the commit subject for every licence edit, so the git log
@@ -185,9 +199,18 @@ const licenseCommitMsg = "docs: update LICENSE"
 // licence at all, i.e. a junk commit for a file that appears not to exist.
 // Saving "" over an EXISTING licence is the legitimate "clear it" action and
 // must still write, so the distinguishing signal is whether ReadFact
-// succeeded, not the content by itself — a licence file that is merely
-// unreadable (e.g. over the size cap) also errors here and is treated the
-// same as absent, matching ReadLicense's own "absent (or unreadable)" stance.
+// succeeded, not the content by itself.
+//
+// ReadFact enforces NO size cap of its own — unlike ReadLicense, which reports
+// an over-cap LICENSE as oversize rather than streaming its content (see its
+// doc comment). So ReadFact below still succeeds for a >64KiB LICENSE, and
+// without the explicit check first, this method would fall through to either
+// the byte-identical branch (content will never match, since the caller never
+// saw the real bytes) or the WriteRootFile call at the bottom — meaning a
+// blank "Add license" draft, offered because the UI could not display a file
+// it never read, would silently commit an empty LICENSE over the original.
+// Refusing the write and reporting ErrLicenseTooLargeToReplace closes that:
+// there is no safe rewrite of content this call cannot see.
 func (ri *RepoInstance) WriteLicense(ctx context.Context, content string) (committed bool, err error) {
 	if len(content) > MaxRepoDescriptionBytes {
 		return false, fmt.Errorf("%w: %d bytes exceeds the maximum of %d",
@@ -203,6 +226,11 @@ func (ri *RepoInstance) WriteLicense(ctx context.Context, content string) (commi
 	// write never happened" into a silent success.
 	acquireErr := ri.WithRead(func(svc *store.Service) {
 		cur, rerr := svc.Facts().ReadFact(ctx, branch, LicensePath, nil)
+		if rerr == nil && len(cur.Content) > MaxRepoDescriptionBytes {
+			writeErr = fmt.Errorf("%w: existing LICENSE is %d bytes",
+				ErrLicenseTooLargeToReplace, len(cur.Content))
+			return
+		}
 		if rerr == nil && cur.Content == content {
 			return // byte-identical to what is already there
 		}

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -95,9 +95,10 @@ func TestReadLicense_AbsentIsNotAnError(t *testing.T) {
 	ri := m.Get(testRepoName)
 	require.NotNil(t, ri)
 
-	got, err := ri.ReadLicense(context.Background())
+	got, oversize, err := ri.ReadLicense(context.Background())
 	require.NoError(t, err)
 	require.Empty(t, got)
+	require.False(t, oversize, "absent is not oversize")
 }
 
 // Verbatim: a licence is a legal text, and reformatting it is not knomit's
@@ -114,16 +115,20 @@ func TestReadLicense_ReturnsVerbatim(t *testing.T) {
 		require.NoError(t, werr)
 	}))
 
-	got, err := ri.ReadLicense(context.Background())
+	got, oversize, err := ri.ReadLicense(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, mit, got)
+	require.False(t, oversize)
 }
 
-// The read guard bounds the wire response. WriteLicense rejects oversized
-// input at the door; this only catches a LICENSE that arrived some other
-// way — a clone, or a hand-edited working tree — which degrades to "no
-// licence" rather than streaming.
-func TestReadLicense_OverCapIsOmitted(t *testing.T) {
+// The read guard bounds the wire response, but must not collapse into "no
+// licence": ReadLicense reports oversize=true so a caller (repoView) can
+// distinguish "nothing here" from "something here we could not read" — the
+// distinction the UI needs to avoid offering "Add license" over a file it
+// never actually read. WriteLicense rejects oversized input at the door; this
+// only catches a LICENSE that arrived some other way — a clone, or a
+// hand-edited working tree.
+func TestReadLicense_OverCapReportsOversizeNotAbsent(t *testing.T) {
 	m := newLifetimeTestManager(t)
 	ri := m.Get(testRepoName)
 	require.NotNil(t, ri)
@@ -134,9 +139,10 @@ func TestReadLicense_OverCapIsOmitted(t *testing.T) {
 		require.NoError(t, werr)
 	}))
 
-	got, err := ri.ReadLicense(context.Background())
+	got, oversize, err := ri.ReadLicense(context.Background())
 	require.NoError(t, err)
-	require.Empty(t, got)
+	require.Empty(t, got, "content is withheld either way")
+	require.True(t, oversize, "must be distinguishable from an absent LICENSE")
 }
 
 // Round-trip plus the unchanged-content skip: re-writing identical bytes
@@ -183,7 +189,7 @@ func TestReadLicense_IsCaseSensitive(t *testing.T) {
 		}
 	}))
 
-	got, err := ri.ReadLicense(context.Background())
+	got, _, err := ri.ReadLicense(context.Background())
 	require.NoError(t, err)
 	require.Empty(t, got, "only the exact name LICENSE is resolved")
 }
@@ -201,7 +207,7 @@ func TestWriteLicense_RoundTrips(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, committed)
 
-	got, err := ri.ReadLicense(ctx)
+	got, _, err := ri.ReadLicense(ctx)
 	require.NoError(t, err)
 	require.Equal(t, mit, got, "verbatim, newlines intact")
 }
@@ -235,7 +241,7 @@ func TestWriteLicense_EmptyContentNoExistingFile_NoCommit(t *testing.T) {
 	require.NotNil(t, ri)
 	ctx := context.Background()
 
-	got, err := ri.ReadLicense(ctx)
+	got, _, err := ri.ReadLicense(ctx)
 	require.NoError(t, err)
 	require.Empty(t, got, "sanity: no LICENSE exists yet")
 
@@ -248,7 +254,7 @@ func TestWriteLicense_EmptyContentNoExistingFile_NoCommit(t *testing.T) {
 	after := mustHeadCommit(t, ri, ctx)
 	require.Equal(t, before, after, "no new commit must land on the agent branch")
 
-	got, err = ri.ReadLicense(ctx)
+	got, _, err = ri.ReadLicense(ctx)
 	require.NoError(t, err)
 	require.Empty(t, got, "still no licence")
 }
@@ -276,9 +282,77 @@ func TestWriteLicense_EmptyContentClearsExistingFile_Commits(t *testing.T) {
 	after := mustHeadCommit(t, ri, ctx)
 	require.NotEqual(t, before, after, "clearing must land a new commit")
 
-	got, err := ri.ReadLicense(ctx)
+	got, _, err := ri.ReadLicense(ctx)
 	require.NoError(t, err)
 	require.Empty(t, got, "the licence is now cleared")
+}
+
+// The destructive path this whole guard exists for: the UI cannot display an
+// over-cap LICENSE and, before ErrLicenseTooLargeToReplace existed, offered
+// "Add license" over it — a blank draft whose Save called WriteLicense("").
+// ReadFact has no size cap, so that read succeeds, the byte-identical check
+// never matches (this call never saw the real bytes), and the empty-content
+// skip only fires when NO licence exists — so without the explicit oversize
+// check, this call would fall through to WriteRootFile and silently commit
+// an empty LICENSE over the original. It must refuse instead.
+func TestWriteLicense_RefusesToReplaceOversizeExisting_EmptyContent(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+	ctx := context.Background()
+
+	oversized := strings.Repeat("x", MaxRepoDescriptionBytes+1)
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteRootFile(ctx, ri.AgentBranch(),
+			"LICENSE", oversized, "docs: add oversize LICENSE", "update")
+		require.NoError(t, werr)
+	}))
+	before := mustHeadCommit(t, ri, ctx)
+
+	committed, err := ri.WriteLicense(ctx, "")
+	require.ErrorIs(t, err, ErrLicenseTooLargeToReplace)
+	require.False(t, committed)
+
+	after := mustHeadCommit(t, ri, ctx)
+	require.Equal(t, before, after, "the refused write must not land a commit")
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		res, rerr := svc.Facts().ReadFact(ctx, ri.AgentBranch(), LicensePath, nil)
+		require.NoError(t, rerr)
+		require.Equal(t, oversized, res.Content, "the original must survive untouched")
+	}))
+}
+
+// Same guard, non-empty replacement content: an oversize existing LICENSE
+// must be refused whether the caller is trying to clear it or overwrite it
+// with new terms — WriteLicense cannot safely diff against content it never
+// read, so it must not write over it at all.
+func TestWriteLicense_RefusesToReplaceOversizeExisting_NonEmptyContent(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+	ctx := context.Background()
+
+	oversized := strings.Repeat("x", MaxRepoDescriptionBytes+1)
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteRootFile(ctx, ri.AgentBranch(),
+			"LICENSE", oversized, "docs: add oversize LICENSE", "update")
+		require.NoError(t, werr)
+	}))
+	before := mustHeadCommit(t, ri, ctx)
+
+	committed, err := ri.WriteLicense(ctx, "MIT License\n")
+	require.ErrorIs(t, err, ErrLicenseTooLargeToReplace)
+	require.False(t, committed)
+
+	after := mustHeadCommit(t, ri, ctx)
+	require.Equal(t, before, after, "the refused write must not land a commit")
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		res, rerr := svc.Facts().ReadFact(ctx, ri.AgentBranch(), LicensePath, nil)
+		require.NoError(t, rerr)
+		require.Equal(t, oversized, res.Content, "the original must survive untouched")
+	}))
 }
 
 func mustHeadCommit(t *testing.T, ri *RepoInstance, ctx context.Context) string {

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -222,6 +222,76 @@ func TestWriteLicense_UnchangedContentMakesNoCommit(t *testing.T) {
 	require.False(t, committed, "identical content is a no-op")
 }
 
+// Saving a blank "Add license" draft when no LICENSE exists yet must not
+// commit an empty file: ReadFact errors on an absent file, so the
+// byte-identical skip never fires, and without a dedicated check
+// WriteRootFile would happily commit "" under "docs: update LICENSE" — a
+// junk commit (and push) for a file that still reads back as no licence.
+// Asserting the HEAD commit hash is unchanged, not just committed==false,
+// is what proves nothing landed on the branch.
+func TestWriteLicense_EmptyContentNoExistingFile_NoCommit(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+	ctx := context.Background()
+
+	got, err := ri.ReadLicense(ctx)
+	require.NoError(t, err)
+	require.Empty(t, got, "sanity: no LICENSE exists yet")
+
+	before := mustHeadCommit(t, ri, ctx)
+
+	committed, err := ri.WriteLicense(ctx, "")
+	require.NoError(t, err)
+	require.False(t, committed, "an empty draft with no existing licence must not commit")
+
+	after := mustHeadCommit(t, ri, ctx)
+	require.Equal(t, before, after, "no new commit must land on the agent branch")
+
+	got, err = ri.ReadLicense(ctx)
+	require.NoError(t, err)
+	require.Empty(t, got, "still no licence")
+}
+
+// Saving an empty string over an EXISTING licence is the legitimate "clear
+// it" action, and the no-existing-file skip above must not swallow it: it is
+// distinguished by whether ReadFact succeeded, not by the content being
+// empty.
+func TestWriteLicense_EmptyContentClearsExistingFile_Commits(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+	ctx := context.Background()
+
+	committed, err := ri.WriteLicense(ctx, "MIT License\n")
+	require.NoError(t, err)
+	require.True(t, committed, "sanity: the licence was written")
+
+	before := mustHeadCommit(t, ri, ctx)
+
+	committed, err = ri.WriteLicense(ctx, "")
+	require.NoError(t, err)
+	require.True(t, committed, "clearing an existing licence must still commit")
+
+	after := mustHeadCommit(t, ri, ctx)
+	require.NotEqual(t, before, after, "clearing must land a new commit")
+
+	got, err := ri.ReadLicense(ctx)
+	require.NoError(t, err)
+	require.Empty(t, got, "the licence is now cleared")
+}
+
+func mustHeadCommit(t *testing.T, ri *RepoInstance, ctx context.Context) string {
+	t.Helper()
+	var hash string
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		h, herr := svc.Branches().HeadCommit(ctx, ri.AgentBranch())
+		require.NoError(t, herr)
+		hash = h
+	}))
+	return hash
+}
+
 // The cap is enforced in the domain, so every writer of LICENSE is bound by it.
 func TestWriteLicense_RejectsOverCap(t *testing.T) {
 	m := newLifetimeTestManager(t)

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -119,8 +119,10 @@ func TestReadLicense_ReturnsVerbatim(t *testing.T) {
 	require.Equal(t, mit, got)
 }
 
-// The read guard bounds the wire response. There is no write path to reject
-// on, so an oversized file degrades to "no licence" rather than streaming.
+// The read guard bounds the wire response. WriteLicense rejects oversized
+// input at the door; this only catches a LICENSE that arrived some other
+// way — a clone, or a hand-edited working tree — which degrades to "no
+// licence" rather than streaming.
 func TestReadLicense_OverCapIsOmitted(t *testing.T) {
 	m := newLifetimeTestManager(t)
 	ri := m.Get(testRepoName)
@@ -232,8 +234,28 @@ func TestWriteLicense_RejectsOverCap(t *testing.T) {
 	require.False(t, committed)
 }
 
+// A write to a torn-down instance must report the failure. WithRead does not
+// invoke fn when no store is reachable, so an implementation that only captures
+// errors set inside the closure returns nil — reporting success for a write
+// that never happened. This is the same regression TestWriteReadme_ClosedInstance_ReportsError
+// guards against, for the acquireErr/writeErr separation in WriteLicense.
+func TestWriteLicense_ClosedInstance_ReportsError(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+
+	ri.shutdown()
+
+	committed, err := ri.WriteLicense(context.Background(), "# after close")
+	require.ErrorIs(t, err, ErrRepoClosed)
+	require.False(t, committed)
+}
+
 // LICENSE lives at the tree root, outside the ontology root, so writing it must
-// not put anything into the fact index.
+// not put anything into the fact index. A genuine kb/-rooted fact written in
+// the same test is the positive control: without it, RecentFacts returning
+// nothing at all would pass this test for the wrong reason (an empty index,
+// not a correctly excluded LICENSE).
 func TestWriteLicense_DoesNotEnterTheFactIndex(t *testing.T) {
 	m := newLifetimeTestManager(t)
 	ri := m.Get(testRepoName)
@@ -243,11 +265,27 @@ func TestWriteLicense_DoesNotEnterTheFactIndex(t *testing.T) {
 	_, err := ri.WriteLicense(ctx, "terms\n")
 	require.NoError(t, err)
 
+	const factPath = "kb/notes/control.md"
 	require.NoError(t, ri.WithRead(func(svc *store.Service) {
-		res, _, serr := svc.FactQuery().RecentFacts(ctx, ri.AgentBranch(), store.SearchOptions{})
+		_, werr := svc.Facts().WriteFact(ctx, ri.AgentBranch(), factPath,
+			adoptFact("a genuine fact, indexed as a positive control"),
+			"test: write "+factPath, "created")
+		require.NoError(t, werr)
+	}))
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		// Limit must be > 0: SearchOptions{} zero-values Limit to 0, which the
+		// query below turns into a literal SQL LIMIT 0 — an always-empty result
+		// that would make both assertions here pass vacuously.
+		res, _, serr := svc.FactQuery().RecentFacts(ctx, ri.AgentBranch(), store.SearchOptions{Limit: 50})
 		require.NoError(t, serr)
+		var sawControlFact bool
 		for _, e := range res {
 			require.NotEqual(t, LicensePath, e.Path, "LICENSE must never be indexed as a fact")
+			if e.Path == factPath {
+				sawControlFact = true
+			}
 		}
+		require.True(t, sawControlFact, "a genuine kb/-rooted fact must be indexed, proving RecentFacts is not simply empty")
 	}))
 }

--- a/internal/repos/manifest_test.go
+++ b/internal/repos/manifest_test.go
@@ -185,3 +185,69 @@ func TestReadLicense_IsCaseSensitive(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, got, "only the exact name LICENSE is resolved")
 }
+
+// Verbatim round-trip: a licence is legal text, and knomit stores exactly what
+// it is given.
+func TestWriteLicense_RoundTrips(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+	ctx := context.Background()
+
+	const mit = "MIT License\n\nCopyright (c) 2026\n\nPermission is hereby granted...\n"
+	committed, err := ri.WriteLicense(ctx, mit)
+	require.NoError(t, err)
+	require.True(t, committed)
+
+	got, err := ri.ReadLicense(ctx)
+	require.NoError(t, err)
+	require.Equal(t, mit, got, "verbatim, newlines intact")
+}
+
+// A byte-identical save must not append an empty commit — the write path always
+// builds a fresh commit object, and re-saving unchanged text would push one.
+func TestWriteLicense_UnchangedContentMakesNoCommit(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+	ctx := context.Background()
+
+	_, err := ri.WriteLicense(ctx, "terms\n")
+	require.NoError(t, err)
+
+	committed, err := ri.WriteLicense(ctx, "terms\n")
+	require.NoError(t, err)
+	require.False(t, committed, "identical content is a no-op")
+}
+
+// The cap is enforced in the domain, so every writer of LICENSE is bound by it.
+func TestWriteLicense_RejectsOverCap(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+
+	oversized := strings.Repeat("x", MaxRepoDescriptionBytes+1)
+	committed, err := ri.WriteLicense(context.Background(), oversized)
+	require.ErrorIs(t, err, ErrRepoDescriptionTooLong)
+	require.False(t, committed)
+}
+
+// LICENSE lives at the tree root, outside the ontology root, so writing it must
+// not put anything into the fact index.
+func TestWriteLicense_DoesNotEnterTheFactIndex(t *testing.T) {
+	m := newLifetimeTestManager(t)
+	ri := m.Get(testRepoName)
+	require.NotNil(t, ri)
+	ctx := context.Background()
+
+	_, err := ri.WriteLicense(ctx, "terms\n")
+	require.NoError(t, err)
+
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		res, _, serr := svc.FactQuery().RecentFacts(ctx, ri.AgentBranch(), store.SearchOptions{})
+		require.NoError(t, serr)
+		for _, e := range res {
+			require.NotEqual(t, LicensePath, e.Path, "LICENSE must never be indexed as a fact")
+		}
+	}))
+}

--- a/internal/repos/registry.go
+++ b/internal/repos/registry.go
@@ -355,14 +355,31 @@ func (r *Registry) Rename(uid, name string) error {
 	return requireOneRow(res, uid)
 }
 
-// RenameIfNamed reverts uid's name to `to` ONLY IF it currently holds `from`.
-// Reports whether the row changed.
+// RenameIfNamed sets uid's name to `to` ONLY IF it currently holds `from`.
+// Reports whether the row changed: (false, nil) means the predicate did not
+// hold — a legitimate outcome, NOT an error. Contrast Rename, which is
+// unconditional and reports zero rows as ErrRegistryNotFound; the two have
+// different zero-row semantics and mixing them up is the trap here.
 //
-// This is the compensating form of Rename. An unconditional revert is wrong as
-// a compensation: when a concurrent operation has legitimately renamed the same
-// uid in between, the revert clobbers the winner's durable name while its
-// in-memory state keeps the new one — the registry and the live map then
-// disagree until the next boot resolves it in favour of the stale value.
+// This is a compare-and-swap, and Manager.RenameRepo uses it for BOTH halves of
+// a rename — the forward write and its compensating revert. Neither may be
+// unconditional, for two different reasons:
+//
+//   - FORWARD (the primitive's main job today). Two RenameRepo calls racing
+//     from the same old name would both durably succeed under a plain UPDATE,
+//     with the last writer winning independently of which one goes on to win
+//     the in-memory map. As a CAS, only one can see the old name still there;
+//     the loser matches zero rows, learns it lost before writing anything, and
+//     never needs compensating at all.
+//   - COMPENSATING (RenameIfNamed(uid, new, old), undoing this call's own
+//     forward write after a lost revalidate). An unconditional revert clobbers
+//     a concurrent winner: it would restore the old name durably while the
+//     winner's in-memory state keeps the new one, and the next boot resolves
+//     the disagreement in favour of the stale value.
+//
+// A caller that only wants "set the name, whatever it is now" is describing
+// Rename, not this — but think twice: unconditional is what made the forward
+// write racy in the first place.
 func (r *Registry) RenameIfNamed(uid, from, to string) (bool, error) {
 	res, err := r.db.Exec(`UPDATE repos SET name = ? WHERE uid = ? AND name = ?`, to, uid, from)
 	if err != nil {

--- a/internal/repos/registry.go
+++ b/internal/repos/registry.go
@@ -355,6 +355,26 @@ func (r *Registry) Rename(uid, name string) error {
 	return requireOneRow(res, uid)
 }
 
+// RenameIfNamed reverts uid's name to `to` ONLY IF it currently holds `from`.
+// Reports whether the row changed.
+//
+// This is the compensating form of Rename. An unconditional revert is wrong as
+// a compensation: when a concurrent operation has legitimately renamed the same
+// uid in between, the revert clobbers the winner's durable name while its
+// in-memory state keeps the new one — the registry and the live map then
+// disagree until the next boot resolves it in favour of the stale value.
+func (r *Registry) RenameIfNamed(uid, from, to string) (bool, error) {
+	res, err := r.db.Exec(`UPDATE repos SET name = ? WHERE uid = ? AND name = ?`, to, uid, from)
+	if err != nil {
+		return false, classifyRegistryErr(err, to)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("registry rename if named: %w", err)
+	}
+	return n > 0, nil
+}
+
 // SetProfile upserts the serving profile (code | chat | generic).
 func (r *Registry) SetProfile(uid, profile string) error {
 	switch profile {

--- a/internal/repos/rename_test.go
+++ b/internal/repos/rename_test.go
@@ -171,6 +171,24 @@ func TestRenameRepo_ConcurrentDifferentTargets_ExactlyOneWins(t *testing.T) {
 
 	// Whichever name won, it is still the SAME instance, and byUID agrees.
 	require.Same(t, ri, m.GetByUID(ri.UID()))
+
+	// The durable half must agree with the live map. This is the assertion an
+	// UNCONDITIONAL compensation fails: the loser only reaches the revalidate
+	// AFTER the winner's map swap has already completed (it takes m.mu after
+	// the winner releases it), so an unconditional revert-to-oldName runs
+	// chronologically last and clobbers the winner's registry row — leaving
+	// the registry holding oldName while the live map/instance report the
+	// winner's name, undetected until the next restart re-reads the registry
+	// and disagrees with the state that existed right before it.
+	winnerName := "beta"
+	if gammaResolves {
+		winnerName = "gamma"
+	}
+	rec, ok, err := m.reg.Get(ri.UID())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, winnerName, rec.Name,
+		"the registry row must hold the same name the live map resolves, not oldName")
 }
 
 // TestRenameRepo_ConcurrentReadersDuringRenameLoop is the -race regression for

--- a/internal/repos/rename_test.go
+++ b/internal/repos/rename_test.go
@@ -1,0 +1,84 @@
+package repos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// newTestManagerWithRepo returns a started Manager with one preset-ontology
+// repo already registered under name, built from the package's real test
+// harness (newTestManager + createRepo — see testhelpers_test.go) rather than
+// a parallel one.
+func newTestManagerWithRepo(t *testing.T, name string) (*Manager, *RepoInstance) {
+	t.Helper()
+	m := newTestManager(t)
+	require.NoError(t, m.Start())
+	ri := createRepo(t, m, name)
+	return m, ri
+}
+
+// addTestRepo creates a second preset-ontology repo named name in an
+// already-started manager. Thin wrapper over createRepo so rename tests read
+// the same as the brief without a parallel harness.
+func addTestRepo(t *testing.T, m *Manager, name string) *RepoInstance {
+	t.Helper()
+	return createRepo(t, m, name)
+}
+
+// TestRenameRepo_RekeysWithoutClosingTheStore is the whole point of choosing
+// in-place re-key over Remove+Add: the SAME instance pointer must survive, with
+// its store still open, because a rename changes a display string and must not
+// cost a store close, an SSE drop and an index re-warm.
+func TestRenameRepo_RekeysWithoutClosingTheStore(t *testing.T) {
+	m, _ := newTestManagerWithRepo(t, "alpha")
+
+	before := m.Get("alpha")
+	require.NotNil(t, before)
+	uid := before.UID()
+
+	require.NoError(t, m.RenameRepo("alpha", "beta"))
+
+	require.Nil(t, m.Get("alpha"), "the old name must no longer resolve")
+	after := m.Get("beta")
+	require.NotNil(t, after, "the new name must resolve")
+	require.Same(t, before, after, "same instance — the store was never closed")
+	require.Equal(t, "beta", after.Name(), "the instance reports its new name")
+	require.Equal(t, uid, after.UID(), "uid is identity and never changes")
+	require.Same(t, before, m.GetByUID(uid), "byUID still points at the live instance")
+
+	// The store is still usable — this is what Remove+Add would have broken.
+	require.NoError(t, after.WithRead(func(svc *store.Service) {}))
+}
+
+func TestRenameRepo_RejectsInvalidName(t *testing.T) {
+	m, _ := newTestManagerWithRepo(t, "alpha")
+	require.ErrorIs(t, m.RenameRepo("alpha", "Has Capitals"), ErrInvalidName)
+	require.ErrorIs(t, m.RenameRepo("alpha", ""), ErrInvalidName)
+	require.NotNil(t, m.Get("alpha"), "a rejected rename leaves the repo alone")
+}
+
+func TestRenameRepo_RejectsNameHeldByAnotherActiveRepo(t *testing.T) {
+	m, _ := newTestManagerWithRepo(t, "alpha")
+	addTestRepo(t, m, "beta")
+
+	require.ErrorIs(t, m.RenameRepo("alpha", "beta"), ErrRepoExists)
+	require.NotNil(t, m.Get("alpha"))
+	require.NotNil(t, m.Get("beta"))
+}
+
+func TestRenameRepo_UnknownRepo(t *testing.T) {
+	m, _ := newTestManagerWithRepo(t, "alpha")
+	require.ErrorIs(t, m.RenameRepo("ghost", "beta"), ErrRepoNotFound)
+}
+
+// Renaming to the current name is a successful no-op, not a self-collision.
+func TestRenameRepo_SameNameIsNoOp(t *testing.T) {
+	m, _ := newTestManagerWithRepo(t, "alpha")
+	before := m.Get("alpha")
+
+	require.NoError(t, m.RenameRepo("alpha", "alpha"))
+	require.Same(t, before, m.Get("alpha"))
+}

--- a/internal/repos/rename_test.go
+++ b/internal/repos/rename_test.go
@@ -1,42 +1,23 @@
 package repos
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"knomit/internal/config"
 	"knomit/internal/store"
 )
-
-// newTestManagerWithRepo returns a started Manager with one preset-ontology
-// repo already registered under name, built from the package's real test
-// harness (newTestManager + createRepo — see testhelpers_test.go) rather than
-// a parallel one.
-func newTestManagerWithRepo(t *testing.T, name string) (*Manager, *RepoInstance) {
-	t.Helper()
-	m := newTestManager(t)
-	require.NoError(t, m.Start())
-	ri := createRepo(t, m, name)
-	return m, ri
-}
-
-// addTestRepo creates a second preset-ontology repo named name in an
-// already-started manager. Thin wrapper over createRepo so rename tests read
-// the same as the brief without a parallel harness.
-func addTestRepo(t *testing.T, m *Manager, name string) *RepoInstance {
-	t.Helper()
-	return createRepo(t, m, name)
-}
 
 // TestRenameRepo_RekeysWithoutClosingTheStore is the whole point of choosing
 // in-place re-key over Remove+Add: the SAME instance pointer must survive, with
 // its store still open, because a rename changes a display string and must not
 // cost a store close, an SSE drop and an index re-warm.
 func TestRenameRepo_RekeysWithoutClosingTheStore(t *testing.T) {
-	m, _ := newTestManagerWithRepo(t, "alpha")
-
-	before := m.Get("alpha")
-	require.NotNil(t, before)
+	m := newTestManager(t)
+	before := bootNamedRepo(t, m, "alpha")
 	uid := before.UID()
 
 	require.NoError(t, m.RenameRepo("alpha", "beta"))
@@ -49,20 +30,26 @@ func TestRenameRepo_RekeysWithoutClosingTheStore(t *testing.T) {
 	require.Equal(t, uid, after.UID(), "uid is identity and never changes")
 	require.Same(t, before, m.GetByUID(uid), "byUID still points at the live instance")
 
-	// The store is still usable — this is what Remove+Add would have broken.
-	require.NoError(t, after.WithRead(func(svc *store.Service) {}))
+	// The store is still usable — a REAL read, not just a successful Acquire.
+	// This is what Remove+Add would have broken (a closed store fails here).
+	require.NoError(t, after.WithRead(func(svc *store.Service) {
+		_, err := svc.Branches().HeadCommit(context.Background(), after.AgentBranch())
+		require.NoError(t, err)
+	}))
 }
 
 func TestRenameRepo_RejectsInvalidName(t *testing.T) {
-	m, _ := newTestManagerWithRepo(t, "alpha")
+	m := newTestManager(t)
+	bootNamedRepo(t, m, "alpha")
 	require.ErrorIs(t, m.RenameRepo("alpha", "Has Capitals"), ErrInvalidName)
 	require.ErrorIs(t, m.RenameRepo("alpha", ""), ErrInvalidName)
 	require.NotNil(t, m.Get("alpha"), "a rejected rename leaves the repo alone")
 }
 
 func TestRenameRepo_RejectsNameHeldByAnotherActiveRepo(t *testing.T) {
-	m, _ := newTestManagerWithRepo(t, "alpha")
-	addTestRepo(t, m, "beta")
+	m := newTestManager(t)
+	bootNamedRepo(t, m, "alpha")
+	createRepo(t, m, "beta")
 
 	require.ErrorIs(t, m.RenameRepo("alpha", "beta"), ErrRepoExists)
 	require.NotNil(t, m.Get("alpha"))
@@ -70,15 +57,167 @@ func TestRenameRepo_RejectsNameHeldByAnotherActiveRepo(t *testing.T) {
 }
 
 func TestRenameRepo_UnknownRepo(t *testing.T) {
-	m, _ := newTestManagerWithRepo(t, "alpha")
+	m := newTestManager(t)
+	bootNamedRepo(t, m, "alpha")
 	require.ErrorIs(t, m.RenameRepo("ghost", "beta"), ErrRepoNotFound)
 }
 
 // Renaming to the current name is a successful no-op, not a self-collision.
 func TestRenameRepo_SameNameIsNoOp(t *testing.T) {
-	m, _ := newTestManagerWithRepo(t, "alpha")
-	before := m.Get("alpha")
+	m := newTestManager(t)
+	before := bootNamedRepo(t, m, "alpha")
 
 	require.NoError(t, m.RenameRepo("alpha", "alpha"))
 	require.Same(t, before, m.Get("alpha"))
+}
+
+// A lens may hold newName even though no repo does — repos and lenses share
+// one namespace (gotcha M-1). Same guard Create and Restore run; RenameRepo
+// must run it too, and until this test existed nothing pinned that it did.
+func TestRenameRepo_RejectsNameHeldByLens(t *testing.T) {
+	m := newTestManager(t)
+	bootNamedRepo(t, m, "alpha")
+	writer := createRepo(t, m, "writer")
+
+	_, err := m.CreateLens(context.Background(), Lens{Name: "beta", WriteUID: writer.UID()})
+	require.NoError(t, err)
+
+	require.ErrorIs(t, m.RenameRepo("alpha", "beta"), ErrRepoNameConflictsLens)
+	require.NotNil(t, m.Get("alpha"), "a rejected rename leaves the repo alone")
+}
+
+// A concurrent Create/Restore already bringing newName into the active map
+// must block RenameRepo from claiming it too — reserveNameAndOrigin is the
+// shared gate, and until this test existed nothing pinned that RenameRepo
+// actually goes through it. Held directly here to stand in for the concurrent
+// operation, the same technique TestRestore_HonorsInFlightReservation uses.
+func TestRenameRepo_RejectsWhenTargetNameInFlight(t *testing.T) {
+	m := newTestManager(t)
+	bootNamedRepo(t, m, "alpha")
+
+	release, err := m.reserveNameAndOrigin("beta", "")
+	require.NoError(t, err)
+	defer release()
+
+	require.ErrorIs(t, m.RenameRepo("alpha", "beta"), ErrCreateInFlight)
+	require.NotNil(t, m.Get("alpha"), "a rejected rename leaves the repo alone")
+}
+
+// TestRenameRepo_PersistsAcrossRestart pins the durable half: the UPDATE to
+// control.db, not just the in-memory map move. An implementation that only
+// re-keyed m.repos and never called reg.Rename would pass every other test in
+// this file (they all inspect the live Manager) but fail this one, because a
+// fresh boot re-reads names from the registry, not from the map that just got
+// torn down by m1.Close().
+func TestRenameRepo_PersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	boot := func() *Manager {
+		m := New(context.Background(), Deps{
+			Cfg:                   config.Config{Home: dir},
+			AgentBranch:           "machine/test",
+			DisableBackgroundSync: true,
+		})
+		require.NoError(t, m.Start())
+		return m
+	}
+
+	m1 := boot()
+	createRepo(t, m1, "alpha")
+	require.NoError(t, m1.RenameRepo("alpha", "beta"))
+	require.NoError(t, m1.Close())
+
+	m2 := boot()
+	t.Cleanup(func() { _ = m2.Close() })
+	require.Nil(t, m2.Get("alpha"), "the old name must not resurrect on reboot")
+	require.NotNil(t, m2.Get("beta"),
+		"the rename must have reached the registry row, not only the in-memory map")
+}
+
+// TestRenameRepo_ConcurrentDifferentTargets_ExactlyOneWins reproduces Race A
+// from the review: two RenameRepo calls on the SAME oldName to DIFFERENT
+// newNames reserve different names, so reserveNameAndOrigin alone excludes
+// neither from the other. Before the revalidate-under-the-lock fix, both
+// would pass every check and both would land in the map (repos["beta"] AND
+// repos["gamma"] pointing at the same instance) — this assertion is what
+// catches that: exactly one of the two names may resolve afterwards, because
+// the map holds one instance under one name, not two.
+func TestRenameRepo_ConcurrentDifferentTargets_ExactlyOneWins(t *testing.T) {
+	m := newTestManager(t)
+	ri := bootNamedRepo(t, m, "alpha")
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var errBeta, errGamma error
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		errBeta = m.RenameRepo("alpha", "beta")
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		errGamma = m.RenameRepo("alpha", "gamma")
+	}()
+	close(start)
+	wg.Wait()
+
+	betaResolves := m.Get("beta") != nil
+	gammaResolves := m.Get("gamma") != nil
+	require.NotEqual(t, betaResolves, gammaResolves,
+		"exactly one of beta/gamma must resolve, got beta=%v gamma=%v (errBeta=%v errGamma=%v)",
+		betaResolves, gammaResolves, errBeta, errGamma)
+
+	// Whichever name won, it is still the SAME instance, and byUID agrees.
+	require.Same(t, ri, m.GetByUID(ri.UID()))
+}
+
+// TestRenameRepo_ConcurrentReadersDuringRenameLoop is the -race regression for
+// the reason ri.name became an atomic.Pointer in the first place: RenameRepo
+// writes it on a live instance while unsynchronised readers — mostly
+// Get/Names/ForEach callers and Name() itself — read it concurrently. This
+// test does not assert particular values (a renamer racing readers makes any
+// single observation meaningless); its only job is to give `go test -race`
+// something to catch if setName, Get, Names, or ForEach ever stop agreeing on
+// how they're synchronised.
+func TestRenameRepo_ConcurrentReadersDuringRenameLoop(t *testing.T) {
+	m := newTestManager(t)
+	ri := bootNamedRepo(t, m, "alpha")
+
+	const iterations = 200
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(stop)
+		cur, other := "alpha", "beta"
+		for i := 0; i < iterations; i++ {
+			require.NoError(t, m.RenameRepo(cur, other))
+			cur, other = other, cur
+		}
+	}()
+
+	const readers = 4
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = ri.Name()
+				_ = m.Get("alpha")
+				_ = m.Get("beta")
+				_ = m.Names()
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/internal/repos/swapstore.go
+++ b/internal/repos/swapstore.go
@@ -53,7 +53,7 @@ func (m *Manager) reinjectOrigin(ri *RepoInstance, svc *store.Service) {
 	}
 	o, err := origins.Get(ri.uid)
 	if err != nil {
-		log.Warn().Err(err).Str("repo", ri.name).Str("uid", ri.uid).
+		log.Warn().Err(err).Str("repo", ri.Name()).Str("uid", ri.uid).
 			Msg("SwapStore: could not read the stored origin; sync stays inactive until the next boot")
 		return
 	}
@@ -167,12 +167,12 @@ func (m *Manager) SwapStore(ri *RepoInstance, tempDBPath string) error {
 	reopenLocal := func() *store.Service {
 		svc, err := store.Open(ri.dbPath)
 		if err != nil {
-			log.Error().Err(err).Str("repo", ri.name).Msg("SwapStore: recovery reopen failed; repo store unavailable")
+			log.Error().Err(err).Str("repo", ri.Name()).Msg("SwapStore: recovery reopen failed; repo store unavailable")
 			return nil
 		}
 		if err := svc.OpenRepo(); err != nil {
 			svc.Close()
-			log.Error().Err(err).Str("repo", ri.name).Msg("SwapStore: recovery git reopen failed; repo store unavailable")
+			log.Error().Err(err).Str("repo", ri.Name()).Msg("SwapStore: recovery git reopen failed; repo store unavailable")
 			return nil
 		}
 		return svc
@@ -238,11 +238,11 @@ func (m *Manager) recordSwappedIdentity(ri *RepoInstance) {
 
 	id := ri.ID()
 	if id == "" {
-		log.Warn().Str("repo", ri.name).Msg("SwapStore: root commit unresolved; registry identity not updated")
+		log.Warn().Str("repo", ri.Name()).Msg("SwapStore: root commit unresolved; registry identity not updated")
 		return
 	}
 	if err := reg.RecordRepoID(ri.uid, id); err != nil {
-		log.Error().Err(err).Str("repo", ri.name).Str("uid", ri.uid).Str("repo_id", id).
+		log.Error().Err(err).Str("repo", ri.Name()).Str("uid", ri.uid).Str("repo_id", id).
 			Msg("SwapStore: registry identity not updated; the pre-swap uniqueness check was skipped or raced")
 	}
 }

--- a/internal/repos/testhelpers_test.go
+++ b/internal/repos/testhelpers_test.go
@@ -23,8 +23,16 @@ const testRepoName = "core"
 // Start had produced a default repo.
 func bootRepo(t *testing.T, m *Manager) *RepoInstance {
 	t.Helper()
+	return bootNamedRepo(t, m, testRepoName)
+}
+
+// bootNamedRepo is bootRepo generalised to a caller-chosen name, for tests
+// that need more than one repo (or a name other than testRepoName) in the
+// same manager.
+func bootNamedRepo(t *testing.T, m *Manager, name string) *RepoInstance {
+	t.Helper()
 	require.NoError(t, m.Start())
-	return createRepo(t, m, testRepoName)
+	return createRepo(t, m, name)
 }
 
 // newTestManager returns an unstarted Manager rooted at a temp home, with

--- a/internal/store/revisions_before_test.go
+++ b/internal/store/revisions_before_test.go
@@ -122,16 +122,17 @@ func TestRevisionsBefore_RespectsLimit(t *testing.T) {
 // kb/invariants/store/resolver/first-parent-not-wall-clock/00a49427.md.
 //
 // Setup: main writes v1, then a feature branch writes v2 to the SAME path, then
-// main writes v3, then feature merges into main. The feature commit (v2) is NOT
-// the newest by wall clock — v3 is — but the point of the test is the SHAPE: on
-// the merged history, the version active at main's tip must be the one reached
-// by walking FIRST PARENTS from the tip, which stays on main's own line and
-// finds v3. An implementation ordering candidates by committed_at can pick the
-// merged-in sibling instead.
-//
-// commit_log_path_time is an index on (path, committed_at DESC), which makes
-// `ORDER BY committed_at DESC LIMIT 1` the easiest query to write here and the
-// wrong one. If this test ever fails, do not relax it — the query regressed.
+// main writes v3, then feature merges into main. After the merge, the feature
+// commit (v2) is reachable from main's tip only through the merge commit's
+// SECOND parent — walking first parents from the tip stays on main's own line
+// and never visits it. `branch_commits`, however, is populated by a full
+// reachability walk (see derived_from.go's SCHEMA INVARIANT comment), so once
+// the merge lands, v2 IS a branch_commits row for "main" even though it is off
+// main's first-parent line. A query that joins commit_log straight to
+// branch_commits — which is exactly what the (path, committed_at DESC) index
+// on commit_log invites — will surface v2 as a candidate for "main"; only
+// walking the first-parent CTE and intersecting with branch_commits correctly
+// excludes it. If this test ever fails, do not relax it — the query regressed.
 func TestRevisionsBefore_MergeAnomalyPicksFirstParent(t *testing.T) {
 	dir := t.TempDir()
 	svc, err := Open(filepath.Join(dir, "k.db"))
@@ -172,4 +173,20 @@ func TestRevisionsBefore_MergeAnomalyPicksFirstParent(t *testing.T) {
 		"first-parent ancestry from main's tip must reach main's own v3, not the merged-in feature commit %s",
 		featureRes.CommitHash)
 	require.NotZero(t, revs[0].CommittedAt, "committed_at must be populated for display")
+
+	// Tie-break-independent guard: regardless of limit or ordering, the
+	// feature commit must never appear anywhere in the result. It is
+	// reachable from main's tip only through the merge commit's second
+	// parent, so a correct first-parent walk never visits it. This does not
+	// depend on committed_at at all, unlike the limit=1 assertion above —
+	// it catches an implementation that walks branch_commits (full
+	// reachability) instead of the first-parent chain, even if that
+	// implementation happens to break committed_at ties in main's favor.
+	allRevs, err := svc.Search().RevisionsBefore(ctx, "main", "kb/t.md", tip, 10)
+	require.NoError(t, err)
+	for _, r := range allRevs {
+		require.NotEqual(t, featureRes.CommitHash, r.Commit,
+			"feature commit %s is reachable from main's tip only via the merge commit's second parent; "+
+				"it must never surface for branch=main regardless of limit or ordering", featureRes.CommitHash)
+	}
 }

--- a/internal/store/revisions_before_test.go
+++ b/internal/store/revisions_before_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,4 +116,60 @@ func TestRevisionsBefore_RespectsLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, revs, 2)
 	require.Equal(t, []string{c3, c2}, []string{revs[0].Commit, revs[1].Commit})
+}
+
+// TestRevisionsBefore_MergeAnomalyPicksFirstParent is the guard on
+// kb/invariants/store/resolver/first-parent-not-wall-clock/00a49427.md.
+//
+// Setup: main writes v1, then a feature branch writes v2 to the SAME path, then
+// main writes v3, then feature merges into main. The feature commit (v2) is NOT
+// the newest by wall clock — v3 is — but the point of the test is the SHAPE: on
+// the merged history, the version active at main's tip must be the one reached
+// by walking FIRST PARENTS from the tip, which stays on main's own line and
+// finds v3. An implementation ordering candidates by committed_at can pick the
+// merged-in sibling instead.
+//
+// commit_log_path_time is an index on (path, committed_at DESC), which makes
+// `ORDER BY committed_at DESC LIMIT 1` the easiest query to write here and the
+// wrong one. If this test ever fails, do not relax it — the query regressed.
+func TestRevisionsBefore_MergeAnomalyPicksFirstParent(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
+	ctx := context.Background()
+
+	_, err = svc.Facts().WriteFact(ctx, "main", "kb/t.md", testFactBody("v1", 0.9, nil), "v1 on main", "")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Branches().CreateBranch(ctx, "feature", "main"))
+	featureRes, err := svc.Facts().WriteFact(ctx, "feature", "kb/t.md", testFactBody("v2", 0.8, nil), "v2 on feature", "")
+	require.NoError(t, err)
+	// Also touch a disjoint path on feature so the merged tree differs from
+	// dst's tree even with LocalWins on kb/t.md — otherwise mergeIntoBranch
+	// treats the merge as a no-op (merged tree identical to dst) and never
+	// produces a real two-parent merge commit.
+	_, err = svc.Facts().WriteFact(ctx, "feature", "kb/other.md", testFactBody("side", 0.5, nil), "side file on feature", "")
+	require.NoError(t, err)
+
+	mainRes, err := svc.Facts().WriteFact(ctx, "main", "kb/t.md", testFactBody("v3", 0.7, nil), "v3 on main", "")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Branches().MergeBranch(ctx, "feature", "main", StrategyLocalWins))
+
+	tip, err := svc.Branches().HeadCommit(ctx, "main")
+	require.NoError(t, err)
+
+	mergeCommit, err := svc.rh.repo.CommitObject(plumbing.NewHash(tip))
+	require.NoError(t, err)
+	require.Len(t, mergeCommit.ParentHashes, 2, "setup must actually produce a two-parent merge commit, or this test proves nothing")
+
+	revs, err := svc.Search().RevisionsBefore(ctx, "main", "kb/t.md", tip, 1)
+	require.NoError(t, err)
+	require.Len(t, revs, 1)
+	require.Equal(t, mainRes.CommitHash, revs[0].Commit,
+		"first-parent ancestry from main's tip must reach main's own v3, not the merged-in feature commit %s",
+		featureRes.CommitHash)
+	require.NotZero(t, revs[0].CommittedAt, "committed_at must be populated for display")
 }

--- a/internal/store/session_schema.sql
+++ b/internal/store/session_schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE tool_sessions (
     tool         TEXT NOT NULL,
     branch       TEXT NOT NULL,
     path_prefix  TEXT NOT NULL DEFAULT '',
-    binding      TEXT NOT NULL DEFAULT '',   -- binding (lens or repo) name the cursor is frozen to; resume through another binding is rejected
+    binding      TEXT NOT NULL DEFAULT '',   -- binding IDENTITY the cursor is frozen to: `repo:<uid>` or `lens:<uid>` (Binding.PinID, lenses RFC §7.3) — NOT the display name, so a repo/lens rename leaves an in-flight cursor resumable; resume through another binding is rejected
     read_set     TEXT NOT NULL DEFAULT '',   -- canonical read-set fingerprint (id12@branch,… sorted) the cursor is frozen to; resume against a re-pinned read set is rejected, indistinguishably from expiry (lenses RFC §7.3)
     last_commit  TEXT NOT NULL DEFAULT '',
     status       TEXT NOT NULL DEFAULT 'active',

--- a/internal/web/fact_as_of_date_wire_test.go
+++ b/internal/web/fact_as_of_date_wire_test.go
@@ -1,0 +1,154 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// The as_of.date wire tests.
+//
+// fact_version_date_test.go covers versionDateFromService in isolation, which
+// says nothing about whether any handler actually CALLS it. Each of the three
+// stamp lines — handlers_fact_read.go, handlers_commit_anchored.go,
+// handlers_lenses_read.go — is one line, individually deletable, and before
+// these tests existed the whole Go suite stayed green with any of them gone.
+// Every test below is written so that deleting its handler's stamp line fails
+// it; that is the property to preserve when editing them.
+//
+// They run against REAL stores, not stubFactReader: the date comes from the
+// repo's commit_log via RevisionsBefore, so a stubbed reader would report ""
+// no matter what the handler did.
+
+// seedFactRepo writes one real fact into ri on its agent branch and returns the
+// commit that wrote it.
+func seedFactRepo(t *testing.T, ri *repos.RepoInstance, path, title string) string {
+	t.Helper()
+	var commit string
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		require.NotNil(t, svc, "the test repo must have a live store")
+		res, err := svc.Facts().WriteFact(context.Background(), ri.AgentBranch(), path,
+			"---\ntype: observation\nconfidence: 0.9\ndomain: [test]\n---\n# "+title+"\n\nbody\n",
+			"add "+path, "")
+		require.NoError(t, err)
+		commit = res.CommitHash
+	}))
+	require.NotEmpty(t, commit)
+	return commit
+}
+
+// urlBranch renders an agent branch for a {branch} path segment: the router
+// takes the colon form ("machine:test") and BranchFromContext hands the handler
+// back the slash form ("machine/test").
+func urlBranch(b string) string { return strings.ReplaceAll(b, "/", ":") }
+
+// requireRFC3339Date is the shared assertion: as_of.date must be present and a
+// real RFC3339 timestamp, not "" and not the 1970 zero value a naive
+// time.Unix(0) stamp would render.
+func requireRFC3339Date(t *testing.T, got string, where string) {
+	t.Helper()
+	require.NotEmpty(t, got, "%s: as_of.date must be stamped on the wire", where)
+	parsed, err := time.Parse(time.RFC3339, got)
+	require.NoError(t, err, "%s: as_of.date must be RFC3339, got %q", where, got)
+	require.WithinDuration(t, time.Now(), parsed, time.Hour,
+		"%s: as_of.date must be the commit's real date", where)
+}
+
+// decodeAsOfDate pulls as_of.date out of a single-fact response body.
+func decodeAsOfDate(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var body struct {
+		AsOf AsOf `json:"as_of"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body), "body=%s", rec.Body.String())
+	return body.AsOf.Date
+}
+
+// TestFactAsOfDate_HEADRead pins the stamp on
+// GET /repos/{repo}/branches/{branch}/facts/{path...} (handlers_fact_read.go).
+func TestFactAsOfDate_HEADRead(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	ri := m.Get("alpha")
+	require.NotNil(t, ri)
+	seedFactRepo(t, ri, "kb/x/one.md", "One")
+
+	r := (&Server{Manager: m, AgentBranch: "machine/test"}).NewAPIRouter()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/repos/alpha/branches/"+urlBranch(ri.AgentBranch())+"/facts/kb/x/one.md", nil))
+
+	requireRFC3339Date(t, decodeAsOfDate(t, rec), "HEAD read")
+}
+
+// TestFactAsOfDate_CommitAnchoredRead pins the stamp on
+// GET /repos/{repo}/branches/{branch}/commits/{sha}/facts/{path...}
+// (handlers_commit_anchored.go).
+func TestFactAsOfDate_CommitAnchoredRead(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	ri := m.Get("alpha")
+	require.NotNil(t, ri)
+	commit := seedFactRepo(t, ri, "kb/x/one.md", "One")
+
+	r := (&Server{Manager: m, AgentBranch: "machine/test"}).NewAPIRouter()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/repos/alpha/branches/"+urlBranch(ri.AgentBranch())+"/commits/"+commit+"/facts/kb/x/one.md", nil))
+
+	requireRFC3339Date(t, decodeAsOfDate(t, rec), "commit-anchored read")
+}
+
+// TestFactAsOfDate_LensReadMountFact pins the stamp on
+// GET /lenses/{lens}/facts/{path...} (handlers_lenses_read.go) — and it reads a
+// fact on a READ MOUNT, addressed kb://<id12>/…, on purpose.
+//
+// A write-repo fact would not cover the trap the stamp line's own comment
+// warns about: `rel` is the MOUNT-RELATIVE path that commit_log stores, while
+// view.Path is rewritten to the kb://<id12>/… wire form a few lines later. For
+// the write repo the two are the same string, so a stamp that used view.Path
+// would still pass. For a read mount they differ, commit_log matches no row,
+// and the date silently becomes "" for every read-mount fact in the product.
+// This test is the only thing standing between that swap and a green suite.
+func TestFactAsOfDate_LensReadMountFact(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	beta := m.Get("beta")
+	require.NotNil(t, beta)
+	seedFactRepo(t, beta, "kb/y/two.md", "Two")
+
+	s := &Server{Manager: m, AgentBranch: "machine/test"}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	// kb://<beta's id12>/kb/y/two.md — the read mount, not the write repo.
+	qualified := "kb://" + federate.ID12(beta.ID()) + "/kb/y/two.md"
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/lenses/eng/facts/"+url.PathEscape(qualified), nil))
+
+	// Guard the guard: if the address stopped resolving to the read mount this
+	// test would be asserting about the write repo (or a 404) without saying so.
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var body struct {
+		Path   string `json:"path"`
+		AsOf   AsOf   `json:"as_of"`
+		Source struct {
+			Repo string `json:"repo"`
+		} `json:"source"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body), "body=%s", rec.Body.String())
+	require.Equal(t, "beta", body.Source.Repo, "must be served from the READ mount")
+	require.Equal(t, qualified, body.Path, "must be the kb://-qualified wire path")
+
+	requireRFC3339Date(t, body.AsOf.Date, "lens read-mount fact")
+}

--- a/internal/web/fact_version_date.go
+++ b/internal/web/fact_version_date.go
@@ -1,0 +1,61 @@
+package web
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// factVersionDate returns the RFC3339 commit date of the version of `path`
+// visible at `anchor` on `branch`, or "" when it cannot be resolved.
+//
+// "The version visible at the anchor" means the newest commit at or before the
+// anchor that ADDED or MODIFIED this path — the fact's own last-changed date,
+// not the anchor commit's date. In a HEAD view the anchor is the branch tip,
+// whose own date would mean "when the repo last changed" and would tick every
+// time an unrelated fact was written.
+//
+// Never fatal: a fact whose commit_log row is missing (an unindexed or GC'd
+// commit) yields "" and the field is omitted from the response, rather than
+// rendering as 1970.
+func factVersionDate(ctx context.Context, ri *repos.RepoInstance, branch, path, anchor string) string {
+	var out string
+	// WithRead's error means the store was closed or detached, in which case fn
+	// never ran. That is a missing date, not a failed request — the fact body
+	// has already been read successfully by the time we are called.
+	_ = ri.WithRead(func(svc *store.Service) {
+		out = versionDateFromService(ctx, svc, branch, path, anchor)
+	})
+	return out
+}
+
+// versionDateFromService is factVersionDate's testable core: same contract,
+// against an already-acquired service.
+//
+// RevisionsBefore is the ONLY correct source here. It walks first-parent
+// ancestry via the shared firstParentChainCTE and joins branch_commits, so a
+// sibling-branch commit merged back in cannot win. Do NOT replace this with a
+// direct commit_log query: the index commit_log_path_time (path, committed_at
+// DESC) makes `ORDER BY committed_at DESC LIMIT 1` look like the obvious
+// implementation, and it is precisely the wall-clock ordering that
+// kb/invariants/store/resolver/first-parent-not-wall-clock/00a49427.md forbids.
+// TestRevisionsBefore_MergeAnomalyPicksFirstParent is the guard.
+func versionDateFromService(ctx context.Context, svc *store.Service, branch, path, anchor string) string {
+	if svc == nil || anchor == "" || path == "" {
+		return ""
+	}
+	revs, err := svc.Search().RevisionsBefore(ctx, branch, path, anchor, 1)
+	if err != nil {
+		log.Warn().Err(err).Str("branch", branch).Str("path", path).Str("anchor", anchor).
+			Msg("fact version date: RevisionsBefore failed; omitting as_of.date")
+		return ""
+	}
+	if len(revs) == 0 || revs[0].CommittedAt == 0 {
+		return ""
+	}
+	return time.Unix(revs[0].CommittedAt, 0).UTC().Format(time.RFC3339)
+}

--- a/internal/web/fact_version_date_test.go
+++ b/internal/web/fact_version_date_test.go
@@ -1,0 +1,46 @@
+package web
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// openTestStore builds a real store with one fact on "main" and returns the
+// service plus the commit that wrote the fact.
+func openTestStore(t *testing.T) (*store.Service, string) {
+	t.Helper()
+	svc, err := store.Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
+	res, err := svc.Facts().WriteFact(context.Background(), "main", "kb/t.md",
+		"---\ntype: observation\nconfidence: 0.9\n---\n# t\n\nbody\n", "create t", "")
+	require.NoError(t, err)
+	return svc, res.CommitHash
+}
+
+func TestVersionDateFromService_ReturnsRFC3339(t *testing.T) {
+	svc, commit := openTestStore(t)
+
+	got := versionDateFromService(context.Background(), svc, "main", "kb/t.md", commit)
+
+	require.NotEmpty(t, got, "a fact with a commit_log row must yield a date")
+	parsed, err := time.Parse(time.RFC3339, got)
+	require.NoError(t, err, "must be RFC3339, got %q", got)
+	require.WithinDuration(t, time.Now(), parsed, time.Hour)
+}
+
+func TestVersionDateFromService_EmptyWhenUnresolvable(t *testing.T) {
+	svc, commit := openTestStore(t)
+
+	require.Empty(t, versionDateFromService(context.Background(), svc, "main", "kb/nope.md", commit),
+		"unknown path yields no date, never the zero time")
+	require.Empty(t, versionDateFromService(context.Background(), svc, "main", "kb/t.md", ""),
+		"empty anchor yields no date")
+}

--- a/internal/web/fact_view.go
+++ b/internal/web/fact_view.go
@@ -39,6 +39,14 @@ type FactView struct {
 type AsOf struct {
 	Branch string `json:"branch"`
 	Commit string `json:"commit"`
+	// Date is when the VERSION OF THIS FACT on display was committed —
+	// RFC3339, UTC. Not the anchor commit's date: in a HEAD view the anchor is
+	// the branch tip, and its date says when the repo last changed, which has
+	// nothing to do with the fact being read.
+	//
+	// omitempty is load-bearing: an unresolvable commit must omit the field so
+	// the client renders nothing, never a zero time formatted as 1970.
+	Date string `json:"date,omitempty"`
 }
 
 // MarshalJSON emits FactView with the _links map under its canonical key.

--- a/internal/web/handlers_commit_anchored.go
+++ b/internal/web/handlers_commit_anchored.go
@@ -79,6 +79,7 @@ func handleCommitAnchoredFact(b hal.URLBuilder, reader FactReader, subProvider f
 		// graph invariant).
 		resolver := readerRefResolver{ctx: r.Context(), reader: reader, ri: ri, branch: branch, commit: viewAnchor.Commit}
 		view := BuildFactView(b, repoName, viewAnchor, head, f, resolver, knomitfact.ID12(ri.ID()))
+		view.AsOf.Date = factVersionDate(r.Context(), ri, viewAnchor.Branch, f.Path(), view.AsOf.Commit)
 		hal.WriteHAL(w, http.StatusOK, view)
 	}
 }

--- a/internal/web/handlers_fact_read.go
+++ b/internal/web/handlers_fact_read.go
@@ -225,6 +225,7 @@ func handleHALFact(b hal.URLBuilder, reader FactReader, subProvider factSubProvi
 		// invariant (retracted-but-recoverable targets still classify as fact).
 		resolver := readerRefResolver{ctx: r.Context(), reader: reader, ri: ri, branch: branch, commit: ""}
 		view := BuildFactView(b, repoName, a, head, f, resolver, knomitfact.ID12(ri.ID()))
+		view.AsOf.Date = factVersionDate(r.Context(), ri, a.Branch, f.Path(), view.AsOf.Commit)
 		hal.WriteHAL(w, http.StatusOK, view)
 	}
 }

--- a/internal/web/handlers_lenses_hal.go
+++ b/internal/web/handlers_lenses_hal.go
@@ -81,8 +81,11 @@ type createLensRequest struct {
 // patchLensRequest is the PATCH body for editing a lens. Every field is a
 // pointer so an omitted field (JSON key absent → nil) is distinguishable from a
 // provided-but-empty one: omitted = keep the current value, provided = replace it
-// wholesale (reads replace as a set, never merge). The name is immutable and has
-// no field here.
+// wholesale (reads replace as a set, never merge). The name has no field here:
+// it is not patchable through PATCH, which is not the same as immutable —
+// POST /lenses/{lens}/rename (handleHALLensRename) changes it, because a rename
+// invalidates the identifier the request was addressed by and so cannot share a
+// resource with the response.
 type patchLensRequest struct {
 	Write       *lensMember    `json:"write"`
 	Description *string        `json:"description"`
@@ -367,8 +370,10 @@ func handleHALLensesCreate(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc 
 }
 
 // handleHALLensPatch serves PATCH /api/v1/lenses/{lens}. It edits a lens's write
-// repo, read mounts, and description; the name is immutable. Omitted fields keep
-// their current value, provided fields replace wholesale. The merge starts from
+// repo, read mounts, and description. It does NOT touch the name — renaming is
+// POST /lenses/{lens}/rename (handleHALLensRename), a separate route precisely
+// because the response has to be re-read through the NEW name. Omitted fields
+// keep their current value, provided fields replace wholesale. The merge starts from
 // the persisted lens (a 404 if unknown), then Manager.UpdateLens re-runs the full
 // create-time validation (member existence, replica, branch pins, description
 // cap) under the same locking discipline before persisting.

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -495,6 +495,10 @@ func handleHALLensFact(b hal.URLBuilder, reader FactReader) http.HandlerFunc {
 
 		resolver := readerRefResolver{ctx: r.Context(), reader: reader, ri: ri, branch: branch, commit: ""}
 		view := BuildFactView(b, ri.Name(), a, head, f, resolver, knomitfact.ID12(ri.ID()))
+		// `rel` is the MOUNT-RELATIVE path, which is what commit_log stores. Must
+		// not use view.Path — that is rewritten to the kb://<id12>/… wire form
+		// below and would match no commit_log row.
+		view.AsOf.Date = factVersionDate(r.Context(), ri, branch, rel, view.AsOf.Commit)
 		// The top-level `path` echoes the canonical wire address (RFC §6.2): bare
 		// for the write repo, kb://<id12>/… for a read mount — so a client can
 		// round-trip it into another lens request and land on the SAME fact. The

--- a/internal/web/handlers_lenses_rename.go
+++ b/internal/web/handlers_lenses_rename.go
@@ -40,6 +40,14 @@ func lensRenameErrStatus(err error, oldName, newName string) (status int, title,
 	case errors.Is(err, repos.ErrLensExists):
 		return http.StatusConflict, "Name already in use",
 			"another lens is already called \"" + newName + "\""
+	case errors.Is(err, repos.ErrCreateInFlight):
+		// RenameLens reserves newName in the same in-flight set repo Create
+		// reserves into, so an in-flight create/restore/lens-create claiming
+		// the target surfaces here. Same wording as the repo route: the
+		// sentinel says "create", but the caller did not ask for one — report
+		// what is true for them, that the name is being taken.
+		return http.StatusConflict, "Name already in use",
+			"another operation is currently claiming \"" + newName + "\"; try again"
 	case errors.Is(err, repos.ErrLensNotFound):
 		// On the repo side, ErrRepoNotFound reaching renameErrStatus means
 		// RepoMiddleware already resolved oldName before the handler ran, so

--- a/internal/web/handlers_lenses_rename.go
+++ b/internal/web/handlers_lenses_rename.go
@@ -1,0 +1,131 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	"knomit/internal/repos"
+	"knomit/internal/web/hal"
+)
+
+// renameLensRequest is the POST /lenses/{lens}/rename body.
+type renameLensRequest struct {
+	Name string `json:"name"`
+}
+
+// lensRenameErrStatus maps an error from m.RenameLens to the HTTP status and
+// problem body fields the handler should write. Mirrors renameErrStatus in
+// handlers_repos_rename.go arm-for-arm where the reasoning transfers; see the
+// ErrLensNotFound arm below for the one place it does not.
+func lensRenameErrStatus(err error, oldName, newName string) (status int, title, detail string) {
+	switch {
+	case errors.Is(err, repos.ErrInvalidLensName):
+		return http.StatusUnprocessableEntity, "Invalid lens name",
+			"a lens name may contain only lowercase letters, digits, hyphens and underscores"
+	case errors.Is(err, repos.ErrLensNameConflictsRepo):
+		return http.StatusConflict, "Name already in use",
+			"a repo is already called \"" + newName + "\""
+	case errors.Is(err, repos.ErrLensExists):
+		return http.StatusConflict, "Name already in use",
+			"another lens is already called \"" + newName + "\""
+	case errors.Is(err, repos.ErrLensNotFound):
+		// On the repo side, ErrRepoNotFound reaching renameErrStatus means
+		// RepoMiddleware already resolved oldName before the handler ran, so
+		// the only way to still see it is a concurrent change — hence 409,
+		// not 404. That reasoning does NOT transfer here: GET/PATCH/DELETE
+		// /lenses/{lens}, and this rename route registered alongside them in
+		// router.go, sit OUTSIDE the LensMiddleware group — that middleware
+		// wraps only the binding-dependent subroutes (facts, search, stats,
+		// topics, mcp). Nothing resolves {lens} before this handler runs; it
+		// is the first and only lookup, exactly like handleHALLens,
+		// handleHALLensPatch and handleHALLensDelete, which all answer an
+		// unknown name with a plain 404. So does this one.
+		//
+		// (RenameLens's own doc comment notes a second source of this same
+		// sentinel — LensRegistry.Rename's CAS reporting !changed — but calls
+		// it unreachable today: the whole function runs under one
+		// m.mu.Lock(), so nothing can move oldName between the Get and the
+		// Rename call. No race to attribute differently here.)
+		return http.StatusNotFound, "Lens not found",
+			"no lens named \"" + oldName + "\""
+	default:
+		return http.StatusInternalServerError, "Rename failed", "could not rename the lens"
+	}
+}
+
+// handleHALLensRename serves POST /api/v1/lenses/{lens}/rename.
+//
+// Same reasoning as handleHALRepoRename: not PATCH /lenses/{lens} — the
+// response re-reads the lens through the NEW name, and a rename invalidates
+// the very identifier the request was addressed by, so the write and its
+// response cannot share one resource. Slash form, matching
+// POST /repos/{repo}/rename and POST /archived/{id}/restore. Deliberately
+// NOT the AIP colon form (/lenses/{lens}:rename) — that convention is scoped
+// to COLLECTION-level actions with no {lens} segment. Do not "fix" this to
+// /lenses/{lens}:rename.
+//
+// Registered in router.go alongside the lens CRUD trio (GET/PATCH/DELETE),
+// not inside the LensMiddleware group: like them, it resolves {lens} itself
+// and attributes its own not-found/conflict errors — see the ErrLensNotFound
+// arm of lensRenameErrStatus for why that matters for the status code.
+//
+// The registry-unavailable check up front mirrors every other lens handler
+// (handleHALLens, handleHALLensPatch, handleHALLensDelete, ...): unlike
+// RenameRepo, RenameLens never calls controlHandles() and so never returns
+// ErrManagerStopped — an unopened registry surfaces from it as a bare
+// non-sentinel error ("lens registry not open"). Checking here, the same way
+// the siblings do, is what turns that into a 503 instead of falling through
+// lensRenameErrStatus's default 500 arm.
+func handleHALLensRename(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reg := m.LensRegistry()
+		if reg == nil {
+			hal.WriteProblem(w, http.StatusServiceUnavailable, "Lens registry unavailable",
+				"the lens registry is not open", r.URL.Path)
+			return
+		}
+		oldName := chi.URLParam(r, "lens")
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxRenameBodyBytes)
+		var req renameLensRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid request body", err.Error(), r.URL.Path)
+			return
+		}
+		if req.Name == "" {
+			hal.WriteProblem(w, http.StatusBadRequest, "Missing name",
+				"a new name is required", r.URL.Path)
+			return
+		}
+
+		if err := m.RenameLens(oldName, req.Name); err != nil {
+			status, title, detail := lensRenameErrStatus(err, oldName, req.Name)
+			if status == http.StatusInternalServerError {
+				log.Error().Err(err).Str("from", oldName).Str("to", req.Name).Msg("rename lens failed")
+			}
+			hal.WriteProblem(w, status, title, detail, r.URL.Path)
+			return
+		}
+
+		// Re-read under the NEW name so the response — self link included —
+		// addresses the lens as it now exists.
+		l, ok, err := reg.Get(req.Name)
+		if err != nil {
+			log.Error().Err(err).Str("to", req.Name).Msg("get lens after rename failed")
+			hal.WriteProblem(w, http.StatusInternalServerError, "Rename failed",
+				"the lens was renamed but could not be re-read", r.URL.Path)
+			return
+		}
+		if !ok {
+			log.Error().Str("to", req.Name).Msg("rename succeeded but the lens is not resolvable")
+			hal.WriteProblem(w, http.StatusInternalServerError, "Rename failed",
+				"the lens was renamed but could not be re-read", r.URL.Path)
+			return
+		}
+		writeLensView(w, r, b, m.Repos(), http.StatusOK, l)
+	}
+}

--- a/internal/web/handlers_lenses_rename.go
+++ b/internal/web/handlers_lenses_rename.go
@@ -24,7 +24,15 @@ type renameLensRequest struct {
 func lensRenameErrStatus(err error, oldName, newName string) (status int, title, detail string) {
 	switch {
 	case errors.Is(err, repos.ErrInvalidLensName):
-		return http.StatusUnprocessableEntity, "Invalid lens name",
+		// 400, not 422: this is a fixed-grammar syntax check on the name
+		// itself, matching every other name-grammar rejection in this
+		// package — repo create (handlers_repos_create.go), lens
+		// create/patch (handlers_lenses_hal.go), archive/restore
+		// (handlers_archived_hal.go). 422 here is reserved for
+		// cross-referential failures: syntactically fine, wrong against
+		// other state (an unknown repo/branch reference, an over-cap
+		// description). A bad-characters name is not that.
+		return http.StatusBadRequest, "Invalid lens name",
 			"a lens name may contain only lowercase letters, digits, hyphens and underscores"
 	case errors.Is(err, repos.ErrLensNameConflictsRepo):
 		return http.StatusConflict, "Name already in use",

--- a/internal/web/handlers_lenses_rename_test.go
+++ b/internal/web/handlers_lenses_rename_test.go
@@ -22,17 +22,22 @@ func postLensRename(t *testing.T, r http.Handler, lens, body string) *httptest.R
 	return rec
 }
 
-// TestHandleLensRename_InvalidNameIs422 needs no seeded lens: RenameLens
+// TestHandleLensRename_InvalidNameIs400 needs no seeded lens: RenameLens
 // checks isValidRepoName(newName) before it even looks at oldName. It DOES
 // need a started manager (real registry), though — the handler's own
 // registry-unavailable check runs first and would otherwise answer 503
 // before RenameLens is ever called.
-func TestHandleLensRename_InvalidNameIs422(t *testing.T) {
+//
+// 400, not 422: a name-grammar failure is a fixed-grammar syntax check,
+// matching repo create, lens create/patch, and archive/restore. 422 is
+// reserved for cross-referential failures (unknown repo/branch reference,
+// over-cap description) — a bad-characters name is not that.
+func TestHandleLensRename_InvalidNameIs400(t *testing.T) {
 	m, _ := newTestLensManager(t)
 	r := (&Server{Manager: m}).NewAPIRouter()
 	rec := postLensRename(t, r, "eng", `{"name":"Has Capitals"}`)
-	if rec.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -157,7 +162,7 @@ func TestHandleLensRename_ErrStatusMapping(t *testing.T) {
 		wantStatus int
 		wantTitle  string
 	}{
-		{"invalid name", repos.ErrInvalidLensName, http.StatusUnprocessableEntity, "Invalid lens name"},
+		{"invalid name", repos.ErrInvalidLensName, http.StatusBadRequest, "Invalid lens name"},
 		{"name conflicts repo", repos.ErrLensNameConflictsRepo, http.StatusConflict, "Name already in use"},
 		{"lens exists", repos.ErrLensExists, http.StatusConflict, "Name already in use"},
 		{"lens not found", repos.ErrLensNotFound, http.StatusNotFound, "Lens not found"},

--- a/internal/web/handlers_lenses_rename_test.go
+++ b/internal/web/handlers_lenses_rename_test.go
@@ -165,6 +165,12 @@ func TestHandleLensRename_ErrStatusMapping(t *testing.T) {
 		{"invalid name", repos.ErrInvalidLensName, http.StatusBadRequest, "Invalid lens name"},
 		{"name conflicts repo", repos.ErrLensNameConflictsRepo, http.StatusConflict, "Name already in use"},
 		{"lens exists", repos.ErrLensExists, http.StatusConflict, "Name already in use"},
+		// Reachable only since RenameLens started reserving the target name in
+		// the shared m.creating set: an in-flight Create/Restore/CreateLens
+		// claiming it now surfaces as this sentinel instead of slipping past
+		// the in-lock m.repos check. Same 409 and same wording as the repo
+		// route's arm.
+		{"create in flight", repos.ErrCreateInFlight, http.StatusConflict, "Name already in use"},
 		{"lens not found", repos.ErrLensNotFound, http.StatusNotFound, "Lens not found"},
 		{"unmapped", errors.New("boom"), http.StatusInternalServerError, "Rename failed"},
 	}

--- a/internal/web/handlers_lenses_rename_test.go
+++ b/internal/web/handlers_lenses_rename_test.go
@@ -1,0 +1,174 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"knomit/internal/repos"
+)
+
+// postLensRename POSTs a rename request verbatim — renames never carry a
+// uid-spelled member, so there is nothing for lensReq to translate.
+func postLensRename(t *testing.T, r http.Handler, lens, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/lenses/"+lens+"/rename", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestHandleLensRename_InvalidNameIs422 needs no seeded lens: RenameLens
+// checks isValidRepoName(newName) before it even looks at oldName. It DOES
+// need a started manager (real registry), though — the handler's own
+// registry-unavailable check runs first and would otherwise answer 503
+// before RenameLens is ever called.
+func TestHandleLensRename_InvalidNameIs422(t *testing.T) {
+	m, _ := newTestLensManager(t)
+	r := (&Server{Manager: m}).NewAPIRouter()
+	rec := postLensRename(t, r, "eng", `{"name":"Has Capitals"}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleLensRename_MissingNameIs400(t *testing.T) {
+	m, _ := newTestLensManager(t)
+	r := (&Server{Manager: m}).NewAPIRouter()
+	rec := postLensRename(t, r, "eng", `{}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleLensRename_BadJSONIs400(t *testing.T) {
+	m, _ := newTestLensManager(t)
+	r := (&Server{Manager: m}).NewAPIRouter()
+	rec := postLensRename(t, r, "eng", `{not json`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleLensRename_UnknownLensIs404 pins the not-found answer: unlike
+// the repo route, nothing resolves {lens} ahead of this handler (see the
+// ErrLensNotFound arm of lensRenameErrStatus), so an unknown oldName is a
+// plain 404, not the repo route's 409.
+func TestHandleLensRename_UnknownLensIs404(t *testing.T) {
+	m, _ := newTestLensManager(t)
+	r := (&Server{Manager: m}).NewAPIRouter()
+	rec := postLensRename(t, r, "ghost", `{"name":"beta"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleLensRename_NameTakenByLensIs409(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, m, r) // "eng", write alpha, read beta
+	if rec := postLens(t, m, r, `{"name":"other","write":"alpha","reads":[{"repo":"beta"}]}`); rec.Code != http.StatusCreated {
+		t.Fatalf("seed other: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec := postLensRename(t, r, "eng", `{"name":"other"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleLensRename_NameTakenByRepoIs409(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, m, r) // "eng", write alpha, read beta
+
+	rec := postLensRename(t, r, "eng", `{"name":"beta"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleLensRename_SameNameIsNoop covers RenameLens's documented
+// successful no-op: renaming a lens to its own current name is not an error.
+func TestHandleLensRename_SameNameIsNoop(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, m, r)
+
+	rec := postLensRename(t, r, "eng", `{"name":"eng"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleLensRename_SelfLinkPointsAtTheNewName(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	r := (&Server{Manager: m}).NewAPIRouter()
+	seedEng(t, m, r)
+
+	rec := postLensRename(t, r, "eng", `{"name":"renamed"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensViewBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Name != "renamed" {
+		t.Errorf("name: got %q, want %q", body.Name, "renamed")
+	}
+	if !strings.Contains(body.Links["self"].Href, "/lenses/renamed") {
+		t.Errorf("self link: got %q, must address the lens by its new name", body.Links["self"].Href)
+	}
+
+	// The old name must no longer resolve.
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/lenses/eng", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("get old name: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleLensRename_RegistryNil503(t *testing.T) {
+	m := newTestManagerWithRepos(t) // never Start()-ed: nil lens registry
+	r := (&Server{Manager: m}).NewAPIRouter()
+
+	rec := postLensRename(t, r, "eng", `{"name":"renamed"}`)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleLensRename_ErrStatusMapping pins the sentinel→(status,title)
+// mapping directly, the same way TestLensCreateErrStatus does for create/
+// patch. The ErrLensNotFound arm is the one deliberate divergence from
+// renameErrStatus's repo-side mapping (409 there, 404 here) — see the
+// comment on that arm for why. Named with the TestHandleLensRename_ prefix,
+// not TestLensRenameErrStatus, so it runs under the same
+// `-run TestHandleLensRename` filter as the HTTP-level tests above.
+func TestHandleLensRename_ErrStatusMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantTitle  string
+	}{
+		{"invalid name", repos.ErrInvalidLensName, http.StatusUnprocessableEntity, "Invalid lens name"},
+		{"name conflicts repo", repos.ErrLensNameConflictsRepo, http.StatusConflict, "Name already in use"},
+		{"lens exists", repos.ErrLensExists, http.StatusConflict, "Name already in use"},
+		{"lens not found", repos.ErrLensNotFound, http.StatusNotFound, "Lens not found"},
+		{"unmapped", errors.New("boom"), http.StatusInternalServerError, "Rename failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, title, _ := lensRenameErrStatus(tc.err, "old", "new")
+			if status != tc.wantStatus || title != tc.wantTitle {
+				t.Errorf("got (%d, %q), want (%d, %q)", status, title, tc.wantStatus, tc.wantTitle)
+			}
+		})
+	}
+}

--- a/internal/web/handlers_repos_hal.go
+++ b/internal/web/handlers_repos_hal.go
@@ -219,6 +219,35 @@ func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 			hal.WriteHAL(w, http.StatusOK, repoView(b, r, name, ri))
 			return
 		}
+
+		// Validate BOTH lengths before writing EITHER. The two writes are two
+		// separate git commits and there is no transaction spanning them, so a
+		// patch carrying a fine description and an over-cap license would
+		// otherwise commit README.md and only then answer 422 — the client sees
+		// an error, reasonably concludes nothing happened, and is wrong. Both
+		// fields share one cap (WriteLicense reuses ErrRepoDescriptionTooLong on
+		// purpose) and both lengths are knowable before any git work, so the
+		// half-applied outcome is avoidable outright rather than compensated.
+		//
+		// This does NOT make the pair atomic in general — a store fault on the
+		// second write still leaves the first committed — it removes the only
+		// failure mode that is both fully predictable up front and reachable by
+		// an ordinary request. The per-write checks below stay: WriteReadme and
+		// WriteLicense own the cap for every OTHER caller, and this handler must
+		// not become the only place it is enforced.
+		if req.Description != nil && len(*req.Description) > repos.MaxRepoDescriptionBytes {
+			hal.WriteProblem(w, http.StatusUnprocessableEntity, "Repo description too long",
+				fmt.Sprintf("description is %d bytes (max %d)",
+					len(*req.Description), repos.MaxRepoDescriptionBytes), r.URL.Path)
+			return
+		}
+		if req.License != nil && len(*req.License) > repos.MaxRepoDescriptionBytes {
+			hal.WriteProblem(w, http.StatusUnprocessableEntity, "License too long",
+				fmt.Sprintf("license is %d bytes (max %d)",
+					len(*req.License), repos.MaxRepoDescriptionBytes), r.URL.Path)
+			return
+		}
+
 		// The cap, the branch check and the unchanged-content skip all live in
 		// WriteReadme, so every writer of README.md gets them; this maps its
 		// errors onto status codes.

--- a/internal/web/handlers_repos_hal.go
+++ b/internal/web/handlers_repos_hal.go
@@ -172,11 +172,16 @@ func handleHALRepo(b hal.URLBuilder) http.HandlerFunc {
 	}
 }
 
-// patchRepoRequest is the PATCH /repos/{repo} body. Only description is
-// editable — name, id and agent_branch are all derived from the repo itself.
-// A pointer distinguishes "omitted" (keep) from "" (empty the manifest).
+// patchRepoRequest is the PATCH /repos/{repo} body. Description and License are
+// the editable fields — name has its own action (POST /repos/{repo}/rename,
+// because a rename invalidates this URL), and id and agent_branch are derived
+// from the repo itself.
+//
+// Pointers distinguish "omitted" (keep) from "" (empty the file), per field
+// independently: a patch may edit one and leave the other untouched.
 type patchRepoRequest struct {
 	Description *string `json:"description"`
+	License     *string `json:"license"`
 }
 
 // maxRepoPatchBodyBytes bounds what the decoder will buffer, so the size check
@@ -188,9 +193,10 @@ type patchRepoRequest struct {
 const maxRepoPatchBodyBytes = 8 * repos.MaxRepoDescriptionBytes
 
 // handleHALRepoPatch serves PATCH /api/v1/repos/{repo}. It edits the repo's
-// description by committing README.md on the agent branch, then returns the
-// same view GET does — re-read from git, so the response reflects what was
-// actually persisted rather than what was requested.
+// description and/or license by committing README.md and/or LICENSE on the
+// agent branch, then returns the same view GET does — re-read from git, so
+// the response reflects what was actually persisted rather than what was
+// requested.
 func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := chi.URLParam(r, "repo")
@@ -209,31 +215,57 @@ func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 			return
 		}
 		// Nothing to do — an empty patch is a successful no-op, not an error.
-		if req.Description == nil {
+		if req.Description == nil && req.License == nil {
 			hal.WriteHAL(w, http.StatusOK, repoView(b, r, name, ri))
 			return
 		}
 		// The cap, the branch check and the unchanged-content skip all live in
 		// WriteReadme, so every writer of README.md gets them; this maps its
 		// errors onto status codes.
-		if _, err := ri.WriteReadme(r.Context(), *req.Description); err != nil {
-			switch {
-			case errors.Is(err, repos.ErrRepoDescriptionTooLong):
-				hal.WriteProblem(w, http.StatusUnprocessableEntity, "Repo description too long",
-					err.Error(), r.URL.Path)
-			case errors.Is(err, repos.ErrAgentBranchUnset):
-				hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
-					"the repo has no agent branch yet", r.URL.Path)
-			case errors.Is(err, repos.ErrRepoClosed), errors.Is(err, repos.ErrStoreUnavailable):
-				log.Warn().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write README.md: store not available")
-				hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
-					"the repo's store is not available; try again", r.URL.Path)
-			default:
-				log.Error().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write README.md failed")
-				hal.WriteProblem(w, http.StatusInternalServerError, "Update failed",
-					"could not write the repo description", r.URL.Path)
+		if req.Description != nil {
+			if _, err := ri.WriteReadme(r.Context(), *req.Description); err != nil {
+				switch {
+				case errors.Is(err, repos.ErrRepoDescriptionTooLong):
+					hal.WriteProblem(w, http.StatusUnprocessableEntity, "Repo description too long",
+						err.Error(), r.URL.Path)
+				case errors.Is(err, repos.ErrAgentBranchUnset):
+					hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
+						"the repo has no agent branch yet", r.URL.Path)
+				case errors.Is(err, repos.ErrRepoClosed), errors.Is(err, repos.ErrStoreUnavailable):
+					log.Warn().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write README.md: store not available")
+					hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
+						"the repo's store is not available; try again", r.URL.Path)
+				default:
+					log.Error().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write README.md failed")
+					hal.WriteProblem(w, http.StatusInternalServerError, "Update failed",
+						"could not write the repo description", r.URL.Path)
+				}
+				return
 			}
-			return
+		}
+		if req.License != nil {
+			// Same cap, same sentinel, same branch check as the description —
+			// WriteLicense reuses ErrRepoDescriptionTooLong deliberately, so
+			// this maps identically.
+			if _, err := ri.WriteLicense(r.Context(), *req.License); err != nil {
+				switch {
+				case errors.Is(err, repos.ErrRepoDescriptionTooLong):
+					hal.WriteProblem(w, http.StatusUnprocessableEntity, "License too long",
+						err.Error(), r.URL.Path)
+				case errors.Is(err, repos.ErrAgentBranchUnset):
+					hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
+						"the repo has no agent branch yet", r.URL.Path)
+				case errors.Is(err, repos.ErrRepoClosed), errors.Is(err, repos.ErrStoreUnavailable):
+					log.Warn().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write LICENSE: store not available")
+					hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",
+						"the repo's store is not available; try again", r.URL.Path)
+				default:
+					log.Error().Err(err).Str("path", r.URL.Path).Str("repo", name).Msg("write LICENSE failed")
+					hal.WriteProblem(w, http.StatusInternalServerError, "Update failed",
+						"could not write the repo license", r.URL.Path)
+				}
+				return
+			}
 		}
 		hal.WriteHAL(w, http.StatusOK, repoView(b, r, name, ri))
 	}

--- a/internal/web/handlers_repos_hal.go
+++ b/internal/web/handlers_repos_hal.go
@@ -118,14 +118,18 @@ func readReadme(r *http.Request, ri *repos.RepoInstance) string {
 	return content
 }
 
-// readLicense returns the verbatim LICENSE at the repo's agent-branch tip, or
-// "" when there is none — non-fatal for a view, exactly like readReadme.
-func readLicense(r *http.Request, ri *repos.RepoInstance) string {
-	content, err := ri.ReadLicense(r.Context())
+// readLicense returns the verbatim LICENSE at the repo's agent-branch tip, ""
+// when there is none, and whether a LICENSE exists but is too large to show
+// (see RepoInstance.ReadLicense) — all non-fatal for a view, exactly like
+// readReadme. oversize is only ever true alongside content == "": the two are
+// mutually exclusive states the caller must not collapse into one, because
+// repoView needs to tell "no LICENSE" from "a LICENSE we could not read".
+func readLicense(r *http.Request, ri *repos.RepoInstance) (content string, oversize bool) {
+	content, oversize, err := ri.ReadLicense(r.Context())
 	if err != nil {
-		return ""
+		return "", false
 	}
-	return content
+	return content, oversize
 }
 
 // repoView builds the single-repo body. GET and PATCH share it so a write's
@@ -157,8 +161,18 @@ func repoView(b hal.URLBuilder, r *http.Request, name string, ri *repos.RepoInst
 	// license is the verbatim LICENSE read at HEAD. Single-repo GET only, the
 	// same scoping description has — the repo LIST stays a cheap index and must
 	// not grow a second per-repo git read.
-	if lic := readLicense(r, ri); lic != "" {
+	//
+	// license_oversize is the other half: a LICENSE that exists but exceeds
+	// the read cap must not be reported the same way an absent one is, or the
+	// UI offers "Add license" over a file it never actually read — the trap
+	// WriteLicense's ErrLicenseTooLargeToReplace guard closes on the write
+	// side. Omitted entirely rather than sent as false, matching how every
+	// other optional field on this body behaves.
+	lic, licOversize := readLicense(r, ri)
+	if lic != "" {
 		body["license"] = lic
+	} else if licOversize {
+		body["license_oversize"] = true
 	}
 	return body
 }
@@ -280,6 +294,12 @@ func handleHALRepoPatch(b hal.URLBuilder) http.HandlerFunc {
 				switch {
 				case errors.Is(err, repos.ErrRepoDescriptionTooLong):
 					hal.WriteProblem(w, http.StatusUnprocessableEntity, "License too long",
+						err.Error(), r.URL.Path)
+				case errors.Is(err, repos.ErrLicenseTooLargeToReplace):
+					// 409, not 422: the request is well-formed, but the resource
+					// is in a state — an existing LICENSE this call cannot read
+					// back — that makes it unsafe to act on blindly.
+					hal.WriteProblem(w, http.StatusConflict, "License too large to replace",
 						err.Error(), r.URL.Path)
 				case errors.Is(err, repos.ErrAgentBranchUnset):
 					hal.WriteProblem(w, http.StatusServiceUnavailable, "Repo not ready",

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -537,6 +537,24 @@ func repoDescription(t *testing.T, r http.Handler, repo string) string {
 	return body.Description
 }
 
+// repoLicense is repoDescription's sibling: the licence as the GET reports it,
+// "" when the field is absent.
+func repoLicense(t *testing.T, r http.Handler, repo string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/repos/"+repo, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		License string `json:"license"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return body.License
+}
+
 // A PATCHed description is committed to README.md and is visible to the very next
 // GET — the write and the read must agree on file AND branch, or the edit
 // silently disappears.
@@ -623,6 +641,76 @@ func TestHandleHALRepoPatch_RejectsOversizeDescription(t *testing.T) {
 
 	// Exactly at the cap is accepted.
 	atCap := mustJSON(t, map[string]any{"description": strings.Repeat("x", repos.MaxRepoDescriptionBytes)})
+	if rec := patchRepo(t, r, "work", atCap); rec.Code != http.StatusOK {
+		t.Fatalf("at-cap status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A PATCHed licence is committed to LICENSE and visible to the very next GET.
+// Newlines survive verbatim — the whole point of the file.
+func TestHandleHALRepoPatch_WritesLicenseAndRoundTrips(t *testing.T) {
+	r := newRepoPatchServer(t)
+	const mit = "MIT License\n\nCopyright (c) 2026\n\n* not a bullet\n"
+
+	if rec := patchRepo(t, r, "work", mustJSON(t, map[string]any{"license": mit})); rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoLicense(t, r, "work"); got != mit {
+		t.Errorf("licence round-trip: got %q, want %q", got, mit)
+	}
+}
+
+// The two fields are independent: patching one must not disturb the other.
+func TestHandleHALRepoPatch_OmittedLicenseKeepsCurrent(t *testing.T) {
+	r := newRepoPatchServer(t)
+	if rec := patchRepo(t, r, "work", `{"license":"terms\n"}`); rec.Code != http.StatusOK {
+		t.Fatalf("seed PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	beforeDesc := repoDescription(t, r, "work")
+
+	if rec := patchRepo(t, r, "work", `{"description":"new text\n"}`); rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoLicense(t, r, "work"); got != "terms\n" {
+		t.Errorf("a description-only patch changed the licence: got %q", got)
+	}
+	if beforeDesc == "" {
+		t.Fatal("precondition: seeded repo should have a README.md description")
+	}
+}
+
+// An explicit empty string clears the file — it then drops out of the GET body
+// entirely, exactly as an emptied description does.
+func TestHandleHALRepoPatch_EmptyLicenseClears(t *testing.T) {
+	r := newRepoPatchServer(t)
+	if rec := patchRepo(t, r, "work", `{"license":"terms\n"}`); rec.Code != http.StatusOK {
+		t.Fatalf("seed PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := patchRepo(t, r, "work", `{"license":""}`); rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoLicense(t, r, "work"); got != "" {
+		t.Errorf("licence should be cleared; got %q", got)
+	}
+}
+
+// Over-cap licences are refused with 422 and the stored file is untouched — a
+// rejected write must not partially land. At the cap exactly is accepted.
+func TestHandleHALRepoPatch_RejectsOversizeLicense(t *testing.T) {
+	r := newRepoPatchServer(t)
+	if rec := patchRepo(t, r, "work", `{"license":"terms\n"}`); rec.Code != http.StatusOK {
+		t.Fatalf("seed PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	body := mustJSON(t, map[string]any{"license": strings.Repeat("x", repos.MaxRepoDescriptionBytes+1)})
+	if rec := patchRepo(t, r, "work", body); rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoLicense(t, r, "work"); got != "terms\n" {
+		t.Errorf("rejected write must not change the licence; got %q", got)
+	}
+
+	atCap := mustJSON(t, map[string]any{"license": strings.Repeat("x", repos.MaxRepoDescriptionBytes)})
 	if rec := patchRepo(t, r, "work", atCap); rec.Code != http.StatusOK {
 		t.Fatalf("at-cap status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -716,6 +716,81 @@ func TestHandleHALRepoPatch_RejectsOversizeLicense(t *testing.T) {
 	}
 }
 
+// A two-field PATCH is validated BEFORE either write. The handler commits
+// README.md and LICENSE as two separate git commits with no transaction across
+// them, so a body with a fine description and an over-cap licence used to
+// commit the description and only then answer 422 — the client sees an error,
+// reasonably concludes nothing happened, and is wrong.
+//
+// Both caps are knowable up front (they are the same cap), so the fix is to
+// check both lengths before touching git. The assertion that matters is not the
+// status code — that was always 422 — but that the DESCRIPTION IS UNCHANGED
+// afterwards.
+func TestHandleHALRepoPatch_OversizeLicenseDoesNotLandTheDescription(t *testing.T) {
+	r := newRepoPatchServer(t)
+	before := repoDescription(t, r, "work")
+	if before == "" {
+		t.Fatal("precondition: seeded repo should have a README.md description")
+	}
+
+	body := mustJSON(t, map[string]any{
+		"description": "this description is perfectly fine\n",
+		"license":     strings.Repeat("x", repos.MaxRepoDescriptionBytes+1),
+	})
+	rec := patchRepo(t, r, "work", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoDescription(t, r, "work"); got != before {
+		t.Errorf("the rejected patch half-landed: description is now %q, want %q (unchanged)", got, before)
+	}
+	if got := repoLicense(t, r, "work"); got != "" {
+		t.Errorf("the rejected licence must not have landed either; got %q", got)
+	}
+}
+
+// The mirror: an over-cap DESCRIPTION alongside a fine licence must leave the
+// licence alone too. That direction already held (the description is written
+// first, so its rejection precedes the licence write), and this pins it so a
+// future reordering of the two writes cannot quietly break it.
+func TestHandleHALRepoPatch_OversizeDescriptionDoesNotLandTheLicense(t *testing.T) {
+	r := newRepoPatchServer(t)
+	if rec := patchRepo(t, r, "work", `{"license":"terms\n"}`); rec.Code != http.StatusOK {
+		t.Fatalf("seed PATCH status: %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	body := mustJSON(t, map[string]any{
+		"description": strings.Repeat("x", repos.MaxRepoDescriptionBytes+1),
+		"license":     "brand new terms\n",
+	})
+	rec := patchRepo(t, r, "work", body)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoLicense(t, r, "work"); got != "terms\n" {
+		t.Errorf("the rejected patch half-landed: licence is now %q, want %q (unchanged)", got, "terms\n")
+	}
+}
+
+// Both fields within the cap still apply BOTH — the pre-check must not have
+// become a gate that quietly drops one of them.
+func TestHandleHALRepoPatch_BothFieldsApplyTogether(t *testing.T) {
+	r := newRepoPatchServer(t)
+	body := mustJSON(t, map[string]any{
+		"description": "# Work\n\nmanifest\n",
+		"license":     "MIT License\n",
+	})
+	if rec := patchRepo(t, r, "work", body); rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := repoDescription(t, r, "work"); got != "# Work\n\nmanifest\n" {
+		t.Errorf("description: got %q", got)
+	}
+	if got := repoLicense(t, r, "work"); got != "MIT License\n" {
+		t.Errorf("licence: got %q", got)
+	}
+}
+
 // A body far larger than any legitimate manifest is refused by the reader
 // before it is buffered, as a 413 rather than a decode error.
 func TestHandleHALRepoPatch_RejectsOversizeBody(t *testing.T) {

--- a/internal/web/handlers_repos_hal_test.go
+++ b/internal/web/handlers_repos_hal_test.go
@@ -273,6 +273,67 @@ func TestHandleHALRepo_IncludesLicenseWhenPresent(t *testing.T) {
 	}
 }
 
+// TestHandleHALRepo_ReportsLicenseOversize verifies that a LICENSE exceeding
+// repos.MaxRepoDescriptionBytes is reported as "license_oversize": true with
+// no "license" field, NOT as an absent licence. ReadFact enforces no size cap
+// of its own, so it is possible for a >64KiB LICENSE to land on the branch
+// (a clone, or a hand-edited working tree — WriteLicense itself rejects
+// oversized input at the door). Before this flag existed, repoView had no way
+// to say anything but "absent" for that file, and the UI offered "Add
+// license" over content it could not actually read.
+func TestHandleHALRepo_ReportsLicenseOversize(t *testing.T) {
+	home := t.TempDir()
+	m := repos.New(context.Background(), repos.Deps{
+		Cfg: config.Config{
+			Home:         home,
+			ClusterCache: config.ClusterCacheConfig{},
+		},
+		AgentBranch:           "machine/test",
+		DisableBackgroundSync: true,
+	})
+	if err := m.Start(); err != nil {
+		t.Fatalf("manager start: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+
+	if _, err := m.Create(context.Background(), repos.CreateSpec{Name: "work", Mode: "preset"}, nil); err != nil {
+		t.Fatalf("create work: %v", err)
+	}
+
+	ri := m.Get("work")
+	require.NotNil(t, ri)
+	oversized := strings.Repeat("x", repos.MaxRepoDescriptionBytes+1)
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteRootFile(context.Background(), ri.AgentBranch(),
+			"LICENSE", oversized, "docs: add oversize LICENSE", "update")
+		require.NoError(t, werr)
+	}))
+
+	s := &Server{Manager: m, AgentBranch: "machine/test"}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/repos/work", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		License         string `json:"license"`
+		LicenseOversize bool   `json:"license_oversize"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !body.LicenseOversize {
+		t.Errorf("license_oversize: got false, want true; body=%s", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `"license"`) {
+		t.Errorf("an oversize licence must not also appear under \"license\"; body=%s", rec.Body.String())
+	}
+}
+
 // TestHandleHALRepo_OmitsLicenseWhenNoStore verifies a stub instance with no
 // store does not panic and simply omits the license, exactly like
 // TestHandleHALRepo_OmitsDescriptionWhenNoStore does for description.
@@ -713,6 +774,40 @@ func TestHandleHALRepoPatch_RejectsOversizeLicense(t *testing.T) {
 	atCap := mustJSON(t, map[string]any{"license": strings.Repeat("x", repos.MaxRepoDescriptionBytes)})
 	if rec := patchRepo(t, r, "work", atCap); rec.Code != http.StatusOK {
 		t.Fatalf("at-cap status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleHALRepoPatch_RefusesToReplaceOversizeLicense is the write-side
+// half of TestHandleHALRepo_ReportsLicenseOversize: an existing LICENSE over
+// the cap must be refused with 409 (the resource is in a state this request
+// cannot safely act on), both for a blank "clear" draft and for genuine new
+// terms — and the original bytes on the branch must survive untouched
+// either way. This is the exact trap the oversize flag exists to close: a UI
+// that could not display the file must not be able to erase it either.
+func TestHandleHALRepoPatch_RefusesToReplaceOversizeLicense(t *testing.T) {
+	r, m := newRepoPatchServerWithManager(t)
+	ri := m.Get("work")
+	require.NotNil(t, ri)
+	oversized := strings.Repeat("x", repos.MaxRepoDescriptionBytes+1)
+	require.NoError(t, ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteRootFile(context.Background(), ri.AgentBranch(),
+			"LICENSE", oversized, "docs: add oversize LICENSE", "update")
+		require.NoError(t, werr)
+	}))
+
+	for _, attempt := range []string{"", "new terms\n"} {
+		body := mustJSON(t, map[string]any{"license": attempt})
+		rec := patchRepo(t, r, "work", body)
+		if rec.Code != http.StatusConflict {
+			t.Fatalf("license=%q: status got %d, want 409; body=%s", attempt, rec.Code, rec.Body.String())
+		}
+		require.NoError(t, ri.WithRead(func(svc *store.Service) {
+			res, rerr := svc.Facts().ReadFact(context.Background(), ri.AgentBranch(), repos.LicensePath, nil)
+			require.NoError(t, rerr)
+			if res.Content != oversized {
+				t.Errorf("license=%q: the original LICENSE must survive untouched", attempt)
+			}
+		}))
 	}
 }
 

--- a/internal/web/handlers_repos_rename.go
+++ b/internal/web/handlers_repos_rename.go
@@ -29,7 +29,15 @@ const maxRenameBodyBytes = 4 << 10
 func renameErrStatus(err error, oldName, newName string) (status int, title, detail string) {
 	switch {
 	case errors.Is(err, repos.ErrInvalidName):
-		return http.StatusUnprocessableEntity, "Invalid repo name",
+		// 400, not 422: this is a fixed-grammar syntax check on the name
+		// itself, matching every other name-grammar rejection in this
+		// package — repo create (handlers_repos_create.go), lens
+		// create/patch (handlers_lenses_hal.go), archive/restore
+		// (handlers_archived_hal.go). 422 here is reserved for
+		// cross-referential failures: syntactically fine, wrong against
+		// other state (an unknown repo/branch reference, an over-cap
+		// description). A bad-characters name is not that.
+		return http.StatusBadRequest, "Invalid repo name",
 			"a repo name may contain only lowercase letters, digits, hyphens and underscores"
 	case errors.Is(err, repos.ErrRepoExists):
 		return http.StatusConflict, "Name already in use",

--- a/internal/web/handlers_repos_rename.go
+++ b/internal/web/handlers_repos_rename.go
@@ -47,15 +47,32 @@ func renameErrStatus(err error, oldName, newName string) (status int, title, det
 		// genuinely unknown {repo} — it is NOT the same case. By the time
 		// RenameRepo runs, the middleware has already resolved oldName against
 		// a live repo; the only way RenameRepo can still return
-		// ErrRepoNotFound is the lost-race path in its CAS (RenameIfNamed
-		// matched zero rows because a concurrent rename or removal moved
-		// oldName first) — see lifecycle.go's RenameRepo doc comment. The repo
-		// this request named did exist a moment ago, so telling the client
-		// "not found" would be false; it changed out from under the request,
-		// which is a conflict the client should resolve by re-reading the repo
-		// and retrying, not by concluding the name never existed.
+		// ErrRepoNotFound is that oldName stopped resolving between the
+		// middleware's lookup and this call. RenameRepo has two places that can
+		// produce that: the forward CAS (RenameIfNamed(oldName, newName))
+		// matching zero rows because a concurrent rename beat this one to
+		// oldName, or the later revalidate-under-lock step catching Archive/
+		// Remove pulling oldName out of the map after this call's own CAS had
+		// already landed, in which case it reverts its write before returning
+		// — see lifecycle.go's RenameRepo doc comment for both mechanisms. In
+		// every case the repo this request named did exist a moment ago, so
+		// telling the client "not found" would be false; it changed out from
+		// under the request, which is a conflict the client should resolve by
+		// re-reading the repo and retrying, not by concluding the name never
+		// existed.
 		return http.StatusConflict, "Repo changed during rename",
 			"repo \"" + oldName + "\" was renamed or removed while this request was in flight; re-read it and retry"
+	case errors.Is(err, repos.ErrManagerStopped):
+		// Reachable in production, not just in tests: cmd/serve.go's shutdown
+		// gives in-flight handlers a 5s grace window between Shutdown and the
+		// deferred Close, and a request that lands in that window sees the
+		// control.db tenants already nilled out (see controlHandles). That is
+		// the same transient, retryable class handleHALRepoPatch already maps
+		// to 503 for ErrRepoClosed/ErrStoreUnavailable — a stopped manager
+		// deserves the same answer, not a 500 that implies the server is
+		// broken rather than mid-restart.
+		return http.StatusServiceUnavailable, "Repo not ready",
+			"the repo manager is starting up or shutting down; try again"
 	default:
 		return http.StatusInternalServerError, "Rename failed", "could not rename the repository"
 	}

--- a/internal/web/handlers_repos_rename.go
+++ b/internal/web/handlers_repos_rename.go
@@ -1,0 +1,109 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	"knomit/internal/repos"
+	"knomit/internal/web/hal"
+)
+
+// renameRepoRequest is the POST /repos/{repo}/rename body.
+type renameRepoRequest struct {
+	Name string `json:"name"`
+}
+
+// maxRenameBodyBytes bounds the decoder. A repo name is [a-z0-9_-]+ with no
+// length cap, but a legitimate one is tens of bytes; this only stops bodies
+// nowhere near a real request.
+const maxRenameBodyBytes = 4 << 10
+
+// renameErrStatus maps an error from m.RenameRepo to the HTTP status and
+// problem body fields the handler should write. Split out from the handler so
+// the ErrRepoNotFound-means-409-here case (see below) can be exercised
+// directly, without racing goroutines against the manager just to reach it.
+func renameErrStatus(err error, oldName, newName string) (status int, title, detail string) {
+	switch {
+	case errors.Is(err, repos.ErrInvalidName):
+		return http.StatusUnprocessableEntity, "Invalid repo name",
+			"a repo name may contain only lowercase letters, digits, hyphens and underscores"
+	case errors.Is(err, repos.ErrRepoExists):
+		return http.StatusConflict, "Name already in use",
+			"another repository is already called \"" + newName + "\""
+	case errors.Is(err, repos.ErrRepoNameConflictsLens):
+		return http.StatusConflict, "Name already in use",
+			"a lens is already called \"" + newName + "\""
+	case errors.Is(err, repos.ErrCreateInFlight):
+		// The sentinel says "create", but the caller did not ask for one —
+		// report what is true for them: the name is being taken.
+		return http.StatusConflict, "Name already in use",
+			"another operation is currently claiming \"" + newName + "\"; try again"
+	case errors.Is(err, repos.ErrRepoNotFound):
+		// This looks like the same sentinel RepoMiddleware maps to 404 for a
+		// genuinely unknown {repo} — it is NOT the same case. By the time
+		// RenameRepo runs, the middleware has already resolved oldName against
+		// a live repo; the only way RenameRepo can still return
+		// ErrRepoNotFound is the lost-race path in its CAS (RenameIfNamed
+		// matched zero rows because a concurrent rename or removal moved
+		// oldName first) — see lifecycle.go's RenameRepo doc comment. The repo
+		// this request named did exist a moment ago, so telling the client
+		// "not found" would be false; it changed out from under the request,
+		// which is a conflict the client should resolve by re-reading the repo
+		// and retrying, not by concluding the name never existed.
+		return http.StatusConflict, "Repo changed during rename",
+			"repo \"" + oldName + "\" was renamed or removed while this request was in flight; re-read it and retry"
+	default:
+		return http.StatusInternalServerError, "Rename failed", "could not rename the repository"
+	}
+}
+
+// handleHALRepoRename serves POST /api/v1/repos/{repo}/rename.
+//
+// A custom action rather than PATCH /repos/{repo}: repoView re-reads the repo
+// through the name in the URL, and a rename invalidates the very identifier the
+// request was addressed by, so the write and its response cannot share one
+// resource. The slash form matches the existing resource-level action
+// POST /archived/{id}/restore. Deliberately NOT the AIP colon form — that
+// convention is scoped to COLLECTION-level actions with no {repo} segment
+// (/repos:rescan). Do not "fix" this to /repos/{repo}:rename.
+func handleHALRepoRename(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		oldName := chi.URLParam(r, "repo")
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxRenameBodyBytes)
+		var req renameRepoRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid request body", err.Error(), r.URL.Path)
+			return
+		}
+		if req.Name == "" {
+			hal.WriteProblem(w, http.StatusBadRequest, "Missing name",
+				"a new name is required", r.URL.Path)
+			return
+		}
+
+		if err := m.RenameRepo(oldName, req.Name); err != nil {
+			status, title, detail := renameErrStatus(err, oldName, req.Name)
+			if status == http.StatusInternalServerError {
+				log.Error().Err(err).Str("from", oldName).Str("to", req.Name).Msg("rename repo failed")
+			}
+			hal.WriteProblem(w, status, title, detail, r.URL.Path)
+			return
+		}
+
+		// Re-read under the NEW name so the response — self link included —
+		// addresses the repo as it now exists.
+		ri := m.Get(req.Name)
+		if ri == nil {
+			log.Error().Str("to", req.Name).Msg("rename succeeded but the repo is not resolvable")
+			hal.WriteProblem(w, http.StatusInternalServerError, "Rename failed",
+				"the repository was renamed but could not be re-read", r.URL.Path)
+			return
+		}
+		hal.WriteHAL(w, http.StatusOK, repoView(b, r, req.Name, ri))
+	}
+}

--- a/internal/web/handlers_repos_rename_test.go
+++ b/internal/web/handlers_repos_rename_test.go
@@ -1,0 +1,102 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/repos"
+)
+
+func postRename(t *testing.T, r http.Handler, repo, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/repos/"+repo+"/rename", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandleRepoRename_InvalidNameIs422(t *testing.T) {
+	s := &Server{Manager: newTestManagerWithRepos(t, "alpha")}
+	rec := postRename(t, s.NewAPIRouter(), "alpha", `{"name":"Has Capitals"}`)
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+// TestHandleRepoRename_NameTakenIs409 must reach RenameRepo's own
+// already-active-name check (ErrRepoExists), which needs a running registry —
+// the bare-stub manager from newTestManagerWithRepos has none (its repos are
+// never Start()-ed), so RenameRepo would fail earlier with ErrManagerStopped
+// instead. Uses the on-disk-repo harness with a second repo created alongside
+// "work".
+func TestHandleRepoRename_NameTakenIs409(t *testing.T) {
+	r, m := newRepoPatchServerWithManager(t)
+	_, err := m.Create(context.Background(), repos.CreateSpec{Name: "other", Mode: "preset"}, nil)
+	require.NoError(t, err)
+
+	rec := postRename(t, r, "work", `{"name":"other"}`)
+	require.Equal(t, http.StatusConflict, rec.Code, "body=%s", rec.Body.String())
+}
+
+func TestHandleRepoRename_MissingNameIs400(t *testing.T) {
+	s := &Server{Manager: newTestManagerWithRepos(t, "alpha")}
+	rec := postRename(t, s.NewAPIRouter(), "alpha", `{}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleRepoRename_UnknownRepoIs404(t *testing.T) {
+	s := &Server{Manager: newTestManagerWithRepos(t, "alpha")}
+	rec := postRename(t, s.NewAPIRouter(), "ghost", `{"name":"beta"}`)
+	require.Equal(t, http.StatusNotFound, rec.Code, "RepoMiddleware answers this")
+}
+
+// TestHandleRepoRename_SelfLinkPointsAtTheNewName needs a rename that actually
+// commits, which requires a real registry behind the manager —
+// newTestManagerWithRepos only registers bare *repos.RepoInstance{} stubs, so
+// it uses the on-disk-repo harness instead (see newRepoPatchServerWithManager).
+func TestHandleRepoRename_SelfLinkPointsAtTheNewName(t *testing.T) {
+	r, _ := newRepoPatchServerWithManager(t)
+	rec := postRename(t, r, "work", `{"name":"renamed"}`)
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+
+	var body struct {
+		Name  string `json:"name"`
+		Links struct {
+			Self struct{ Href string } `json:"self"`
+		} `json:"_links"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "renamed", body.Name)
+	require.Contains(t, body.Links.Self.Href, "/repos/renamed",
+		"the response must address the repo by its new name")
+}
+
+// TestHandleRepoRename_LostRaceIs409 covers the finding parked from Task 4's
+// review: once RenameRepo returns ErrRepoNotFound because a concurrent rename
+// (or removal) won the race on oldName, the repo this request was addressed to
+// plainly still exists — just under a different name — so it must not be
+// reported as 404. That would tell the client "this name never existed" when
+// the truth is "retry, someone else changed it out from under you".
+//
+// Constructing this without reaching into the manager's internals is not
+// practical from the HTTP layer: it requires racing two RenameRepo calls
+// against the same oldName and observing the loser, which is exactly what
+// internal/repos/rename_test.go's
+// TestRenameRepo_ConcurrentDifferentTargets_ExactlyOneWins already does at the
+// manager layer. Rather than duplicate that race here with real goroutines
+// (flaky, and not testing anything the handler owns), this drives the exact
+// same error the loser observes — repos.ErrRepoNotFound wrapping oldName —
+// straight into renameErrStatus and asserts the mapping directly.
+func TestHandleRepoRename_LostRaceIs409(t *testing.T) {
+	lostRace := fmt.Errorf("%w: %q", repos.ErrRepoNotFound, "alpha")
+	status, title, _ := renameErrStatus(lostRace, "alpha", "beta")
+	require.Equal(t, http.StatusConflict, status)
+	require.NotContains(t, title, "not found",
+		"the repo this request named plainly still exists; do not tell the client otherwise")
+}

--- a/internal/web/handlers_repos_rename_test.go
+++ b/internal/web/handlers_repos_rename_test.go
@@ -100,3 +100,15 @@ func TestHandleRepoRename_LostRaceIs409(t *testing.T) {
 	require.NotContains(t, title, "not found",
 		"the repo this request named plainly still exists; do not tell the client otherwise")
 }
+
+// TestHandleRepoRename_ManagerStoppedIs503 covers the shutdown-grace-window
+// case: a request that lands in the 5s gap between Shutdown and the deferred
+// Close finds the control.db tenants already nilled out, and RenameRepo
+// reports that as repos.ErrManagerStopped. This is transient and retryable —
+// the same class handleHALRepoPatch already answers 503 for on
+// ErrRepoClosed/ErrStoreUnavailable — not a 500 implying the server is broken.
+func TestHandleRepoRename_ManagerStoppedIs503(t *testing.T) {
+	status, title, _ := renameErrStatus(repos.ErrManagerStopped, "alpha", "beta")
+	require.Equal(t, http.StatusServiceUnavailable, status)
+	require.Equal(t, "Repo not ready", title)
+}

--- a/internal/web/handlers_repos_rename_test.go
+++ b/internal/web/handlers_repos_rename_test.go
@@ -23,10 +23,15 @@ func postRename(t *testing.T, r http.Handler, repo, body string) *httptest.Respo
 	return rec
 }
 
-func TestHandleRepoRename_InvalidNameIs422(t *testing.T) {
+// TestHandleRepoRename_InvalidNameIs400 pins the name-grammar rejection to
+// 400, matching every other name-grammar check in this package (repo
+// create, lens create/patch, archive/restore) — 422 is reserved for
+// cross-referential failures, not a fixed-grammar syntax check on the name
+// itself.
+func TestHandleRepoRename_InvalidNameIs400(t *testing.T) {
 	s := &Server{Manager: newTestManagerWithRepos(t, "alpha")}
 	rec := postRename(t, s.NewAPIRouter(), "alpha", `{"name":"Has Capitals"}`)
-	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // TestHandleRepoRename_NameTakenIs409 must reach RenameRepo's own

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -193,11 +193,13 @@ func (s *Server) NewAPIRouter() chi.Router {
 	r.Post("/lenses", handleHALLensesCreate(b, s.Manager))
 
 	r.Route("/lenses/{lens}", func(r chi.Router) {
-		// The lens CRUD trio resolves through the registry directly and
-		// reports its own errors, so it stays outside the binding group.
+		// The lens CRUD quartet — including rename — resolves through the
+		// registry directly and reports its own errors, so it stays outside
+		// the binding group below.
 		r.Get("/", handleHALLens(b, s.Manager))
 		r.Patch("/", handleHALLensPatch(b, s.Manager))
 		r.Delete("/", handleHALLensDelete(s.Manager))
+		r.Post("/rename", handleHALLensRename(b, s.Manager))
 
 		r.Group(func(r chi.Router) {
 			r.Use(LensMiddleware(s.Manager))

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -116,6 +116,12 @@ func (s *Server) NewAPIRouter() chi.Router {
 			r.Get("/", handleHALRepo(b))
 			r.Patch("/", handleHALRepoPatch(b))
 
+			// Inside the middleware group, unlike Archive: {repo} must exist
+			// for a rename, so the middleware's 404 is the right answer, and
+			// every error this handler raises is about the NEW name, which the
+			// middleware never sees.
+			r.Post("/rename", handleHALRepoRename(b, s.Manager))
+
 			r.Get("/origin", handleHALGetOrigin(b, p.origin))
 			r.Put("/origin", handleHALSetOrigin(b, s.Manager, p.origin))
 			r.Patch("/origin/upstream", handleHALSetOriginUpstream(b, s.Manager, p.origin))

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -234,7 +234,6 @@ paths:
               schema: { $ref: "#/components/schemas/Repo" }
         "400": { $ref: "#/components/responses/Problem" }
         "409": { $ref: "#/components/responses/Problem" }
-        "422": { $ref: "#/components/responses/Problem" }
         "503": { $ref: "#/components/responses/Problem" }
         "500": { $ref: "#/components/responses/Problem" }
 
@@ -1291,7 +1290,6 @@ paths:
         "400": { $ref: "#/components/responses/Problem" }
         "404": { $ref: "#/components/responses/Problem" }
         "409": { $ref: "#/components/responses/Problem" }
-        "422": { $ref: "#/components/responses/Problem" }
         "503": { $ref: "#/components/responses/Problem" }
         "500": { $ref: "#/components/responses/Problem" }
 

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -148,6 +148,12 @@ paths:
         Content identical to the current file is accepted but makes no
         commit, so re-saving unchanged text does not grow the branch.
 
+        `license` has one more failure mode: if the LICENSE already on the
+        agent branch exceeds 65536 bytes (see `license_oversize` on `Repo`),
+        this call cannot read it back to safely diff or replace it, so any
+        `license` value — including an empty string — is refused with 409
+        rather than committed. The existing file is left untouched.
+
         The response is the re-read repository view, identical in shape to GET.
       operationId: updateRepo
       requestBody:
@@ -1771,9 +1777,22 @@ components:
           type: string
           description: >
             Verbatim contents of LICENSE at the repository root, read at the
-            agent-branch tip. Absent when the repository has no LICENSE or the
-            file exceeds 65536 bytes. Editable via PATCH, with the same
-            pointer semantics as `description`.
+            agent-branch tip. Omitted when the repository has no LICENSE, or
+            when one exists but exceeds 65536 bytes (see `license_oversize`
+            below — that case is NOT "no LICENSE"). Editable via PATCH, with
+            the same pointer semantics as `description`; PATCHing a license
+            while `license_oversize` is true is refused with 409, since the
+            request can only replace content it never actually read.
+        license_oversize:
+          type: boolean
+          description: >
+            True when a LICENSE exists at the repository root but exceeds the
+            65536-byte read cap, so `license` is omitted rather than a
+            truncated or partial read. Mutually exclusive with `license` being
+            present, and omitted entirely (never sent as `false`) in every
+            other case. Clients must render this distinctly from "no
+            LICENSE" — a UI that offers to Add/Edit a LICENSE it never read
+            risks a save that silently destroys the original.
         _links: { $ref: "#/components/schemas/LinkMap" }
 
     BranchSummary:

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -128,21 +128,24 @@ paths:
         "500": { $ref: "#/components/responses/Problem" }
     patch:
       tags: [repos]
-      summary: Update repository description
+      summary: Update repository description and/or license
       description: |
-        Edits the repo's description, which is the verbatim content of the
-        `README.md` root manifest. The new content is committed to `README.md`
-        on the repo's agent branch, so the change is part of the repo's git
-        history and syncs with it.
+        Edits the repo's description and/or license. `description` is the
+        verbatim content of the `README.md` root manifest; `license` is the
+        verbatim content of `LICENSE`. Each field's new content is committed
+        to its own file on the repo's agent branch, so the change is part of
+        the repo's git history and syncs with it. The two fields are
+        independent — a patch may edit either one, or both, without disturbing
+        the other.
 
-        `description` is markdown and is stored byte-for-byte — no
-        normalization. Omitting the field leaves the manifest unchanged; an
-        explicit empty string empties `README.md` (the file stays, and
-        `description` is then absent from the response). The maximum size is
+        Both fields are stored byte-for-byte — no normalization. For each
+        field, omitting it leaves the corresponding file unchanged; an
+        explicit empty string empties the file (the file stays, and the field
+        is then absent from the response). The maximum size for each is
         65536 bytes; a larger request body is refused with 413 before it is
-        read, and an over-cap description with 422.
+        read, and an over-cap value with 422.
 
-        Content identical to the current manifest is accepted but makes no
+        Content identical to the current file is accepted but makes no
         commit, so re-saving unchanged text does not grow the branch.
 
         The response is the re-read repository view, identical in shape to GET.
@@ -157,6 +160,10 @@ paths:
                 description:
                   type: string
                   description: Markdown content for README.md; omit to keep the current manifest.
+                  maxLength: 65536
+                license:
+                  type: string
+                  description: Verbatim content for LICENSE; omit to keep the current file.
                   maxLength: 65536
       responses:
         "200":
@@ -1691,11 +1698,11 @@ components:
             Omitted when the repo has no readable README.md.
         license:
           type: string
-          readOnly: true
           description: >
             Verbatim contents of LICENSE at the repository root, read at the
             agent-branch tip. Absent when the repository has no LICENSE or the
-            file exceeds 65536 bytes. Read-only — there is no write path.
+            file exceeds 65536 bytes. Editable via PATCH, with the same
+            pointer semantics as `description`.
         _links: { $ref: "#/components/schemas/LinkMap" }
 
     BranchSummary:

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -205,6 +205,39 @@ paths:
         "404": { $ref: "#/components/responses/Problem" }
         "409": { $ref: "#/components/responses/Problem" }
 
+  /repos/{repo}/rename:
+    parameters:
+      - $ref: "#/components/parameters/Repo"
+    post:
+      tags: [repos]
+      summary: Rename a repository
+      description: |
+        A custom action rather than PATCH /repos/{repo}: the response re-reads
+        the repo through the NEW name, and a rename invalidates the very
+        identifier the request was addressed by, so the write and its
+        response cannot share one resource. Renaming to the current name is
+        a successful no-op. 409 covers both an actively-held name (repo or
+        lens — the two share one namespace) and the repo named in the URL
+        having changed underneath the request (it still exists, just not
+        under `{repo}` any more; re-read and retry).
+      operationId: renameRepo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/RenameRequest" }
+      responses:
+        "200":
+          description: Repository renamed; response addresses it by the new name
+          content:
+            application/hal+json:
+              schema: { $ref: "#/components/schemas/Repo" }
+        "400": { $ref: "#/components/responses/Problem" }
+        "409": { $ref: "#/components/responses/Problem" }
+        "422": { $ref: "#/components/responses/Problem" }
+        "503": { $ref: "#/components/responses/Problem" }
+        "500": { $ref: "#/components/responses/Problem" }
+
   /repos/{repo}/branches:
     parameters:
       - $ref: "#/components/parameters/Repo"
@@ -1227,6 +1260,41 @@ paths:
         "503": { $ref: "#/components/responses/Problem" }
         "500": { $ref: "#/components/responses/Problem" }
 
+  /lenses/{lens}/rename:
+    parameters:
+      - $ref: "#/components/parameters/Lens"
+    post:
+      tags: [lenses]
+      summary: Rename a lens
+      description: |
+        A custom action rather than PATCH /lenses/{lens}, for the same reason
+        as the repo rename route: the response re-reads the lens through the
+        NEW name, and a rename invalidates the very identifier the request
+        was addressed by. Renaming to the current name is a successful
+        no-op. 409 covers the new name being held by another lens or by a
+        repo — repos and lenses share one namespace. Unlike the repo route,
+        an unknown `{lens}` is a plain 404: GET/PATCH/DELETE/rename on
+        `/lenses/{lens}` resolve the name directly rather than through
+        middleware, so this handler is the first (and only) lookup.
+      operationId: renameLens
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/RenameRequest" }
+      responses:
+        "200":
+          description: Lens renamed; response addresses it by the new name
+          content:
+            application/hal+json:
+              schema: { $ref: "#/components/schemas/Lens" }
+        "400": { $ref: "#/components/responses/Problem" }
+        "404": { $ref: "#/components/responses/Problem" }
+        "409": { $ref: "#/components/responses/Problem" }
+        "422": { $ref: "#/components/responses/Problem" }
+        "503": { $ref: "#/components/responses/Problem" }
+        "500": { $ref: "#/components/responses/Problem" }
+
   /lenses/{lens}/facts:
     parameters:
       - $ref: "#/components/parameters/Lens"
@@ -2207,6 +2275,15 @@ components:
         new_name:
           type: string
           description: Optional new name for the restored repo (defaults to original name).
+
+    RenameRequest:
+      type: object
+      required: [name]
+      description: Body for POST /repos/{repo}/rename and POST /lenses/{lens}/rename.
+      properties:
+        name:
+          type: string
+          description: The new name. Must match the shared repo/lens grammar `[a-z0-9_-]+`.
 
     # Origin
     # Mirrors originView in handlers_origin_hal.go exactly. The sync/push status

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -219,7 +219,11 @@ paths:
         a successful no-op. 409 covers both an actively-held name (repo or
         lens — the two share one namespace) and the repo named in the URL
         having changed underneath the request (it still exists, just not
-        under `{repo}` any more; re-read and retry).
+        under `{repo}` any more; re-read and retry). A 404 comes from
+        RepoMiddleware, which resolves `{repo}` before this handler runs — an
+        unknown repo never reaches the rename itself. That is why 404 and 409
+        are both listed and mean different things here: 404 is "no such repo
+        to begin with", 409 is "it was there and moved mid-request".
       operationId: renameRepo
       requestBody:
         required: true
@@ -233,6 +237,7 @@ paths:
             application/hal+json:
               schema: { $ref: "#/components/schemas/Repo" }
         "400": { $ref: "#/components/responses/Problem" }
+        "404": { $ref: "#/components/responses/Problem" }
         "409": { $ref: "#/components/responses/Problem" }
         "503": { $ref: "#/components/responses/Problem" }
         "500": { $ref: "#/components/responses/Problem" }
@@ -1807,6 +1812,16 @@ components:
       properties:
         branch: { type: string }
         commit: { type: string }
+        date:
+          type: string
+          format: date-time
+          description: |
+            RFC3339 commit date of the version of this fact visible at the
+            anchor — the newest commit at or before `commit` that added or
+            modified this path, NOT the anchor commit's own date. Optional:
+            omitted entirely when it cannot be resolved (an unindexed or GC'd
+            commit), so a client must treat absence as "unknown", never as
+            the epoch.
 
     Fact:
       type: object
@@ -2456,7 +2471,9 @@ components:
       description: |
         Every field is optional. An absent key keeps the current value; a
         present key replaces it wholesale. `reads` replaces as a set — it never
-        merges. The name is immutable and cannot be patched.
+        merges. The name cannot be patched here; it is not immutable, though —
+        use POST /lenses/{lens}/rename, which exists as its own route because
+        the response must be re-read through the new name.
       properties:
         write:       { $ref: "#/components/schemas/LensMember" }
         description: { type: string }

--- a/web/src/App.resolveLens.test.ts
+++ b/web/src/App.resolveLens.test.ts
@@ -144,16 +144,28 @@ describe('refreshContextAfterChange — post-mutation resync', () => {
   // A rename elsewhere (or of a different lens) must not hijack this lens's
   // own deleted-fallback path — `renamed` only steers the branch when it
   // names the lens that was actually active.
+  //
+  // The rename TARGET must be present in listLenses for this to discriminate,
+  // exactly as its repo mirror below keeps 'other2' in the repo list. With an
+  // empty lens list the `lenses.some(l => l.name === renamed.to)` half of the
+  // condition is false on its own, so the test passed whether or not the
+  // `renamed.from === context.name` half was there at all — it asserted
+  // nothing about the guard it exists to protect. Keep 'other2' listed.
   it('ignores a rename hint for a different lens and falls back normally', async () => {
     const actions: Action[] = [];
     const dispatch = (a: Action) => void actions.push(a);
     await refreshContextAfterChange(dispatch, { kind: 'lens', name: 'gone' }, 'core', {
-      listLenses: vi.fn().mockResolvedValue([]),
+      // 'other' was renamed to 'other2' — an UNRELATED lens, which is why the
+      // active 'gone' must still take the deleted path. 'other2' is listed, so
+      // only the from-matches-active guard can keep us off it.
+      listLenses: vi.fn().mockResolvedValue([{ name: 'other2', write: { uid: 'uid-work', name: 'work' }, reads: [] }]),
       repos: vi.fn().mockResolvedValue(repos('core', 'work')),
       getLens: vi.fn(),
     }, () => true, { from: 'other', to: 'other2' });
     expect(actions.some(a => a.type === 'SET_NOTICE')).toBe(true);
     expect(actions).toContainEqual({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'core' } });
+    // Dropping the guard would follow the unrelated rename instead.
+    expect(actions).not.toContainEqual({ type: 'SET_CONTEXT', context: { kind: 'lens', name: 'other2' } });
   });
 
   it('switches off an archived active repo in a repo context (existing behavior)', async () => {

--- a/web/src/App.resolveLens.test.ts
+++ b/web/src/App.resolveLens.test.ts
@@ -113,6 +113,49 @@ describe('refreshContextAfterChange — post-mutation resync', () => {
     expect(getLens).not.toHaveBeenCalled();
   });
 
+  // I5 for lenses: a rename of the ACTIVE lens is not the same case as it
+  // going missing. The Danger zone rename control reports {from, to} through
+  // onChanged, and this must follow the browse surface to the new name rather
+  // than falling back to a repo as though the lens had been deleted — a stale
+  // selection still pointed at the old name would 404 on its next read.
+  it('follows the active lens to its new name on a rename, instead of falling back to a repo', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    const getLens = vi.fn();
+    await refreshContextAfterChange(dispatch, { kind: 'lens', name: 'dev' }, 'core', {
+      // 'dev' is no longer listed under its old name — 'devx' is what is left,
+      // exactly what a rename looks like from this function's point of view.
+      listLenses: vi.fn().mockResolvedValue([{ name: 'devx', write: { uid: 'uid-work', name: 'work' }, reads: [] }]),
+      repos: vi.fn().mockResolvedValue(repos('core', 'work')),
+      getLens,
+    }, () => true, { from: 'dev', to: 'devx' });
+    expect(actions).toContainEqual({ type: 'SET_CONTEXT', context: { kind: 'lens', name: 'devx' } });
+    // No deleted-lens notice, and no fallback to a repo — the old
+    // (unfixed) behavior treated the vanished old name as evidence the lens
+    // was gone.
+    expect(actions.some(a => a.type === 'SET_NOTICE')).toBe(false);
+    expect(actions).not.toContainEqual({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'core' } });
+    // Resolution is owned by the lensResolutionPending effect, not this
+    // function — entering the new context via SET_CONTEXT is enough to make
+    // that effect fire, so getLens must NOT be called from here.
+    expect(getLens).not.toHaveBeenCalled();
+  });
+
+  // A rename elsewhere (or of a different lens) must not hijack this lens's
+  // own deleted-fallback path — `renamed` only steers the branch when it
+  // names the lens that was actually active.
+  it('ignores a rename hint for a different lens and falls back normally', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    await refreshContextAfterChange(dispatch, { kind: 'lens', name: 'gone' }, 'core', {
+      listLenses: vi.fn().mockResolvedValue([]),
+      repos: vi.fn().mockResolvedValue(repos('core', 'work')),
+      getLens: vi.fn(),
+    }, () => true, { from: 'other', to: 'other2' });
+    expect(actions.some(a => a.type === 'SET_NOTICE')).toBe(true);
+    expect(actions).toContainEqual({ type: 'SET_CONTEXT', context: { kind: 'repo', repo: 'core' } });
+  });
+
   it('switches off an archived active repo in a repo context (existing behavior)', async () => {
     const actions: Action[] = [];
     const dispatch = (a: Action) => void actions.push(a);

--- a/web/src/App.resolveLens.test.ts
+++ b/web/src/App.resolveLens.test.ts
@@ -123,6 +123,34 @@ describe('refreshContextAfterChange — post-mutation resync', () => {
     expect(actions).toContainEqual({ type: 'SET_REPO', repo: 'core' });
   });
 
+  // I5: a rename of the ACTIVE repo is not the same case as it going missing.
+  // The Danger zone rename control reports {from, to} through onChanged, and
+  // this must follow the browse surface to the new name rather than landing
+  // on whichever remaining repo happens to sort first — a stale selection
+  // still pointed at the old name would 404 on its next read.
+  it('follows the active repo to its new name on a rename, instead of falling back to an unrelated repo', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    await refreshContextAfterChange(dispatch, { kind: 'repo', repo: 'core' }, 'core', {
+      listLenses: vi.fn().mockResolvedValue([]),
+      repos: vi.fn().mockResolvedValue(repos('beta', 'work')), // 'core' renamed to 'beta'; 'beta' sorts before 'work'
+    }, () => true, { from: 'core', to: 'beta' });
+    expect(actions).toContainEqual({ type: 'SET_REPO', repo: 'beta' });
+  });
+
+  // A rename elsewhere must not hijack an UNRELATED archive/removal's
+  // fallback — `renamed` only steers the branch when it names the repo that
+  // was actually active.
+  it('ignores a rename hint for a different repo and falls back normally', async () => {
+    const actions: Action[] = [];
+    const dispatch = (a: Action) => void actions.push(a);
+    await refreshContextAfterChange(dispatch, { kind: 'repo', repo: 'gone' }, 'gone', {
+      listLenses: vi.fn().mockResolvedValue([]),
+      repos: vi.fn().mockResolvedValue(repos('core', 'other2')),
+    }, () => true, { from: 'other', to: 'other2' });
+    expect(actions).toContainEqual({ type: 'SET_REPO', repo: 'core' });
+  });
+
   it('clears the repo context when the last repo is archived', async () => {
     const actions: Action[] = [];
     const dispatch = (a: Action) => void actions.push(a);

--- a/web/src/App.resolveLens.test.ts
+++ b/web/src/App.resolveLens.test.ts
@@ -131,11 +131,17 @@ describe('refreshContextAfterChange — post-mutation resync', () => {
   it('follows the active repo to its new name on a rename, instead of falling back to an unrelated repo', async () => {
     const actions: Action[] = [];
     const dispatch = (a: Action) => void actions.push(a);
+    // 'aaa' is UNRELATED and sorts/lists first — readable[0] — so the OLD
+    // fallback (and a broken re-implementation of the fix) would dispatch
+    // SET_REPO 'aaa'. Only the renamed-hint branch produces the correct
+    // 'zeta', which is deliberately NOT readable[0], so this test actually
+    // discriminates between the two behaviors.
     await refreshContextAfterChange(dispatch, { kind: 'repo', repo: 'core' }, 'core', {
       listLenses: vi.fn().mockResolvedValue([]),
-      repos: vi.fn().mockResolvedValue(repos('beta', 'work')), // 'core' renamed to 'beta'; 'beta' sorts before 'work'
-    }, () => true, { from: 'core', to: 'beta' });
-    expect(actions).toContainEqual({ type: 'SET_REPO', repo: 'beta' });
+      repos: vi.fn().mockResolvedValue(repos('aaa', 'zeta')), // 'core' renamed to 'zeta'
+    }, () => true, { from: 'core', to: 'zeta' });
+    expect(actions).toContainEqual({ type: 'SET_REPO', repo: 'zeta' });
+    expect(actions).not.toContainEqual({ type: 'SET_REPO', repo: 'aaa' });
   });
 
   // A rename elsewhere must not hijack an UNRELATED archive/removal's

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -110,8 +110,11 @@ export async function resolveLens(
 
 // refreshContextAfterChange re-syncs the browse surface after a repo/lens
 // mutation reported by the RepoManager (I4). It re-fetches both lists and:
-//   - lens context, lens still exists → re-run resolveLens so edited mounts
-//     refresh state.lens (reads/write/description);
+//   - lens context, `renamed` says the active lens is the one that got
+//     renamed → follow it to the new name (I5, same reasoning as the repo
+//     case below) rather than treating the old name as gone;
+//   - lens context, lens still exists under its current name → re-run
+//     resolveLens so edited mounts refresh state.lens (reads/write/description);
 //   - lens context, lens gone → fall back to the first repo with the same
 //     deleted-lens notice resolveLens uses, so no dead empty library is left;
 //   - repo context → keep the prior behavior: if the active repo was
@@ -166,7 +169,16 @@ export async function refreshContextAfterChange(
     return { lenses, repos: repoList };
   }
   if (context.kind === 'lens') {
-    if (lenses.some(l => l.name === context.name)) {
+    // A rename is not the lens vanishing: if this is the same lens under its
+    // new name, follow it there rather than treating the old name as deleted
+    // (I5, mirrored from the repo-rename handling below). Only SET_CONTEXT is
+    // dispatched here — resolution is owned by the lensResolutionPending
+    // effect, the same "single owner" rule every other lens-context entry
+    // follows (TopBar switcher, manager Browse, bootstrap restore); entering
+    // the new context clears state.lens, which is what makes that effect fire.
+    if (renamed && renamed.from === context.name && lenses.some(l => l.name === renamed.to)) {
+      dispatch({ type: 'SET_CONTEXT', context: { kind: 'lens', name: renamed.to } });
+    } else if (lenses.some(l => l.name === context.name)) {
       // `repoList`, NOT `readable`. resolveLens's readability check
       // (brokenLensMember) counts only POSITIVE evidence — a member the listing
       // carries in a broken state — so handing it a list with the broken repos

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -116,7 +116,9 @@ export async function resolveLens(
 //     deleted-lens notice resolveLens uses, so no dead empty library is left;
 //   - repo context → keep the prior behavior: if the active repo was
 //     archived/removed, switch to a remaining one (the first in the list; no
-//     repo name is privileged);
+//     repo name is privileged) — UNLESS `renamed` says the active repo is the
+//     one that got renamed, in which case it follows to the new name instead
+//     of landing on an unrelated repo (I5: a rename is not a disappearance);
 //   - no repos left at all → clear the repo context outright, whatever the
 //     browse surface was. This case precedes the other two: with an empty list
 //     there is nothing to fall back TO, and leaving state.repo on the archived
@@ -134,6 +136,11 @@ export async function refreshContextAfterChange(
     getLens?: (name: string) => Promise<Lens>;
   } = {},
   isCurrentLens: (name: string) => boolean = () => true,
+  // Set when the mutation that triggered this call WAS a rename. Lets the
+  // repo-context branch below distinguish "the active repo is gone" (jump to
+  // whatever is left) from "the active repo is still here, just renamed"
+  // (follow it) — the RepoManager Danger zone's `onChanged({from, to})`.
+  renamed?: { from: string; to: string },
 ): Promise<{ lenses: Lens[]; repos: RepoInfo[] }> {
   const listLenses = deps.listLenses ?? api.listLenses;
   const listRepos = deps.repos ?? api.repos;
@@ -177,7 +184,13 @@ export async function refreshContextAfterChange(
     // repo going unavailable across a server restart has to move the surface,
     // exactly as an archived one does.
   } else if (!readable.some(r => r.name === currentRepo)) {
-    dispatch({ type: 'SET_REPO', repo: readable[0].name });
+    // A rename is not the active repo vanishing: if this is the same repo
+    // under its new name, follow it there rather than landing on whichever
+    // unrelated repo happens to sort first.
+    const to = renamed && renamed.from === currentRepo && readable.some(r => r.name === renamed.to)
+      ? renamed.to
+      : readable[0].name;
+    dispatch({ type: 'SET_REPO', repo: to });
   }
   return { lenses, repos: repoList };
 }
@@ -787,12 +800,13 @@ export default function App() {
     const depth = selectTrail(stateRef.current).length - 1; // index of the current crumb
     for (let k = 0; k < depth - i; k++) dispatch({ type: 'NAV_BACK' });
   }, [dispatch]);
-  const onRepoMgrChanged = useCallback(() => {
+  const onRepoMgrChanged = useCallback((renamed?: { from: string; to: string }) => {
     // Re-sync after a repo/lens mutation. In a lens context this re-resolves the
     // browsed lens (so edited mounts refresh state.lens) or falls back with a
     // notice if it was deleted; in a repo context it switches off an
-    // archived/removed active repo (I4).
-    void refreshContextAfterChange(dispatch, stateRef.current.context, stateRef.current.repo, {}, isCurrentLens)
+    // archived/removed active repo (I4) — or, when `renamed` says the active
+    // repo is the one that got renamed, follows it to its new name instead.
+    void refreshContextAfterChange(dispatch, stateRef.current.context, stateRef.current.repo, {}, isCurrentLens, renamed)
       .then(({ lenses: ls, repos: rs }) => { setLenses(ls); setRepos(rs); })
       .catch(() => {});
   }, [dispatch, isCurrentLens]);

--- a/web/src/ManageOverview.test.tsx
+++ b/web/src/ManageOverview.test.tsx
@@ -112,7 +112,7 @@ describe('Manage Overview', () => {
     await waitFor(() => expect(screen.queryByText(/needs attention/i)).not.toBeInTheDocument());
   });
 
-  it('does NOT flag a missing licence, because nothing here can set one', async () => {
+  it('does NOT flag a missing licence, even though it is now fixable', async () => {
     // Healthy remotes throughout, so a missing licence is the ONLY thing that
     // could possibly raise a row — otherwise this would pass for the wrong
     // reason on the back of "no remote configured".
@@ -121,9 +121,11 @@ describe('Manage Overview', () => {
     render(<RepoManager {...baseProps} />);
     await screen.findByTestId('fleet-row-core');
     await waitFor(() => expect(screen.getByTestId('fleet-row-core').textContent).toContain('none'));
-    // LICENSE is read-only server-side (manifest.go has no write path), so a
-    // checklist row offering to fix it would name an action that does not
-    // exist. It stays a column, which reports, not a row, which acts.
+    // A missing licence is actionable now — the repo pane offers to create
+    // one, and this "none" cell links straight there — but it is still not an
+    // ATTENTION row: a local-only KB stating no terms is a legitimate steady
+    // state, not a fault. It stays a column, which reports, not a row, which
+    // acts.
     expect(screen.queryByText(/licence/i)).toBeInTheDocument();   // the column header
     expect(screen.queryByTestId('attention-core')).not.toBeInTheDocument();
   });

--- a/web/src/ManageOverview.tsx
+++ b/web/src/ManageOverview.tsx
@@ -15,10 +15,11 @@ import { PlusIcon, LayersIcon, RefreshIcon } from './icons';
 // for Manage is configuration, so this page answers the two questions the rest
 // of the app cannot: what needs doing, and what is wired to what.
 //
-// Deliberately NOT here: a "no licence" check. LICENSE is read-only — the Go
-// side has ReadReadme/WriteReadme but only a read path for LicensePath — so a
-// row offering to fix it would name an action that does not exist. It stays a
-// column in the table, which reports, rather than a checklist row, which acts.
+// Deliberately NOT here: a "no licence" check. A missing LICENSE is now
+// actionable (the repo pane offers to create one, and the table's "none" cell
+// links straight to it), but it is still not an ATTENTION row: this page's
+// attention list is things that need doing, and a local-only KB that states no
+// terms is a legitimate steady state, not a fault.
 
 /** One repository's configuration, assembled from the per-repo fan-out. */
 interface FleetRow {

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -740,15 +740,58 @@ describe('RepoManager', () => {
     expect((await screen.findByTestId('repo-license')).textContent).toBe(mit);
   });
 
-  // No LICENSE ⇒ no block at all. Unlike the description there is nothing to
-  // write (manifest.go has no write path for LicensePath), so an empty block
-  // would head a section that offers an action which does not exist.
-  it('omits the license block when the repo has no LICENSE', async () => {
+  // No LICENSE and nothing writable ⇒ no block at all, mirroring the
+  // description's rule: a read-only repo with neither a file to show nor a
+  // way to create one gets no heading for it.
+  it('omits the license block when read-only and the repo has no LICENSE', async () => {
     (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core' });
-    render(<RepoManager {...baseProps} />);
+    render(<RepoManager {...baseProps} readOnly />);
     await waitFor(() => expect(api.getRepo).toHaveBeenCalledWith('core'));
     expect(screen.queryByTestId('block-license')).toBeNull();
     expect(screen.queryByTestId('toc-license')).toBeNull();
+  });
+
+  // Offers to add a LICENSE when there is none, mirroring the description's
+  // empty-but-writable state.
+  it('offers to add a LICENSE when there is none', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', description: '' });
+    render(<RepoManager {...baseProps} />);
+    await selectRepo();
+
+    expect(await screen.findByText(/No LICENSE at the repo root/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add license/i })).toBeEnabled();
+  });
+
+  // Saving a new LICENSE goes through the same PATCH the description uses,
+  // just with `license` instead of `description` in the body — the two
+  // fields are independent, so this must not touch the README.
+  it('saves a new LICENSE through updateRepo', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core' });
+    (api.updateRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'core', license: 'MIT\n' });
+    render(<RepoManager {...baseProps} />);
+    await selectRepo();
+
+    fireEvent.click(await screen.findByRole('button', { name: /add license/i }));
+    fireEvent.change(screen.getByTestId('license-textarea'), { target: { value: 'MIT' } });
+    fireEvent.click(screen.getByTestId('repo-license-save'));
+
+    await waitFor(() => expect(api.updateRepo).toHaveBeenCalledWith('core', { license: 'MIT' }));
+  });
+
+  // The trap this whole feature is built around: reusing DescriptionBody's
+  // read view for the licence would run it through ReactMarkdown, which
+  // reflows single newlines and turns "* not a bullet" into a real bullet.
+  it('renders the licence preformatted, not as markdown', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'core', license: 'MIT License\n\n* not a bullet\nsecond line\n',
+    });
+    render(<RepoManager {...baseProps} />);
+    await selectRepo();
+
+    const pre = await screen.findByTestId('repo-license');
+    expect(pre.tagName).toBe('PRE');
+    expect(pre).toHaveTextContent('* not a bullet');
+    expect(screen.queryByRole('listitem')).toBeNull();
   });
 
   // With no README.md the block is still offered so a description can be

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -795,6 +795,41 @@ describe('RepoManager', () => {
     expect(screen.queryByRole('listitem')).toBeNull();
   });
 
+  // The trap this state exists to close: a LICENSE too large for the server
+  // to hand back must render as "present but unreadable", not as "absent" —
+  // and crucially must offer neither Add nor Edit, since either control would
+  // open a blank textarea over a file the server never actually read, and a
+  // Save from there would look like an ordinary edit while destroying the
+  // original (the server now refuses that write too, but the control must
+  // not even be there to invite it).
+  it('renders the oversize-license state with no Add/Edit control', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'core', license_oversize: true,
+    });
+    render(<RepoManager {...baseProps} />);
+    await selectRepo();
+
+    expect(await screen.findByTestId('repo-license-oversize')).toHaveTextContent(/too large/i);
+    expect(screen.queryByTestId('repo-license')).toBeNull();
+    expect(screen.queryByRole('button', { name: /add license/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /edit license/i })).toBeNull();
+    expect(screen.queryByTestId('license-textarea')).toBeNull();
+  });
+
+  // A read-only repo with an oversize LICENSE has something to report (a file
+  // exists) even though readOnly already forbids Add/Edit for other reasons —
+  // the block must still appear and say so, mirroring how a readable LICENSE
+  // renders under readOnly.
+  it('shows the oversize-license state even when read-only', async () => {
+    (api.getRepo as ReturnType<typeof vi.fn>).mockResolvedValue({
+      name: 'core', license_oversize: true,
+    });
+    render(<RepoManager {...baseProps} readOnly />);
+    await selectRepo();
+
+    expect(await screen.findByTestId('repo-license-oversize')).toBeInTheDocument();
+  });
+
   // With no README.md the block is still offered so a description can be
   // written — but only when the user could actually write one.
   it('offers an empty description block when the repo has no README.md', async () => {

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -33,6 +33,7 @@ vi.mock('./api', async importOriginal => ({
     getAgentBranch: vi.fn().mockResolvedValue('agent/test'),
     getRepo: vi.fn().mockResolvedValue({ name: 'core' }),
     updateRepo: vi.fn().mockResolvedValue({ name: 'core' }),
+    renameRepo: vi.fn().mockResolvedValue({ name: 'core' }),
     getOrigin: vi.fn().mockResolvedValue(null),
     deleteOrigin: vi.fn(),
     rebuild: vi.fn().mockResolvedValue({ id: 'job1', state: 'running' }),
@@ -575,6 +576,125 @@ describe('RepoManager', () => {
     const danger = await screen.findByTestId('block-danger');
     expect(within(danger).getByTestId('repo-archive')).toBeInTheDocument();
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  // Rename shares the Danger zone with Archive: same tint, same fence, and the
+  // same typed-confirmation friction — but it deletes nothing and is freely
+  // reversible, which is why its warning names the one real consequence
+  // (agent MCP URLs) instead of borrowing Archive's "this is dangerous" tone.
+  describe('Rename', () => {
+    it('puts Rename in the Danger zone block, beside Archive', async () => {
+      render(<RepoManager {...baseProps} />);
+      await selectRepo();
+      const danger = await screen.findByTestId('block-danger');
+      expect(within(danger).getByTestId('repo-rename-submit')).toBeInTheDocument();
+    });
+
+    // The warning must name what ACTUALLY breaks post-rename (the MCP
+    // endpoint URL) and must say in-flight agent queries survive it — MCP
+    // tool-session cursors are pinned to the repo's stable uid, not its
+    // display name, so a query outlives a rename that runs underneath it. It
+    // must not read as "agent activity breaks" generally.
+    it('warns that MCP endpoint URLs break but in-flight agent queries are unaffected', async () => {
+      render(<RepoManager {...baseProps} />);
+      await selectRepo();
+      const warning = await screen.findByTestId('repo-rename-warning');
+      expect(warning).toHaveTextContent(/MCP/i);
+      expect(warning.textContent).toMatch(/in-flight agent quer(y|ies) (is|are) unaffected/i);
+    });
+
+    it('keeps Rename disabled until the current name is typed exactly', async () => {
+      render(<RepoManager {...baseProps} />);
+      await selectRepo();
+
+      const submit = await screen.findByTestId('repo-rename-submit');
+      expect(submit).toBeDisabled();
+
+      fireEvent.change(screen.getByTestId('repo-rename-input'), { target: { value: 'beta' } });
+      expect(submit).toBeDisabled();
+
+      fireEvent.change(screen.getByTestId('repo-rename-confirm'), { target: { value: 'cor' } });
+      expect(submit).toBeDisabled();
+
+      fireEvent.change(screen.getByTestId('repo-rename-confirm'), { target: { value: 'core' } });
+      expect(submit).toBeEnabled();
+    });
+
+    // A no-op rename (new name === current name) would report success and
+    // change nothing — confusing rather than dangerous, so it is disabled
+    // rather than sent.
+    it('disables Rename when the new name equals the current name', async () => {
+      render(<RepoManager {...baseProps} />);
+      await selectRepo();
+
+      fireEvent.change(screen.getByTestId('repo-rename-input'), { target: { value: 'core' } });
+      fireEvent.change(screen.getByTestId('repo-rename-confirm'), { target: { value: 'core' } });
+      expect(screen.getByTestId('repo-rename-submit')).toBeDisabled();
+    });
+
+    it('calls renameRepo with the new name and follows the pane to it', async () => {
+      (api.renameRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'beta' });
+      render(<RepoManager {...baseProps} />);
+      await selectRepo();
+
+      fireEvent.change(screen.getByTestId('repo-rename-input'), { target: { value: 'beta' } });
+      fireEvent.change(screen.getByTestId('repo-rename-confirm'), { target: { value: 'core' } });
+      fireEvent.click(screen.getByTestId('repo-rename-submit'));
+
+      await waitFor(() => expect(api.renameRepo).toHaveBeenCalledWith('core', 'beta'));
+      // The pane is addressed by name; it must follow the repo to its new one
+      // rather than show a 404 on the next read under the old name. The rail
+      // itself still reads "core"/"work" here — this component gets its repo
+      // LIST from a prop the parent owns and hasn't re-fetched in this test —
+      // but the selected detail pane's own heading must already say "beta".
+      await waitFor(() => expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('beta'));
+    });
+
+    // The parent learns about the rename too — with BOTH names — so it can
+    // re-point a stale "currently browsed repo" selection at the new one
+    // instead of falling back to an arbitrary remaining repo.
+    it('reports the rename to the parent as {from, to}, not a bare refresh', async () => {
+      (api.renameRepo as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'beta' });
+      const onChanged = vi.fn();
+      render(<RepoManager {...baseProps} onChanged={onChanged} />);
+      await selectRepo();
+
+      fireEvent.change(screen.getByTestId('repo-rename-input'), { target: { value: 'beta' } });
+      fireEvent.change(screen.getByTestId('repo-rename-confirm'), { target: { value: 'core' } });
+      fireEvent.click(screen.getByTestId('repo-rename-submit'));
+
+      await waitFor(() => expect(onChanged).toHaveBeenCalledWith({ from: 'core', to: 'beta' }));
+    });
+
+    // A concurrent rename (someone else won the race) is a 409 whose detail
+    // already tells the user the right move — re-read and retry. The UI must
+    // not swallow that into invented copy the way Rebuild's "already running"
+    // 409 does: there is no "someone else broke this" framing to invent, and
+    // the server's own sentence already says what to do.
+    it('surfaces the server detail verbatim on a 409 conflict, without inventing new copy', async () => {
+      (api.renameRepo as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('/api/v1/repos/core/rename → 409 repo "core" was renamed or removed while this request was in flight; re-read it and retry'),
+      );
+      render(<RepoManager {...baseProps} />);
+      await selectRepo();
+
+      fireEvent.change(screen.getByTestId('repo-rename-input'), { target: { value: 'beta' } });
+      fireEvent.change(screen.getByTestId('repo-rename-confirm'), { target: { value: 'core' } });
+      fireEvent.click(screen.getByTestId('repo-rename-submit'));
+
+      expect(await screen.findByText(/re-read it and retry/i)).toBeInTheDocument();
+    });
+
+    it('is disabled entirely when the repo is read-only', async () => {
+      render(<RepoManager {...baseProps} readOnly />);
+      await selectRepo();
+
+      fireEvent.change(screen.getByTestId('repo-rename-input'), { target: { value: 'beta' } });
+      fireEvent.change(screen.getByTestId('repo-rename-confirm'), { target: { value: 'core' } });
+      expect(screen.getByTestId('repo-rename-input')).toBeDisabled();
+      expect(screen.getByTestId('repo-rename-confirm')).toBeDisabled();
+      expect(screen.getByTestId('repo-rename-submit')).toBeDisabled();
+    });
   });
 
   it('renders the README.md description in the detail pane', async () => {

--- a/web/src/RepoManager.test.tsx
+++ b/web/src/RepoManager.test.tsx
@@ -29,6 +29,7 @@ vi.mock('./api', async importOriginal => ({
     createLens: vi.fn().mockResolvedValue({ name: 'newlens', write: { uid: 'uid-core', name: 'core' }, reads: [] }),
     updateLens: vi.fn().mockResolvedValue({ name: 'dev', write: { uid: 'uid-work', name: 'work' }, reads: [{ uid: 'uid-core', name: 'core', branch: 'main' }, { uid: 'uid-work', name: 'work' }] }),
     deleteLens: vi.fn().mockResolvedValue(undefined),
+    renameLens: vi.fn().mockResolvedValue({ name: 'dev' }),
     listBranchNames: vi.fn().mockResolvedValue([]),
     getAgentBranch: vi.fn().mockResolvedValue('agent/test'),
     getRepo: vi.fn().mockResolvedValue({ name: 'core' }),
@@ -1047,6 +1048,116 @@ describe('RepoManager', () => {
     fireEvent.click(within(screen.getByTestId('block-danger')).getByTestId('lens-delete'));
     fireEvent.click(screen.getByTestId('lens-delete-confirm'));
     await waitFor(() => expect(api.deleteLens).toHaveBeenCalledWith('dev'));
+  });
+
+  // Rename shares the Danger zone with Delete — same typed-confirmation
+  // friction as the repo control, but the warning is written for a lens: it
+  // has no history of its own to lose, and its identity (uid) survives the
+  // rename, so mounts and in-flight agent queries are unaffected.
+  describe('Lens rename', () => {
+    async function selectLens(name = 'dev') {
+      fireEvent.click(await screen.findByTestId(`repomgr-lens-${name}`));
+    }
+
+    it('puts Rename in the Danger zone block, beside Delete', async () => {
+      render(<RepoManager {...baseProps} />);
+      await selectLens();
+      const danger = await screen.findByTestId('block-danger');
+      expect(within(danger).getByTestId('lens-rename-submit')).toBeInTheDocument();
+    });
+
+    // The warning must be lens-specific: no "history/facts" language (a lens
+    // has none of its own), and it must say the lens's IDENTITY survives the
+    // rename — the MCP cursor pin is lens:<uid>, never the name.
+    it('warns that MCP endpoint URLs break but the lens keeps its identity', async () => {
+      render(<RepoManager {...baseProps} />);
+      await selectLens();
+      const warning = await screen.findByTestId('lens-rename-warning');
+      expect(warning).toHaveTextContent(/MCP/i);
+      expect(warning.textContent).toMatch(/lens keeps its identity/i);
+      expect(warning.textContent).toMatch(/mounts.*unaffected/i);
+    });
+
+    it('keeps Rename disabled until the current name is typed exactly', async () => {
+      render(<RepoManager {...baseProps} />);
+      await selectLens();
+
+      const submit = await screen.findByTestId('lens-rename-submit');
+      expect(submit).toBeDisabled();
+
+      fireEvent.change(screen.getByTestId('lens-rename-input'), { target: { value: 'newdev' } });
+      expect(submit).toBeDisabled();
+
+      fireEvent.change(screen.getByTestId('lens-rename-confirm'), { target: { value: 'de' } });
+      expect(submit).toBeDisabled();
+
+      fireEvent.change(screen.getByTestId('lens-rename-confirm'), { target: { value: 'dev' } });
+      expect(submit).toBeEnabled();
+    });
+
+    it('disables Rename when the new name equals the current name', async () => {
+      render(<RepoManager {...baseProps} />);
+      await selectLens();
+
+      fireEvent.change(screen.getByTestId('lens-rename-input'), { target: { value: 'dev' } });
+      fireEvent.change(screen.getByTestId('lens-rename-confirm'), { target: { value: 'dev' } });
+      expect(screen.getByTestId('lens-rename-submit')).toBeDisabled();
+    });
+
+    it('calls renameLens with the new name and follows the pane to it', async () => {
+      (api.renameLens as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'newdev' });
+      render(<RepoManager {...baseProps} />);
+      await selectLens();
+
+      fireEvent.change(screen.getByTestId('lens-rename-input'), { target: { value: 'newdev' } });
+      fireEvent.change(screen.getByTestId('lens-rename-confirm'), { target: { value: 'dev' } });
+      fireEvent.click(screen.getByTestId('lens-rename-submit'));
+
+      await waitFor(() => expect(api.renameLens).toHaveBeenCalledWith('dev', 'newdev'));
+      // The pane is addressed by name; it must follow the lens to its new one.
+      await waitFor(() => expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('newdev'));
+    });
+
+    // The parent learns about the rename too — with BOTH names — so it can
+    // re-point a stale "currently browsed lens" selection at the new one
+    // instead of treating the old name as though the lens was deleted.
+    it('reports the rename to the parent as {from, to}, not a bare refresh', async () => {
+      (api.renameLens as ReturnType<typeof vi.fn>).mockResolvedValue({ name: 'newdev' });
+      const onChanged = vi.fn();
+      render(<RepoManager {...baseProps} onChanged={onChanged} />);
+      await selectLens();
+
+      fireEvent.change(screen.getByTestId('lens-rename-input'), { target: { value: 'newdev' } });
+      fireEvent.change(screen.getByTestId('lens-rename-confirm'), { target: { value: 'dev' } });
+      fireEvent.click(screen.getByTestId('lens-rename-submit'));
+
+      await waitFor(() => expect(onChanged).toHaveBeenCalledWith({ from: 'dev', to: 'newdev' }));
+    });
+
+    it('surfaces the server detail verbatim on a 409 conflict, without inventing new copy', async () => {
+      (api.renameLens as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('/api/v1/lenses/dev/rename → 409 name "newdev" is held by another lens or repository'),
+      );
+      render(<RepoManager {...baseProps} />);
+      await selectLens();
+
+      fireEvent.change(screen.getByTestId('lens-rename-input'), { target: { value: 'newdev' } });
+      fireEvent.change(screen.getByTestId('lens-rename-confirm'), { target: { value: 'dev' } });
+      fireEvent.click(screen.getByTestId('lens-rename-submit'));
+
+      expect(await screen.findByText(/held by another lens or repository/i)).toBeInTheDocument();
+    });
+
+    it('is disabled entirely when read-only', async () => {
+      render(<RepoManager {...baseProps} readOnly />);
+      await selectLens();
+
+      fireEvent.change(screen.getByTestId('lens-rename-input'), { target: { value: 'newdev' } });
+      fireEvent.change(screen.getByTestId('lens-rename-confirm'), { target: { value: 'dev' } });
+      expect(screen.getByTestId('lens-rename-input')).toBeDisabled();
+      expect(screen.getByTestId('lens-rename-confirm')).toBeDisabled();
+      expect(screen.getByTestId('lens-rename-submit')).toBeDisabled();
+    });
   });
 
   it('lens Browse button fires onBrowse with the lens context', async () => {

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { api, repoAvailable, brokenLensMember, MAX_LENS_DESCRIPTION_BYTES, MAX_REPO_DESCRIPTION_BYTES, type ArchivedRepo, type RepoInfo, type Lens, type LensReadRef } from './api';
 import { RepoStateChip } from './RepoStateChip';
@@ -520,6 +520,14 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
   // License is now editable, mirroring the description above it — but its READ
   // view stays <pre>. See the section body for why that must not change.
   const [license, setLicense] = useState('');
+  // A LICENSE that exists but is too large for the server to hand back (see
+  // RepoDetails.license_oversize). Mutually exclusive with `license` being
+  // non-empty. While this is true the block must render neither Add nor Edit
+  // — opening a blank editor over a file the server never read is exactly
+  // what let a Save silently destroy the original (see WriteLicense's
+  // ErrLicenseTooLargeToReplace guard on the server, which now refuses that
+  // write too).
+  const [licenseOversize, setLicenseOversize] = useState(false);
   const [licEditing, setLicEditing] = useState(false);
   const licEditor = useDescriptionEditor({
     markdown: license,
@@ -555,11 +563,13 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
     api.getAgentBranch(name).then(b => { if (!cancelled) setAgentBranch(b); }).catch(() => {});
     setDescription('');
     setLicense('');
+    setLicenseOversize(false);
     setRenameTo(''); setRenameConfirm('');
     api.getRepo(name).then(r => {
       if (cancelled) return;
       setDescription(r.description ?? '');
       setLicense(r.license ?? '');
+      setLicenseOversize(!!r.license_oversize);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [name]);
@@ -641,16 +651,29 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
 
   // Shown whenever there is something to read OR the user could write one —
   // the same rule the Description block above uses. A read-only repo with no
-  // LICENSE gets no block: nothing to read, nothing to offer.
-  if (license || !readOnly) {
+  // LICENSE gets no block: nothing to read, nothing to offer. An oversize
+  // LICENSE counts as "something to read" even though its content did not
+  // come down the wire — there IS a file, and the block must say so.
+  if (license || licenseOversize || !readOnly) {
     sections.push({
       id: 'license',
       title: 'License',
       hint: `LICENSE at the repo root · up to ${Math.round(MAX_REPO_DESCRIPTION_BYTES / 1024)} KiB`,
-      action: readOnly ? undefined : (
+      // No control at all when oversize: neither "Edit" (there is nothing
+      // here to seed the textarea with) nor "Add" (there already IS a
+      // LICENSE — offering "Add" would imply there is not, and a blank draft
+      // saved over it is exactly the silent-destruction bug this state
+      // exists to prevent; the server refuses the write too, but the control
+      // must not be there to invite it).
+      action: readOnly || licenseOversize ? undefined : (
         <DescriptionActions editor={licEditor} label={license ? 'Edit license' : 'Add license'} testIdPrefix="repo-license" />
       ),
-      body: licEditing ? (
+      body: licenseOversize ? (
+        <div data-testid="repo-license-oversize" style={{ fontSize: 12.5, color: '#888' }}>
+          A LICENSE is present at the repo root but is too large to display or
+          edit here.
+        </div>
+      ) : licEditing ? (
         // The EDITOR is the shared monospace textarea; only the read view
         // below differs from the description block.
         <DescriptionBody editor={licEditor} readOnly={readOnly}
@@ -953,14 +976,25 @@ export function useDescriptionEditor({ markdown, maxBytes, editing, onEditing, o
   //
   // The empty description is the one case with nothing to measure, and nobody
   // writes a README from scratch in the 20px a placeholder line would give.
-  // HTMLElement, not HTMLDivElement: the description block attaches this to a
+  //
+  // A CALLBACK ref, not a RefObject: the description block attaches this to a
   // <div> (DescriptionBody's markdown render), but the licence block attaches
   // it directly to its <pre> read view — DescriptionBody never renders the
-  // licence's read view, so there is no <div> for licEditor to measure.
-  const bodyRef = useRef<HTMLElement>(null);
+  // licence's read view, so there is no <div> for licEditor to measure. A
+  // `RefObject<HTMLElement | null>` reads fine for either call site but is
+  // NOT assignable to `Ref<HTMLDivElement>` or `Ref<HTMLPreElement>` — the two
+  // element types are unrelated as far as the object-identity ref's exact
+  // generic is concerned, so `tsc -b` (unlike `tsc --noEmit -p .`, which
+  // missed this) rejects it at both attach sites. A callback ref sidesteps
+  // that: `Ref<T>` for any element T also accepts `(el: T | null) => void`,
+  // and function parameters check contravariantly, so one callback typed at
+  // the wider `HTMLElement | null` is assignable everywhere a narrower
+  // `HTMLDivElement | null` or `HTMLPreElement | null` callback is expected.
+  const elRef = useRef<HTMLElement | null>(null);
+  const bodyRef = useCallback((el: HTMLElement | null) => { elRef.current = el; }, []);
   const readHeight = useRef<number | null>(null);
   useLayoutEffect(() => {
-    if (!editing && bodyRef.current) readHeight.current = bodyRef.current.offsetHeight;
+    if (!editing && elRef.current) readHeight.current = elRef.current.offsetHeight;
   });
   const height = markdown ? (readHeight.current ?? DESC_BODY_MAX) : DESC_BODY_BLANK;
 

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -512,8 +512,20 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
       setDescription(updated.description ?? '');
     },
   });
-  // license is read-only: set once from the GET response, never written back.
+  // License is now editable, mirroring the description above it — but its READ
+  // view stays <pre>. See the section body for why that must not change.
   const [license, setLicense] = useState('');
+  const [licEditing, setLicEditing] = useState(false);
+  const licEditor = useDescriptionEditor({
+    markdown: license,
+    maxBytes: MAX_REPO_DESCRIPTION_BYTES,
+    editing: licEditing,
+    onEditing: setLicEditing,
+    onSave: async text => {
+      const updated = await api.updateRepo(name, { license: text });
+      setLicense(updated.license ?? '');
+    },
+  });
   const [rebuilding, setRebuilding] = useState(false);
   const [rebuildMsg, setRebuildMsg] = useState('');
   const [busy, setBusy] = useState(false);
@@ -617,19 +629,33 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
     });
   }
 
-  // LICENSE is read-only: internal/repos/manifest.go has ReadReadme/WriteReadme
-  // but only a read path for LicensePath, so there is nothing to offer beyond
-  // showing it. No block at all when the file is absent — an empty "License"
-  // heading would imply a control that does not exist.
-  if (license) {
+  // Shown whenever there is something to read OR the user could write one —
+  // the same rule the Description block above uses. A read-only repo with no
+  // LICENSE gets no block: nothing to read, nothing to offer.
+  if (license || !readOnly) {
     sections.push({
       id: 'license',
       title: 'License',
-      hint: 'LICENSE at the repo root',
-      body: (
-        // Preformatted, NOT markdown: a licence's single newlines are
-        // meaningful, and a markdown renderer reflows them away.
+      hint: `LICENSE at the repo root · up to ${Math.round(MAX_REPO_DESCRIPTION_BYTES / 1024)} KiB`,
+      action: readOnly ? undefined : (
+        <DescriptionActions editor={licEditor} label={license ? 'Edit license' : 'Add license'} testIdPrefix="repo-license" />
+      ),
+      body: licEditing ? (
+        // The EDITOR is the shared monospace textarea; only the read view
+        // below differs from the description block.
+        <DescriptionBody editor={licEditor} readOnly={readOnly}
+          containerTestId="repo-license-editor" textareaTestId="license-textarea" />
+      ) : license ? (
+        // PREFORMATTED, NOT MARKDOWN. A licence's single newlines are
+        // meaningful and a markdown renderer reflows them away — the MIT text
+        // loses every line break. This is the one thing that must not be
+        // copied from the Description block, whose read view IS markdown.
         <pre style={licenseText} data-testid="repo-license">{license}</pre>
+      ) : (
+        <div style={{ fontSize: 12.5, color: '#888' }}>
+          No LICENSE at the repo root. knomit stores whatever terms you supply;
+          it does not generate them.
+        </div>
       ),
     });
   }
@@ -937,11 +963,16 @@ export type DescriptionEditor = ReturnType<typeof useDescriptionEditor>;
 // README.md on the agent branch" directly under a heading that already reads
 // "README.md, committed to the agent branch". The byte counter did, and it is
 // here, where it can appear and disappear without reflowing the page either.
-export function DescriptionActions({ editor, label }: { editor: DescriptionEditor; label: string }) {
+export function DescriptionActions({ editor, label, testIdPrefix = 'repo-description' }: {
+  editor: DescriptionEditor; label: string;
+  // Lets a second block (the licence) reuse this control without colliding
+  // testids with the description block it sits beside on the same page.
+  testIdPrefix?: string;
+}) {
   const { editing, busy, over, bytes, maxBytes, showCount, save, cancel } = editor;
   if (!editing) {
     return (
-      <button type="button" className="k-bare" data-testid="repo-description-edit"
+      <button type="button" className="k-bare" data-testid={`${testIdPrefix}-edit`}
         title={label} aria-label={label}
         style={cardIconBtn()} onClick={editor.edit}>
         <PencilIcon color="#888" size={13} />
@@ -951,16 +982,16 @@ export function DescriptionActions({ editor, label }: { editor: DescriptionEdito
   return (
     <>
       {showCount && (
-        <span data-testid="repo-description-count"
+        <span data-testid={`${testIdPrefix}-count`}
           style={{ fontSize: 11, color: over ? '#f88' : '#888', whiteSpace: 'nowrap' }}>
           {bytes.toLocaleString()} / {maxBytes.toLocaleString()} bytes
         </span>
       )}
-      <button type="button" data-testid="repo-description-save" style={descBtn(busy || over, 'primary')} disabled={busy || over}
+      <button type="button" data-testid={`${testIdPrefix}-save`} style={descBtn(busy || over, 'primary')} disabled={busy || over}
         title={over ? `too long by ${(bytes - maxBytes).toLocaleString()} bytes` : undefined} onClick={save}>
         {busy ? 'Saving…' : 'Save'}
       </button>
-      <button type="button" data-testid="repo-description-cancel" style={descBtn(busy)} disabled={busy} onClick={cancel}>Cancel</button>
+      <button type="button" data-testid={`${testIdPrefix}-cancel`} style={descBtn(busy)} disabled={busy} onClick={cancel}>Cancel</button>
     </>
   );
 }
@@ -977,16 +1008,22 @@ export function DescriptionActions({ editor, label }: { editor: DescriptionEdito
 // bounded band — a long manifest must not push the wiring blocks off the page —
 // and the editor is a plain textarea over the raw markdown, with no rich-text
 // layer that could rewrite what gets committed.
-export function DescriptionBody({ editor, readOnly }: {
+export function DescriptionBody({ editor, readOnly, containerTestId = 'repo-description', textareaTestId = 'repo-description-input' }: {
   editor: DescriptionEditor; readOnly: boolean;
+  // Same reason as DescriptionActions' testIdPrefix: the licence block reuses
+  // this component for its EDITOR only (its read view is <pre>, never this),
+  // and needs its own textarea identity — `data-testid="license-textarea"` —
+  // without colliding with the description block's, which sits on the page
+  // at the same time.
+  containerTestId?: string; textareaTestId?: string;
 }) {
   const { markdown, editing, text, busy, err, setDraft, bodyRef, height } = editor;
   return (
-    <div data-testid="repo-description">
+    <div data-testid={containerTestId}>
       {editing ? (
         <>
           <textarea
-            data-testid="repo-description-input"
+            data-testid={textareaTestId}
             value={text}
             disabled={busy}
             onChange={e => setDraft(e.target.value)}

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -531,6 +531,11 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
       setLicense(updated.license ?? '');
     },
   });
+  // Destructured to a local, not read as `licEditor.bodyRef` at the JSX site
+  // below: the licence read view attaches this ref directly (DescriptionBody
+  // never renders it — see the section body for why), and a bare local
+  // matches how DescriptionBody itself takes bodyRef off its `editor` prop.
+  const { bodyRef: licBodyRef } = licEditor;
   const [rebuilding, setRebuilding] = useState(false);
   const [rebuildMsg, setRebuildMsg] = useState('');
   const [busy, setBusy] = useState(false);
@@ -655,7 +660,16 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
         // meaningful and a markdown renderer reflows them away — the MIT text
         // loses every line break. This is the one thing that must not be
         // copied from the Description block, whose read view IS markdown.
-        <pre style={licenseText} data-testid="repo-license">{license}</pre>
+        //
+        // ref={licBodyRef}: this IS the licence's read view (unlike the
+        // description block, whose read view lives inside DescriptionBody), so
+        // it — not DescriptionBody's markdown div, which the licence editor
+        // never renders while reading — is what useDescriptionEditor's
+        // useLayoutEffect must measure. Without this the hook's bodyRef never
+        // attaches to anything for licEditor, readHeight.current stays null
+        // forever, and the editor falls back to DESC_BODY_MAX on every open —
+        // a three-line MIT header expanding to full height.
+        <pre ref={licBodyRef} style={licenseText} data-testid="repo-license">{license}</pre>
       ) : (
         <div style={{ fontSize: 12.5, color: '#888' }}>
           No LICENSE at the repo root. knomit stores whatever terms you supply;
@@ -939,7 +953,11 @@ export function useDescriptionEditor({ markdown, maxBytes, editing, onEditing, o
   //
   // The empty description is the one case with nothing to measure, and nobody
   // writes a README from scratch in the 20px a placeholder line would give.
-  const bodyRef = useRef<HTMLDivElement>(null);
+  // HTMLElement, not HTMLDivElement: the description block attaches this to a
+  // <div> (DescriptionBody's markdown render), but the licence block attaches
+  // it directly to its <pre> read view — DescriptionBody never renders the
+  // licence's read view, so there is no <div> for licEditor to measure.
+  const bodyRef = useRef<HTMLElement>(null);
   const readHeight = useRef<number | null>(null);
   useLayoutEffect(() => {
     if (!editing && bodyRef.current) readHeight.current = bodyRef.current.offsetHeight;

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -29,7 +29,12 @@ interface Props {
   hideRemoteConfig: boolean;
   // No onClose: leaving Manage is the top bar's job now, not this pane's. The
   // surface has no chrome of its own to dismiss.
-  onChanged: () => void;             // parent re-fetches the repo list
+  //
+  // Optionally carries a rename: {from, to} so the caller can re-point a
+  // currently-BROWSED repo (state.repo, tracked outside this pane entirely) at
+  // its new name instead of falling back to an arbitrary remaining repo — the
+  // same repo, just renamed, is not the same case as one that vanished.
+  onChanged: (renamed?: { from: string; to: string }) => void;  // parent re-fetches the repo list
   onBrowse: (ctx: BrowseContext) => void;  // switch the app to browse a repo/lens
   // True while a connect commit is in flight. Withholding the rail is not
   // enough on its own: the app's own exits (Escape, the top bar's step-out)
@@ -294,6 +299,12 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 onArchived={() => { onChanged(); refresh(); setSel(null); }}
                 onConnect={() => setSel({ kind: 'connect', name: view.name })}
                 onChanged={onChanged}
+                // refresh() picks up the lens list's re-derived member names
+                // (Mounted-in reads them off `lenses`, held in THIS pane's
+                // state); onChanged(...) is the repo-list reload plus the
+                // rename hint that lets the app follow a stale browse
+                // selection to the new name (see the Props.onChanged doc).
+                onRenamed={newName => { onChanged({ from: view.name, to: newName }); refresh(); setSel({ kind: 'repo', name: newName }); }}
                 onBrowse={onBrowse}
                 onError={setErr}
               />
@@ -469,7 +480,7 @@ function CreateBlocked({ what }: { what: 'repository' | 'lens' }) {
   );
 }
 
-function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfig, onArchived, onConnect, onChanged, onBrowse, onSelectLens, onError }: {
+function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfig, onArchived, onConnect, onChanged, onRenamed, onBrowse, onSelectLens, onError }: {
   name: string; canArchive: boolean; readOnly: boolean; hideRemoteConfig: boolean;
   // Every lens, so the Mounted-in block can be derived rather than fetched —
   // it is the reverse of a lens's read mounts, and the list is already here.
@@ -478,6 +489,10 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
   // failing remote is in view rather than at the bottom of a page you must hunt.
   focus?: string;
   onArchived: () => void; onConnect: () => void; onChanged: () => void;
+  // Fired with the NEW name once the server confirms the rename. The pane is
+  // keyed on `name` by its caller, so this is how the parent learns to stop
+  // addressing it by the old one.
+  onRenamed: (newName: string) => void;
   onBrowse: (ctx: BrowseContext) => void; onSelectLens: (name: string) => void;
   onError: (m: string) => void;
 }) {
@@ -503,6 +518,11 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
   const [rebuildMsg, setRebuildMsg] = useState('');
   const [busy, setBusy] = useState(false);
   const [confirming, setConfirming] = useState<'disconnect' | null>(null);
+  // Rename draft + its typed confirmation. Local to the danger zone; cleared
+  // when the pane switches repos by the same effect that clears description.
+  const [renameTo, setRenameTo] = useState('');
+  const [renameConfirm, setRenameConfirm] = useState('');
+  const [renaming, setRenaming] = useState(false);
   // The pane owns the remote so the Remote block can render the right thing for
   // each state — Connect when there is none, the card when there is, the error
   // when the read failed. RemoteCard is the display half of that same state.
@@ -513,6 +533,7 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
     api.getAgentBranch(name).then(b => { if (!cancelled) setAgentBranch(b); }).catch(() => {});
     setDescription('');
     setLicense('');
+    setRenameTo(''); setRenameConfirm('');
     api.getRepo(name).then(r => {
       if (cancelled) return;
       setDescription(r.description ?? '');
@@ -558,6 +579,25 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
     try { await api.deleteOrigin(name); remote.reload(); setConfirming(null); onChanged(); }
     catch (e) { onError(`disconnect failed: ${String(e)}`); }
     finally { setBusy(false); }
+  };
+  // Unlike rebuild's 409, this one is NOT rewritten into invented copy: the
+  // server's detail for the "changed during rename" conflict already tells the
+  // user the one true thing to do (re-read and retry), and every sibling
+  // mutation in this file (archive, disconnect, restore, purge…) already
+  // surfaces `String(e)` verbatim rather than guessing at friendlier words.
+  const rename = async () => {
+    onError(''); setRenaming(true);
+    try {
+      const updated = await api.renameRepo(name, renameTo);
+      setRenameTo(''); setRenameConfirm('');
+      // The pane is addressed by name, so it must follow the repo to its new
+      // one — leaving it on the old name would show a 404 on the next read.
+      onRenamed(updated.name);
+    } catch (e) {
+      onError(`rename failed: ${String(e)}`);
+    } finally {
+      setRenaming(false);
+    }
   };
 
   // Blocks, ordered identity → wiring → operations → danger. That ordering is
@@ -746,6 +786,45 @@ function RepoDetail({ name, lenses, focus, canArchive, readOnly, hideRemoteConfi
         </div>
         <div style={{ fontSize: 11.5, color: '#777', marginTop: 6 }}>
           Recoverable — it moves into Archived under Repositories, and nothing is deleted.
+        </div>
+        <div style={{ borderTop: '1px solid #3a2020', marginTop: 14, paddingTop: 14 }}>
+          <div style={{ fontSize: 13, color: '#ddd', marginBottom: 4 }}>Rename this repository</div>
+          {/* Name the actual consequence rather than saying "this is
+              dangerous". Nothing is deleted and the rename is reversible; what
+              breaks is the URL agents are configured against — NOT their
+              in-flight queries, which resolve through the uid, not the name. */}
+          <div data-testid="repo-rename-warning" style={{ fontSize: 11.5, color: '#777', marginBottom: 10 }}>
+            Agent MCP endpoint URLs contain this repository's name and will stop
+            resolving until each agent is reconfigured. Facts, history, lens
+            mounts and in-flight agent queries are unaffected.
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+            <input
+              data-testid="repo-rename-input"
+              value={renameTo}
+              onChange={e => setRenameTo(e.target.value)}
+              placeholder="new-name"
+              disabled={readOnly || renaming}
+              style={renameInput}
+            />
+            <input
+              data-testid="repo-rename-confirm"
+              value={renameConfirm}
+              onChange={e => setRenameConfirm(e.target.value)}
+              placeholder={`type "${name}" to confirm`}
+              disabled={readOnly || renaming}
+              style={renameInput}
+            />
+            <button
+              type="button"
+              data-testid="repo-rename-submit"
+              style={btn(readOnly || renaming || renameConfirm !== name || !renameTo || renameTo === name, 'danger')}
+              disabled={readOnly || renaming || renameConfirm !== name || !renameTo || renameTo === name}
+              onClick={rename}
+            >
+              {renaming ? 'Renaming…' : 'Rename'}
+            </button>
+          </div>
         </div>
       </div>
     ),
@@ -1605,6 +1684,13 @@ const licenseText: React.CSSProperties = {
 // as a fenced-off area rather than one more setting.
 const dangerBox: React.CSSProperties = {
   background: '#161111', border: '1px solid #3a2626', borderRadius: 6, padding: '11px 13px',
+};
+// Monospace: a repo name is an identifier that appears in URLs, so it is typed
+// and compared character by character.
+const renameInput: React.CSSProperties = {
+  background: '#141414', border: '1px solid #3a2020', borderRadius: 4,
+  color: '#ddd', fontFamily: 'var(--k-font-mono)', fontSize: 12,
+  padding: '5px 8px', minWidth: 170, outline: 'none',
 };
 // mountOrdinal numbers a lens's read mounts. The union resolves top to bottom,
 // so the position IS information — this is a rank, not a bullet.

--- a/web/src/RepoManager.tsx
+++ b/web/src/RepoManager.tsx
@@ -364,6 +364,11 @@ export function RepoManager({ open, repos, currentRepo, readOnly, hideRemoteConf
                 readOnly={readOnly}
                 onDeleted={() => { onChanged(); refresh(); setSel(null); }}
                 onSaved={() => { onChanged(); refresh(); }}
+                // Same rename hint as RepoDetail's onRenamed (see its comment
+                // above): the pane is keyed on `name`, so onChanged carries
+                // {from, to} for the app to follow a browsed lens to its new
+                // name instead of treating the old one as vanished.
+                onRenamed={newName => { onChanged({ from: view.name, to: newName }); refresh(); setSel({ kind: 'lens', name: newName }); }}
                 onBrowse={onBrowse}
                 onError={setErr}
               />
@@ -1194,9 +1199,15 @@ function ArchivedDetail({ info, readOnly, activeNames, onRestored, onPurged, onE
 // CreateLensForm (checkbox rows, LENS tokens) rather than importing its row
 // component: that form's rows are tightly coupled to its own reads/branchData
 // state, so extraction would force a risky refactor for no shared behavior.
-function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, onBrowse, onError }: {
+function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, onRenamed, onBrowse, onError }: {
   lens?: Lens; name: string; repos: RepoInfo[]; readOnly: boolean;
-  onDeleted: () => void; onSaved: () => void; onBrowse: (ctx: BrowseContext) => void; onError: (m: string) => void;
+  onDeleted: () => void; onSaved: () => void;
+  // Fired with the NEW name once the server confirms the rename — same
+  // contract as RepoDetail's onRenamed. The pane is keyed on `name` by its
+  // caller, so this is how the parent learns to stop addressing it by the old
+  // one.
+  onRenamed: (newName: string) => void;
+  onBrowse: (ctx: BrowseContext) => void; onError: (m: string) => void;
 }) {
   const [lens, setLens] = useState<Lens | undefined>(initial);
   // Owned here for the same reason as a repo's descEditing: the Note block's
@@ -1216,6 +1227,11 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
   const [writeBranch, setWriteBranch] = useState('');
   const [busy, setBusy] = useState(false);
   const [confirming, setConfirming] = useState(false);
+  // Rename draft + its typed confirmation. Local to the danger zone; cleared
+  // when the pane switches lenses by the same effect that resets editReads.
+  const [renameTo, setRenameTo] = useState('');
+  const [renameConfirm, setRenameConfirm] = useState('');
+  const [renaming, setRenaming] = useState(false);
   // Edit mode: reads maps a mounted read repo → its branch pin ('' = default).
   // The write repo is never a key (it is read implicitly). null = not editing.
   const [editReads, setEditReads] = useState<Record<string, string> | null>(null);
@@ -1237,6 +1253,7 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
   useEffect(() => {
     setLens(initial);
     setEditReads(null);
+    setRenameTo(''); setRenameConfirm('');
     // Always refresh the full detail — the list view can omit the description,
     // and getLens returns the canonical reads set.
     let cancelled = false;
@@ -1269,6 +1286,25 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
     try { await api.deleteLens(name); onDeleted(); }
     catch (e) { onError(`delete failed: ${String(e)}`); }
     finally { setBusy(false); setConfirming(false); }
+  };
+
+  // Mirrors RepoDetail's rename: the server's detail for a 409 (name taken by
+  // another lens, or by a repo — they share one namespace) already tells the
+  // user the one true thing to do, so it is surfaced verbatim like every
+  // sibling mutation in this file rather than rewritten into invented copy.
+  const rename = async () => {
+    onError(''); setRenaming(true);
+    try {
+      const updated = await api.renameLens(name, renameTo);
+      setRenameTo(''); setRenameConfirm('');
+      // The pane is addressed by name, so it must follow the lens to its new
+      // one — leaving it on the old name would show a 404 on the next read.
+      onRenamed(updated.name);
+    } catch (e) {
+      onError(`rename failed: ${String(e)}`);
+    } finally {
+      setRenaming(false);
+    }
   };
 
   // ── edit mode ──
@@ -1445,6 +1481,45 @@ function LensDetail({ lens: initial, name, repos, readOnly, onDeleted, onSaved, 
             </div>
           </div>
         )}
+        <div style={{ borderTop: '1px solid #3a2020', marginTop: 14, paddingTop: 14 }}>
+          <div style={{ fontSize: 13, color: '#ddd', marginBottom: 4 }}>Rename this lens</div>
+          {/* Differs from the repo warning: a lens has no history or mounts of
+              its OWN to lose, and its identity (uid) is stable across the
+              rename — the MCP binding pin is lens:<uid>, never the name (RFC
+              §7.3) — so the one real consequence is the endpoint URL. */}
+          <div data-testid="lens-rename-warning" style={{ fontSize: 11.5, color: '#777', marginBottom: 10 }}>
+            Agent MCP endpoint URLs contain this lens's name and will stop resolving
+            until each agent is reconfigured. The lens keeps its identity, so its
+            mounts, and any in-flight agent queries against it, are unaffected.
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+            <input
+              data-testid="lens-rename-input"
+              value={renameTo}
+              onChange={e => setRenameTo(e.target.value)}
+              placeholder="new-name"
+              disabled={readOnly || renaming}
+              style={renameInput}
+            />
+            <input
+              data-testid="lens-rename-confirm"
+              value={renameConfirm}
+              onChange={e => setRenameConfirm(e.target.value)}
+              placeholder={`type "${name}" to confirm`}
+              disabled={readOnly || renaming}
+              style={renameInput}
+            />
+            <button
+              type="button"
+              data-testid="lens-rename-submit"
+              style={btn(readOnly || renaming || renameConfirm !== name || !renameTo || renameTo === name, 'danger')}
+              disabled={readOnly || renaming || renameConfirm !== name || !renameTo || renameTo === name}
+              onClick={rename}
+            >
+              {renaming ? 'Renaming…' : 'Rename'}
+            </button>
+          </div>
+        </div>
       </div>
     ),
   });

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -98,8 +98,28 @@ function renderFact(
             style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0, marginTop: 4 }}
           >
             {fact.commit_date && (
-              <span title={new Date(fact.commit_date).toLocaleString()} style={{ color: '#555', fontSize: 11 }}>
-                {relativeTime(fact.commit_date)}
+              // WHEN THIS VERSION OF THE FACT WAS COMMITTED — not the anchor's
+              // date. It sits here, left of the control strip, for two reasons:
+              // the band never scrolls, so it survives a long fact; and it lands
+              // beside the version chip, so "v4 · 3d ago" reads as one
+              // statement. Deliberately NOT inside the strip — every cell in
+              // there is a control, and this is a readout.
+              //
+              // Amber when anchored, matching the timeline rail and the status
+              // pill, where amber already means "you are not at HEAD".
+              <span
+                data-testid="fact-version-date"
+                title={new Date(fact.commit_date).toLocaleString()}
+                style={{
+                  color: anchorCommit ? '#e5a23c' : '#555',
+                  fontSize: 11, fontFamily: 'var(--k-font-mono)',
+                  whiteSpace: 'nowrap', flexShrink: 0,
+                }}
+              >
+                {anchorCommit
+                  ? new Date(fact.commit_date).toLocaleDateString(undefined,
+                      { day: 'numeric', month: 'short', year: 'numeric' })
+                  : relativeTime(fact.commit_date)}
               </span>
             )}
             {/*

--- a/web/src/RightPanel.versiondate.test.tsx
+++ b/web/src/RightPanel.versiondate.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { RightPanel } from './RightPanel';
+import { init } from './state';
+import type { AppState } from './state';
+import type { Fact } from './api';
+
+vi.mock('./api', () => ({
+  api: {
+    fact: vi.fn(),
+    factDiff: vi.fn().mockResolvedValue({ from: null, to: null }),
+    stats: vi.fn().mockResolvedValue(null),
+    activity: vi.fn().mockResolvedValue(null),
+    factCommits: vi.fn().mockResolvedValue({ entries: [] }),
+    explain: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }),
+  },
+}));
+
+import { api } from './api';
+
+const baseFact: Fact = {
+  path: 'kb/test/foo.md',
+  title: 'Foo',
+  body: 'body',
+  domain: [],
+  confidence: 1,
+  sources: 1,
+  entities: [],
+  refs: [],
+  commit_hash: 'bbb2222',
+};
+
+function renderPanel({ fact, anchorCommit }: { fact: Fact; anchorCommit?: string }) {
+  (api.fact as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fact);
+  const state: AppState = {
+    ...init,
+    repo: 'knomit',
+    branch: 'machine/test',
+    view: 'library',
+    factPath: fact.path,
+    asOf: anchorCommit ? { mode: 'history', commit: anchorCommit } : { mode: 'live' },
+    headCommit: 'ccc3333',
+  };
+  const dispatch = vi.fn();
+  const result = render(<RightPanel state={state} dispatch={dispatch} />);
+  return { ...result, dispatch, state };
+}
+
+describe('RightPanel — fact version date', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The fact band shows the fact's OWN version date. Live: relative. History:
+  // an absolute date in amber, because "3d ago" is meaningless once the reader
+  // has deliberately travelled to a fixed point.
+  it('renders a relative time in live mode', async () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 86400_000).toISOString();
+    renderPanel({ fact: { ...baseFact, commit_date: threeDaysAgo }, anchorCommit: undefined });
+
+    const el = await screen.findByTestId('fact-version-date');
+    expect(el).toHaveTextContent('3d ago');
+    expect(el).toHaveAttribute('title', new Date(threeDaysAgo).toLocaleString());
+  });
+
+  it('renders an absolute amber date when anchored in history', async () => {
+    const when = '2026-01-14T09:30:00Z';
+    renderPanel({ fact: { ...baseFact, commit_date: when }, anchorCommit: 'c4f9e21' });
+
+    const el = await screen.findByTestId('fact-version-date');
+    expect(el).not.toHaveTextContent('ago');
+    expect(el).toHaveTextContent('2026');
+    expect(el).toHaveStyle({ color: '#e5a23c' });
+  });
+
+  it('renders nothing when the server sent no date', async () => {
+    renderPanel({ fact: { ...baseFact, commit_date: undefined }, anchorCommit: undefined });
+
+    await waitFor(() => expect(screen.getByTestId('fact-title')).toBeInTheDocument());
+    expect(screen.queryByTestId('fact-version-date')).toBeNull();
+  });
+});

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -166,6 +166,18 @@ async function updateRepo(repo: string, body: { description?: string }): Promise
   });
 }
 
+// renameRepo POSTs /api/v1/repos/{repo}/rename. A custom action, not a PATCH:
+// the rename invalidates the URL the request was addressed by, so the response
+// is the repo re-read under its NEW name. Callers must stop using the old name
+// the moment this resolves.
+async function renameRepo(repo: string, name: string): Promise<RepoDetails> {
+  return fetchJSON<RepoDetails>(`${repoBase(repo)}/rename`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+}
+
 // LensMember identifies one member repo of a lens. `uid` is the registry key —
 // the ONLY spelling requests may send, and the one thing that survives a rename.
 // `name` is derived by the server and read-only: it is here so the UI can render
@@ -854,6 +866,7 @@ export const api = {
   getAgentBranch,
   getRepo,
   updateRepo,
+  renameRepo,
 
   repos: (): Promise<RepoInfo[]> =>
     fetchJSON<any>(apiUrl('/api/v1/repos')).then(data => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -180,6 +180,18 @@ async function renameRepo(repo: string, name: string): Promise<RepoDetails> {
   });
 }
 
+// renameLens POSTs /api/v1/lenses/{lens}/rename — the lens counterpart of
+// renameRepo above, same reasoning: a custom action rather than a PATCH
+// because the rename invalidates the URL the request was addressed by, and
+// the response is the lens re-read under its NEW name.
+async function renameLens(lens: string, name: string): Promise<Lens> {
+  return fetchJSON<Lens>(`${lensBase(lens)}/rename`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+}
+
 // LensMember identifies one member repo of a lens. `uid` is the registry key —
 // the ONLY spelling requests may send, and the one thing that survives a rename.
 // `name` is derived by the server and read-only: it is here so the UI can render
@@ -891,6 +903,7 @@ export const api = {
   createLens,
   updateLens,
   deleteLens,
+  renameLens,
   listLensFacts,
   lensSearch,
   lensCompletions,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -154,11 +154,13 @@ async function getRepo(repo: string): Promise<RepoDetails> {
 export const MAX_REPO_DESCRIPTION_BYTES = 64 * 1024;
 export const MAX_LENS_DESCRIPTION_BYTES = 4096;
 
-// updateRepo PATCHes /api/v1/repos/{repo}. The only editable field is
-// description, which the server commits to the repo's README.md root manifest
-// on the agent branch — so editing it here writes a real commit into the
-// repo's history. Returns the re-read repo view (same shape as getRepo).
-async function updateRepo(repo: string, body: { description?: string }): Promise<RepoDetails> {
+// updateRepo PATCHes /api/v1/repos/{repo}. The editable fields are
+// description and license, each committed to the repo's README.md or LICENSE
+// root manifest on the agent branch — so editing either here writes a real
+// commit into the repo's history. The two are independent: a field omitted
+// from the body is left alone, so sending only `license` does not touch the
+// README. Returns the re-read repo view (same shape as getRepo).
+async function updateRepo(repo: string, body: { description?: string; license?: string }): Promise<RepoDetails> {
   return fetchJSON<RepoDetails>(repoBase(repo), {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -135,7 +135,17 @@ export function lensAvailable(l: LensMembership, repos: RepoInfo[]): boolean {
 // RepoDetails is the single-repo GET shape. description is the verbatim
 // README.md root manifest read at HEAD; license is the verbatim LICENSE. Both
 // are absent when the repo has no readable copy.
-export interface RepoDetails { name: string; agent_branch?: string; description?: string; license?: string }
+//
+// license_oversize is a THIRD state for the licence, distinct from both "no
+// license field" (no LICENSE exists) and a present license: a LICENSE exists
+// on the branch but exceeds the server's read cap
+// (repos.MaxRepoDescriptionBytes), so its content is withheld. The Manage
+// pane must render this differently from "no LICENSE" — offering Add/Edit
+// over a file the server never actually read is what let a save silently
+// destroy an oversize LICENSE (see WriteLicense's ErrLicenseTooLargeToReplace
+// guard, which now refuses that write server-side too). Only ever true when
+// license is absent; never sent as false.
+export interface RepoDetails { name: string; agent_branch?: string; description?: string; license?: string; license_oversize?: boolean }
 
 // getRepo fetches GET /api/v1/repos/{repo} — name, agent branch, and the
 // README.md description when available.


### PR DESCRIPTION
Three features that were asked for, plus lens identity work that fell out of the third.

## What changed

**Fact version timestamps.** Every fact now shows when *its displayed version* was committed — in the band beside the version chip, relative when live and absolute + amber in history. Works for repo and lens facts alike. Server-side this is a new `as_of.date`, resolved through the existing first-parent-correct `RevisionsBefore`.

**Repo rename.** Manage → Danger zone, gated on typing the current name. A registry compare-and-swap plus an in-place re-key of the manager's map — the store is never closed, so SSE subscribers and the search index survive.

**LICENSE write path.** A missing LICENSE can be created from Manage and an existing one edited. The read view stays preformatted; a markdown renderer would reflow away every line break.

**Lens identity.** Lenses gained a `uid` primary key with an in-place migration on open, so a lens name is display-only and renameable. MCP tool-session cursors moved off names onto `repo:<uid>` / `lens:<uid>`, which also closes a pre-existing gap where a deleted-and-recreated lens could resume another lens's cursor.

## Notable

**The cursor pin was already wrong.** `Binding.Name()` was the cursor-pinning identity, so adding rename would have silently orphaned every in-flight `knomit_query` / `knomit_explain` cursor. Renaming didn't break it — it made a latent bug reachable.

**Migration was exercised against a real `control.db`** (a copy — the original was untouched): all lenses and mounts survived, uids minted and distinct, idempotent on re-open, rename preserving the uid. `Manager.Start`'s boot guard means the pre-registry shape can never reach the new path.

**Guards are proven, not asserted.** Several tests here pass only because the fix is present — each was verified by deleting the fix, watching the test fail, and restoring. `TestRevisionsBefore_MergeAnomalyPicksFirstParent` is the one worth knowing about: the obvious implementation of "last commit touching this path" is `ORDER BY committed_at DESC`, which an existing index makes easy to write and which is wrong across a merge.

**Two data-integrity fixes found late.** A concurrent double-rename could leave the registry and the live map permanently disagreeing (both writes are now compare-and-swap). And a LICENSE over the 64 KiB read cap presented as absent, so one click on "Add license" could erase it — `WriteLicense` now refuses, and the API and UI report a third `license_oversize` state.

## Verification

`go build ./...`, `go vet ./internal/...`, 23 Go packages, `go test -race ./internal/repos/...`, `npm run build` (the CI path — `tsc -b` plus the bundle), 1028 web tests.

## Known follow-ups, deliberately not in this PR

- `Restore` has three unconditional registry compensations of the same class as the rename race fixed here.
- `validateLensLocked` shares the unavailable-repo blind spot fixed in `RenameLens`.
- Once `Restore` migrates to `RenameIfNamed`, `Registry.Rename` should be deleted — three rename primitives with three zero-row contracts is a trap.
- Whether `factVersionDate`'s recursive CTE short-circuits per fact read is contested and wants a measurement, not a blind depth bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)