### PR TITLE
Deprecate migrate-registry; make verify report the truth about a real home

### DIFF
--- a/cmd/migrate_registry.go
+++ b/cmd/migrate_registry.go
@@ -110,6 +110,20 @@ func (o migrateOpts) out() io.Writer {
 	return o.Out
 }
 
+// deprecationNotice heads every run, including --dry-run. The command is not
+// given cobra's own Deprecated field on purpose: cobra's IsAvailableCommand
+// treats a deprecated command as unavailable and drops it from `knomit --help`,
+// and this is the command a legacy home's boot refusal tells the operator to
+// run. Hiding it would leave that refusal pointing at something they cannot
+// find.
+const deprecationNotice = `WARNING: migrate-registry is DEPRECATED and will be REMOVED in a future build.
+  It converts a home shape that predates the control.db repo registry. If this
+  home still needs converting, convert it now — once the command is gone the
+  only path off the legacy shape is re-cloning each knowledge base from its
+  remote, and a repo with no recorded remote cannot be recovered that way.
+
+`
+
 // migrateRegistryCmd builds the `knomit migrate-registry` subcommand.
 func migrateRegistryCmd() *cobra.Command {
 	var (
@@ -122,8 +136,21 @@ func migrateRegistryCmd() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "migrate-registry",
-		Short: "Convert a pre-registry knomit home to the control.db repo registry",
-		Long: `Converts a home created before the repo registry moved into control.db.
+		Short: "DEPRECATED: convert a pre-registry knomit home to the control.db repo registry",
+		Long: `DEPRECATED — this command will be REMOVED in a future build.
+
+It converts a home shape that only exists on installations predating the
+control.db repo registry. Once your home is converted there is no reason to
+run it again, and a home created by a current build never needs it at all.
+If you still have an unconverted home, migrate it now: after this command is
+removed, the only supported path off the legacy shape will be to re-clone
+each knowledge base from its remote — and a repo whose remote was never
+recorded anywhere else cannot be recovered that way.
+
+Deliberately still listed in ` + "`knomit --help`" + ` rather than hidden: a legacy
+home makes the server refuse to boot, and the refusal names this command.
+
+Converts a home created before the repo registry moved into control.db.
 
 Run it ONCE, with the server stopped. It reads every repo database's remote
 connection config BEFORE migrating any of them (the schema migration that
@@ -148,6 +175,10 @@ creates a -shm and a zero-length -wal beside each database it opens;
 neither carries committed data and the next clean read-write close clears
 both.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Printed on stdout with the plan rather than only in --help,
+			// because the operator who most needs to see it is the one who
+			// pasted the command from a two-year-old runbook.
+			fmt.Fprint(cmd.OutOrStdout(), deprecationNotice)
 			if home == "" {
 				cfg, err := config.Load()
 				if err != nil {

--- a/cmd/migrate_registry_test.go
+++ b/cmd/migrate_registry_test.go
@@ -1408,3 +1408,53 @@ func TestMigrateRegistryCmd_HelpSaysItIsIrreversible(t *testing.T) {
 	require.NotContains(t, c.Long, "leaving every file in the home as it")
 	require.Contains(t, c.Flags().Lookup("dry-run").Usage, "no file contents are changed")
 }
+
+// The command is deprecated, and the deprecation has to reach an operator who
+// never reads --help. Both surfaces are asserted: the help text for whoever
+// looks, and the run banner for whoever pastes the command from a runbook.
+func TestMigrateRegistryCmd_AnnouncesItsDeprecation(t *testing.T) {
+	c := migrateRegistryCmd()
+	require.Contains(t, c.Short, "DEPRECATED")
+	require.Contains(t, c.Long, "REMOVED in a future build")
+	require.Contains(t, deprecationNotice, "DEPRECATED")
+	require.Contains(t, deprecationNotice, "REMOVED in a future build")
+}
+
+// A deprecated command that vanishes from `knomit --help` is worse than one
+// that stays: a legacy home refuses to boot with a message naming this command,
+// and cobra's own Deprecated field would make IsAvailableCommand report false
+// and drop it from the listing. Assert the command remains discoverable.
+func TestMigrateRegistryCmd_StaysListedInHelp(t *testing.T) {
+	c := migrateRegistryCmd()
+	require.Empty(t, c.Deprecated,
+		"setting cobra's Deprecated field hides the command from `knomit --help`")
+	require.True(t, c.IsAvailableCommand(), "migrate-registry must stay listed in help")
+
+	root := RootCmd()
+	var found bool
+	for _, sub := range root.Commands() {
+		if sub.Name() == "migrate-registry" {
+			found = true
+			require.True(t, sub.IsAvailableCommand())
+		}
+	}
+	require.True(t, found, "migrate-registry must stay registered on the root command")
+}
+
+// The banner has to print before the plan, on the ordinary path AND on the path
+// most likely to be taken by someone evaluating whether to run this at all.
+func TestMigrateRegistry_DryRunPrintsTheDeprecationBanner(t *testing.T) {
+	home := buildLegacyHome(t)
+
+	c := migrateRegistryCmd()
+	var out writerRecorder
+	c.SetOut(&out)
+	c.SetErr(&out)
+	c.SetArgs([]string{"--home", home, "--dry-run"})
+	require.NoError(t, c.Execute())
+
+	got := out.String()
+	require.Contains(t, got, "DEPRECATED")
+	require.Less(t, strings.Index(got, "DEPRECATED"), strings.Index(got, "dry run"),
+		"the warning must come before the plan, not after it")
+}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,106 +1,310 @@
 package cmd
 
 import (
-	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"knomit/internal/app"
 	"knomit/internal/config"
+	"knomit/internal/repos"
 	"knomit/internal/store"
+)
+
+// Exit codes. Kept as named constants because the difference between 1 and 2 is
+// the whole contract: a script that treats "the tool could not run" as "the
+// repo is damaged" pages someone at 3am for a typo in a flag.
+const (
+	exitClean  = 0
+	exitDirty  = 1
+	exitFailed = 2
 )
 
 // verifyCmd builds the `knomit verify` subcommand. It boots the full app to
 // open all configured repos through the usual manager path, then runs
 // Verify on one or all repos and prints the report.
-//
-// Exit codes:
-//
-//	0 clean
-//	1 at least one repo had integrity issues
-//	2 verify itself errored (bad config, unknown repo, etc.)
 func verifyCmd() *cobra.Command {
-	var repoName string
-	var all bool
-	var deep bool
+	var (
+		repoName    string
+		all         bool
+		deep        bool
+		asJSON      bool
+		maxIssues   int
+		allBranches bool
+		pruneRefs   bool
+	)
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Run an integrity check on one or all knomit repositories",
 		Long: `Walks the git object chain, SQLite tables, and search index for the
-specified repo (or all repos with --all) and reports any structural issues.
+specified repo (or all active repos with --all) and reports any structural
+issues.
 
-For definitive results on a busy repo, stop the agent first — verify is
-read-only but acquires per-branch locks one branch at a time, so it does
-not produce an atomic snapshot of the whole repo.
+Verify is read-only and it is a SNAPSHOT: it takes the read lock on every
+branch it checks up front and holds all of them until it finishes. That is
+what makes the report internally consistent, and it means the run BLOCKS
+EVERY WRITER on those branches for its whole duration. Do not fire it at a
+busy agent expecting a cheap probe — budget for it, or stop the agent.
+
+Only branches the index maintains are parity-checked. Other refs under
+refs/heads/* — another machine's agent branch arriving by fetch, or refs
+left by a removed feature — have no SQLite rows by design; they are listed
+as "not indexed" rather than reported as thousands of errors. Pass
+--all-branches to check every ref anyway.
+
+--all covers ACTIVE repos. An archived repo is not opened and cannot be
+verified; the run names any it skipped.
 
 Exit codes:
-  0   clean
-  1   integrity issues found
-  2   the verify command itself errored`,
+  0   clean (no errors; warnings do not fail the run)
+  1   integrity errors found
+  2   verify itself could not run (bad flags, unknown repo, boot failure)`,
+		// The command reports findings; a non-clean repo is not a misuse of the
+		// CLI, so cobra must not print the usage block after the report.
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.Load()
+			code, err := runVerify(cmd, verifyOpts{
+				repoName:    repoName,
+				all:         all,
+				allBranches: allBranches,
+				deep:        deep,
+				asJSON:      asJSON,
+				maxIssues:   maxIssues,
+				pruneRefs:   pruneRefs,
+			})
+			// os.Exit skips deferred calls, so it must not run until runVerify
+			// has returned and its own defers — app.Close among them — are done.
+			// Calling it inside runVerify used to leak every open repo on any
+			// non-clean run.
 			if err != nil {
-				return fmt.Errorf("load config: %w", err)
+				fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
 			}
-			// Checked BEFORE app.New: booting the app opens every repo and
-			// launches index heals and startup reconciles, all of it wasted when
-			// the invocation was never valid to begin with.
-			if !all && repoName == "" {
-				// No default repo exists to fall back on, so name one or ask for
-				// all of them.
-				return fmt.Errorf("--repo is required (or pass --all to verify every repo)")
-			}
-			ctx := context.Background()
-			a, err := app.New(ctx, cfg, app.Options{})
-			if err != nil {
-				return fmt.Errorf("init app: %w", err)
-			}
-			defer a.Close()
-
-			opts := store.VerifyOpts{Deep: deep}
-			anyDirty := false
-			anyErr := false
-
-			run := func(name string) {
-				ri := a.Manager().Get(name)
-				if ri == nil {
-					fmt.Fprintf(os.Stderr, "repo %q not found\n", name)
-					anyErr = true
-					return
-				}
-				report, err := ri.Verify(ctx, opts)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "verify %q: %v\n", name, err)
-					anyErr = true
-					return
-				}
-				fmt.Print(report.String())
-				if !report.IsClean() {
-					anyDirty = true
-				}
-			}
-
-			if all {
-				for _, n := range a.Manager().Names() {
-					run(n)
-				}
-			} else {
-				run(repoName)
-			}
-
-			switch {
-			case anyErr:
-				os.Exit(2)
-			case anyDirty:
-				os.Exit(1)
+			if code != exitClean {
+				os.Exit(code)
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&repoName, "repo", "", "repo name (required unless --all)")
-	cmd.Flags().BoolVar(&all, "all", false, "verify all repos")
+	cmd.Flags().BoolVar(&all, "all", false, "verify all active repos")
 	cmd.Flags().BoolVar(&deep, "deep", false, "enable deep checks (parses every fact)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit the report(s) as JSON instead of text")
+	cmd.Flags().IntVar(&maxIssues, "max-issues", 100,
+		"maximum issues to print per repo in TEXT output (0 = all); the per-category summary is "+
+			"always complete, and --json is never truncated")
+	cmd.Flags().BoolVar(&allBranches, "all-branches", false,
+		"parity-check every refs/heads/* ref, not only the branches the index maintains")
+	cmd.Flags().BoolVar(&pruneRefs, "prune-generated-refs", false,
+		"DELETE the generated okf/* refs left by the removed server-side export, and their markers")
 	return cmd
+}
+
+type verifyOpts struct {
+	repoName    string
+	all         bool
+	allBranches bool
+	deep        bool
+	asJSON      bool
+	maxIssues   int
+	pruneRefs   bool
+}
+
+// jsonReport is the --json shape. Separate from store.IntegrityReport so the
+// wire format is owned here and does not shift when the store struct changes.
+type jsonReport struct {
+	Repo      string         `json:"repo"`
+	CheckedAt string         `json:"checked_at"`
+	Branches  []string       `json:"branches_checked"`
+	Skipped   []string       `json:"branches_not_indexed"`
+	Clean     bool           `json:"clean"`
+	Counts    map[string]int `json:"counts_by_category"`
+	Issues    []jsonIssue    `json:"issues"`
+	Pruned    []string       `json:"pruned_refs,omitempty"`
+	Markers   int64          `json:"pruned_markers,omitempty"`
+}
+
+// emptyIfNil keeps a nil slice from marshalling as JSON null. Consumers branch
+// on these arrays being empty; `null` makes that a type error instead.
+func emptyIfNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+type jsonIssue struct {
+	Severity string `json:"severity"`
+	Category string `json:"category"`
+	Branch   string `json:"branch,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Commit   string `json:"commit,omitempty"`
+	Detail   string `json:"detail"`
+}
+
+// runVerify owns the app's lifetime so every defer runs before the caller
+// exits. It returns the process exit code and, separately, an error worth
+// printing — a repo with integrity errors is a result (code 1), not an error.
+func runVerify(cmd *cobra.Command, opts verifyOpts) (int, error) {
+	// Checked BEFORE app.New: booting the app opens every repo and launches
+	// index heals and startup reconciles, all of it wasted when the invocation
+	// was never valid to begin with.
+	if !opts.all && opts.repoName == "" {
+		// No default repo exists to fall back on, so name one or ask for all.
+		return exitFailed, fmt.Errorf("--repo is required (or pass --all to verify every repo)")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return exitFailed, fmt.Errorf("load config: %w", err)
+	}
+
+	// cmd.Context(), not context.Background(): main.go installs a SIGINT/SIGTERM
+	// handler that cancels this context, and Verify checks it between branches.
+	// With Background the signal wiring existed and could not stop anything.
+	ctx := cmd.Context()
+
+	a, err := app.New(ctx, cfg, app.Options{})
+	if err != nil {
+		return exitFailed, fmt.Errorf("init app: %w", err)
+	}
+	defer a.Close()
+
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+	vopts := store.VerifyOpts{Deep: opts.deep, AllBranches: opts.allBranches}
+
+	names := []string{opts.repoName}
+	if opts.all {
+		names = a.Manager().Names()
+		sort.Strings(names)
+		reportSkippedArchived(errOut, a.Manager())
+	}
+
+	var (
+		anyDirty bool
+		anyErr   bool
+	)
+	// Non-nil so a home with no active repos encodes as [] rather than the bare
+	// `null` document a nil slice produces.
+	payload := make([]jsonReport, 0, len(names))
+	for _, name := range names {
+		ri := a.Manager().Get(name)
+		if ri == nil {
+			fmt.Fprintf(errOut, "repo %q not found\n", name)
+			anyErr = true
+			continue
+		}
+		report, err := ri.Verify(ctx, vopts)
+		if err != nil {
+			fmt.Fprintf(errOut, "verify %q: %v\n", name, err)
+			anyErr = true
+			continue
+		}
+
+		var pruned store.PruneResult
+		if opts.pruneRefs {
+			// pruned is reported even on error: PruneResult.Refs holds only what
+			// was actually deleted, so a partial failure still has to say which
+			// refs are already gone.
+			if pruned, err = ri.PruneGeneratedRefs(ctx); err != nil {
+				fmt.Fprintf(errOut, "prune %q: %v\n", name, err)
+				anyErr = true
+			}
+		}
+
+		if opts.asJSON {
+			payload = append(payload, toJSON(report, pruned))
+		} else {
+			fmt.Fprint(out, report.Format(opts.maxIssues))
+			for _, ref := range pruned.Refs {
+				fmt.Fprintf(out, "  pruned generated ref: %s\n", ref)
+			}
+			if pruned.Markers > 0 {
+				fmt.Fprintf(out, "  pruned %d okf marker row(s)\n", pruned.Markers)
+			}
+		}
+		if !report.IsClean() {
+			anyDirty = true
+		}
+	}
+
+	if opts.asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(payload); err != nil {
+			return exitFailed, fmt.Errorf("encode json: %w", err)
+		}
+	}
+
+	switch {
+	case anyErr:
+		return exitFailed, nil
+	case anyDirty:
+		return exitDirty, nil
+	}
+	return exitClean, nil
+}
+
+// reportSkippedArchived names the archived repos --all did not cover.
+//
+// Manager.Names() returns active repos only, so --all has always silently meant
+// "all active repos". Archived ones are not opened and so genuinely cannot be
+// verified — but an archived knowledge base is exactly the kind nobody notices
+// rotting, and "verify --all said nothing about it" is the wrong way to find
+// that out. State the omission instead of leaving it to be inferred.
+func reportSkippedArchived(w io.Writer, m *repos.Manager) {
+	archived, err := m.ListArchived()
+	if err != nil {
+		fmt.Fprintf(w, "note: could not list archived repos: %v\n", err)
+		return
+	}
+	if len(archived) == 0 {
+		return
+	}
+	names := make([]string, 0, len(archived))
+	for _, a := range archived {
+		names = append(names, a.Name)
+	}
+	sort.Strings(names)
+	fmt.Fprintf(w, "note: %d archived repo(s) not verified (--all covers active repos only): %s\n",
+		len(names), strings.Join(names, ", "))
+}
+
+// toJSON converts a report to the wire shape.
+//
+// Every slice is initialised, never left nil: a nil slice marshals to `null`,
+// not `[]`, and a consumer iterating report.issues would hit a type error on a
+// CLEAN repo — the exact case that should be easiest to handle.
+//
+// maxIssues is deliberately NOT applied here. Truncating machine-readable
+// output would hand a CI job a report that looks complete and is not; the flag
+// is documented as affecting the text rendering only.
+func toJSON(r store.IntegrityReport, pruned store.PruneResult) jsonReport {
+	out := jsonReport{
+		Repo:      r.Repo,
+		CheckedAt: r.CheckedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		Branches:  emptyIfNil(r.Branches),
+		Skipped:   emptyIfNil(r.Skipped),
+		Clean:     r.IsClean(),
+		Counts:    r.CountsByCategory(),
+		Pruned:    pruned.Refs,
+		Markers:   pruned.Markers,
+	}
+	out.Issues = make([]jsonIssue, 0, len(r.Issues))
+	for _, i := range r.Issues {
+		out.Issues = append(out.Issues, jsonIssue{
+			Severity: i.Severity.String(),
+			Category: i.Category,
+			Branch:   i.Branch,
+			Path:     i.Path,
+			Commit:   i.Commit,
+			Detail:   i.Detail,
+		})
+	}
+	return out
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -91,6 +91,17 @@ Exit codes:
 			return nil
 		},
 	}
+	// A malformed flag is "verify could not run", which the help documents as
+	// exit 2. Cobra returns parse errors up to ExecuteContext, where main.go
+	// prints them and exits 1 — so without this, `verify --max-issues=abc`
+	// exits 1 and a CI job reads a typo as a damaged corpus. Exactly the page
+	// at 3am the exit codes exist to prevent.
+	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+		fmt.Fprintln(c.ErrOrStderr(), "Error:", err)
+		fmt.Fprintf(c.ErrOrStderr(), "Run '%s --help' for usage.\n", c.CommandPath())
+		os.Exit(exitFailed)
+		return err
+	})
 	cmd.Flags().StringVar(&repoName, "repo", "", "repo name (required unless --all)")
 	cmd.Flags().BoolVar(&all, "all", false, "verify all active repos")
 	cmd.Flags().BoolVar(&deep, "deep", false, "enable deep checks (parses every fact)")
@@ -199,34 +210,48 @@ func runVerify(cmd *cobra.Command, opts verifyOpts) (int, error) {
 			anyErr = true
 			continue
 		}
-		report, err := ri.Verify(ctx, vopts)
-		if err != nil {
-			fmt.Fprintf(errOut, "verify %q: %v\n", name, err)
-			anyErr = true
-			continue
-		}
-
+		// The prune runs BEFORE the report, so the report describes the repo as
+		// it stands afterwards. Running it after meant a single invocation
+		// printed "remove with --prune-generated-refs" and "pruned generated
+		// ref: okf/main" within three lines of each other, and left the pruned
+		// refs listed under branches_not_indexed in the JSON.
 		var pruned store.PruneResult
 		if opts.pruneRefs {
 			// pruned is reported even on error: PruneResult.Refs holds only what
 			// was actually deleted, so a partial failure still has to say which
 			// refs are already gone.
-			if pruned, err = ri.PruneGeneratedRefs(ctx); err != nil {
-				fmt.Fprintf(errOut, "prune %q: %v\n", name, err)
+			var perr error
+			if pruned, perr = ri.PruneGeneratedRefs(ctx); perr != nil {
+				fmt.Fprintf(errOut, "prune %q: %v\n", name, perr)
 				anyErr = true
 			}
+			if !opts.asJSON && !pruned.Empty() {
+				for _, ref := range pruned.Refs {
+					fmt.Fprintf(out, "pruned generated ref: %s\n", ref)
+				}
+				if pruned.Markers > 0 {
+					fmt.Fprintf(out, "pruned %d okf marker row(s)\n", pruned.Markers)
+				}
+			}
+		}
+
+		report, err := ri.Verify(ctx, vopts)
+		if err != nil {
+			fmt.Fprintf(errOut, "verify %q: %v\n", name, err)
+			anyErr = true
+			// A cancelled context will not un-cancel for the next repo, so
+			// carrying on just prints one "context canceled" per remaining
+			// repo. One Ctrl-C should stop the run, not be re-attempted.
+			if ctx.Err() != nil {
+				break
+			}
+			continue
 		}
 
 		if opts.asJSON {
 			payload = append(payload, toJSON(report, pruned))
 		} else {
 			fmt.Fprint(out, report.Format(opts.maxIssues))
-			for _, ref := range pruned.Refs {
-				fmt.Fprintf(out, "  pruned generated ref: %s\n", ref)
-			}
-			if pruned.Markers > 0 {
-				fmt.Fprintf(out, "  pruned %d okf marker row(s)\n", pruned.Markers)
-			}
 		}
 		if !report.IsClean() {
 			anyDirty = true

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+func TestVerifyCmd_FlagsRegistered(t *testing.T) {
+	c := verifyCmd()
+	for _, name := range []string{
+		"repo", "all", "deep", "json", "max-issues", "all-branches", "prune-generated-refs",
+	} {
+		require.NotNil(t, c.Flags().Lookup(name), "--%s must be registered", name)
+	}
+	require.Equal(t, "100", c.Flags().Lookup("max-issues").DefValue)
+}
+
+// The exit-code contract is the whole interface for anything automated. 1 must
+// mean "the repo has integrity errors" and nothing else; a usage mistake used
+// to exit 1 too, so a CI job could not tell a typo from a damaged corpus.
+func TestVerifyCmd_HelpDocumentsExitCodes(t *testing.T) {
+	c := verifyCmd()
+	require.Contains(t, c.Long, "0   clean")
+	require.Contains(t, c.Long, "1   integrity errors found")
+	require.Contains(t, c.Long, "2   verify itself could not run")
+	require.Equal(t, exitClean, 0)
+	require.Equal(t, exitDirty, 1)
+	require.Equal(t, exitFailed, 2)
+}
+
+// A missing --repo is a misuse of the CLI, not a finding about the corpus, so
+// it must map to 2. Checked before any app boot, so no repo is opened.
+func TestVerify_MissingRepoIsAUsageFailureNotADirtyRepo(t *testing.T) {
+	c := verifyCmd()
+	code, err := runVerify(c, verifyOpts{})
+	require.Error(t, err)
+	require.Equal(t, exitFailed, code, "a usage error must not be reported as integrity errors")
+	require.Contains(t, err.Error(), "--repo is required")
+}
+
+// The help used to promise the OPPOSITE of what the code does — that verify
+// locks one branch at a time and gives no snapshot. It takes every branch read
+// lock up front and holds them, which means it blocks writers for the whole
+// run. An operator who believes the old text fires this at a live agent.
+func TestVerifyCmd_HelpDescribesLockingHonestly(t *testing.T) {
+	c := verifyCmd()
+	require.Contains(t, c.Long, "SNAPSHOT")
+	require.Contains(t, c.Long, "BLOCKS")
+	require.NotContains(t, c.Long, "one branch at a time")
+	require.NotContains(t, c.Long, "does not produce an atomic snapshot")
+}
+
+// --all has always covered active repos only; the help now says so, because the
+// silent version meant an archived knowledge base could rot unmentioned.
+func TestVerifyCmd_HelpSaysAllMeansActive(t *testing.T) {
+	c := verifyCmd()
+	require.Contains(t, c.Long, "active repos")
+	require.Contains(t, c.Long, "archived repo is not opened")
+}
+
+func TestReportSkippedArchived_SaysNothingWhenThereAreNone(t *testing.T) {
+	var buf bytes.Buffer
+	reportSkippedArchived(&buf, &repos.Manager{})
+	// A zero-value Manager cannot reach control.db; either outcome is
+	// acceptable, but it must never claim repos were skipped when none were.
+	require.NotContains(t, buf.String(), "not verified (--all covers active repos only)")
+}
+
+// The JSON shape is a contract for anything consuming this from CI, so its
+// field names are pinned rather than left to drift with the store struct.
+func TestToJSON_ShapeIsStable(t *testing.T) {
+	r := store.IntegrityReport{
+		Repo:      "kb",
+		CheckedAt: time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC),
+		Branches:  []string{"main"},
+		Skipped:   []string{"okf/main"},
+		Issues: []store.IntegrityIssue{{
+			Severity: store.SeverityWarning,
+			Category: store.CategoryGeneratedRefs,
+			Branch:   "okf/main",
+			Detail:   "residue",
+		}},
+	}
+	raw, err := json.Marshal(toJSON(r, store.PruneResult{Refs: []string{"okf/main"}, Markers: 2}))
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	for _, key := range []string{
+		"repo", "checked_at", "branches_checked", "branches_not_indexed",
+		"clean", "counts_by_category", "issues", "pruned_refs",
+	} {
+		require.Contains(t, got, key, "JSON field %q must be present", key)
+	}
+	require.Equal(t, true, got["clean"], "warnings alone must serialize as clean")
+
+	issues := got["issues"].([]any)
+	first := issues[0].(map[string]any)
+	require.Equal(t, "WARN", first["severity"], "severity must serialize as a name, not an int")
+	require.Equal(t, store.CategoryGeneratedRefs, first["category"])
+}
+
+// A clean report must not carry empty issue noise, so consumers can branch on
+// the array being empty — and "empty" has to mean [], not null. A nil slice
+// marshals to null, and a consumer looping over report["issues"] then fails on
+// the one case that should be easiest: a healthy repo.
+func TestToJSON_CleanReportEncodesEmptyArraysNotNull(t *testing.T) {
+	out := toJSON(store.IntegrityReport{Repo: "kb", Branches: []string{"main"}}, store.PruneResult{})
+	require.Empty(t, out.Issues)
+	require.True(t, out.Clean)
+
+	raw, err := json.Marshal(out)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"issues":[]`)
+	require.Contains(t, string(raw), `"branches_not_indexed":[]`)
+	require.NotContains(t, string(raw), `null`)
+	require.False(t, strings.Contains(string(raw), `"pruned_refs"`),
+		"pruned_refs is omitempty: absent when nothing was pruned")
+}
+
+// --max-issues truncates the human rendering only. Truncating JSON would hand a
+// CI job a report that looks complete and is not.
+func TestToJSON_IsNeverTruncated(t *testing.T) {
+	r := store.IntegrityReport{Repo: "kb"}
+	for i := range 150 {
+		r.Issues = append(r.Issues, store.IntegrityIssue{
+			Severity: store.SeverityError,
+			Category: store.CategoryCommitLog,
+			Detail:   fmt.Sprintf("issue %d", i),
+		})
+	}
+	require.Len(t, toJSON(r, store.PruneResult{}).Issues, 150)
+	require.Contains(t, verifyCmd().Flags().Lookup("max-issues").Usage, "--json is never truncated")
+}

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/repos"
@@ -125,6 +126,23 @@ func TestToJSON_CleanReportEncodesEmptyArraysNotNull(t *testing.T) {
 	require.NotContains(t, string(raw), `null`)
 	require.False(t, strings.Contains(string(raw), `"pruned_refs"`),
 		"pruned_refs is omitempty: absent when nothing was pruned")
+}
+
+// The help promises exit 2 for "verify itself could not run", and a malformed
+// flag is exactly that. Cobra returns parse errors up to ExecuteContext, where
+// main.go prints and exits 1 — so the promise needs a FlagErrorFunc to be true.
+// Asserting the help text alone (as the exit-code test above does) passes while
+// the binary contradicts it.
+func TestVerifyCmd_FlagParseErrorsAreWiredToExitTwo(t *testing.T) {
+	c := verifyCmd()
+	require.NotNil(t, c.FlagErrorFunc(), "a flag parse error must not fall through to main's exit 1")
+
+	// The default FlagErrorFunc returns the error unchanged; ours is distinct.
+	plain := &cobra.Command{}
+	require.NotEqual(t,
+		fmt.Sprintf("%p", plain.FlagErrorFunc()),
+		fmt.Sprintf("%p", c.FlagErrorFunc()),
+		"verify must install its own flag error handler")
 }
 
 // --max-issues truncates the human rendering only. Truncating JSON would hand a

--- a/internal/repos/instance.go
+++ b/internal/repos/instance.go
@@ -476,6 +476,21 @@ func (ri *RepoInstance) Verify(ctx context.Context, opts store.VerifyOpts) (stor
 	return report, err
 }
 
+// PruneGeneratedRefs deletes this repo's residual okf/* export refs. Held under
+// the same Acquire as Verify, so a concurrent SwapStore/Archive drains the call
+// rather than closing the service while it is deleting refs.
+//
+// Unlike Verify this one WRITES, which is why it is a separate call an operator
+// asks for by name rather than something Verify does when it finds residue.
+func (ri *RepoInstance) PruneGeneratedRefs(ctx context.Context) (store.PruneResult, error) {
+	svc, release, err := ri.Acquire()
+	if err != nil {
+		return store.PruneResult{}, err
+	}
+	defer release()
+	return svc.PruneGeneratedRefs(ctx)
+}
+
 // NewTestInstance creates a minimal RepoInstance for use in tests that
 // exercise Manager operations (Set, Get, Replace, ForEach, Names, context).
 // Production code must use Manager.openOne instead.

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -849,7 +849,10 @@ func (m *Manager) warnOrphanFiles(reposDir string, registered map[string]struct{
 // Restart=on-failure, Docker) turns "refuse loudly" into "refuse once, at 3am,
 // into a log nobody reads".
 func refuseUnmigratedHome(repoReg *Registry, reposDir string) error {
-	const advice = "this home predates the control.db repo registry. Run `knomit migrate-registry` to convert it"
+	// The command named here is deprecated and scheduled for removal, so the
+	// advice says "now": an operator who defers this until the next upgrade may
+	// find the only converter gone.
+	const advice = "this home predates the control.db repo registry. Run `knomit migrate-registry` to convert it now — that command is deprecated and will be removed in a future build"
 
 	legacyLenses, err := HasLegacyLensSchema(repoReg.DB())
 	if err != nil {

--- a/internal/store/verify.go
+++ b/internal/store/verify.go
@@ -258,11 +258,18 @@ func (s *Service) Verify(ctx context.Context, opts VerifyOpts) (IntegrityReport,
 
 	// Read once, compared per branch below. Inside the lock window, so it is
 	// one query rather than one per commit on every branch.
-	commitParents, err := s.loadCommitParents(ctx)
-	if err != nil {
+	//
+	// On failure the comparison is SKIPPED, not run against the empty map. An
+	// unreadable commit_parents makes every non-root commit look like it lost
+	// its parent edges, so a single transient query error would manufacture one
+	// ERROR per commit — thousands on a real branch, and a permanent exit 1.
+	// That is the exact failure this whole change removes; it must not come
+	// back through the error path.
+	commitParents, cpErr := s.loadCommitParents(ctx)
+	if cpErr != nil {
 		report.Issues = append(report.Issues, IntegrityIssue{
 			Severity: SeverityError, Category: CategoryCommitParents,
-			Detail: fmt.Sprintf("read commit_parents: %v", err),
+			Detail: fmt.Sprintf("read commit_parents: %v (per-commit comparison skipped)", cpErr),
 		})
 	}
 
@@ -274,7 +281,9 @@ func (s *Service) Verify(ctx context.Context, opts VerifyOpts) (IntegrityReport,
 		}
 		report.Issues = append(report.Issues, s.checkGitReachability(ctx, br)...)
 		report.Issues = append(report.Issues, s.checkCommitLogParity(ctx, br)...)
-		report.Issues = append(report.Issues, s.checkCommitParents(ctx, br, commitParents)...)
+		if cpErr == nil {
+			report.Issues = append(report.Issues, s.checkCommitParents(ctx, br, commitParents)...)
+		}
 		report.Issues = append(report.Issues, s.checkFactsCoherence(ctx, br)...)
 		if opts.Deep {
 			report.Issues = append(report.Issues, s.checkFactFormat(ctx, br)...)
@@ -292,7 +301,7 @@ func (s *Service) Verify(ctx context.Context, opts VerifyOpts) (IntegrityReport,
 	report.Issues = append(report.Issues, s.checkDatabase(ctx)...)
 	report.Issues = append(report.Issues, s.checkSchemaVersion(ctx)...)
 	report.Issues = append(report.Issues, s.checkOrphanObjects(ctx)...)
-	report.Issues = append(report.Issues, s.reportUnindexedBranches(skipped)...)
+	report.Issues = append(report.Issues, s.reportUnindexedBranches(allBranches)...)
 
 	sortIssues(report.Issues)
 	return report, nil
@@ -391,6 +400,12 @@ func (s *Service) indexedBranches(ctx context.Context) (map[string]bool, error) 
 
 // reportUnindexedBranches raises an issue only for GENERATED refs, not for
 // every unchecked branch.
+//
+// It is fed ALL branch names, not just the skipped ones, so that
+// --all-branches cannot suppress it. Under that flag generated refs move into
+// the checked set and produce hard parity errors; without this the one message
+// naming --prune-generated-refs would vanish exactly when an operator went
+// looking for why those refs have no rows.
 //
 // The transparency requirement — "CLEAN" must never quietly mean "nothing was
 // examined" — is met by IntegrityReport.Skipped, which Format always prints.

--- a/internal/store/verify.go
+++ b/internal/store/verify.go
@@ -1,20 +1,37 @@
-// Verify reports structural integrity issues across the store. It walks every
-// branch ref, verifies git object reachability, parity between SQLite tables
-// and git/tree state, and (with Deep) parses every fact for format errors.
+// Verify reports structural integrity issues across the store: git object
+// reachability, parity between SQLite tables and git/tree state, database-level
+// soundness, and (with Deep) fact format.
 //
-// TODO(verify): orphan object scan for history-rewrite scenarios. Currently
-// only walks objects reachable from refs; commits made unreachable by force
-// pushes are not reported.
+// # WHICH BRANCHES ARE CHECKED
 //
-// Verify is read-only. It acquires per-branch read locks one branch at a time;
-// the report is therefore not a snapshot of the whole repo at one instant.
-// For definitive results on a busy repo, take the agent offline first.
+// Parity checks run ONLY for branches the index actually maintains, which is
+// the set carrying a meta.last_commit:<branch> row. That is narrower than
+// refs/heads/*, deliberately: repoBuilder.setupIndex maintains the agent branch
+// plus upstreamMain and nothing else, so every other local ref — another
+// machine's agent branch arriving by fetch, or a generated ref left by a
+// removed feature — has no SQLite rows and never will. Demanding parity for
+// those refs is demanding an invariant the system never promised; doing it
+// produced 8128 errors on a healthy five-repo home, every one of them false.
+// Unmaintained refs are reported once each, as warnings, so they stay visible
+// without failing the run.
+//
+// # LOCKING
+//
+// Verify is read-only, and it is a SNAPSHOT. It acquires the read lock on every
+// branch it is about to check UP FRONT and holds all of them for the whole run,
+// so no writer can advance a ref or mutate branch_facts mid-report and no torn
+// state can appear. The cost is the other side of that coin: for its whole
+// duration Verify BLOCKS EVERY WRITER on every branch it covers, and a
+// concurrent index Rebuild (which takes the write side of the same per-branch
+// RWMutex) blocks Verify. It is not a cheap probe to fire at a live agent —
+// budget for it, or take the repo offline.
 package store
 
 import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -50,20 +67,32 @@ type VerifyOpts struct {
 	// Deep enables the fact-format check (parses every .md as a Fact).
 	// Slow on large repos; off by default.
 	Deep bool
+	// AllBranches runs the parity checks against every refs/heads/* ref rather
+	// than only the branches the index maintains. Off by default, and off is
+	// the answer you want: see the package doc. It exists so a developer
+	// chasing "why does this branch have no rows" can ask for the old
+	// behaviour deliberately, and so tests can pin it.
+	AllBranches bool
 }
 
-// Canonical issue category strings. Implementations of the per-category
-// checks (tasks 1.2-1.8) MUST use exactly these constants when populating
-// IntegrityIssue.Category — no string literals at the call sites.
+// Canonical issue category strings. Every check MUST use exactly these
+// constants when populating IntegrityIssue.Category — no string literals at the
+// call sites.
 const (
 	CategoryGitReachability    = "git-reachability"
 	CategoryCommitLog          = "commit-log"
+	CategoryCommitParents      = "commit-parents"
 	CategoryFactsCoherence     = "facts-coherence"
 	CategoryEmbeddingsCoverage = "embeddings-coverage"
+	CategoryEmbeddingIdentity  = "embedding-identity"
 	CategoryBranchesTable      = "branches-table"
-	CategoryBranchFactsTable   = "branch-facts-table"
 	CategoryFactFormat         = "fact-format"
 	CategoryGraphCoherence     = "graph-coherence"
+	CategoryDerivedTables      = "derived-tables"
+	CategoryDatabase           = "database"
+	CategorySchemaVersion      = "schema-version"
+	CategoryOrphanObjects      = "orphan-objects"
+	CategoryGeneratedRefs      = "generated-refs"
 )
 
 // IntegrityIssue is a single finding from Verify.
@@ -84,8 +113,23 @@ type IntegrityReport struct {
 	// containing manager does.
 	Repo      string
 	CheckedAt time.Time
-	Branches  []string
-	Issues    []IntegrityIssue
+	// Branches are the branches whose parity was CHECKED — the maintained set.
+	Branches []string
+	// Skipped are refs/heads/* refs that exist but carry no index, and so were
+	// not parity-checked. Reported rather than silently dropped: "verify found
+	// nothing wrong" must not be able to mean "verify looked at nothing".
+	Skipped []string
+	Issues  []IntegrityIssue
+}
+
+// CountsByCategory returns issue counts keyed by category, for a summary that
+// stays readable when the detail runs to thousands of lines.
+func (r IntegrityReport) CountsByCategory() map[string]int {
+	out := make(map[string]int, len(r.Issues))
+	for _, i := range r.Issues {
+		out[i.Category]++
+	}
+	return out
 }
 
 // IsClean returns true iff there are no Error-severity issues.
@@ -102,17 +146,48 @@ func (r IntegrityReport) IsClean() bool {
 // IsStrictlyClean returns true iff there are no issues at all (no errors, no warnings).
 func (r IntegrityReport) IsStrictlyClean() bool { return len(r.Issues) == 0 }
 
-// String formats the report as a multi-line human-readable summary.
-func (r IntegrityReport) String() string {
+// String formats the report as a multi-line human-readable summary, printing
+// every issue. Equivalent to Format(0).
+func (r IntegrityReport) String() string { return r.Format(0) }
+
+// Format renders the report, listing at most maxIssues findings (0 = all). The
+// per-category summary is always printed in full, so a truncated report still
+// says how much it found — a raw tail of 1600 identical lines tells an operator
+// less than six counts do.
+func (r IntegrityReport) Format(maxIssues int) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Verify report for %q at %s\n", r.Repo, r.CheckedAt.Format(time.RFC3339))
 	fmt.Fprintf(&b, "  Branches checked: %s\n", strings.Join(r.Branches, ", "))
+	if len(r.Skipped) > 0 {
+		fmt.Fprintf(&b, "  Not indexed (parity not checked): %s\n", strings.Join(r.Skipped, ", "))
+	}
 	if r.IsStrictlyClean() {
 		b.WriteString("  Status: CLEAN\n")
 		return b.String()
 	}
-	fmt.Fprintf(&b, "  Issues: %d\n", len(r.Issues))
+
+	counts := r.CountsByCategory()
+	cats := make([]string, 0, len(counts))
+	for c := range counts {
+		cats = append(cats, c)
+	}
+	sort.Strings(cats)
+	errs := 0
 	for _, i := range r.Issues {
+		if i.Severity == SeverityError {
+			errs++
+		}
+	}
+	fmt.Fprintf(&b, "  Issues: %d (%d error, %d warning)\n", len(r.Issues), errs, len(r.Issues)-errs)
+	for _, c := range cats {
+		fmt.Fprintf(&b, "    %-20s %d\n", c, counts[c])
+	}
+
+	shown := r.Issues
+	if maxIssues > 0 && len(shown) > maxIssues {
+		shown = shown[:maxIssues]
+	}
+	for _, i := range shown {
 		fmt.Fprintf(&b, "    [%s] %s", i.Severity, i.Category)
 		if i.Branch != "" {
 			fmt.Fprintf(&b, " branch=%s", i.Branch)
@@ -125,6 +200,9 @@ func (r IntegrityReport) String() string {
 		}
 		fmt.Fprintf(&b, " — %s\n", i.Detail)
 	}
+	if len(shown) < len(r.Issues) {
+		fmt.Fprintf(&b, "    … %d more (use --max-issues 0 for all)\n", len(r.Issues)-len(shown))
+	}
 	return b.String()
 }
 
@@ -134,12 +212,31 @@ func (s *Service) Verify(ctx context.Context, opts VerifyOpts) (IntegrityReport,
 
 	// Enumerate branches via git refs (storer-level), since the branches
 	// SQLite table is one of the things we're going to verify.
-	branches, err := s.listBranchRefsForVerify(ctx)
+	allBranches, err := s.listBranchRefsForVerify(ctx)
 	if err != nil {
 		return report, fmt.Errorf("verify: list branches: %w", err)
 	}
-	sort.Strings(branches)
-	report.Branches = branches
+	sort.Strings(allBranches)
+
+	// Split into the branches the index maintains and the rest. Parity is only
+	// an invariant for the former — see the package doc.
+	checked, skipped := allBranches, []string(nil)
+	if !opts.AllBranches {
+		indexed, ierr := s.indexedBranches(ctx)
+		if ierr != nil {
+			return report, fmt.Errorf("verify: list indexed branches: %w", ierr)
+		}
+		checked, skipped = nil, nil
+		for _, br := range allBranches {
+			if indexed[br] {
+				checked = append(checked, br)
+			} else {
+				skipped = append(skipped, br)
+			}
+		}
+	}
+	report.Branches = checked
+	report.Skipped = skipped
 
 	// Acquire the per-branch read lock on every branch we're about to
 	// check and hold it for the whole Verify run. This gives us a
@@ -150,29 +247,266 @@ func (s *Service) Verify(ctx context.Context, opts VerifyOpts) (IntegrityReport,
 	// write side of the same RWMutex via lockBranch, so they block until
 	// Verify completes. This is the read-locking behavior promised in
 	// the package doc.
-	for _, br := range branches {
+	//
+	// Locked over `checked` only. A skipped branch is not read by any check
+	// below, and locking it would extend the writer stall to refs this run
+	// never looks at.
+	for _, br := range checked {
 		unlock := s.rh.lockBranchRead(br)
 		defer unlock()
 	}
 
+	// Read once, compared per branch below. Inside the lock window, so it is
+	// one query rather than one per commit on every branch.
+	commitParents, err := s.loadCommitParents(ctx)
+	if err != nil {
+		report.Issues = append(report.Issues, IntegrityIssue{
+			Severity: SeverityError, Category: CategoryCommitParents,
+			Detail: fmt.Sprintf("read commit_parents: %v", err),
+		})
+	}
+
 	// Per-category checks. Each check runs against the frozen snapshot
 	// held by the read locks above.
-	// TODO(verify): add a `select { case <-ctx.Done(): return report, ctx.Err() }`
-	// check between branches so cancellation can interrupt long verifies.
-	for _, br := range branches {
+	for _, br := range checked {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
 		report.Issues = append(report.Issues, s.checkGitReachability(ctx, br)...)
 		report.Issues = append(report.Issues, s.checkCommitLogParity(ctx, br)...)
+		report.Issues = append(report.Issues, s.checkCommitParents(ctx, br, commitParents)...)
 		report.Issues = append(report.Issues, s.checkFactsCoherence(ctx, br)...)
-		report.Issues = append(report.Issues, s.checkBranchFactsParity(ctx, br)...)
 		if opts.Deep {
 			report.Issues = append(report.Issues, s.checkFactFormat(ctx, br)...)
 		}
 	}
-	report.Issues = append(report.Issues, s.checkBranchesTable(ctx, branches)...)
+	if err := ctx.Err(); err != nil {
+		return report, err
+	}
+	report.Issues = append(report.Issues, s.checkBranchesTable(ctx, checked, allBranches)...)
+	report.Issues = append(report.Issues, s.checkCommitLogOrphans(ctx)...)
 	report.Issues = append(report.Issues, s.checkEmbeddingsCoverage(ctx)...)
+	report.Issues = append(report.Issues, s.checkEmbeddingIdentity(ctx)...)
 	report.Issues = append(report.Issues, s.checkGraphCoherence(ctx)...)
+	report.Issues = append(report.Issues, s.checkDerivedTables(ctx)...)
+	report.Issues = append(report.Issues, s.checkDatabase(ctx)...)
+	report.Issues = append(report.Issues, s.checkSchemaVersion(ctx)...)
+	report.Issues = append(report.Issues, s.checkOrphanObjects(ctx)...)
+	report.Issues = append(report.Issues, s.reportUnindexedBranches(skipped)...)
 
+	sortIssues(report.Issues)
 	return report, nil
+}
+
+// sortIssues puts the report in a stable order. Several checks iterate Go maps,
+// so without this two runs over an unchanged repo emit the same findings in
+// different orders and the reports cannot be diffed.
+// Severity leads the ordering, not category. Format truncates the flat slice at
+// maxIssues, so ordering by category first lets one alphabetically-early
+// category of warnings eat the whole budget and hide every error behind it —
+// schema-version sorts last of all categories, so a DIRTY migration would be
+// guaranteed invisible on any repo with 100 earlier findings. Errors first
+// means truncation can only ever drop the least severe findings.
+func sortIssues(issues []IntegrityIssue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		a, b := issues[i], issues[j]
+		if a.Severity != b.Severity {
+			return a.Severity < b.Severity // SeverityError == 0, so errors lead
+		}
+		if a.Category != b.Category {
+			return a.Category < b.Category
+		}
+		if a.Branch != b.Branch {
+			return a.Branch < b.Branch
+		}
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		if a.Commit != b.Commit {
+			return a.Commit < b.Commit
+		}
+		return a.Detail < b.Detail
+	})
+}
+
+// indexedBranches returns the set of branches whose SQLite parity is an
+// invariant — the ones the index maintains.
+//
+// Three sources, unioned, because no single one is complete:
+//
+//  1. meta.last_commit:<branch>, written by the index every time it syncs a
+//     branch. This is the primary signal and the only one that covers the
+//     upstream branch. Deliberately NOT meta.graph_schema_version:<branch>,
+//     which looks like the same signal and is not: migration 000016 backfilled
+//     the old global schema-version row onto every branch known at the time, so
+//     an unindexed branch can carry one. On a live home that mistake reads
+//     another machine's never-indexed agent branch as maintained and then
+//     reports all 1366 of its commits as missing from branch_commits.
+//
+//  2. HEAD's target. A freshly created repo has NO meta rows at all — the first
+//     last_commit row appears only after the first write — so source 1 alone
+//     returns the empty set for a new repo and verify would check nothing and
+//     report CLEAN. That silent skip is the same class of bug as the false
+//     positives this function exists to remove, pointing the other way.
+//
+//  3. meta.agent_branch_owner, when set: the branch this database records as
+//     the one it writes. Empty on a database that has never completed a boot,
+//     which is why it cannot be the only source either.
+//
+// What the union deliberately does NOT include: any other refs/heads/* ref.
+// Another machine's agent branch arriving by fetch has a `branches` row and no
+// index, so the `branches` table is not usable as a fourth source.
+func (s *Service) indexedBranches(ctx context.Context) (map[string]bool, error) {
+	const prefix = "last_commit:"
+	rows, err := s.rh.gits.DB().QueryContext(ctx,
+		`SELECT key FROM meta WHERE key LIKE ? || '%'`, prefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		if br, ok := strings.CutPrefix(key, prefix); ok && br != "" {
+			out[br] = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Errors here are not fatal: a detached HEAD or an unstamped database is a
+	// legitimate state, and source 1 still stands on its own.
+	if head, herr := s.rh.DefaultBranch(ctx); herr == nil && head != "" {
+		out[head] = true
+	}
+	if owner, oerr := s.rh.AgentBranchOwner(ctx); oerr == nil && owner != "" {
+		out[owner] = true
+	}
+	return out, nil
+}
+
+// reportUnindexedBranches raises an issue only for GENERATED refs, not for
+// every unchecked branch.
+//
+// The transparency requirement — "CLEAN" must never quietly mean "nothing was
+// examined" — is met by IntegrityReport.Skipped, which Format always prints.
+// An unindexed branch is the normal, healthy state for a local `main` with no
+// origin and for another machine's agent branch arriving by fetch, so raising a
+// warning per branch would put a permanent warning on ordinary repos. A check
+// that cries wolf on healthy input is the defect this whole pass exists to
+// remove; it would be an odd thing to reintroduce in the fix.
+//
+// Generated okf/* refs are different in kind: residue from the server-side OKF
+// export removed in bf9becbe, which nothing creates any more and which has an
+// actual repair. Those get a warning naming it.
+func (s *Service) reportUnindexedBranches(skipped []string) []IntegrityIssue {
+	var issues []IntegrityIssue
+	for _, br := range skipped {
+		if !isGeneratedRef(br) {
+			continue
+		}
+		issues = append(issues, IntegrityIssue{
+			Severity: SeverityWarning, Category: CategoryGeneratedRefs, Branch: br,
+			Detail: "generated ref left by the removed server-side OKF export; " +
+				"nothing creates these now — remove with --prune-generated-refs",
+		})
+	}
+	return issues
+}
+
+// generatedRefPrefix is the branch-name prefix the removed server-side OKF
+// export wrote under refs/heads/. Nothing creates these any more (the producer
+// went in bf9becbe, and TestVerify_NoGeneratedRefs pins that), so a ref matching
+// it on a live home is residue from before that commit.
+//
+// Deliberately narrow. knomit-okf's own fetched source history lives at
+// refs/knomit-okf/source/*, OUTSIDE refs/heads, and is live, deliberate and not
+// matched here — see kb/invariants/okf/source-refs-stay-local.
+const generatedRefPrefix = "okf/"
+
+// isGeneratedRef reports whether a BRANCH NAME (no refs/heads/ prefix) is
+// export residue.
+func isGeneratedRef(branch string) bool {
+	return strings.HasPrefix(branch, generatedRefPrefix)
+}
+
+// PruneResult reports what a prune actually removed — not what it considered.
+type PruneResult struct {
+	// Refs are the branch names whose refs were deleted, sorted. On a partial
+	// failure this holds the ones that were already gone, so a caller can print
+	// it without claiming a still-present ref was removed.
+	Refs []string
+	// Markers is the number of okf:marker:* kv rows deleted. Separate from Refs
+	// because markers are keyed by source branch and can outlive every ref.
+	Markers int64
+}
+
+// Empty reports whether the prune removed nothing at all.
+func (p PruneResult) Empty() bool { return len(p.Refs) == 0 && p.Markers == 0 }
+
+// PruneGeneratedRefs deletes the generated okf/* branch refs and their
+// okf:marker:* bookkeeping rows, reporting what it removed. It is the
+// repair for the residue reportUnindexedBranches warns about.
+//
+// Not called by Verify. Verify stays read-only, and this runs only when the
+// operator asks for it by name (`--prune-generated-refs`), because it deletes
+// git refs and there is no undo short of a reflog knomit does not keep.
+//
+// Scope is exactly the refs isGeneratedRef matches under refs/heads/*, so it
+// cannot touch a real branch, and cannot touch refs/knomit-okf/source/*.
+func (s *Service) PruneGeneratedRefs(ctx context.Context) (PruneResult, error) {
+	var out PruneResult
+
+	iter, err := s.rh.gits.IterReferences()
+	if err != nil {
+		return out, fmt.Errorf("prune: iterate refs: %w", err)
+	}
+	var targets []plumbing.ReferenceName
+	if err := iter.ForEach(func(ref *plumbing.Reference) error {
+		if name, ok := strings.CutPrefix(ref.Name().String(), "refs/heads/"); ok && isGeneratedRef(name) {
+			targets = append(targets, ref.Name())
+		}
+		return nil
+	}); err != nil {
+		return out, fmt.Errorf("prune: collect refs: %w", err)
+	}
+
+	for _, ref := range targets {
+		// Under the same per-branch write lock a normal ref update takes, so a
+		// concurrent read of that branch cannot see it half-removed.
+		branch, _ := strings.CutPrefix(ref.String(), "refs/heads/")
+		unlock := s.rh.lockBranch(branch)
+		err := s.rh.gits.RemoveReference(ref)
+		unlock()
+		if err != nil {
+			// Refs is what was ACTUALLY deleted, never what was merely found.
+			// Returning the full candidate list here would have the CLI print
+			// "pruned generated ref: X" for a ref still sitting in the store.
+			sort.Strings(out.Refs)
+			return out, fmt.Errorf("prune: remove %s: %w", ref, err)
+		}
+		out.Refs = append(out.Refs, branch)
+	}
+	sort.Strings(out.Refs)
+
+	// The markers are keyed by SOURCE branch, not by the generated ref, so they
+	// are removed by prefix rather than by the ref names above — and they can
+	// outlive the refs, so this runs even when no ref matched. The row count is
+	// returned rather than swallowed: a prune that quietly deleted rows in a
+	// repo it reported nothing about is an invisible write.
+	res, err := s.rh.gits.DB().ExecContext(ctx,
+		`DELETE FROM kv WHERE key LIKE 'okf:marker:%'`)
+	if err != nil {
+		return out, fmt.Errorf("prune: delete okf markers: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		out.Markers = n
+	}
+	return out, nil
 }
 
 // listBranchRefsForVerify enumerates refs/heads/* directly from the storer.
@@ -464,6 +798,63 @@ func (s *Service) checkCommitLogParity(ctx context.Context, branch string) []Int
 	return issues
 }
 
+// checkCommitLogOrphans reports commit_log rows whose commit is not in the
+// object store at all.
+//
+// checkCommitLogParity is named for commit_log and does not read it: it moved
+// onto branch_commits, because a legitimate no-op commit (a write whose blob
+// equals the parent's at the same path) produces zero commit_log rows and the
+// old join reported that as a gap. Correct, but it left the table the category
+// is named after with no coverage whatsoever.
+//
+// Orphans are the direction that has no such exception. A commit_log row for a
+// commit no object exists for is drift under any policy about no-op commits,
+// and it is what a partially-applied history rewrite leaves behind. The other
+// direction (a commit with no commit_log rows) stays unchecked ON PURPOSE —
+// that is exactly the no-op case.
+//
+// Repo-global, not per branch: commit_log is keyed by (commit_hash, path) with
+// no branch dimension.
+func (s *Service) checkCommitLogOrphans(ctx context.Context) []IntegrityIssue {
+	rows, err := s.rh.gits.DB().QueryContext(ctx,
+		`SELECT DISTINCT commit_hash FROM commit_log`)
+	if err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryCommitLog,
+			Detail: fmt.Sprintf("query commit_log: %v", err),
+		}}
+	}
+	defer rows.Close()
+	var hashes []string
+	for rows.Next() {
+		var h string
+		if err := rows.Scan(&h); err != nil {
+			return []IntegrityIssue{{
+				Severity: SeverityError, Category: CategoryCommitLog,
+				Detail: fmt.Sprintf("scan commit_log: %v", err),
+			}}
+		}
+		hashes = append(hashes, h)
+	}
+	if err := rows.Err(); err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryCommitLog,
+			Detail: fmt.Sprintf("iterate commit_log: %v", err),
+		}}
+	}
+
+	var issues []IntegrityIssue
+	for _, h := range hashes {
+		if _, err := object.GetCommit(s.rh.gits, plumbing.NewHash(h)); err != nil {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryCommitLog, Commit: h,
+				Detail: "commit_log rows reference a commit that is not in the object store",
+			})
+		}
+	}
+	return issues
+}
+
 // deleteBranchFactsRowForTest removes a branch_facts row for (branch, path).
 // Test-only escape hatch for integrity-check tests.
 func (s *Service) deleteBranchFactsRowForTest(branch, path string) error {
@@ -675,18 +1066,470 @@ func (s *Service) checkEmbeddingsCoverage(ctx context.Context) []IntegrityIssue 
 
 	return issues
 }
-func (s *Service) checkBranchFactsParity(_ context.Context, _ string) []IntegrityIssue {
+
+// checkEmbeddingIdentity reports derived state written under a different
+// embedding model than the one now configured. checkEmbeddingsCoverage counts
+// rows and so cannot see this: every facts row can have a facts_vec row and
+// every vector still be from the wrong model, which makes similarity search
+// quietly meaningless rather than broken.
+func (s *Service) checkEmbeddingIdentity(ctx context.Context) []IntegrityIssue {
+	emb := s.rh.getEmbedder()
+	if emb == nil {
+		return nil
+	}
+	storedID, err := s.si.persistedEmbedModelID(ctx)
+	if err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryEmbeddingIdentity,
+			Detail: fmt.Sprintf("read meta.embed_model_id: %v", err),
+		}}
+	}
+	storedDim, err := s.si.persistedEmbedDim(ctx)
+	if err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryEmbeddingIdentity,
+			Detail: fmt.Sprintf("read meta.embed_dim: %v", err),
+		}}
+	}
+	// Unset means nothing has ever been embedded under a recorded identity;
+	// checkEmbeddingsCoverage owns the "rows are missing" story, and reporting
+	// it a second time here would just double-count.
+	if storedID == "" && storedDim == 0 {
+		return nil
+	}
+
+	var issues []IntegrityIssue
+	if storedID != "" && storedID != emb.ID() {
+		issues = append(issues, IntegrityIssue{
+			Severity: SeverityError, Category: CategoryEmbeddingIdentity,
+			Detail: fmt.Sprintf(
+				"facts_vec was written by embedding model %q but %q is configured; "+
+					"similarity results are meaningless until the index is rebuilt",
+				storedID, emb.ID()),
+		})
+	}
+	if storedDim != 0 && storedDim != emb.Dim() {
+		issues = append(issues, IntegrityIssue{
+			Severity: SeverityError, Category: CategoryEmbeddingIdentity,
+			Detail: fmt.Sprintf(
+				"facts_vec holds %d-dimensional vectors but the configured model emits %d",
+				storedDim, emb.Dim()),
+		})
+	}
+	return issues
+}
+
+// checkCommitParents verifies the third leg of the commit index. commit_log
+// (per-path) and branch_commits (visibility) are checked elsewhere;
+// commit_parents holds the DAG edges, and drift there is invisible to both —
+// history walks silently take the wrong shape.
+func (s *Service) checkCommitParents(ctx context.Context, branch string, stored map[string][]string) []IntegrityIssue {
+	ref, err := s.rh.gits.Reference(plumbing.NewBranchReferenceName(branch))
+	if err != nil {
+		return nil // git-reachability already reported it
+	}
+
+	var issues []IntegrityIssue
+	seen := map[string]bool{}
+	stack := []plumbing.Hash{ref.Hash()}
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if cur.IsZero() || seen[cur.String()] {
+			continue
+		}
+		seen[cur.String()] = true
+		commit, err := object.GetCommit(s.rh.gits, cur)
+		if err != nil {
+			continue // git-reachability owns this
+		}
+		stack = append(stack, commit.ParentHashes...)
+
+		want := make([]string, 0, len(commit.ParentHashes))
+		for _, p := range commit.ParentHashes {
+			want = append(want, p.String())
+		}
+		got := stored[cur.String()]
+		// A root commit has no parents and therefore no rows: absence is
+		// correct, not a gap. Only a MISMATCH is reported.
+		if len(want) == 0 && len(got) == 0 {
+			continue
+		}
+		if !slices.Equal(want, got) {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryCommitParents, Branch: branch, Commit: cur.String(),
+				Detail: fmt.Sprintf("commit_parents has %v but the commit object has %v", got, want),
+			})
+		}
+	}
+	return issues
+}
+
+// loadCommitParents reads the whole commit_parents table once, keyed by commit
+// and ordered by parent_order.
+//
+// One query for the repo, not one per commit. The per-commit form issued
+// thousands of round trips on a real repo — all of them inside the window where
+// Verify holds every branch's read lock and therefore blocks every writer. The
+// table is small (two hashes and an int per parent edge) and the walk visits
+// most of it anyway, so reading it whole is cheaper in both time and lock-hold
+// than querying per commit, and it is shared across branches.
+func (s *Service) loadCommitParents(ctx context.Context) (map[string][]string, error) {
+	rows, err := s.rh.gits.DB().QueryContext(ctx,
+		`SELECT commit_hash, parent_hash FROM commit_parents ORDER BY commit_hash, parent_order`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string][]string{}
+	for rows.Next() {
+		var commit, parent string
+		if err := rows.Scan(&commit, &parent); err != nil {
+			return nil, err
+		}
+		out[commit] = append(out[commit], parent)
+	}
+	return out, rows.Err()
+}
+
+// checkDerivedTables verifies the three fact_* projections that domain and
+// entity search read. Nothing else checks them, and their failure mode is the
+// quiet one: the facts are all present and correct, and searching by domain
+// returns nothing.
+//
+// The two directions differ in severity ON PURPOSE.
+//
+// Orphan rows and a fact present in one table but not the other are structural
+// and are ERRORS. A (fact_id, domain) set difference between fact_domains and
+// fact_domain_tokens is a WARNING, because the two columns legitimately hold
+// different STRINGS: both writers insert canonicalizeDomain(d), but that
+// function gained a de-hyphenize step after some rows were written, and only
+// the token side was ever repopulated. Comparing the strings and calling the
+// difference corruption reports healthy repos as broken — which is the exact
+// bug this whole pass exists to remove.
+func (s *Service) checkDerivedTables(ctx context.Context) []IntegrityIssue {
+	var issues []IntegrityIssue
+
+	orphans := []struct{ table, col string }{
+		{"fact_domains", "fact_id"},
+		{"fact_domain_tokens", "fact_id"},
+		{"fact_entities", "fact_id"},
+	}
+	for _, o := range orphans {
+		var n int
+		if err := s.rh.gits.DB().QueryRowContext(ctx, fmt.Sprintf(
+			`SELECT COUNT(*) FROM %s WHERE %s NOT IN (SELECT id FROM facts)`, o.table, o.col),
+		).Scan(&n); err != nil {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDerivedTables,
+				Detail: fmt.Sprintf("query %s orphans: %v", o.table, err),
+			})
+			continue
+		}
+		if n > 0 {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDerivedTables,
+				Detail: fmt.Sprintf("%s has %d row(s) referencing a missing facts row", o.table, n),
+			})
+		}
+	}
+
+	// A fact indexed for domain filtering but not for token containment (or the
+	// reverse) is half-searchable. Compared at fact_id granularity, which is
+	// immune to the canonicalization skew above.
+	for _, d := range []struct{ have, missing string }{
+		{"fact_domains", "fact_domain_tokens"},
+		{"fact_domain_tokens", "fact_domains"},
+	} {
+		var n int
+		if err := s.rh.gits.DB().QueryRowContext(ctx, fmt.Sprintf(
+			`SELECT COUNT(*) FROM (SELECT DISTINCT fact_id FROM %s
+			  WHERE fact_id NOT IN (SELECT fact_id FROM %s))`, d.have, d.missing),
+		).Scan(&n); err != nil {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDerivedTables,
+				Detail: fmt.Sprintf("compare %s to %s: %v", d.have, d.missing, err),
+			})
+			continue
+		}
+		if n > 0 {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDerivedTables,
+				Detail: fmt.Sprintf("%d fact(s) present in %s but absent from %s", n, d.have, d.missing),
+			})
+		}
+	}
+
+	var skew int
+	if err := s.rh.gits.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM (
+		   SELECT fact_id, domain FROM fact_domains
+		   EXCEPT
+		   SELECT fact_id, domain FROM fact_domain_tokens)`).Scan(&skew); err != nil {
+		return append(issues, IntegrityIssue{
+			Severity: SeverityError, Category: CategoryDerivedTables,
+			Detail: fmt.Sprintf("compare domain strings: %v", err),
+		})
+	}
+	if skew > 0 {
+		issues = append(issues, IntegrityIssue{
+			Severity: SeverityWarning, Category: CategoryDerivedTables,
+			Detail: fmt.Sprintf(
+				"%d (fact_id, domain) pair(s) in fact_domains have no fact_domain_tokens row for "+
+					"the same string — canonicalizeDomain drift, so domain filtering and token "+
+					"containment disagree for these facts; a rebuild re-canonicalizes both", skew),
+		})
+	}
+	return issues
+}
+
+// checkDatabase runs SQLite's own structural checks. Every parity check in this
+// file assumes the pages underneath are readable and the declared foreign keys
+// hold; this is the check that stops that assumption being silent.
+func (s *Service) checkDatabase(ctx context.Context) []IntegrityIssue {
+	var issues []IntegrityIssue
+
+	rows, err := s.rh.gits.DB().QueryContext(ctx, `PRAGMA quick_check`)
+	if err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryDatabase,
+			Detail: fmt.Sprintf("quick_check: %v", err),
+		}}
+	}
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			rows.Close()
+			return append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDatabase,
+				Detail: fmt.Sprintf("scan quick_check: %v", err),
+			})
+		}
+		if line != "ok" {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDatabase,
+				Detail: "quick_check: " + line,
+			})
+		}
+	}
+	// Checked, not assumed: a cursor that dies mid-iteration (cancellation, or
+	// an I/O error on exactly the damaged page this check exists to find) ends
+	// the loop with zero rows. Without this the integrity checker would swallow
+	// its own read failure and report the database sound.
+	rerr := rows.Err()
+	rows.Close()
+	if rerr != nil {
+		return append(issues, IntegrityIssue{
+			Severity: SeverityError, Category: CategoryDatabase,
+			Detail: fmt.Sprintf("iterate quick_check: %v", rerr),
+		})
+	}
+
+	// foreign_key_check reports violations even when PRAGMA foreign_keys is
+	// OFF for the connection — which is the case that matters, since a cascade
+	// that never ran is exactly how orphan rows survive.
+	fkRows, err := s.rh.gits.DB().QueryContext(ctx, `PRAGMA foreign_key_check`)
+	if err != nil {
+		return append(issues, IntegrityIssue{
+			Severity: SeverityError, Category: CategoryDatabase,
+			Detail: fmt.Sprintf("foreign_key_check: %v", err),
+		})
+	}
+	defer fkRows.Close()
+	violations := map[string]int{}
+	for fkRows.Next() {
+		var table string
+		var rowid sql.NullInt64
+		var parent string
+		var fkid int
+		if err := fkRows.Scan(&table, &rowid, &parent, &fkid); err != nil {
+			return append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDatabase,
+				Detail: fmt.Sprintf("scan foreign_key_check: %v", err),
+			})
+		}
+		violations[table+" -> "+parent]++
+	}
+	if err := fkRows.Err(); err != nil {
+		return append(issues, IntegrityIssue{
+			Severity: SeverityError, Category: CategoryDatabase,
+			Detail: fmt.Sprintf("iterate foreign_key_check: %v", err),
+		})
+	}
+	for pair, n := range violations {
+		issues = append(issues, IntegrityIssue{
+			Severity: SeverityError, Category: CategoryDatabase,
+			Detail: fmt.Sprintf("foreign key violated: %s (%d row(s))", pair, n),
+		})
+	}
+	return issues
+}
+
+// checkSchemaVersion reports a database left mid-migration. golang-migrate sets
+// dirty=1 before applying a step and clears it after; a dirty row means a
+// migration died part-way and every check above is reading a schema that is
+// neither the old shape nor the new one.
+func (s *Service) checkSchemaVersion(ctx context.Context) []IntegrityIssue {
+	var version int64
+	var dirty bool
+	err := s.rh.gits.DB().QueryRowContext(ctx,
+		`SELECT version, dirty FROM schema_migrations`).Scan(&version, &dirty)
+	if err == sql.ErrNoRows {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategorySchemaVersion,
+			Detail: "schema_migrations is empty: this database was never stamped by the migrator",
+		}}
+	}
+	if err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategorySchemaVersion,
+			Detail: fmt.Sprintf("read schema_migrations: %v", err),
+		}}
+	}
+	if dirty {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategorySchemaVersion,
+			Detail: fmt.Sprintf(
+				"schema_migrations is DIRTY at version %d: a migration failed part-way and the "+
+					"schema is in neither the old nor the new shape", version),
+		}}
+	}
 	return nil
 }
 
