### PR TITLE
feat(obs): name the request behind every slow-request warning

### DIFF
--- a/internal/mcp/reqinfo_hook_test.go
+++ b/internal/mcp/reqinfo_hook_test.go
@@ -1,0 +1,40 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"knomit/internal/obs/reqinfo"
+)
+
+func callToolMessage(name string) json.RawMessage {
+	return json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + name + `","arguments":{}}}`)
+}
+
+// The HTTP slow-request log names the MCP tool that was slow. That name is only
+// known once the JSON-RPC body is parsed, so the BeforeCallTool hook writes it
+// back into the annotation the web middleware left in the request context.
+//
+// The tool named here is deliberately one that is not registered: the hook runs
+// ahead of dispatch, so the call resolves to a "tool not found" error instead of
+// reaching a handler that would need a repo binding. That is also the behaviour
+// we want in the log — the warning reports what the client ASKED for, whether or
+// not the tool exists.
+func TestBeforeCallToolRecordsToolNameInReqInfo(t *testing.T) {
+	s := NewServer("kb", nil, false)
+	ctx, info := reqinfo.NewContext(context.Background())
+
+	s.HandleMessage(ctx, callToolMessage("knomit_no_such_tool"))
+
+	if got := info.Tool(); got != "knomit_no_such_tool" {
+		t.Errorf("Tool() = %q, want %q", got, "knomit_no_such_tool")
+	}
+}
+
+// stdio sessions and in-process callers carry no annotation. The hook must be a
+// no-op there, never a panic.
+func TestBeforeCallToolWithoutReqInfoDoesNotPanic(t *testing.T) {
+	s := NewServer("kb", nil, false)
+	s.HandleMessage(context.Background(), callToolMessage("knomit_no_such_tool"))
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog/log"
 
+	"knomit/internal/obs/reqinfo"
 	"knomit/internal/repos"
 	"knomit/internal/store"
 )