-// checkBranchesTable verifies that the branches SQLite table exactly mirrors
-// the git branch refs. Every git ref in refs/heads/* must have a row in
-// branches whose name matches and whose git_ref equals "refs/heads/" + name.
-// Every row in branches must correspond to a git ref.
+// checkOrphanObjects counts git objects unreachable from any ref. This is the
+// scan the package TODO asked for: a force push or a dropped branch leaves the
+// old commits, trees and blobs in the objects table, where they are invisible
+// to every other check and count only as growth.
 //
-// This check is called once per Verify (not per branch) with the full list
-// of git branch names enumerated by listBranchRefsForVerify.
-func (s *Service) checkBranchesTable(ctx context.Context, gitBranches []string) []IntegrityIssue {
+// Reported as a WARNING and as a COUNT, not per object. Unreachable objects are
+// not corruption — git accumulates them normally — so failing a run over them
+// would be as wrong as the false positives this pass removes.
+//
+// NOT branch-scoped, which is why it takes no branch list: it roots from EVERY
+// ref via IterReferences, including refs/remotes and the refs/knomit/*
+// bookkeeping refs, so nothing legitimately retained is counted. Scoping it to
+// the maintained branches would report everything the other refs hold as
+// garbage.
+//
+// Note for callers: knomit has no git-object GC, so a count here is currently
+// informational only. PruneGeneratedRefs makes it RISE, because the export
+// commits its refs held become unreachable the moment the refs go.
+func (s *Service) checkOrphanObjects(ctx context.Context) []IntegrityIssue {
+	reachable := map[string]bool{}
+
+	iter, err := s.rh.gits.IterReferences()
+	if err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryOrphanObjects,
+			Detail: fmt.Sprintf("iterate refs: %v", err),
+		}}
+	}
+	var roots []plumbing.Hash
+	if err := iter.ForEach(func(ref *plumbing.Reference) error {
+		if !ref.Hash().IsZero() {
+			roots = append(roots, ref.Hash())
+		}
+		return nil
+	}); err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryOrphanObjects,
+			Detail: fmt.Sprintf("collect ref roots: %v", err),
+		}}
+	}
+
+	var markTree func(h plumbing.Hash)
+	markTree = func(h plumbing.Hash) {
+		if h.IsZero() || reachable[h.String()] {
+			return
+		}
+		reachable[h.String()] = true
+		tree, err := object.GetTree(s.rh.gits, h)
+		if err != nil {
+			return
+		}
+		for _, e := range tree.Entries {
+			if e.Mode == filemode.Dir {
+				markTree(e.Hash)
+				continue
+			}
+			reachable[e.Hash.String()] = true
+		}
+	}
+
+	stack := roots
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if cur.IsZero() || reachable[cur.String()] {
+			continue
+		}
+		commit, err := object.GetCommit(s.rh.gits, cur)
+		if err != nil {
+			// Not a commit (an annotated tag or a ref straight at a tree/blob).
+			// Mark it reachable so it is never counted as an orphan, and move on.
+			reachable[cur.String()] = true
+			continue
+		}
+		reachable[cur.String()] = true
+		markTree(commit.TreeHash)
+		stack = append(stack, commit.ParentHashes...)
+	}
+
+	rows, err := s.rh.gits.DB().QueryContext(ctx, `SELECT DISTINCT hash FROM objects`)
+	if err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryOrphanObjects,
+			Detail: fmt.Sprintf("query objects: %v", err),
+		}}
+	}
+	defer rows.Close()
+	orphans := 0
+	for rows.Next() {
+		var h string
+		if err := rows.Scan(&h); err != nil {
+			return []IntegrityIssue{{
+				Severity: SeverityError, Category: CategoryOrphanObjects,
+				Detail: fmt.Sprintf("scan objects: %v", err),
+			}}
+		}
+		if !reachable[h] {
+			orphans++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return []IntegrityIssue{{
+			Severity: SeverityError, Category: CategoryOrphanObjects,
+			Detail: fmt.Sprintf("iterate objects: %v", err),
+		}}
+	}
+	if orphans == 0 {
+		return nil
+	}
+	return []IntegrityIssue{{
+		Severity: SeverityWarning, Category: CategoryOrphanObjects,
+		Detail: fmt.Sprintf(
+			"%d git object(s) unreachable from any ref (history rewrite or dropped branch residue); "+
+				"they cost space only", orphans),
+	}}
+}
+
+// checkBranchesTable verifies the branches SQLite table against the git refs,
+// in two directions with deliberately different scopes.
+//
+// Direction 1 (a git ref must have a correct branches row) runs over the
+// MAINTAINED branches only. A ref the index does not maintain is not required
+// to have a row — an unindexed ref having no branches row is the normal
+// consequence of not indexing it, and demanding one produced two errors per
+// repo for refs left behind by a feature that no longer exists.
+//
+// Direction 2 (a branches row must have a git ref) runs over ALL refs. A row
+// pointing at a branch that no longer exists anywhere is drift under any
+// scoping, and scoping this direction to maintained branches would make the
+// check unable to see the rows it is most needed for.
+//
+// Called once per Verify, not per branch.
+func (s *Service) checkBranchesTable(ctx context.Context, checked, allBranches []string) []IntegrityIssue {
 	var issues []IntegrityIssue
 
 	rows, err := s.rh.gits.DB().QueryContext(ctx, `SELECT name, git_ref FROM branches`)
@@ -716,13 +1559,14 @@ func (s *Service) checkBranchesTable(ctx context.Context, gitBranches []string) 
 		}}
 	}
 
-	gitSet := make(map[string]bool, len(gitBranches))
-	for _, b := range gitBranches {
+	gitSet := make(map[string]bool, len(allBranches))
+	for _, b := range allBranches {
 		gitSet[b] = true
 	}
 
-	// Direction 1: every git ref has a matching branches row with correct git_ref.
-	for _, b := range gitBranches {
+	// Direction 1: every MAINTAINED git ref has a matching branches row with
+	// the correct git_ref.
+	for _, b := range checked {
 		ref, ok := tableRows[b]
 		if !ok {
 			issues = append(issues, IntegrityIssue{

--- a/internal/store/verify_scope_test.go
+++ b/internal/store/verify_scope_test.go
@@ -1,0 +1,447 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+// newVerifyRepo opens a store with one fact on the agent branch — the smallest
+// repo that has real commits, tree entries and index rows to be wrong about.
+func newVerifyRepo(t *testing.T) *Service {
+	t.Helper()
+	svc, err := Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+	_, err = svc.Facts().WriteFact(context.Background(), "agent/test", "kb/decisions/x/aaaaaaaa.md",
+		testFactBody("A", 0.9, nil), "seed", "learn")
+	require.NoError(t, err)
+	return svc
+}
+
+func categories(report IntegrityReport, cat string) []IntegrityIssue {
+	var out []IntegrityIssue
+	for _, i := range report.Issues {
+		if i.Category == cat {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// The regression this whole pass exists for. A branch the index does not
+// maintain has no branch_commits, no branch_facts and no branches row, all
+// correctly — and Verify used to report one ERROR per commit and per fact on
+// it. On a live five-repo home that was 8128 errors, every one false, and the
+// tool exited 1 forever.
+//
+// The branch here is created directly through the storer, NOT via CreateBranch:
+// a fetched foreign agent branch arrives as a bare ref with no index behind it,
+// and that is the state being pinned.
+func TestVerify_UnindexedBranchIsSkippedNotReported(t *testing.T) {
+	svc := newVerifyRepo(t)
+	ctx := context.Background()
+
+	head, err := svc.rh.gits.Reference(plumbing.NewBranchReferenceName("agent/test"))
+	require.NoError(t, err)
+	foreign := plumbing.NewBranchReferenceName("agent/other-machine-deadbeef")
+	require.NoError(t, svc.rh.gits.SetReference(plumbing.NewHashReference(foreign, head.Hash())))
+
+	report, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+
+	require.Contains(t, report.Skipped, "agent/other-machine-deadbeef",
+		"an unindexed ref must be reported as skipped, not silently dropped")
+	require.NotContains(t, report.Branches, "agent/other-machine-deadbeef")
+	require.True(t, report.IsClean(), "an unindexed branch must not produce errors: %v", report.Issues)
+	for _, i := range report.Issues {
+		require.NotEqual(t, "agent/other-machine-deadbeef", i.Branch,
+			"no issue may be raised against a branch that was never parity-checked")
+	}
+}
+
+// The escape hatch has to actually check what the default skips, or it is
+// decoration. With AllBranches the same unindexed ref DOES produce errors.
+func TestVerify_AllBranchesOptsBackIn(t *testing.T) {
+	svc := newVerifyRepo(t)
+	ctx := context.Background()
+
+	head, err := svc.rh.gits.Reference(plumbing.NewBranchReferenceName("agent/test"))
+	require.NoError(t, err)
+	require.NoError(t, svc.rh.gits.SetReference(plumbing.NewHashReference(
+		plumbing.NewBranchReferenceName("agent/other-machine-deadbeef"), head.Hash())))
+
+	report, err := svc.Verify(ctx, VerifyOpts{AllBranches: true})
+	require.NoError(t, err)
+	require.Contains(t, report.Branches, "agent/other-machine-deadbeef")
+	require.Empty(t, report.Skipped)
+	require.False(t, report.IsClean(), "--all-branches must surface the parity gaps the default hides")
+}
+
+// A brand-new repo has NO meta rows at all — the first last_commit:<branch> row
+// appears only after the first write. So the maintained-branch oracle cannot be
+// last_commit alone, or Verify checks nothing on a fresh repo and calls it
+// CLEAN. That silent skip is the same defect as the false positives, pointing
+// the other way.
+func TestVerify_FreshRepoStillChecksItsAgentBranch(t *testing.T) {
+	svc, err := Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+
+	var metaRows int
+	require.NoError(t, svc.rh.gits.DB().QueryRow(
+		`SELECT COUNT(*) FROM meta WHERE key LIKE 'last_commit:%'`).Scan(&metaRows))
+	require.Zero(t, metaRows, "precondition: a fresh repo has no last_commit row")
+
+	report, err := svc.Verify(context.Background(), VerifyOpts{})
+	require.NoError(t, err)
+	require.Contains(t, report.Branches, "agent/test",
+		"the agent branch must be checked even before the index has ever synced it")
+}
+
+// Generated okf/* refs are residue from the server-side export removed in
+// bf9becbe. They are warned about (not errored on, so they cannot fail a run)
+// and the warning names the repair.
+func TestVerify_GeneratedRefIsWarnedNotErrored(t *testing.T) {
+	svc := newVerifyRepo(t)
+
+	head, err := svc.rh.gits.Reference(plumbing.NewBranchReferenceName("agent/test"))
+	require.NoError(t, err)
+	require.NoError(t, svc.rh.gits.SetReference(plumbing.NewHashReference(
+		plumbing.NewBranchReferenceName("okf/main"), head.Hash())))
+
+	report, err := svc.Verify(context.Background(), VerifyOpts{})
+	require.NoError(t, err)
+	require.True(t, report.IsClean(), "generated refs must not fail the run: %v", report.Issues)
+
+	found := categories(report, CategoryGeneratedRefs)
+	require.Len(t, found, 1)
+	require.Equal(t, SeverityWarning, found[0].Severity)
+	require.Equal(t, "okf/main", found[0].Branch)
+	require.Contains(t, found[0].Detail, "--prune-generated-refs")
+}
+
+// The repair removes exactly the generated refs and their markers, and nothing
+// else — a prune that took a real branch with it would be far worse than the
+// residue it cleans up.
+//
+// SCOPE NOTE: the fixture points okf/* at the SAME commit as agent/test, so no
+// object becomes unreachable here. That is not an accident and it is not full
+// coverage: on a real home the generated refs hold their own export commits,
+// and pruning them RAISES the orphan-objects count (2805 → 8378 on knomit-kb).
+// That is expected — see checkOrphanObjects — and it is why orphan-objects is a
+// warning and a count. Do not read this test as evidence that a prune leaves
+// the object store unchanged.
+func TestPruneGeneratedRefs_RemovesResidueAndNothingElse(t *testing.T) {
+	svc := newVerifyRepo(t)
+	ctx := context.Background()
+
+	head, err := svc.rh.gits.Reference(plumbing.NewBranchReferenceName("agent/test"))
+	require.NoError(t, err)
+	for _, name := range []string{"okf/main", "okf/agent/test"} {
+		require.NoError(t, svc.rh.gits.SetReference(plumbing.NewHashReference(
+			plumbing.NewBranchReferenceName(name), head.Hash())))
+	}
+	_, err = svc.rh.gits.DB().Exec(
+		`INSERT OR REPLACE INTO kv(key, value) VALUES ('okf:marker:main', 'x')`)
+	require.NoError(t, err)
+
+	pruned, err := svc.PruneGeneratedRefs(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"okf/main", "okf/agent/test"}, pruned.Refs)
+	require.EqualValues(t, 1, pruned.Markers, "the marker row must be counted, not silently deleted")
+
+	// The real branches survive.
+	_, err = svc.rh.gits.Reference(plumbing.NewBranchReferenceName("agent/test"))
+	require.NoError(t, err, "prune must not touch a real branch")
+	_, err = svc.rh.gits.Reference(plumbing.NewBranchReferenceName("main"))
+	require.NoError(t, err, "prune must not touch main")
+
+	// The generated ones are gone, markers included.
+	for _, name := range []string{"okf/main", "okf/agent/test"} {
+		_, err := svc.rh.gits.Reference(plumbing.NewBranchReferenceName(name))
+		require.Error(t, err, "%s must be gone", name)
+	}
+	var markers int
+	require.NoError(t, svc.rh.gits.DB().QueryRow(
+		`SELECT COUNT(*) FROM kv WHERE key LIKE 'okf:marker:%'`).Scan(&markers))
+	require.Zero(t, markers)
+
+	report, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+	require.Empty(t, categories(report, CategoryGeneratedRefs),
+		"after the prune there is nothing left to warn about")
+}
+
+// commit_parents is the third leg of the commit index and had no coverage:
+// commit-log parity reads branch_commits and nothing read the DAG edges, so a
+// history walk could take the wrong shape unnoticed.
+func TestVerify_DetectsCommitParentsDrift(t *testing.T) {
+	svc := newVerifyRepo(t)
+	ctx := context.Background()
+
+	res, err := svc.Facts().WriteFact(ctx, "agent/test", "kb/decisions/x/bbbbbbbb.md",
+		testFactBody("B", 0.9, nil), "second", "learn")
+	require.NoError(t, err)
+
+	_, err = svc.rh.gits.DB().Exec(
+		`UPDATE commit_parents SET parent_hash = ? WHERE commit_hash = ?`,
+		"0000000000000000000000000000000000000000", res.CommitHash)
+	require.NoError(t, err)
+
+	report, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+	found := categories(report, CategoryCommitParents)
+	require.NotEmpty(t, found, "a rewritten parent edge must be reported: %v", report.Issues)
+	require.Equal(t, SeverityError, found[0].Severity)
+}
+
+// A root commit has no parents and therefore no commit_parents rows. Absence is
+// correct there, and reporting it would make every repo dirty from birth.
+func TestVerify_RootCommitWithoutParentRowsIsClean(t *testing.T) {
+	svc := newVerifyRepo(t)
+	report, err := svc.Verify(context.Background(), VerifyOpts{})
+	require.NoError(t, err)
+	require.Empty(t, categories(report, CategoryCommitParents),
+		"a root commit's missing parent rows are correct, not drift")
+}
+
+// The category is called commit-log and, since parity moved onto
+// branch_commits, nothing read commit_log at all. Orphans are the direction
+// with no legitimate exception.
+func TestVerify_DetectsCommitLogOrphan(t *testing.T) {
+	svc := newVerifyRepo(t)
+
+	_, err := svc.rh.gits.DB().Exec(
+		`INSERT INTO commit_log(commit_hash, path, committed_at, message)
+		 VALUES ('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef', 'kb/ghost.md', 0, 'ghost')`)
+	require.NoError(t, err)
+
+	report, err := svc.Verify(context.Background(), VerifyOpts{})
+	require.NoError(t, err)
+	found := categories(report, CategoryCommitLog)
+	require.NotEmpty(t, found, "a commit_log row for a nonexistent commit must be reported")
+	require.Equal(t, SeverityError, found[0].Severity)
+}
+
+// A no-op commit (a write whose blob equals the parent's at the same path) has
+// zero commit_log rows by design. That is exactly why parity moved off
+// commit_log, and the orphan check must not reintroduce the false positive by
+// checking the other direction.
+func TestVerify_CommitWithoutCommitLogRowsIsClean(t *testing.T) {
+	svc := newVerifyRepo(t)
+	ctx := context.Background()
+
+	body := testFactBody("A", 0.9, nil)
+	_, err := svc.Facts().WriteFact(ctx, "agent/test", "kb/decisions/x/cccccccc.md", body, "first", "learn")
+	require.NoError(t, err)
+	// Same content at the same path: no tree change, so no commit_log rows.
+	_, err = svc.Facts().WriteFact(ctx, "agent/test", "kb/decisions/x/cccccccc.md", body, "again", "learn")
+	require.NoError(t, err)
+
+	report, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+	require.True(t, report.IsClean(), "a no-op commit must not be reported: %v", report.Issues)
+}
+
+// The fact_* projections are what domain and entity search read, and their
+// failure mode is silent: every fact present and correct, and searching by
+// domain returns nothing.
+// The orphan is inserted with foreign keys OFF because the connection enforces
+// them, which is precisely why this check is defensive rather than routine: the
+// rows it looks for cannot be produced by normal operation, only by a database
+// written or restored without enforcement. That is worth checking and is not
+// worth pretending is common.
+func TestVerify_DetectsDerivedTableOrphan(t *testing.T) {
+	svc := newVerifyRepo(t)
+
+	_, err := svc.rh.gits.DB().Exec(`PRAGMA foreign_keys = OFF`)
+	require.NoError(t, err)
+	_, err = svc.rh.gits.DB().Exec(
+		`INSERT INTO fact_domains(fact_id, domain) VALUES (999999, 'ghost')`)
+	require.NoError(t, err)
+	_, err = svc.rh.gits.DB().Exec(`PRAGMA foreign_keys = ON`)
+	require.NoError(t, err)
+
+	report, err := svc.Verify(context.Background(), VerifyOpts{})
+	require.NoError(t, err)
+	found := categories(report, CategoryDerivedTables)
+	require.NotEmpty(t, found, "an orphan fact_domains row must be reported")
+	require.Equal(t, SeverityError, found[0].Severity)
+}
+
+// Both writers insert canonicalizeDomain(d) into fact_domains AND
+// fact_domain_tokens, so the strings "must" match — and on a live repo they do
+// not, because canonicalizeDomain gained a de-hyphenize step and only the token
+// side was repopulated. That skew is a WARNING: calling it corruption would
+// report a healthy repo as broken, which is the bug this pass removes.
+func TestVerify_DomainCanonicalizationSkewIsWarningOnly(t *testing.T) {
+	svc := newVerifyRepo(t)
+
+	var factID int64
+	require.NoError(t, svc.rh.gits.DB().QueryRow(`SELECT id FROM facts LIMIT 1`).Scan(&factID))
+	_, err := svc.rh.gits.DB().Exec(
+		`INSERT OR REPLACE INTO fact_domains(fact_id, domain) VALUES (?, 'claude-code')`, factID)
+	require.NoError(t, err)
+	_, err = svc.rh.gits.DB().Exec(
+		`INSERT OR REPLACE INTO fact_domain_tokens(fact_id, domain, token) VALUES (?, 'claude code', 'claude')`,
+		factID)
+	require.NoError(t, err)
+
+	report, err := svc.Verify(context.Background(), VerifyOpts{})
+	require.NoError(t, err)
+	require.True(t, report.IsClean(),
+		"a canonicalization skew must not fail the run: %v", report.Issues)
+	found := categories(report, CategoryDerivedTables)
+	require.NotEmpty(t, found)
+	require.Equal(t, SeverityWarning, found[0].Severity)
+	require.Contains(t, found[0].Detail, "canonicalizeDomain drift")
+}
+
+// A database left mid-migration is neither the old schema nor the new one, and
+// every other check is reading it as though it were one of the two.
+func TestVerify_DetectsDirtySchemaVersion(t *testing.T) {
+	svc := newVerifyRepo(t)
+
+	_, err := svc.rh.gits.DB().Exec(`UPDATE schema_migrations SET dirty = 1`)
+	require.NoError(t, err)
+
+	report, err := svc.Verify(context.Background(), VerifyOpts{})
+	require.NoError(t, err)
+	found := categories(report, CategorySchemaVersion)
+	require.NotEmpty(t, found, "a dirty migration must be reported")
+	require.Equal(t, SeverityError, found[0].Severity)
+	require.Contains(t, found[0].Detail, "DIRTY")
+}
+
+// A prune that removes only some of its targets must report only what it
+// actually deleted. Reporting the full candidate list alongside the error has
+// the CLI print "pruned generated ref: X" for a ref still sitting in the store,
+// and puts it in the JSON pruned_refs array.
+func TestPruneGeneratedRefs_ReportsOnlyWhatItDeleted(t *testing.T) {
+	svc := newVerifyRepo(t)
+
+	head, err := svc.rh.gits.Reference(plumbing.NewBranchReferenceName("agent/test"))
+	require.NoError(t, err)
+	require.NoError(t, svc.rh.gits.SetReference(plumbing.NewHashReference(
+		plumbing.NewBranchReferenceName("okf/main"), head.Hash())))
+
+	// Closing the database makes every delete fail, so nothing is removed and
+	// the result must name nothing.
+	require.NoError(t, svc.rh.gits.DB().Close())
+
+	pruned, err := svc.PruneGeneratedRefs(context.Background())
+	require.Error(t, err)
+	require.Empty(t, pruned.Refs, "a prune that deleted nothing must claim nothing")
+	require.Zero(t, pruned.Markers)
+	require.True(t, pruned.Empty())
+}
+
+// Format truncates the flat issue slice, so ordering decides what survives.
+// Category-first ordering let an alphabetically-early category of warnings
+// consume the whole budget and hide every error — schema-version sorts last of
+// all categories, so a DIRTY migration was guaranteed invisible on a repo with
+// 100 earlier findings.
+func TestVerify_ErrorsSortAheadOfWarningsSoTruncationCannotHideThem(t *testing.T) {
+	issues := []IntegrityIssue{
+		{Severity: SeverityWarning, Category: CategoryDerivedTables, Detail: "skew"},
+		{Severity: SeverityError, Category: CategorySchemaVersion, Detail: "DIRTY"},
+		{Severity: SeverityWarning, Category: CategoryGeneratedRefs, Detail: "residue"},
+		{Severity: SeverityError, Category: CategoryCommitLog, Detail: "orphan"},
+	}
+	sortIssues(issues)
+
+	require.Equal(t, SeverityError, issues[0].Severity)
+	require.Equal(t, SeverityError, issues[1].Severity)
+	require.Equal(t, SeverityWarning, issues[2].Severity)
+
+	// Budget for exactly the errors: both survive, both warnings are dropped.
+	// Under category-first ordering "derived-tables" and "generated-refs" would
+	// have taken these two slots and "schema-version" — last alphabetically —
+	// would never print at all.
+	r := IntegrityReport{Repo: "r", Branches: []string{"main"}, Issues: issues}
+	out := r.Format(2)
+	require.Contains(t, out, "DIRTY", "truncation must keep the errors")
+	require.Contains(t, out, "orphan")
+	require.NotContains(t, out, "residue", "warnings must be dropped before any error")
+	require.NotContains(t, out, "skew")
+	// The counts stay complete regardless of what the detail list dropped.
+	require.Contains(t, out, "derived-tables       1")
+}
+
+// Several checks iterate Go maps. Without an explicit sort two runs over an
+// unchanged repo emit the same findings in different orders, and the reports
+// cannot be diffed — which is most of what an operator does with them.
+func TestVerify_ReportOrderIsStable(t *testing.T) {
+	svc := newVerifyRepo(t)
+	ctx := context.Background()
+
+	// Enough distinct ghost rows that map iteration order would show through.
+	var factID int64
+	require.NoError(t, svc.rh.gits.DB().QueryRow(`SELECT id FROM facts LIMIT 1`).Scan(&factID))
+	head, err := svc.rh.HeadCommit(ctx, "agent/test")
+	require.NoError(t, err)
+	for _, p := range []string{"kb/a.md", "kb/b.md", "kb/c.md", "kb/d.md", "kb/e.md"} {
+		_, err := svc.rh.gits.DB().Exec(
+			`INSERT INTO branch_facts(branch_id, path, fact_id, commit_hash)
+			 VALUES ((SELECT id FROM branches WHERE name = 'agent/test'), ?, ?, ?)`,
+			p, factID, head)
+		require.NoError(t, err)
+	}
+
+	first, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+	require.NotEmpty(t, first.Issues)
+	for range 5 {
+		next, err := svc.Verify(ctx, VerifyOpts{})
+		require.NoError(t, err)
+		require.Equal(t, first.Issues, next.Issues, "two runs over an unchanged repo must agree exactly")
+	}
+}
+
+// Cancellation has to actually stop the walk. main.go wires SIGINT/SIGTERM into
+// this context, and before this the signal could not interrupt a long verify.
+func TestVerify_HonoursContextCancellation(t *testing.T) {
+	svc := newVerifyRepo(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := svc.Verify(ctx, VerifyOpts{})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// Format's summary must survive truncation: a report capped at N lines still
+// has to say how much it actually found.
+func TestIntegrityReport_FormatTruncatesDetailNotCounts(t *testing.T) {
+	r := IntegrityReport{
+		Repo:     "r",
+		Branches: []string{"main"},
+		Issues: []IntegrityIssue{
+			{Severity: SeverityError, Category: CategoryCommitLog, Detail: "one"},
+			{Severity: SeverityError, Category: CategoryCommitLog, Detail: "two"},
+			{Severity: SeverityError, Category: CategoryCommitLog, Detail: "three"},
+		},
+	}
+	out := r.Format(1)
+	require.Contains(t, out, "Issues: 3 (3 error, 0 warning)")
+	require.Contains(t, out, "commit-log           3")
+	require.Contains(t, out, "2 more")
+	require.NotContains(t, out, "three")
+
+	require.Contains(t, r.Format(0), "three", "0 means print everything")
+}
+
+// Skipped branches must be visible in the rendered report, because that line is
+// the whole reason a per-branch warning is not raised for them.
+func TestIntegrityReport_FormatNamesSkippedBranches(t *testing.T) {
+	r := IntegrityReport{Repo: "r", Branches: []string{"main"}, Skipped: []string{"okf/main"}}
+	out := r.Format(0)
+	require.Contains(t, out, "Not indexed (parity not checked): okf/main")
+	require.Contains(t, out, "Status: CLEAN")
+}

--- a/internal/store/verify_scope_test.go
+++ b/internal/store/verify_scope_test.go
@@ -82,6 +82,26 @@ func TestVerify_AllBranchesOptsBackIn(t *testing.T) {
 	require.False(t, report.IsClean(), "--all-branches must surface the parity gaps the default hides")
 }
 
+// --all-branches moves generated refs into the checked set, where they produce
+// hard parity errors. The warning naming --prune-generated-refs must survive
+// that, or the one hint pointing at the repair disappears exactly when an
+// operator opts in to ask "why does this branch have no rows".
+func TestVerify_AllBranchesStillNamesTheGeneratedRefRepair(t *testing.T) {
+	svc := newVerifyRepo(t)
+
+	head, err := svc.rh.gits.Reference(plumbing.NewBranchReferenceName("agent/test"))
+	require.NoError(t, err)
+	require.NoError(t, svc.rh.gits.SetReference(plumbing.NewHashReference(
+		plumbing.NewBranchReferenceName("okf/main"), head.Hash())))
+
+	report, err := svc.Verify(context.Background(), VerifyOpts{AllBranches: true})
+	require.NoError(t, err)
+
+	found := categories(report, CategoryGeneratedRefs)
+	require.Len(t, found, 1, "the generated-ref warning must not be suppressed by --all-branches")
+	require.Contains(t, found[0].Detail, "--prune-generated-refs")
+}
+
 // A brand-new repo has NO meta rows at all — the first last_commit:<branch> row
 // appears only after the first write. So the maintained-branch oracle cannot be
 // last_commit alone, or Verify checks nothing on a fresh repo and calls it
@@ -199,6 +219,38 @@ func TestVerify_DetectsCommitParentsDrift(t *testing.T) {
 	found := categories(report, CategoryCommitParents)
 	require.NotEmpty(t, found, "a rewritten parent edge must be reported: %v", report.Issues)
 	require.Equal(t, SeverityError, found[0].Severity)
+}
+
+// An unreadable commit_parents table must produce ONE issue, not one per
+// commit. Comparing every commit against an empty map makes each non-root
+// commit look like it lost its parent edges, so a single transient query error
+// would manufacture thousands of false errors and a permanent exit 1 — the
+// exact failure this whole change exists to remove, coming back in through the
+// error path.
+func TestVerify_UnreadableCommitParentsDoesNotFabricateOneErrorPerCommit(t *testing.T) {
+	svc := newVerifyRepo(t)
+	ctx := context.Background()
+
+	for _, p := range []string{"kb/decisions/x/bbbbbbbb.md", "kb/decisions/x/cccccccc.md"} {
+		_, err := svc.Facts().WriteFact(ctx, "agent/test", p, testFactBody("B", 0.9, nil), "more", "learn")
+		require.NoError(t, err)
+	}
+
+	// Precondition: several commits with real parent edges.
+	var edges int
+	require.NoError(t, svc.rh.gits.DB().QueryRow(`SELECT COUNT(*) FROM commit_parents`).Scan(&edges))
+	require.Greater(t, edges, 1)
+
+	_, err := svc.rh.gits.DB().Exec(`DROP TABLE commit_parents`)
+	require.NoError(t, err)
+
+	report, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+
+	found := categories(report, CategoryCommitParents)
+	require.Len(t, found, 1, "an unreadable table is ONE finding, not one per commit: %v", found)
+	require.Contains(t, found[0].Detail, "read commit_parents")
+	require.Contains(t, found[0].Detail, "skipped")
 }
 
 // A root commit has no parents and therefore no commit_parents rows. Absence is


### PR DESCRIPTION
Two changes, one theme: the tooling should tell you the truth about your home.

## 1. `migrate-registry` deprecated

It converts a home shape predating the control.db repo registry. A home built by a current build never needs it; a converted one never needs it again.

The deprecation is announced on both surfaces an operator can meet: `Short`/`Long` for whoever reads `--help`, and a banner printed before the plan on every run (including `--dry-run`) for whoever pastes the command out of an old runbook. It says what waiting costs — once the command is gone, the only path off the legacy shape is re-cloning each knowledge base from its remote, and a repo with no recorded remote cannot be recovered that way.

Deliberately **not** cobra's `Deprecated` field: that makes `IsAvailableCommand()` false and drops the command from `knomit --help`. This is the command a legacy home's boot refusal names, so hiding it would leave that refusal pointing at something unfindable. A test pins that it stays listed.

## 2. Verify

On a copy of a live five-repo home, `knomit verify --all` reported **8128 integrity errors and exited 1. All 8128 were false** — and zero issues were on any branch the instance actually indexes.

Verify demanded SQLite parity for every `refs/heads/*` ref. The indexer maintains a strictly smaller set (`setupIndex`: agent branch + `upstreamMain`). Everything else produced a wall of errors: 6762 on `okf/*` refs left by the server-side export removed in bf9becbe, 1366 on another machine's agent branch arriving by fetch. bf9becbe removed the *producer* and pinned the invariant for new repos, but shipped no cleanup — so on any home older than 2026-07-25 the Critical it fixed was still live. The only two repos that verified clean were the two created after it.

| | before | after |
|---|---|---|
| issues across 5 repos | 8128 (all false) | 12 warnings, 0 errors |
| exit code | 1 | 0 |
| `--all` wall clock | 13s | 3.9s |

### Scope fix
Parity now runs only over maintained branches. The oracle is the union of `meta.last_commit:<branch>`, HEAD's target, and `meta.agent_branch_owner` — **not** `graph_schema_version:<branch>` (migration 000016 backfilled it onto never-indexed branches) and **not** the `branches` table (a fetch populates it for branches nothing indexes). HEAD is in the union because a fresh repo has no `meta` rows at all, so `last_commit` alone would make a new repo check nothing and report CLEAN — the same defect inverted. `--all-branches` opts back in.

Unindexed refs are named in the report header rather than warned about per branch; a permanent warning on every healthy repo would be the same cry-wolf failure in new clothes. Only generated `okf/*` refs warn, because those have a repair: `--prune-generated-refs` removes them and their `okf:marker:*` rows and nothing else. Verify itself stays read-only.

### New checks
`commit-parents`, `commit-log` orphans (the `commit-log` category had stopped reading `commit_log` entirely), `derived-tables`, `PRAGMA quick_check`/`foreign_key_check`, `schema-version`, `orphan-objects`, `embedding-identity`.

Two calibrated from measurement rather than intuition:
- `fact_domains` ↔ `fact_domain_tokens` compared at `fact_id` granularity, not `(fact_id, domain)`. Both writers insert `canonicalizeDomain(d)` so the strings "must" match — on a live repo they don't (`claude-code` vs `claude code`), because the function gained a de-hyphenize step and only the token side was repopulated. The string-level join reports 6 phantom failures on a healthy repo.
- `orphan-objects` is a warning and a count. Unreachable objects accumulate normally.

### CLI
Usage errors exit 2 (were 1, colliding with "issues found"); `cmd.Context()` so SIGTERM can actually cancel; app lifetime moved into a helper so `os.Exit` stops skipping `defer a.Close()`; `--json`; `--max-issues`; deterministic ordering with errors ahead of warnings so truncation can only drop the least severe; a note naming archived repos `--all` cannot cover. Removed the `checkBranchFactsParity` stub (`return nil`) and its phantom category. Package doc and help stated the locking **backwards** — Verify holds every branch read lock for its whole run and blocks all writers.

## Verification
- `go test ./...` — 44 packages green. 44 verify tests, up from 12.
- Live-home copy, `verify --all --deep`: exit 0, 12 warnings, 0 errors, 3.9s.
- `--prune-generated-refs` on a live copy: removed exactly the two `okf/*` refs and both markers; `agent/*`, `main`, and the `config` kv row untouched.
- Exit codes measured: no args → 2, unknown repo → 2, clean → 0.

A `/code-review high` pass raised 9 findings; 7 were real and are fixed in the second commit's final state (partial-prune misreporting, missing `rows.Err()` after `quick_check`, category-before-severity ordering hiding errors behind truncation, invisible marker delete, JSON `null` arrays, an ignored parameter, and a per-commit query inside the writer-blocking window). Two were accepted as documented behaviour: `--max-issues` does not truncate `--json` (truncated machine output would look complete and not be), and pruning raises the orphan-object count because knomit has no git-object GC.

## Known / not done
- **Pruning raises the orphan count** (2805 → 8378 on `knomit-kb`) since the export history becomes unreachable. Correct and expected, but a gc/repack is the natural follow-up and knomit has no such command.
- **Home-level verification of `control.db`** (registry rows with no `.db`, orphan `repo_origins`, lens rows naming dead uids, duplicate active `repo_id`) is deferred. Worth doing before `migrate-registry` is actually removed — its refusals are currently the only diagnostics for a damaged registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)