@@ -27,6 +28,14 @@ import (
 // warmer is involved.
 func NewServer(defaultOntologyRoot string, mgr *repos.Manager, readOnly bool, embedders ...store.BatchEmbedder) *server.MCPServer {
 	hooks := &server.Hooks{}
+	// Name the tool for the HTTP layer. Over streamable HTTP every call is the
+	// same POST .../mcp, so without this a slow-request warning cannot say which
+	// tool was slow. The annotation rides in the request context (mcp-go derives
+	// tool-call contexts from the HTTP request's); FromContext is nil-safe, so
+	// stdio sessions — which have no HTTP request — simply record nothing.
+	hooks.AddBeforeCallTool(func(ctx context.Context, _ any, req *mcp.CallToolRequest) {
+		reqinfo.FromContext(ctx).SetTool(req.Params.Name)
+	})
 	hooks.AddAfterInitialize(func(ctx context.Context, id any, req *mcp.InitializeRequest, result *mcp.InitializeResult) {
 		_, ok := repos.RepoFromContextOpt(ctx)
 		if !ok {

--- a/internal/obs/reqinfo/reqinfo.go
+++ b/internal/obs/reqinfo/reqinfo.go
@@ -1,0 +1,64 @@
+// Package reqinfo carries a small, mutable annotation alongside an in-flight
+// request so a subsystem deep in the call tree can tell the outermost layer
+// what the request turned out to be doing.
+//
+// Context values normally flow one way — a handler cannot hand anything back to
+// the middleware that wrapped it. The middleware therefore stores a POINTER
+// before dispatching; whoever fills it in is writing into memory the middleware
+// still holds a reference to. That is what lets the HTTP slow-request log name
+// the MCP tool that was slow, when the tool name is only known once the MCP
+// server has parsed the JSON-RPC body.
+//
+// It is a leaf package (stdlib only) so both internal/web and internal/mcp can
+// import it — internal/web imports internal/mcp, so nothing shared may live in
+// either one.
+package reqinfo
+
+import (
+	"context"
+	"sync"
+)
+
+// Info is the per-request annotation. The zero value is not usable; get one
+// from NewContext. A nil *Info is a valid no-op sink, so callers annotate
+// unconditionally without checking whether a carrier is present.
+type Info struct {
+	mu   sync.Mutex
+	tool string
+}
+
+type ctxKey struct{}
+
+// NewContext returns ctx with a fresh Info attached, plus that Info for the
+// caller to read once the request is done.
+func NewContext(ctx context.Context) (context.Context, *Info) {
+	info := &Info{}
+	return context.WithValue(ctx, ctxKey{}, info), info
+}
+
+// FromContext returns the Info carried by ctx, or nil when there is none —
+// stdio MCP sessions and most tests carry no Info. The nil is safe to use.
+func FromContext(ctx context.Context) *Info {
+	info, _ := ctx.Value(ctxKey{}).(*Info)
+	return info
+}
+
+// SetTool records the MCP tool this request dispatched to.
+func (i *Info) SetTool(name string) {
+	if i == nil {
+		return
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.tool = name
+}
+
+// Tool returns the recorded MCP tool name, or "" if none was recorded.
+func (i *Info) Tool() string {
+	if i == nil {
+		return ""
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.tool
+}

--- a/internal/obs/reqinfo/reqinfo_test.go
+++ b/internal/obs/reqinfo/reqinfo_test.go
@@ -1,0 +1,58 @@
+package reqinfo
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestNewContextRoundTrips(t *testing.T) {
+	ctx, info := NewContext(context.Background())
+	if info == nil {
+		t.Fatal("NewContext returned a nil Info")
+	}
+	if got := FromContext(ctx); got != info {
+		t.Errorf("FromContext = %p, want the Info NewContext returned (%p)", got, info)
+	}
+}
+
+func TestFromContextAbsentIsNil(t *testing.T) {
+	if got := FromContext(context.Background()); got != nil {
+		t.Errorf("FromContext on a bare context = %p, want nil", got)
+	}
+}
+
+// A nil *Info must behave like a working sink: subsystems annotate
+// unconditionally, and the stdio MCP transport (or any test) carries no Info at
+// all. Panicking there would turn a logging nicety into an outage.
+func TestNilInfoIsSafe(t *testing.T) {
+	var info *Info
+	info.SetTool("knomit_query") // must not panic
+	if got := info.Tool(); got != "" {
+		t.Errorf("(*Info)(nil).Tool() = %q, want \"\"", got)
+	}
+}
+
+func TestSetToolIsReadBack(t *testing.T) {
+	_, info := NewContext(context.Background())
+	info.SetTool("knomit_learn")
+	if got := info.Tool(); got != "knomit_learn" {
+		t.Errorf("Tool() = %q, want %q", got, "knomit_learn")
+	}
+}
+
+// The writer (an MCP tool hook) and the reader (the HTTP middleware's deferred
+// log) are not guaranteed to be the same goroutine, so the field is mutex-held.
+func TestConcurrentSetAndReadIsRaceFree(t *testing.T) {
+	_, info := NewContext(context.Background())
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); info.SetTool("knomit_query") }()
+		go func() { defer wg.Done(); _ = info.Tool() }()
+	}
+	wg.Wait()
+	if got := info.Tool(); got != "knomit_query" {
+		t.Errorf("Tool() = %q, want %q", got, "knomit_query")
+	}
+}

--- a/internal/web/observability.go
+++ b/internal/web/observability.go
@@ -5,13 +5,26 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"knomit/internal/obs/crashdump"
 	"knomit/internal/obs/metrics"
+	"knomit/internal/obs/reqinfo"
+)
+
+const (
+	// maxLoggedQuery caps the raw query string in the slow-request warning.
+	// Query strings carry user input (knomit_query text, long filter lists) and
+	// are unbounded, so one pathological request must not dominate the log.
+	maxLoggedQuery = 256
+	// truncationSuffix marks a value the logger shortened, so a reader never
+	// mistakes a cut-off query for the whole one.
+	truncationSuffix = "...[truncated]"
 )
 
 // isStreamingResponse reports whether the handler produced a Server-Sent Events
@@ -20,6 +33,40 @@ import (
 // the subscription, so their elapsed time is not a latency signal.
 func isStreamingResponse(w http.ResponseWriter) bool {
 	return strings.HasPrefix(w.Header().Get("Content-Type"), "text/event-stream")
+}
+
+// strIfSet adds key=val to the event, or leaves the event untouched when val is
+// empty. Slow-request warnings are read by eye; a line padded with empty keys
+// buries the fields that actually differ.
+func strIfSet(ev *zerolog.Event, key, val string) *zerolog.Event {
+	if val == "" {
+		return ev
+	}
+	return ev.Str(key, val)
+}
+
+// truncateForLog shortens an unbounded, user-supplied value and marks the cut.
+// The cut is pulled back to a rune boundary: a query string may carry raw UTF-8,
+// and slicing mid-rune would emit invalid bytes into the JSON log.
+func truncateForLog(s string) string {
+	if len(s) <= maxLoggedQuery {
+		return s
+	}
+	cut := s[:maxLoggedQuery]
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + truncationSuffix
+}
+
+// urlParam reads a chi route parameter, tolerating a request that never went
+// through a chi router (direct middleware use in tests, unmatched paths).
+func urlParam(r *http.Request, key string) string {
+	rctx := chi.RouteContext(r.Context())
+	if rctx == nil {
+		return ""
+	}
+	return rctx.URLParam(key)
 }
 
 // reportPanic writes a crash bundle for a recovered HTTP handler panic, then
@@ -60,6 +107,14 @@ func metricsMiddleware(reg *metrics.Registry, slowMS int) func(http.Handler) htt
 			start := time.Now()
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
+			// Carry a mutable annotation into the handler so layers that only
+			// learn what the request IS after parsing it — the MCP server, which
+			// reads the tool name out of the JSON-RPC body — can report back to
+			// this middleware. Attached unconditionally, including when the slow
+			// log is off, so annotating is never conditional on config.
+			ctx, info := reqinfo.NewContext(r.Context())
+			r = r.WithContext(ctx)
+
 			// Record in a defer so a panicking handler is still counted: the
 			// panic unwinds through here on its way to reportPanic/the chi
 			// Recoverer, which render the 500. No WriteHeader ran, so ww.Status()
@@ -86,12 +141,24 @@ func metricsMiddleware(reg *metrics.Registry, slowMS int) func(http.Handler) htt
 				// latency signal and would log a spurious WARN on every normal
 				// disconnect. Exclude them from the slow-request log.
 				if slow > 0 && elapsed > slow && !isStreamingResponse(ww) {
-					log.Warn().
+					ev := log.Warn().
 						Str("route", pattern).
 						Str("method", r.Method).
 						Int("status", status).
 						Dur("elapsed", elapsed).
-						Msg("slow request")
+						Str("path", r.URL.Path)
+					// Everything below is omitted when absent: a plain REST line
+					// stays as short as it was before these fields existed.
+					ev = strIfSet(ev, "query", truncateForLog(r.URL.RawQuery))
+					ev = strIfSet(ev, "req_id", middleware.GetReqID(r.Context()))
+					for _, key := range []string{"repo", "branch", "lens"} {
+						ev = strIfSet(ev, key, urlParam(r, key))
+					}
+					ev = strIfSet(ev, "remote", r.RemoteAddr)
+					ev = strIfSet(ev, "ua", r.UserAgent())
+					ev = strIfSet(ev, "mcp_session", r.Header.Get("Mcp-Session-Id"))
+					ev = strIfSet(ev, "mcp_tool", info.Tool())
+					ev.Msg("slow request")
 				}
 			}()
 

--- a/internal/web/observability.go
+++ b/internal/web/observability.go
@@ -18,12 +18,14 @@ import (
 )
 
 const (
-	// maxLoggedQuery caps the raw query string in the slow-request warning.
-	// Query strings carry user input (knomit_query text, long filter lists) and
-	// are unbounded, so one pathological request must not dominate the log.
-	maxLoggedQuery = 256
+	// maxLoggedField caps EVERY client-supplied field in the slow-request
+	// warning. Paths, query strings and headers are bounded only by the server's
+	// MaxHeaderBytes (1 MB by default), so an uncapped field lets one slow
+	// request emit a megabyte-scale line — and a client that can make requests
+	// slow can repeat it until the log fills the disk.
+	maxLoggedField = 256
 	// truncationSuffix marks a value the logger shortened, so a reader never
-	// mistakes a cut-off query for the whole one.
+	// mistakes a cut-off value for the whole one.
 	truncationSuffix = "...[truncated]"
 )
 
@@ -46,23 +48,30 @@ func strIfSet(ev *zerolog.Event, key, val string) *zerolog.Event {
 }
 
 // truncateForLog shortens an unbounded, user-supplied value and marks the cut.
-// The cut is pulled back to a rune boundary: a query string may carry raw UTF-8,
-// and slicing mid-rune would emit invalid bytes into the JSON log.
+// The cut is pulled back off a partial rune — a value may carry raw UTF-8, and
+// slicing mid-rune would emit a stray byte. The backoff is bounded to one rune:
+// re-validating the whole prefix instead would rewind to the FIRST invalid byte
+// anywhere in it, gutting the field in exactly the malformed-request case worth
+// reading. Invalid bytes further in are left for zerolog, which escapes them.
 func truncateForLog(s string) string {
-	if len(s) <= maxLoggedQuery {
+	if len(s) <= maxLoggedField {
 		return s
 	}
-	cut := s[:maxLoggedQuery]
-	for len(cut) > 0 && !utf8.ValidString(cut) {
+	cut := s[:maxLoggedField]
+	for i := 0; i < utf8.UTFMax-1 && len(cut) > 0; i++ {
+		if r, size := utf8.DecodeLastRuneInString(cut); r != utf8.RuneError || size > 1 {
+			break // a whole rune ends here
+		}
 		cut = cut[:len(cut)-1]
 	}
 	return cut + truncationSuffix
 }
 
 // urlParam reads a chi route parameter, tolerating a request that never went
-// through a chi router (direct middleware use in tests, unmatched paths).
-func urlParam(r *http.Request, key string) string {
-	rctx := chi.RouteContext(r.Context())
+// through a chi router (direct middleware use, unmatched paths) — chi's own
+// RoutePattern is nil-safe, so the middleware works off-router and this must
+// too.
+func urlParam(rctx *chi.Context, key string) string {
 	if rctx == nil {
 		return ""
 	}
@@ -122,7 +131,8 @@ func metricsMiddleware(reg *metrics.Registry, slowMS int) func(http.Handler) htt
 			panicked := false
 			defer func() {
 				elapsed := time.Since(start)
-				pattern := chi.RouteContext(r.Context()).RoutePattern()
+				rctx := chi.RouteContext(r.Context()) // nil off-router; both uses below tolerate it
+				pattern := rctx.RoutePattern()
 				if pattern == "" {
 					pattern = "other" // unmatched paths collapse to one series
 				}
@@ -141,23 +151,32 @@ func metricsMiddleware(reg *metrics.Registry, slowMS int) func(http.Handler) htt
 				// latency signal and would log a spurious WARN on every normal
 				// disconnect. Exclude them from the slow-request log.
 				if slow > 0 && elapsed > slow && !isStreamingResponse(ww) {
+					// route and status are server-derived and bounded; the method
+					// is not — net/http accepts any token there.
 					ev := log.Warn().
 						Str("route", pattern).
-						Str("method", r.Method).
+						Str("method", truncateForLog(r.Method)).
 						Int("status", status).
-						Dur("elapsed", elapsed).
-						Str("path", r.URL.Path)
-					// Everything below is omitted when absent: a plain REST line
-					// stays as short as it was before these fields existed.
-					ev = strIfSet(ev, "query", truncateForLog(r.URL.RawQuery))
-					ev = strIfSet(ev, "req_id", middleware.GetReqID(r.Context()))
-					for _, key := range []string{"repo", "branch", "lens"} {
-						ev = strIfSet(ev, key, urlParam(r, key))
+						Dur("elapsed", elapsed)
+					// Every field below reaches us from the client, so every one
+					// of them goes through the cap — a field added here without
+					// it reopens the whole-log-line hole. They are omitted when
+					// empty, so a plain REST line stays as short as it was before
+					// these fields existed.
+					for _, f := range []struct{ key, val string }{
+						{"path", r.URL.Path},
+						{"query", r.URL.RawQuery},
+						{"req_id", middleware.GetReqID(r.Context())},
+						{"repo", urlParam(rctx, "repo")},
+						{"branch", urlParam(rctx, "branch")},
+						{"lens", urlParam(rctx, "lens")},
+						{"remote", r.RemoteAddr},
+						{"ua", r.UserAgent()},
+						{"mcp_session", r.Header.Get("Mcp-Session-Id")},
+						{"mcp_tool", info.Tool()},
+					} {
+						ev = strIfSet(ev, f.key, truncateForLog(f.val))
 					}
-					ev = strIfSet(ev, "remote", r.RemoteAddr)
-					ev = strIfSet(ev, "ua", r.UserAgent())
-					ev = strIfSet(ev, "mcp_session", r.Header.Get("Mcp-Session-Id"))
-					ev = strIfSet(ev, "mcp_tool", info.Tool())
 					ev.Msg("slow request")
 				}
 			}()

--- a/internal/web/observability_test.go
+++ b/internal/web/observability_test.go
@@ -1,11 +1,13 @@
 package web
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -13,7 +15,42 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"knomit/internal/obs/metrics"
+	"knomit/internal/obs/reqinfo"
 )
+
+// captureLogs redirects the global zerolog logger into a buffer for the
+// duration of the test and returns it.
+func captureLogs(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf)
+	t.Cleanup(func() { log.Logger = orig })
+	return &buf
+}
+
+// slowEntry finds the single "slow request" line in captured log output and
+// decodes it. Fails the test if there isn't exactly one.
+func slowEntry(t *testing.T, out string) map[string]any {
+	t.Helper()
+	var found []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("log line is not JSON: %v\n%s", err, line)
+		}
+		if entry["message"] == "slow request" {
+			found = append(found, entry)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("want exactly 1 slow-request log, got %d:\n%s", len(found), out)
+	}
+	return found[0]
+}
 
 func TestMetricsMiddleware_CountsPanicAs500(t *testing.T) {
 	reg := metrics.NewRegistry()
@@ -84,6 +121,137 @@ func TestMetricsMiddleware_SlowRequestLogs(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "slow request") {
 		t.Errorf("expected a slow-request warning, got:\n%s", buf.String())
+	}
+}
+
+func TestMetricsMiddleware_SlowRequestCarriesRequestDetail(t *testing.T) {
+	buf := captureLogs(t)
+
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(metricsMiddleware(metrics.NewRegistry(), 1))
+	r.Post("/repos/{repo}/branches/{branch}/mcp", func(w http.ResponseWriter, req *http.Request) {
+		reqinfo.FromContext(req.Context()).SetTool("knomit_query")
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("POST", "/repos/core/branches/main/mcp?profile=code", nil)
+	req.RemoteAddr = "10.1.2.3:54321"
+	req.Header.Set("User-Agent", "claude-code/1.2.3")
+	req.Header.Set("Mcp-Session-Id", "sess-abc")
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	entry := slowEntry(t, buf.String())
+	for field, want := range map[string]string{
+		"route":       "/repos/{repo}/branches/{branch}/mcp",
+		"method":      "POST",
+		"path":        "/repos/core/branches/main/mcp",
+		"query":       "profile=code",
+		"repo":        "core",
+		"branch":      "main",
+		"remote":      "10.1.2.3:54321",
+		"ua":          "claude-code/1.2.3",
+		"mcp_session": "sess-abc",
+		"mcp_tool":    "knomit_query",
+	} {
+		if got, _ := entry[field].(string); got != want {
+			t.Errorf("%s = %q, want %q", field, got, want)
+		}
+	}
+	// RequestID is registered ahead of the middleware, so the correlation id
+	// must survive into the warning.
+	if got, _ := entry["req_id"].(string); got == "" {
+		t.Errorf("req_id missing from slow-request log:\n%s", buf.String())
+	}
+}
+
+// A slow request that has no repo/branch/lens, no query, no MCP session and no
+// tool must not log those keys empty — a plain REST line stays short.
+func TestMetricsMiddleware_SlowRequestOmitsAbsentFields(t *testing.T) {
+	buf := captureLogs(t)
+
+	r := chi.NewRouter()
+	r.Use(metricsMiddleware(metrics.NewRegistry(), 1))
+	r.Get("/version", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/version", nil))
+
+	entry := slowEntry(t, buf.String())
+	for _, field := range []string{"repo", "branch", "lens", "query", "mcp_session", "mcp_tool", "req_id"} {
+		if _, present := entry[field]; present {
+			t.Errorf("field %q logged despite being empty:\n%s", field, buf.String())
+		}
+	}
+	// The fields that are always available must still be there.
+	if got, _ := entry["path"].(string); got != "/version" {
+		t.Errorf("path = %q, want %q", got, "/version")
+	}
+}
+
+// A query string is user-supplied and unbounded (knomit_query text, long filter
+// lists). It is truncated so one pathological request cannot dominate the log.
+func TestMetricsMiddleware_SlowRequestTruncatesQuery(t *testing.T) {
+	buf := captureLogs(t)
+
+	r := chi.NewRouter()
+	r.Use(metricsMiddleware(metrics.NewRegistry(), 1))
+	r.Get("/query", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+	long := "text=" + strings.Repeat("x", 4096)
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/query?"+long, nil))
+
+	entry := slowEntry(t, buf.String())
+	got, _ := entry["query"].(string)
+	if len(got) > maxLoggedQuery+len(truncationSuffix) {
+		t.Errorf("query field is %d bytes, want at most %d", len(got), maxLoggedQuery+len(truncationSuffix))
+	}
+	if !strings.HasSuffix(got, truncationSuffix) {
+		t.Errorf("truncated query not marked as truncated: %q", got)
+	}
+	if !strings.HasPrefix(got, "text=xxx") {
+		t.Errorf("truncated query lost its head: %q", got)
+	}
+}
+
+// Truncation must not slice a multi-byte rune in half — the result goes straight
+// into a JSON log line.
+func TestTruncateForLogKeepsValidUTF8(t *testing.T) {
+	// "…" is 3 bytes, so a run of them crosses maxLoggedQuery mid-rune.
+	got := truncateForLog(strings.Repeat("…", maxLoggedQuery))
+	if !utf8.ValidString(got) {
+		t.Errorf("truncated value is not valid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, truncationSuffix) {
+		t.Errorf("truncated value not marked: %q", got)
+	}
+	if len(got) > maxLoggedQuery+len(truncationSuffix) {
+		t.Errorf("truncated value is %d bytes, want at most %d", len(got), maxLoggedQuery+len(truncationSuffix))
+	}
+}
+
+// The annotation must reach handlers even when the slow threshold is disabled:
+// SetTool is called unconditionally by the MCP layer and must never panic.
+func TestMetricsMiddleware_AttachesReqInfoWhenSlowDisabled(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(metricsMiddleware(metrics.NewRegistry(), 0))
+	var info *reqinfo.Info
+	r.Get("/x", func(w http.ResponseWriter, req *http.Request) {
+		info = reqinfo.FromContext(req.Context())
+		info.SetTool("knomit_learn")
+		w.WriteHeader(http.StatusOK)
+	})
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/x", nil))
+
+	if info == nil {
+		t.Fatal("no reqinfo.Info in the request context")
+	}
+	if got := info.Tool(); got != "knomit_learn" {
+		t.Errorf("Tool() = %q, want %q", got, "knomit_learn")
 	}
 }
 

--- a/internal/web/observability_test.go
+++ b/internal/web/observability_test.go
@@ -207,8 +207,8 @@ func TestMetricsMiddleware_SlowRequestTruncatesQuery(t *testing.T) {
 
 	entry := slowEntry(t, buf.String())
 	got, _ := entry["query"].(string)
-	if len(got) > maxLoggedQuery+len(truncationSuffix) {
-		t.Errorf("query field is %d bytes, want at most %d", len(got), maxLoggedQuery+len(truncationSuffix))
+	if len(got) > maxLoggedField+len(truncationSuffix) {
+		t.Errorf("query field is %d bytes, want at most %d", len(got), maxLoggedField+len(truncationSuffix))
 	}
 	if !strings.HasSuffix(got, truncationSuffix) {
 		t.Errorf("truncated query not marked as truncated: %q", got)
@@ -221,16 +221,86 @@ func TestMetricsMiddleware_SlowRequestTruncatesQuery(t *testing.T) {
 // Truncation must not slice a multi-byte rune in half — the result goes straight
 // into a JSON log line.
 func TestTruncateForLogKeepsValidUTF8(t *testing.T) {
-	// "…" is 3 bytes, so a run of them crosses maxLoggedQuery mid-rune.
-	got := truncateForLog(strings.Repeat("…", maxLoggedQuery))
+	// "…" is 3 bytes, so a run of them crosses maxLoggedField mid-rune.
+	got := truncateForLog(strings.Repeat("…", maxLoggedField))
 	if !utf8.ValidString(got) {
 		t.Errorf("truncated value is not valid UTF-8: %q", got)
 	}
 	if !strings.HasSuffix(got, truncationSuffix) {
 		t.Errorf("truncated value not marked: %q", got)
 	}
-	if len(got) > maxLoggedQuery+len(truncationSuffix) {
-		t.Errorf("truncated value is %d bytes, want at most %d", len(got), maxLoggedQuery+len(truncationSuffix))
+	if len(got) > maxLoggedField+len(truncationSuffix) {
+		t.Errorf("truncated value is %d bytes, want at most %d", len(got), maxLoggedField+len(truncationSuffix))
+	}
+}
+
+// EVERY client-supplied field is capped, not just the query. Headers are bounded
+// only by MaxHeaderBytes (1 MB), so an uncapped field lets one slow request emit
+// a megabyte-scale log line — and repeating it fills the log.
+func TestMetricsMiddleware_SlowRequestCapsEveryClientSuppliedField(t *testing.T) {
+	buf := captureLogs(t)
+
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(metricsMiddleware(metrics.NewRegistry(), 1))
+	r.Get("/repos/{repo}", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	huge := strings.Repeat("z", 8192)
+	req := httptest.NewRequest("GET", "/repos/"+huge+"?text="+huge, nil)
+	req.Header.Set("User-Agent", huge)
+	req.Header.Set("X-Request-Id", huge) // chi's RequestID echoes this verbatim
+	req.Header.Set("Mcp-Session-Id", huge)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	entry := slowEntry(t, buf.String())
+	maxField := maxLoggedField + len(truncationSuffix)
+	for _, field := range []string{"path", "query", "req_id", "ua", "mcp_session", "repo"} {
+		got, _ := entry[field].(string)
+		if len(got) > maxField {
+			t.Errorf("%s is %d bytes, want at most %d", field, len(got), maxField)
+		}
+	}
+}
+
+// Truncation must lose only a trailing partial rune. Re-validating the whole
+// prefix would discard everything before the first bad byte, gutting the field
+// in exactly the malformed-request case worth inspecting.
+func TestTruncateForLogKeepsThePrefixBeforeAnInvalidByte(t *testing.T) {
+	// One invalid byte early in a long value: everything before it must survive.
+	got := truncateForLog("a=0123456789\xffb=" + strings.Repeat("x", 4096))
+	if !strings.HasPrefix(got, "a=0123456789") {
+		t.Errorf("prefix before the invalid byte was discarded: %q", got)
+	}
+	if len(got) < maxLoggedField {
+		t.Errorf("value truncated to %d bytes, want ~%d", len(got), maxLoggedField)
+	}
+}
+
+// The middleware must survive being used outside a chi router — there is no
+// route context to read a pattern or params from.
+func TestMetricsMiddleware_WorksWithoutAChiRouter(t *testing.T) {
+	buf := captureLogs(t)
+
+	reg := metrics.NewRegistry()
+	h := metricsMiddleware(reg, 1)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	mux := http.NewServeMux()
+	mux.Handle("/plain", h)
+	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/plain", nil))
+
+	entry := slowEntry(t, buf.String())
+	if got, _ := entry["route"].(string); got != "other" {
+		t.Errorf("route = %q, want %q", got, "other")
+	}
+	var sb strings.Builder
+	reg.WriteProm(&sb)
+	if !strings.Contains(sb.String(), `knomit_http_requests_total{route="other",method="GET",status="200"} 1`) {
+		t.Errorf("request not counted:\n%s", sb.String())
 	}
 }
 

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -28,6 +28,7 @@ const APIBase = "/api/v1"
 // the router root.
 func (s *Server) NewAPIRouter() chi.Router {
 	r := chi.NewRouter()
+	r.Use(middleware.RequestID)                    // correlation id for slow-request warnings
 	r.Use(middleware.Recoverer)                    // produces the 500 response
 	r.Use(reportPanic)                             // captures a crash bundle, re-panics
 	r.Use(metricsMiddleware(nil, s.SlowRequestMS)) // nil → metrics.Default

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -28,7 +28,12 @@ const APIBase = "/api/v1"
 // the router root.
 func (s *Server) NewAPIRouter() chi.Router {
 	r := chi.NewRouter()
-	r.Use(middleware.RequestID)                    // correlation id for slow-request warnings
+	// Correlation id for slow-request warnings. chi echoes an inbound
+	// X-Request-Id verbatim and only generates one when the header is absent, so
+	// req_id is trustworthy exactly as far as the client is: useful for stitching
+	// a proxy's id to ours, forgeable by anyone who wants two requests to look
+	// like one. It labels log lines only — never an authorization decision.
+	r.Use(middleware.RequestID)
 	r.Use(middleware.Recoverer)                    // produces the 500 response
 	r.Use(reportPanic)                             // captures a crash bundle, re-panics
 	r.Use(metricsMiddleware(nil, s.SlowRequestMS)) // nil → metrics.Default


### PR DESCRIPTION
## Problem

The slow-request WARN carried four fields:

```
WRN slow request elapsed=1307.065333 method=POST route=/api/v1/repos/{repo}/branches/{branch}/mcp status=200
```

Every MCP call maps to that one route pattern, so the busiest endpoint in the server produced the least diagnosable line in the log — no repo, no client, no tool.

## After

```
WRN slow request route=/api/v1/repos/{repo}/branches/{branch}/mcp method=POST status=200
    elapsed=1307.065333 path=/api/v1/repos/knomit/branches/main/mcp
    req_id=mindev.local/GpTUqDEdan-000001 repo=knomit branch=main
    remote=127.0.0.1:61234 ua=claude-code/2.0.1 mcp_session=0f2c9a1e-77bd
    mcp_tool=knomit_query
```

Every added field is omitted when empty, so a plain REST line is no longer than it was:

```
WRN slow request route=/api/v1/version method=GET status=200 elapsed=5.649 path=/api/v1/version remote=192.0.2.1:1234
```

## How

| File | Change |
|---|---|
| `internal/obs/reqinfo/` (new) | Leaf package holding a mutable per-request annotation. Nil-safe, mutex-guarded. |
| `internal/web/observability.go` | WARN gains `path`, `query`, `req_id`, `repo`/`branch`/`lens`, `remote`, `ua`, `mcp_session`, `mcp_tool`. |
| `internal/web/router.go` | `middleware.RequestID` added ahead of the metrics middleware. |
| `internal/mcp/server.go` | `BeforeCallTool` hook records the tool name. |

The tool name has to travel **up** the call tree — it is known only once the MCP server has parsed the JSON-RPC body, and context values flow down. So the middleware stores a pointer before dispatch and reads it in its deferred log; the hook fills it in. This works because mcp-go derives tool-call contexts from the HTTP request's (`server/streamable_http.go:420`). `reqinfo` lives under `internal/obs/` because `internal/web` imports `internal/mcp`, so nothing shared may live in either. `FromContext` is nil-safe, so stdio sessions carry no annotation and simply record nothing.

`middleware.RequestID` was never registered anywhere, so `req_id` would otherwise always have been empty.

## Notes

- **`knomit_http_requests_total` is deliberately untouched.** These fields are high-cardinality by design — that is what makes them useful in a log and disqualifying as metric labels. The counter keeps its three bounded labels.
- **`query` is user input.** It is capped at 256 bytes and the cut is pulled back to a rune boundary so a raw-UTF-8 query cannot emit invalid bytes into the JSON log. Truncation is marked `...[truncated]`.
- The `text/event-stream` exclusion is unchanged — streaming responses are still never reported as slow.

## Testing

`go test ./...` passes. `go vet` and `gofmt` clean; `-race` clean on the three touched packages.

New tests: 5 in `internal/web` (all fields present; absent fields omitted, not blank; query truncation; UTF-8 boundary; annotation attached even when the slow log is disabled), 2 in `internal/mcp` (hook records the name; no panic without an annotation), 5 in `internal/obs/reqinfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)