### PR TITLE
fix(claude): let claude init scaffold more than one knomit server

### DIFF
--- a/.claude/skills/knomit-bootstrap/SKILL.md
+++ b/.claude/skills/knomit-bootstrap/SKILL.md
@@ -51,7 +51,7 @@ Word every draft against the body authoring contract in /knomit-remember: name e
 
 Bootstrapping is high-leverage and high-blast-radius. Show drafts as a list (title + 1-line body summary + topic/category) and ask for approval before writing. **Don't write unilaterally.** A bad bootstrap pollutes the corpus and biases all future recall in the area.
 
-### Step 4 — Write approved facts via `mcp__knomit__knomit_learn`
+### Step 4 — Write approved facts via `knomit_learn`
 
 Single batched `knomit_learn` call with all approved facts. Suggested defaults:
 

--- a/.claude/skills/knomit-decided/SKILL.md
+++ b/.claude/skills/knomit-decided/SKILL.md
@@ -44,7 +44,7 @@ Before writing the code/edit the decision authorized, summarize into three parts
 3. **The choice** — concrete decision
 4. **Non-scope** (when foreseeable) — one line on what the decision does NOT authorize. Decisions compress into "we always do X" slogans; if the choice was conditional on context, name the boundary so it isn't stretched later.
 
-Then call `mcp__knomit__knomit_learn` with:
+Then call `knomit_learn` with:
 
 - `topic`: `decisions`
 - `category`: `<area>/<slug>` (e.g. `synthesize/sumproductnorm-default`)

--- a/.claude/skills/knomit-hypothesize/SKILL.md
+++ b/.claude/skills/knomit-hypothesize/SKILL.md
@@ -22,7 +22,7 @@ DON'T invoke:
 
 ## How
 
-Call `mcp__knomit__knomit_hypothesize` with no args to start a session. The tool returns one synthesis fact at a time with a `prompt` and `response_schema`.
+Call `knomit_hypothesize` with no args to start a session. The tool returns one synthesis fact at a time with a `prompt` and `response_schema`.
 
 For each item:
 

--- a/.claude/skills/knomit-principle/SKILL.md
+++ b/.claude/skills/knomit-principle/SKILL.md
@@ -21,7 +21,7 @@ Fire ONLY when the user runs `/knomit-principle` explicitly. Never invoke proact
    - An area path (e.g. `store/resolver`) — surfaces only when `/knomit-recall` touches that area or any parent.
 3. Ask the user for the **title** (short, imperative — the principle as a statement).
 4. Ask the user for the **body** (rationale, scope of applicability, examples of what NOT to do).
-5. Call `mcp__knomit__knomit_learn` with:
+5. Call `knomit_learn` with:
    - `topic`: `principles`
    - `category`: `<bucket>/<slug>` (where `<slug>` is the argument the user passed to `/knomit-principle`)
    - `title`: the user's title

--- a/.claude/skills/knomit-recall/SKILL.md
+++ b/.claude/skills/knomit-recall/SKILL.md
@@ -59,7 +59,7 @@ DON'T fire for:
 
 ## How
 
-Call `mcp__knomit__knomit_query` with:
+Call `knomit_query` with:
 
 - `text`: the user-supplied topic (or your own one-line summary of the area)
 - `entities`: any file paths currently open or about to be edited

--- a/.claude/skills/knomit-remember/SKILL.md
+++ b/.claude/skills/knomit-remember/SKILL.md
@@ -24,9 +24,9 @@ DON'T fire for:
 
 ## How
 
-1. Run `mcp__knomit__knomit_query` on the would-be title to surface similar or contradicting existing facts.
+1. Run `knomit_query` on the would-be title to surface similar or contradicting existing facts.
 2. If a contradicting fact exists: ASK the user whether to `/knomit-update`, `/knomit-retract`, or merge — don't write a duplicate.
-3. Otherwise call `mcp__knomit__knomit_learn` with: `topic`, `category`, `title`, `body`, `kind` (default epistemic), `type` (default observation; use `hypothesis` for predictions), `entities`, `refs`, `confidence` 0.85.
+3. Otherwise call `knomit_learn` with: `topic`, `category`, `title`, `body`, `kind` (default epistemic), `type` (default observation; use `hypothesis` for predictions), `entities`, `refs`, `confidence` 0.85.
 
 ## Body authoring contract — write it so it can't compress into a falsehood
 

--- a/.claude/skills/knomit-retract/SKILL.md
+++ b/.claude/skills/knomit-retract/SKILL.md
@@ -20,7 +20,7 @@ DON'T use for:
 
 ## How
 
-Call `mcp__knomit__knomit_retract` with:
+Call `knomit_retract` with:
 
 - `file`: the fact path (e.g. `kb/decisions/.../<uuid>.md`)
 - `moment_name`: short label explaining why (e.g. `"synthesize/recipes deleted in 0938d83"`)

--- a/.claude/skills/knomit-review/SKILL.md
+++ b/.claude/skills/knomit-review/SKILL.md
@@ -28,14 +28,14 @@ DON'T invoke:
 
 `knomit_review` is a **work-stealing session**, not an async task. The tool returns ONE work item at a time. The calling model burns its own cycles processing each item until the queue drains.
 
-1. First call: `mcp__knomit__knomit_review` with no args.
+1. First call: `knomit_review` with no args.
    - Returns `{session_id, work_item: {prompt, response_schema}}` for the first item, OR `{session_id, done: true}` if nothing dirty.
 2. Process the work item:
    - Read the `prompt` and produce a JSON response matching `response_schema`.
    - For prune items: decide which facts to merge (and the merged content) vs keep distinct.
    - For distill items: decide whether to synthesize a higher-level fact from the cluster, and write its content.
    - For reflect items: emit hypothesis transitions and optionally one methodology.
-3. Continue: `mcp__knomit__knomit_review` with `session_id` and `response`.
+3. Continue: `knomit_review` with `session_id` and `response`.
    - Server applies your decisions (writes new facts, retracts duplicates) and returns the next work item.
 4. Loop until response includes `done: true` — that completes the session and advances the watermark.
 

--- a/.claude/skills/knomit-update/SKILL.md
+++ b/.claude/skills/knomit-update/SKILL.md
@@ -20,7 +20,7 @@ DON'T use for:
 
 ## How
 
-Call `mcp__knomit__knomit_update` with:
+Call `knomit_update` with:
 
 - `file`: the fact path (e.g. `kb/decisions/synthesize/.../<uuid>.md`)
 - `moment_name`: short label (e.g. `"post-rename dirtyFacts → dirty"`)

--- a/.claude/skills/knomit-why/SKILL.md
+++ b/.claude/skills/knomit-why/SKILL.md
@@ -19,13 +19,13 @@ DON'T fire for:
 
 ## How
 
-Call `mcp__knomit__knomit_explain` with the fact path. The tool returns:
+Call `knomit_explain` with the fact path. The tool returns:
 
 - The fact's own body
 - Outgoing refs (what this fact references — both source files and other facts), classified as `local` (other fact paths) and `external` (URLs, src:// anchors)
 - All resolved at the fact's anchor commit, NOT at HEAD
 
-`knomit_explain` does NOT return incoming references (no backlink index). If you need to find facts that reference this one, use `mcp__knomit__knomit_query` with the fact path as a search term.
+`knomit_explain` does NOT return incoming references (no backlink index). If you need to find facts that reference this one, use `knomit_query` with the fact path as a search term.
 
 Walk the source-file refs:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,14 @@
 - NEVER create `plan.md`, `todo.md`, `notes.md` or similar at the project root
 - Commit messages and session logs go in `.claude/plans/`
 
-<!-- knomit:integration -->
+<!-- knomit:integration v2 -->
 ## Working with knomit memory
 
 This project uses knomit as long-term memory. Eleven `/knomit-…` slash commands
 wrap knomit's MCP tools. Use them in these moments:
 
 **Before non-trivial work** — call `/knomit-recall <area>` before:
-- Editing or writing files under <KNOWN_INVARIANT_PATHS>
+- Editing or writing code in an area you have not already recalled for this session
 - Picking where new code goes
 - Implementing a pattern that may already exist
 - Answering "why does X work this way?"

--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -79,22 +79,25 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 ```json
 {
   "mcpServers": {
-    "knomit": {
+    "knomit-personal": {
       "command": "/path/to/dist/knomit-bridge"
     }
   }
 }
 ```
 
-Multiple repos:
+Multiple repos. Name each key `knomit-<scope>` — that is what `knomit-bridge
+claude init` generates, and the Claude Code hooks identify knomit servers by
+their `command`, so a key that does not follow the convention still binds, but
+two servers whose keys collide silently clobber each other:
 
 ```json
 {
   "mcpServers": {
-    "knomit": {
+    "knomit-personal": {
       "command": "/path/to/dist/knomit-bridge"
     },
-    "work-kb": {
+    "knomit-work": {
       "command": "/path/to/dist/knomit-bridge",
       "args": ["--repo", "work"]
     }

--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -86,16 +86,18 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-Multiple repos. Name each key `knomit-<scope>`, matching what `knomit-bridge
-claude init` generates:
+Multiple repos. Name each key `knomit-repo-<name>` (or `knomit-lens-<name>` for
+a lens), matching what `knomit-bridge claude init` generates — the axis is part
+of the key so a repo and a lens sharing a name cannot collide:
 
 ```json
 {
   "mcpServers": {
-    "knomit-personal": {
-      "command": "/path/to/dist/knomit-bridge"
+    "knomit-repo-personal": {
+      "command": "/path/to/dist/knomit-bridge",
+      "args": ["--repo", "personal"]
     },
-    "knomit-work": {
+    "knomit-repo-work": {
       "command": "/path/to/dist/knomit-bridge",
       "args": ["--repo", "work"]
     }
@@ -103,13 +105,22 @@ claude init` generates:
 }
 ```
 
-> **Claude Code projects: one knomit server per project.** The above is Claude
+Claude Code turns the key into the tool-name prefix `mcp__<key>__knomit_learn`,
+and the API caps tool names at 64 characters, so the repo or lens name may be at
+most 27 characters. `claude init` checks this before writing anything and fails
+with the limit named. In repo mode the name defaults to the directory basename,
+so a deeply-named directory can trip it — pass `--repo <shorter>`; the repo name
+does not have to match the directory.
+
+> **Claude Code projects: one knomit SCOPE per project.** The above is Claude
 > Desktop config, where multiple entries are fine. A Claude Code project's
 > `.mcp.json` is different — the hooks (`session-start`, `post-edit`) have to
-> bind to exactly one repo, so a project configuring two knomit servers
-> disables them rather than guess which repo to read and write. The MCP tools
-> themselves keep working for both; only the hooks stand down, and
-> `session-start` says so.
+> bind to exactly one repo, so a project whose knomit entries name two different
+> repos or lenses disables them rather than guess which repo to read and write.
+> The MCP tools themselves keep working for both; only the hooks stand down, and
+> `session-start` says so. Duplicate entries resolving to the *same* scope — what
+> the obvious merge of a `.mcp.json.knomit` companion produces — are not
+> ambiguous and keep the hooks on.
 
 ## Debugging
 

--- a/tools/bridge/README.md
+++ b/tools/bridge/README.md
@@ -86,10 +86,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-Multiple repos. Name each key `knomit-<scope>` — that is what `knomit-bridge
-claude init` generates, and the Claude Code hooks identify knomit servers by
-their `command`, so a key that does not follow the convention still binds, but
-two servers whose keys collide silently clobber each other:
+Multiple repos. Name each key `knomit-<scope>`, matching what `knomit-bridge
+claude init` generates:
 
 ```json
 {
@@ -104,6 +102,14 @@ two servers whose keys collide silently clobber each other:
   }
 }
 ```
+
+> **Claude Code projects: one knomit server per project.** The above is Claude
+> Desktop config, where multiple entries are fine. A Claude Code project's
+> `.mcp.json` is different — the hooks (`session-start`, `post-edit`) have to
+> bind to exactly one repo, so a project configuring two knomit servers
+> disables them rather than guess which repo to read and write. The MCP tools
+> themselves keep working for both; only the hooks stand down, and
+> `session-start` says so.
 
 ## Debugging
 

--- a/tools/bridge/claude/helpers.go
+++ b/tools/bridge/claude/helpers.go
@@ -58,24 +58,46 @@ func knomitBaseURL() string {
 // order. A stray --repo must not demote a lens-configured session to a raw
 // repo scope — lens mode resolves via the API and fails safe (skips) rather
 // than risk reading the wrong repo.
-func mcpBinding(projectDir string) (repo, lens string) {
+func mcpBinding(projectDir string) (repo, lens string, ambiguous bool) {
 	base := filepath.Base(projectDir)
 	data, err := os.ReadFile(filepath.Join(projectDir, ".mcp.json"))
 	if err != nil {
-		return base, ""
+		return base, "", false
 	}
 	var cfg struct {
 		MCPServers map[string]struct {
-			Args []string `json:"args"`
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
 		} `json:"mcpServers"`
 	}
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return base, ""
+		return base, "", false
 	}
-	srv, ok := cfg.MCPServers["knomit"]
-	if !ok {
-		return base, ""
+
+	// Select by COMMAND, not by key. The key used to be the constant "knomit",
+	// but `claude init` now derives it from the scope so that two knomit servers
+	// can coexist in one project — keying off it would silently unbind every
+	// hook the moment a project scaffolds as anything but a knomit-named repo,
+	// which is precisely the wrong-repo hazard the lens rules below exist to
+	// avoid. The command is what actually identifies a knomit server.
+	var matches []string
+	for key, srv := range cfg.MCPServers {
+		if filepath.Base(srv.Command) == "knomit-bridge" {
+			matches = append(matches, key)
+		}
 	}
+	switch len(matches) {
+	case 0:
+		return base, "", false
+	case 1:
+		// fall through to classification below
+	default:
+		// Two or more knomit servers: there is no principled answer to "which
+		// repo do the hooks bind to?", and guessing runs post-edit against
+		// possibly the wrong repo. Fail safe — the caller skips and says why.
+		return "", "", true
+	}
+	srv := cfg.MCPServers[matches[0]]
 	var repoArg string
 	for i := 0; i < len(srv.Args); i++ {
 		a := srv.Args[i]
@@ -88,15 +110,15 @@ func mcpBinding(projectDir string) (repo, lens string) {
 			// rather than the wrong-repo hazard a basename fallback would
 			// reintroduce.
 			if i+1 < len(srv.Args) {
-				return "", srv.Args[i+1]
+				return "", srv.Args[i+1], false
 			}
-			return "", "" // lens flag with no value: lens mode, empty name
+			return "", "", false // lens flag with no value: lens mode, empty name
 		case strings.HasPrefix(a, "--lens=") || strings.HasPrefix(a, "-lens="):
 			// Go-flag combined form. Lens wins immediately, exactly like the
 			// token arm; an empty value after '=' yields an empty lens name
 			// (clean skip downstream), never a basename fallback.
 			_, v, _ := strings.Cut(a, "=")
-			return "", v
+			return "", v, false
 		case a == "--repo" || a == "-repo":
 			if repoArg == "" && i+1 < len(srv.Args) {
 				repoArg = srv.Args[i+1]
@@ -109,9 +131,9 @@ func mcpBinding(projectDir string) (repo, lens string) {
 		}
 	}
 	if repoArg != "" {
-		return repoArg, ""
+		return repoArg, "", false
 	}
-	return base, ""
+	return base, "", false
 }
 
 // repoFromMCP returns the repo-mode target for projectDir (the --repo arg or
@@ -119,7 +141,7 @@ func mcpBinding(projectDir string) (repo, lens string) {
 // repo-mode call path and its regression tests; a lens-configured file yields
 // "" here, so lens-aware callers must use resolveWriteRepo instead.
 func repoFromMCP(projectDir string) string {
-	repo, _ := mcpBinding(projectDir)
+	repo, _, _ := mcpBinding(projectDir)
 	return repo
 }
 
@@ -140,7 +162,13 @@ func repoFromMCP(projectDir string) string {
 // facts land, so session-start / post-edit context stays accurate for the
 // write side.
 func resolveWriteRepo(projectDir string) (repo, skipReason string) {
-	r, lens := mcpBinding(projectDir)
+	r, lens, ambiguous := mcpBinding(projectDir)
+	if ambiguous {
+		// More than one knomit server in this project. Binding to an arbitrary
+		// one would run post-edit against possibly the wrong repo, so skip and
+		// say why rather than go silently dark.
+		return "", "multiple_knomit_servers"
+	}
 	if r != "" {
 		return r, "" // repo mode: configured --repo or basename fallback
 	}

--- a/tools/bridge/claude/helpers.go
+++ b/tools/bridge/claude/helpers.go
@@ -41,11 +41,41 @@ func knomitBaseURL() string {
 	return "http://localhost:19278"
 }
 
+// skipMultipleKnomitServers is the skip reason for a project configuring more
+// than one knomit server. Named because both helpers.go and the session-start
+// hook must agree on it: the hook special-cases this reason to tell the user,
+// since unlike every other skip it is a misconfiguration that never resolves
+// on its own.
+const skipMultipleKnomitServers = "multiple_knomit_servers"
+
+// isKnomitServer reports whether an .mcp.json entry is a knomit bridge.
+//
+// Command first, since that is what actually identifies the process and it
+// survives the key being derived per scope. `.exe` is trimmed because the
+// Makefile builds a GOOS=windows target, where the command is knomit-bridge.exe
+// and a bare basename comparison would miss every Windows install.
+//
+// The knomit-shaped KEY is accepted as a fallback so configs that predate the
+// derived key keep binding: a wrapper script, a renamed symlink, a versioned
+// binary or `go run` all leave a command this cannot recognise, and those
+// configs resolved fine when the lookup was `cfg.MCPServers["knomit"]`. Failing
+// to match there does not fail safe — it falls through to the basename
+// fallback, which is the wrong-repo hazard this file's contract forbids.
+func isKnomitServer(key, command string) bool {
+	if strings.TrimSuffix(filepath.Base(command), ".exe") == "knomit-bridge" {
+		return true
+	}
+	return key == "knomit" || strings.HasPrefix(key, "knomit-")
+}
+
 // mcpBinding classifies the knomit MCP server config in .mcp.json under
 // projectDir into either lens mode or repo mode. It is pure (no I/O beyond the
 // single file read) so the classification is unit-testable in isolation.
 //
-// Returns (repo, lens):
+// Returns (repo, lens, ambiguous):
+//   - ambiguous: the project configures MORE THAN ONE knomit server. There is
+//     no principled answer to which repo the hooks should bind to, so repo and
+//     lens are both "" and the caller must skip rather than pick one.
 //   - lens != "": lens mode — the file configures --lens <name>. repo is "".
 //     A lens-configured file NEVER falls back to the basename; the caller must
 //     resolve the write repo via the API and skip cleanly on failure.
@@ -82,7 +112,7 @@ func mcpBinding(projectDir string) (repo, lens string, ambiguous bool) {
 	// avoid. The command is what actually identifies a knomit server.
 	var matches []string
 	for key, srv := range cfg.MCPServers {
-		if filepath.Base(srv.Command) == "knomit-bridge" {
+		if isKnomitServer(key, srv.Command) {
 			matches = append(matches, key)
 		}
 	}
@@ -167,7 +197,7 @@ func resolveWriteRepo(projectDir string) (repo, skipReason string) {
 		// More than one knomit server in this project. Binding to an arbitrary
 		// one would run post-edit against possibly the wrong repo, so skip and
 		// say why rather than go silently dark.
-		return "", "multiple_knomit_servers"
+		return "", skipMultipleKnomitServers
 	}
 	if r != "" {
 		return r, "" // repo mode: configured --repo or basename fallback

--- a/tools/bridge/claude/helpers.go
+++ b/tools/bridge/claude/helpers.go
@@ -48,24 +48,35 @@ func knomitBaseURL() string {
 // on its own.
 const skipMultipleKnomitServers = "multiple_knomit_servers"
 
-// isKnomitServer reports whether an .mcp.json entry is a knomit bridge.
-//
-// Command first, since that is what actually identifies the process and it
+// isKnomitCommand reports whether an .mcp.json entry's COMMAND identifies the
+// knomit bridge. This is the certain signal: it names the actual process and it
 // survives the key being derived per scope. `.exe` is trimmed because the
 // Makefile builds a GOOS=windows target, where the command is knomit-bridge.exe
 // and a bare basename comparison would miss every Windows install.
-//
-// The knomit-shaped KEY is accepted as a fallback so configs that predate the
-// derived key keep binding: a wrapper script, a renamed symlink, a versioned
-// binary or `go run` all leave a command this cannot recognise, and those
+func isKnomitCommand(command string) bool {
+	return strings.TrimSuffix(filepath.Base(command), ".exe") == "knomit-bridge"
+}
+
+// isKnomitKey reports whether an .mcp.json KEY looks like a knomit server. This
+// is a guess, not proof: a wrapper script, a renamed symlink, a versioned binary
+// or `go run` all leave a command isKnomitCommand cannot recognise, and those
 // configs resolved fine when the lookup was `cfg.MCPServers["knomit"]`. Failing
-// to match there does not fail safe — it falls through to the basename
-// fallback, which is the wrong-repo hazard this file's contract forbids.
-func isKnomitServer(key, command string) bool {
-	if strings.TrimSuffix(filepath.Base(command), ".exe") == "knomit-bridge" {
-		return true
-	}
+// to match them does not fail safe — it falls through to the basename fallback,
+// which is the wrong-repo hazard this file's contract forbids.
+//
+// Because it is a guess it also fires on servers that merely borrowed the
+// namespace (an unrelated `knomit-notes` MCP server). mcpBinding therefore
+// treats key matches as a strictly lower tier than command matches: see the
+// selection there.
+func isKnomitKey(key string) bool {
 	return key == "knomit" || strings.HasPrefix(key, "knomit-")
+}
+
+// isKnomitServer reports whether an .mcp.json entry is a knomit bridge by
+// either signal. Callers that must distinguish proof from guess use the two
+// predicates directly.
+func isKnomitServer(key, command string) bool {
+	return isKnomitCommand(command) || isKnomitKey(key)
 }
 
 // mcpBinding classifies the knomit MCP server config in .mcp.json under
@@ -73,9 +84,11 @@ func isKnomitServer(key, command string) bool {
 // single file read) so the classification is unit-testable in isolation.
 //
 // Returns (repo, lens, ambiguous):
-//   - ambiguous: the project configures MORE THAN ONE knomit server. There is
-//     no principled answer to which repo the hooks should bind to, so repo and
-//     lens are both "" and the caller must skip rather than pick one.
+//   - ambiguous: the project configures MORE THAN ONE knomit server RESOLVING
+//     TO DIFFERENT TARGETS. There is no principled answer to which repo the
+//     hooks should bind to, so repo and lens are both "" and the caller must
+//     skip rather than pick one. Entries that resolve to the same target are
+//     not ambiguous — see the selection below.
 //   - lens != "": lens mode — the file configures --lens <name>. repo is "".
 //     A lens-configured file NEVER falls back to the basename; the caller must
 //     resolve the write repo via the API and skip cleanly on failure.
@@ -110,27 +123,59 @@ func mcpBinding(projectDir string) (repo, lens string, ambiguous bool) {
 	// hook the moment a project scaffolds as anything but a knomit-named repo,
 	// which is precisely the wrong-repo hazard the lens rules below exist to
 	// avoid. The command is what actually identifies a knomit server.
-	var matches []string
+	//
+	// Command matches are proof; key matches are a guess (isKnomitKey). A guess
+	// must never dilute proof: a project running one real bridge alongside an
+	// unrelated server that merely borrowed the `knomit-` namespace would
+	// otherwise count two matches and disable every hook, telling the user to
+	// remove a knomit entry they do not have. So key matches are considered only
+	// when nothing matched on command at all — which is exactly the legacy /
+	// wrapper-script case the key fallback exists for.
+	var byCommand, byKey []string
 	for key, srv := range cfg.MCPServers {
-		if isKnomitServer(key, srv.Command) {
-			matches = append(matches, key)
+		switch {
+		case isKnomitCommand(srv.Command):
+			byCommand = append(byCommand, key)
+		case isKnomitKey(key):
+			byKey = append(byKey, key)
 		}
 	}
-	switch len(matches) {
-	case 0:
-		return base, "", false
-	case 1:
-		// fall through to classification below
-	default:
-		// Two or more knomit servers: there is no principled answer to "which
-		// repo do the hooks bind to?", and guessing runs post-edit against
-		// possibly the wrong repo. Fail safe — the caller skips and says why.
-		return "", "", true
+	matches := byCommand
+	if len(matches) == 0 {
+		matches = byKey
 	}
-	srv := cfg.MCPServers[matches[0]]
+	if len(matches) == 0 {
+		return base, "", false
+	}
+	repo, lens = classifyArgs(cfg.MCPServers[matches[0]].Args, base)
+	// Two or more knomit servers that name DIFFERENT targets: there is no
+	// principled answer to "which repo do the hooks bind to?", and guessing runs
+	// post-edit against possibly the wrong repo. Fail safe — the caller skips
+	// and says why.
+	//
+	// Same-target duplicates are not that case, and they are the likely one:
+	// `.mcp.json` is merge-required, so re-running init drops a companion and the
+	// obvious merge leaves the pre-existing entry beside the freshly derived one,
+	// both pointing at the same repo. Disabling the hooks over a config with a
+	// single unambiguous answer would be a fail-safe that fires on nothing.
+	// Map iteration order is random, so the comparison must be order-independent
+	// — it is: we return only when every match agrees.
+	for _, key := range matches[1:] {
+		r, l := classifyArgs(cfg.MCPServers[key].Args, base)
+		if r != repo || l != lens {
+			return "", "", true
+		}
+	}
+	return repo, lens, false
+}
+
+// classifyArgs maps one server entry's args to its (repo, lens) target, with
+// base as the repo-mode fallback. Split out of mcpBinding so the multi-server
+// path can compare targets without duplicating the precedence rules.
+func classifyArgs(args []string, base string) (repo, lens string) {
 	var repoArg string
-	for i := 0; i < len(srv.Args); i++ {
-		a := srv.Args[i]
+	for i := 0; i < len(args); i++ {
+		a := args[i]
 		switch {
 		case a == "--lens" || a == "-lens":
 			// A --lens token means lens mode even when the value is missing
@@ -139,19 +184,19 @@ func mcpBinding(projectDir string) (repo, lens string, ambiguous bool) {
 			// name, which resolveWriteRepo/lensWriteRepo turn into a clean skip
 			// rather than the wrong-repo hazard a basename fallback would
 			// reintroduce.
-			if i+1 < len(srv.Args) {
-				return "", srv.Args[i+1], false
+			if i+1 < len(args) {
+				return "", args[i+1]
 			}
-			return "", "", false // lens flag with no value: lens mode, empty name
+			return "", "" // lens flag with no value: lens mode, empty name
 		case strings.HasPrefix(a, "--lens=") || strings.HasPrefix(a, "-lens="):
 			// Go-flag combined form. Lens wins immediately, exactly like the
 			// token arm; an empty value after '=' yields an empty lens name
 			// (clean skip downstream), never a basename fallback.
 			_, v, _ := strings.Cut(a, "=")
-			return "", v, false
+			return "", v
 		case a == "--repo" || a == "-repo":
-			if repoArg == "" && i+1 < len(srv.Args) {
-				repoArg = srv.Args[i+1]
+			if repoArg == "" && i+1 < len(args) {
+				repoArg = args[i+1]
 			}
 		case strings.HasPrefix(a, "--repo=") || strings.HasPrefix(a, "-repo="):
 			if repoArg == "" {
@@ -161,9 +206,9 @@ func mcpBinding(projectDir string) (repo, lens string, ambiguous bool) {
 		}
 	}
 	if repoArg != "" {
-		return repoArg, "", false
+		return repoArg, ""
 	}
-	return base, "", false
+	return base, ""
 }
 
 // repoFromMCP returns the repo-mode target for projectDir (the --repo arg or

--- a/tools/bridge/claude/helpers_test.go
+++ b/tools/bridge/claude/helpers_test.go
@@ -88,7 +88,7 @@ func TestMcpBinding_RepoConfigured_RepoMode(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(mcp), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	repo, lens := mcpBinding(dir)
+	repo, lens, _ := mcpBinding(dir)
 	if repo != "myproject" || lens != "" {
 		t.Errorf("mcpBinding = (%q, %q), want (%q, %q)", repo, lens, "myproject", "")
 	}
@@ -108,7 +108,7 @@ func TestMcpBinding_LensConfigured_LensMode(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(mcp), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	repo, lens := mcpBinding(dir)
+	repo, lens, _ := mcpBinding(dir)
 	if lens != "mylens" || repo != "" {
 		t.Errorf("mcpBinding = (%q, %q), want (%q, %q)", repo, lens, "", "mylens")
 	}
@@ -120,7 +120,7 @@ func TestMcpBinding_LensConfigured_LensMode(t *testing.T) {
 
 func TestMcpBinding_MissingFile_BasenameRepoMode(t *testing.T) {
 	dir := t.TempDir()
-	repo, lens := mcpBinding(dir)
+	repo, lens, _ := mcpBinding(dir)
 	if repo != filepath.Base(dir) || lens != "" {
 		t.Errorf("mcpBinding = (%q, %q), want (%q, %q)", repo, lens, filepath.Base(dir), "")
 	}
@@ -142,7 +142,7 @@ func TestMcpBinding_BothFlags_LensWins(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(mcp), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			repo, lens := mcpBinding(dir)
+			repo, lens, _ := mcpBinding(dir)
 			if lens != "mylens" || repo != "" {
 				t.Errorf("mcpBinding = (%q, %q), want lens to win (%q, %q)", repo, lens, "", "mylens")
 			}
@@ -160,7 +160,7 @@ func TestMcpBinding_LensNoValue_LensModeEmptyName(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(mcp), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	repo, lens := mcpBinding(dir)
+	repo, lens, _ := mcpBinding(dir)
 	if repo != "" || lens != "" {
 		t.Errorf("mcpBinding = (%q, %q), want (%q, %q)", repo, lens, "", "")
 	}
@@ -196,7 +196,7 @@ func TestMcpBinding_EqualsForms(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(mcp), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			repo, lens := mcpBinding(dir)
+			repo, lens, _ := mcpBinding(dir)
 			if repo != tc.wantRepo || lens != tc.wantLens {
 				t.Errorf("mcpBinding = (%q, %q), want (%q, %q)", repo, lens, tc.wantRepo, tc.wantLens)
 			}

--- a/tools/bridge/claude/helpers_test.go
+++ b/tools/bridge/claude/helpers_test.go
@@ -399,6 +399,120 @@ func TestMcpBinding_LegacyConfigStillBinds(t *testing.T) {
 	}
 }
 
+// TestMcpBinding_KeyMatchesNeverDiluteCommandMatches pins the tiering. The key
+// arm of isKnomitServer is a guess and fires on any server that borrowed the
+// `knomit-` namespace; counting such a server alongside a real bridge would
+// report ambiguity and disable every hook, with a message telling the user to
+// remove a knomit entry they do not have.
+func TestMcpBinding_KeyMatchesNeverDiluteCommandMatches(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `{"mcpServers":{
+		"knomit":{"command":"knomit-bridge","args":["--repo","real"]},
+		"knomit-notes":{"command":"npx","args":["-y","some-notes-mcp"]},
+		"knomit-docs":{"command":"/usr/bin/docs-mcp"}
+	}}`
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo, lens, ambiguous := mcpBinding(dir)
+	if ambiguous {
+		t.Fatal("unrelated knomit-keyed servers made a single real bridge look ambiguous")
+	}
+	if repo != "real" || lens != "" {
+		t.Errorf("mcpBinding = (%q, %q), want (%q, %q)", repo, lens, "real", "")
+	}
+}
+
+// TestMcpBinding_KeyTierStillBindsWhenNothingMatchesOnCommand is the other half
+// of the tiering: demoting key matches must not disable them. With no
+// command-recognisable entry, the key arm is all there is, and failing to match
+// does not fail safe — it falls through to the basename fallback, i.e. the
+// wrong-repo hazard.
+func TestMcpBinding_KeyTierStillBindsWhenNothingMatchesOnCommand(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `{"mcpServers":{
+		"knomit-eng":{"command":"/opt/wrappers/kb","args":["--lens","eng"]},
+		"postgres":{"command":"/usr/bin/pg-mcp"}
+	}}`
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo, lens, ambiguous := mcpBinding(dir)
+	if ambiguous {
+		t.Fatal("single key-matched server reported ambiguous")
+	}
+	if lens != "eng" {
+		t.Errorf("lens = %q, want %q", lens, "eng")
+	}
+	if repo != "" {
+		t.Errorf("repo = %q, want empty — lens config must never fall back to a basename", repo)
+	}
+}
+
+// TestMcpBinding_SameTargetDuplicatesAreNotAmbiguous pins that the fail-safe
+// fires on a real conflict, not on a redundant one. `.mcp.json` is
+// merge-required, so re-running init drops a companion and the obvious merge
+// leaves the pre-existing entry beside the freshly derived one — both naming the
+// same repo. There is one unambiguous answer there; disabling the hooks over it
+// would be a fail-safe firing on nothing.
+func TestMcpBinding_SameTargetDuplicatesAreNotAmbiguous(t *testing.T) {
+	t.Run("explicit repo twice", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := `{"mcpServers":{
+			"knomit":{"command":"knomit-bridge","args":["--repo","team-kb"]},
+			"knomit-repo-team-kb":{"command":"knomit-bridge","args":["--repo=team-kb"]}
+		}}`
+		if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		repo, lens, ambiguous := mcpBinding(dir)
+		if ambiguous {
+			t.Fatal("two entries naming the same repo reported as ambiguous")
+		}
+		if repo != "team-kb" || lens != "" {
+			t.Errorf("mcpBinding = (%q, %q), want (%q, %q)", repo, lens, "team-kb", "")
+		}
+	})
+
+	t.Run("basename fallback matches an explicit repo", func(t *testing.T) {
+		// The legacy entry carries no args and resolves to the directory
+		// basename; the derived entry names that same repo explicitly.
+		dir := t.TempDir()
+		base := filepath.Base(dir)
+		cfg := `{"mcpServers":{
+			"knomit":{"command":"knomit-bridge"},
+			"knomit-repo-` + base + `":{"command":"knomit-bridge","args":["--repo","` + base + `"]}
+		}}`
+		if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		repo, lens, ambiguous := mcpBinding(dir)
+		if ambiguous {
+			t.Fatal("basename fallback and the equivalent explicit repo reported as ambiguous")
+		}
+		if repo != base || lens != "" {
+			t.Errorf("mcpBinding = (%q, %q), want (%q, %q)", repo, lens, base, "")
+		}
+	})
+
+	t.Run("differing targets stay ambiguous", func(t *testing.T) {
+		// The dedupe must not soften the actual conflict: a repo scope and a
+		// lens scope have no common answer even when they share a name.
+		dir := t.TempDir()
+		cfg := `{"mcpServers":{
+			"knomit-repo-eng":{"command":"knomit-bridge","args":["--repo","eng"]},
+			"knomit-lens-eng":{"command":"knomit-bridge","args":["--lens","eng"]}
+		}}`
+		if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		repo, lens, ambiguous := mcpBinding(dir)
+		if !ambiguous {
+			t.Fatalf("repo and lens scopes not reported as ambiguous (repo=%q lens=%q)", repo, lens)
+		}
+	})
+}
+
 // TestHookSessionStart_MultipleServersTellsTheUser pins that the one skip the
 // user cannot otherwise see is spoken aloud. Every other skip reason is
 // transient; this one never resolves on its own.

--- a/tools/bridge/claude/helpers_test.go
+++ b/tools/bridge/claude/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -343,5 +344,83 @@ func TestWiredEvent(t *testing.T) {
 				t.Errorf("wiredEvent(%q, %q) = %q, want %q", tc.fromInput, tc.fallback, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestIsKnomitServer covers the two ways an entry is recognised. The KEY arm is
+// the compatibility path: configs predating the derived key, or using a wrapper
+// script / renamed symlink / `go run`, leave a command this cannot identify, and
+// failing to match there does NOT fail safe — it falls through to the basename
+// fallback, i.e. the wrong-repo hazard.
+func TestIsKnomitServer(t *testing.T) {
+	for _, tc := range []struct {
+		name, key, command string
+		want               bool
+	}{
+		{"plain command", "anything", "knomit-bridge", true},
+		{"absolute command", "anything", "/usr/local/bin/knomit-bridge", true},
+		// filepath.Base is OS-specific, so a backslash path only splits on
+		// Windows. The portable assertion is the .exe suffix trimming itself,
+		// which is what the GOOS=windows build needs.
+		{"windows exe", "anything", "knomit-bridge.exe", true},
+		{"windows exe with slash path", "anything", "C:/tools/knomit-bridge.exe", true},
+		{"legacy constant key", "knomit", "/opt/wrappers/kb", true},
+		{"derived key, wrapper command", "knomit-eng", "~/bin/kb-wrapper.sh", true},
+		{"unrelated server", "postgres", "/usr/bin/pg-mcp", false},
+		{"knomit-ish command but not the bridge", "db", "knomit-bridgehead", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isKnomitServer(tc.key, tc.command); got != tc.want {
+				t.Errorf("isKnomitServer(%q, %q) = %v, want %v", tc.key, tc.command, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMcpBinding_LegacyConfigStillBinds is the compatibility regression: a
+// pre-existing config keyed "knomit" whose command is a wrapper must keep
+// resolving to lens mode. Selecting on command alone silently demoted it to a
+// basename repo — the hazard mcpBinding's contract forbids.
+func TestMcpBinding_LegacyConfigStillBinds(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `{"mcpServers":{"knomit":{"command":"/opt/wrappers/kb","args":["--lens","eng"]}}}`
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo, lens, ambiguous := mcpBinding(dir)
+	if ambiguous {
+		t.Fatal("single server reported ambiguous")
+	}
+	if lens != "eng" {
+		t.Errorf("lens = %q, want %q", lens, "eng")
+	}
+	if repo != "" {
+		t.Errorf("repo = %q, want empty — lens config must never fall back to a basename", repo)
+	}
+}
+
+// TestHookSessionStart_MultipleServersTellsTheUser pins that the one skip the
+// user cannot otherwise see is spoken aloud. Every other skip reason is
+// transient; this one never resolves on its own.
+func TestHookSessionStart_MultipleServersTellsTheUser(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `{"mcpServers":{
+		"knomit-a":{"command":"knomit-bridge","args":["--repo","a"]},
+		"knomit-b":{"command":"knomit-bridge","args":["--repo","b"]}
+	}}`
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	in := strings.NewReader(`{"cwd":` + strconv.Quote(dir) + `}`)
+	var out bytes.Buffer
+	if err := hookSessionStart(in, &out); err != nil {
+		t.Fatalf("hookSessionStart: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "DISABLED") {
+		t.Errorf("session-start stayed silent about disabled hooks; got %q", got)
+	}
+	if !strings.Contains(got, ".mcp.json") {
+		t.Errorf("notice does not say where to fix it; got %q", got)
 	}
 }

--- a/tools/bridge/claude/hook_session_start.go
+++ b/tools/bridge/claude/hook_session_start.go
@@ -50,6 +50,20 @@ func hookSessionStart(r io.Reader, w io.Writer) error {
 	repo, skip := resolveWriteRepo(in.Cwd)
 	if skip != "" {
 		skipReason = skip
+		// Every other skip reason is a transient or benign state (server down,
+		// no facts yet). This one is a misconfiguration that will never resolve
+		// on its own, and the user cannot see the log field — so say it out
+		// loud. A memory system whose hooks go silently dark is the worst
+		// failure it has: nothing is captured and nobody finds out.
+		if skip == skipMultipleKnomitServers {
+			_, err := fmt.Fprint(w, "knomit hooks are DISABLED: .mcp.json configures more "+
+				"than one knomit server, so there is no single repo to bind to. "+
+				"Keep one knomit entry in this project's .mcp.json to re-enable them.\n")
+			if err != nil {
+				return err
+			}
+			emitted = true
+		}
 		return nil
 	}
 	branch := agentBranch(repo)

--- a/tools/bridge/claude/hook_session_start.go
+++ b/tools/bridge/claude/hook_session_start.go
@@ -29,15 +29,18 @@ func hookSessionStart(r io.Reader, w io.Writer) error {
 	)
 	defer func() {
 		ev := log.Info().Str("event", "session-start").Bool("emitted", emitted)
+		// skip_reason is logged whenever it is set, INDEPENDENT of emitted. The
+		// two are not mutually exclusive: the multiple-servers skip still writes
+		// a notice to the user, and logging only on the not-emitted branch made
+		// that line indistinguishable from a healthy emission — the one skip we
+		// went out of our way to make visible was the one invisible in the log.
+		if skipReason != "" {
+			ev.Str("skip_reason", skipReason)
+		}
 		if emitted {
 			ev.Int("globals", globalsCount).
 				Int("invariants_fallback", invariantsCount).
-				Int("recent", recentCount).
-				Msg("hook result")
-			return
-		}
-		if skipReason != "" {
-			ev.Str("skip_reason", skipReason)
+				Int("recent", recentCount)
 		}
 		ev.Msg("hook result")
 	}()
@@ -56,9 +59,10 @@ func hookSessionStart(r io.Reader, w io.Writer) error {
 		// loud. A memory system whose hooks go silently dark is the worst
 		// failure it has: nothing is captured and nobody finds out.
 		if skip == skipMultipleKnomitServers {
-			_, err := fmt.Fprint(w, "knomit hooks are DISABLED: .mcp.json configures more "+
-				"than one knomit server, so there is no single repo to bind to. "+
-				"Keep one knomit entry in this project's .mcp.json to re-enable them.\n")
+			_, err := fmt.Fprint(w, "knomit hooks are DISABLED: .mcp.json configures knomit "+
+				"servers for more than one scope, so there is no single repo to bind to. "+
+				"Leave one scope (one repo or one lens) in this project's .mcp.json to "+
+				"re-enable them; duplicate entries naming the SAME scope are fine.\n")
 			if err != nil {
 				return err
 			}

--- a/tools/bridge/claude/hook_session_start_test.go
+++ b/tools/bridge/claude/hook_session_start_test.go
@@ -5,9 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -226,4 +231,41 @@ func TestSessionStart_FallsBackToInvariantsWhenNoGlobalPrinciples(t *testing.T) 
 	require.Contains(t, got, "Vtables must not re-enter")
 	require.Contains(t, got, "Refs branch by scheme")
 	require.NotContains(t, got, "PROJECT PRINCIPLES:")
+}
+
+// TestSessionStart_MultipleServersLogsTheSkipReason pins that the notice the
+// user sees is also legible in the bridge log. The multiple-servers case is the
+// one skip that both emits output AND skips, and logging skip_reason only on the
+// not-emitted branch left its line — emitted=true, no counts, no reason —
+// indistinguishable at a glance from a healthy emission. Whoever reads the log
+// to find out why knomit went quiet is exactly who needs that field.
+func TestSessionStart_MultipleServersLogsTheSkipReason(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `{"mcpServers":{
+		"knomit-repo-a":{"command":"knomit-bridge","args":["--repo","a"]},
+		"knomit-repo-b":{"command":"knomit-bridge","args":["--repo","b"]}
+	}}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644))
+
+	var logBuf bytes.Buffer
+	prev := log.Logger
+	log.Logger = zerolog.New(&logBuf)
+	t.Cleanup(func() { log.Logger = prev })
+
+	var out bytes.Buffer
+	in := strings.NewReader(`{"cwd":` + strconv.Quote(dir) + `}`)
+	require.NoError(t, hookSessionStart(in, &out))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(logBuf.Bytes()), &entry),
+		"log line is not a single JSON object: %s", logBuf.String())
+	require.Equal(t, skipMultipleKnomitServers, entry["skip_reason"],
+		"skip_reason missing from the log line: %s", logBuf.String())
+	// emitted stays true — the hook really did write the user-facing notice.
+	// The point is that the two coexist, not that one replaces the other; the
+	// counts alongside it are honestly zero, and skip_reason is what tells a log
+	// reader that this line is the misconfiguration notice, not a healthy run.
+	require.Equal(t, true, entry["emitted"])
+	require.Equal(t, float64(0), entry["globals"])
+	require.Equal(t, float64(0), entry["recent"])
 }

--- a/tools/bridge/claude/init.go
+++ b/tools/bridge/claude/init.go
@@ -61,6 +61,13 @@ func runInit(args []string) error {
 			return fmt.Errorf("invalid --repo %q (%s)", repoName, nameRule)
 		}
 	}
+	// Reject up front rather than emit a .mcp.json whose derived key produces a
+	// tool name over the API's 64-char limit. Repo mode can trip this without
+	// the user naming anything: repoName defaults to the directory basename.
+	if key := serverKey(repoName, *lens); len(key) > maxServerKeyRunes {
+		return fmt.Errorf("derived MCP server key %q is %d characters (max %d); "+
+			"pass a shorter --repo or --lens name", key, len(key), maxServerKeyRunes)
+	}
 
 	var created []string
 	var overwritten []string
@@ -152,12 +159,17 @@ func runInit(args []string) error {
 // scoping wins over a repo scoping because the two are mutually exclusive at the
 // flag layer and the lens is the thing actually being served.
 //
-// The "knomit-" prefix is skipped when the name already carries it, so a repo
-// literally named `knomit` keeps the key `knomit` rather than becoming
-// `knomit-knomit` — a name that is both ugly and, per the routing measurement,
-// carries no more routing signal than the bare one. That also makes the derived
-// key backward-compatible for every project already scoped to a knomit-prefixed
-// repo or lens.
+// The prefix is applied UNCONDITIONALLY, so the mapping from scope to key is
+// injective: distinct scopes can never collide. An earlier draft skipped the
+// prefix when the name already carried it, to avoid the ugly `knomit-knomit`
+// for a repo named `knomit` — but that rule is inherently many-to-one
+// (`web` and `knomit-web` both map to `knomit-web`), which re-creates in one
+// step exactly the clobbering this function exists to remove. A cosmetic
+// objection does not outrank the correctness property.
+//
+// Skipping the prefix bought no backward compatibility either: `.mcp.json` is
+// merge-required, so an existing config is never rewritten in place — init
+// drops a companion file and lets the user merge.
 //
 // Callers must validate name/lens with repos.IsValidName first: the result is
 // interpolated into JSON, and this function does no escaping of its own.
@@ -166,11 +178,18 @@ func serverKey(repoName, lens string) string {
 	if lens != "" {
 		name = lens
 	}
-	if strings.HasPrefix(name, "knomit") {
-		return name
-	}
 	return "knomit-" + name
 }
+
+// maxServerKeyRunes bounds the derived key so the fully-qualified tool name
+// Claude Code builds from it stays under the API's 64-character tool-name
+// limit. The longest tool is knomit_hypothesize, giving
+// len("mcp__") + len(key) + len("__") + len("knomit_hypothesize") = 25 + key.
+//
+// This could not be hit before: the key was a 6-character constant. It can now,
+// because the key derives from a repo name that defaults to the directory
+// basename, and repos.IsValidName constrains the character set but not length.
+const maxServerKeyRunes = 64 - len("mcp____knomit_hypothesize")
 
 // isOwnedByIntegration reports whether dstRel is a file that the integration
 // owns outright (skills). These are always overwritten on re-run, so deleting
@@ -251,6 +270,40 @@ func printSummary(created, overwritten, conflicts []string) {
 	}
 	for _, c := range conflicts {
 		fmt.Printf("WARNING: %s exists — merge from %s manually\n", c, companionRel(c))
+		if c == "CLAUDE.md" {
+			if note := claudeMdBlockNote(c); note != "" {
+				fmt.Printf("         %s\n", note)
+			}
+		}
+	}
+}
+
+// blockMarkerPrefix and blockMarkerCurrent make the integration block's version
+// legible to init. Without a consumer the version in the marker would be inert
+// decoration: a stale installed block would be indistinguishable from a current
+// one, which is the whole reason the block drifted (installed copies saying
+// "Nine /knomit-… slash commands" against a template saying "Eleven").
+const (
+	blockMarkerPrefix  = "<!-- knomit:integration"
+	blockMarkerCurrent = "<!-- knomit:integration v2 -->"
+)
+
+// claudeMdBlockNote reports how the CLAUDE.md already on disk compares to the
+// block this build ships, so the merge warning says WHAT to merge. Returns ""
+// when the file is unreadable or already current — nothing useful to add.
+func claudeMdBlockNote(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	content := string(data)
+	switch {
+	case strings.Contains(content, blockMarkerCurrent):
+		return ""
+	case strings.Contains(content, blockMarkerPrefix):
+		return "its knomit block is from an older version — replace the whole block, not just parts"
+	default:
+		return "it has no knomit block yet — append the companion's contents"
 	}
 }
 

--- a/tools/bridge/claude/init.go
+++ b/tools/bridge/claude/init.go
@@ -63,10 +63,20 @@ func runInit(args []string) error {
 	}
 	// Reject up front rather than emit a .mcp.json whose derived key produces a
 	// tool name over the API's 64-char limit. Repo mode can trip this without
-	// the user naming anything: repoName defaults to the directory basename.
-	if key := serverKey(repoName, *lens); len(key) > maxServerKeyRunes {
-		return fmt.Errorf("derived MCP server key %q is %d characters (max %d); "+
-			"pass a shorter --repo or --lens name", key, len(key), maxServerKeyRunes)
+	// the user naming anything: repoName defaults to the directory basename, so
+	// a long directory name fails an otherwise flagless `claude init`. Say so —
+	// the remedy (name the repo explicitly) is not obvious from the error alone,
+	// because nothing else in the tool requires the repo to match the directory.
+	if key := serverKey(repoName, *lens); len(key) > maxServerKeyLen {
+		scope, flag := repoName, "--repo"
+		if *lens != "" {
+			scope, flag = *lens, "--lens"
+		}
+		return fmt.Errorf("derived MCP server key %q is %d characters (max %d), "+
+			"because %s name %q is %d (max %d); pass a shorter %s "+
+			"(it need not match the directory name)",
+			key, len(key), maxServerKeyLen,
+			strings.TrimPrefix(flag, "--"), scope, len(scope), maxScopeNameLen, flag)
 	}
 
 	var created []string
@@ -159,8 +169,20 @@ func runInit(args []string) error {
 // scoping wins over a repo scoping because the two are mutually exclusive at the
 // flag layer and the lens is the thing actually being served.
 //
-// The prefix is applied UNCONDITIONALLY, so the mapping from scope to key is
-// injective: distinct scopes can never collide. An earlier draft skipped the
+// The prefix names the AXIS as well as the product, and is applied
+// UNCONDITIONALLY, so the mapping from scope to key is injective: distinct
+// scopes can never collide. Both halves are load-bearing.
+//
+// Naming the axis is what makes the two namespaces disjoint. Repos and lenses
+// are separate namespaces validated by the same repos.IsValidName, so nothing
+// stops a lens and a repo sharing a name — a lens named after the repo it
+// writes to is the natural naming — and a shared `knomit-` prefix would map
+// `--repo eng` and `--lens eng` to the same key. Since `knomit-repo-` and
+// `knomit-lens-` are fixed-length and differ, no repo key can ever equal a lens
+// key, whatever the names (a repo literally named `lens-eng` yields
+// `knomit-repo-lens-eng`, not `knomit-lens-eng`). See TestServerKey_IsInjective.
+//
+// Applying it unconditionally is the other half. An earlier draft skipped the
 // prefix when the name already carried it, to avoid the ugly `knomit-knomit`
 // for a repo named `knomit` — but that rule is inherently many-to-one
 // (`web` and `knomit-web` both map to `knomit-web`), which re-creates in one
@@ -174,22 +196,29 @@ func runInit(args []string) error {
 // Callers must validate name/lens with repos.IsValidName first: the result is
 // interpolated into JSON, and this function does no escaping of its own.
 func serverKey(repoName, lens string) string {
-	name := repoName
 	if lens != "" {
-		name = lens
+		return "knomit-lens-" + lens
 	}
-	return "knomit-" + name
+	return "knomit-repo-" + repoName
 }
 
-// maxServerKeyRunes bounds the derived key so the fully-qualified tool name
+// maxServerKeyLen bounds the derived key so the fully-qualified tool name
 // Claude Code builds from it stays under the API's 64-character tool-name
 // limit. The longest tool is knomit_hypothesize, giving
 // len("mcp__") + len(key) + len("__") + len("knomit_hypothesize") = 25 + key.
 //
+// Bytes, not runes: repos.IsValidName restricts names to ASCII, so the two
+// counts coincide and the byte length is what the API actually measures.
+//
 // This could not be hit before: the key was a 6-character constant. It can now,
 // because the key derives from a repo name that defaults to the directory
 // basename, and repos.IsValidName constrains the character set but not length.
-const maxServerKeyRunes = 64 - len("mcp____knomit_hypothesize")
+const maxServerKeyLen = 64 - len("mcp____knomit_hypothesize")
+
+// maxScopeNameLen is the resulting budget for the repo or lens NAME itself —
+// what the error message must quote, since that is the knob the user turns.
+// Both axis prefixes are the same length, so one constant covers both.
+const maxScopeNameLen = maxServerKeyLen - len("knomit-repo-")
 
 // isOwnedByIntegration reports whether dstRel is a file that the integration
 // owns outright (skills). These are always overwritten on re-run, so deleting
@@ -277,29 +306,60 @@ func printSummary(created, overwritten, conflicts []string) {
 			}
 		case ".mcp.json":
 			// Deriving the key makes two knomit servers MERGEABLE, and the
-			// obvious merge — both entries side by side — is exactly what
-			// disables the hooks, since there is then no single repo to bind
-			// to. Say so here; the user finds out otherwise only by noticing
-			// that knomit went quiet.
-			fmt.Println("         note: keep ONE knomit entry — a project with two knomit")
-			fmt.Println("         servers has no single repo to bind to, so the hooks disable")
-			fmt.Println("         themselves (the MCP tools still work for both).")
+			// obvious merge — both entries side by side — can disable the
+			// hooks, since two DIFFERENT scopes leave no single repo to bind
+			// to. (Two entries naming the same scope are fine; mcpBinding
+			// treats them as one.) Say so here; the user finds out otherwise
+			// only by noticing that knomit went quiet.
+			fmt.Println("         note: keep ONE knomit SCOPE — a project whose knomit entries")
+			fmt.Println("         name two different repos or lenses has no single repo to bind")
+			fmt.Println("         to, so the hooks disable themselves (the MCP tools still work")
+			fmt.Println("         for both). Duplicate entries naming the same scope are fine.")
 		}
 	}
 }
 
-// blockMarkerPrefix and blockMarkerCurrent make the integration block's version
-// legible to init. Without a consumer the version in the marker would be inert
-// decoration: a stale installed block would be indistinguishable from a current
-// one, which is the whole reason the block drifted (installed copies saying
-// "Nine /knomit-… slash commands" against a template saying "Eleven").
+// blockMarkerPrefix makes the integration block's version legible to init.
+// Without a consumer the version in the marker would be inert decoration: a
+// stale installed block would be indistinguishable from a current one, which is
+// the whole reason the block drifted (installed copies saying "Nine /knomit-…
+// slash commands" against a template saying "Eleven").
 const (
-	blockMarkerPrefix  = "<!-- knomit:integration"
-	blockMarkerCurrent = "<!-- knomit:integration v2 -->"
+	blockMarkerPrefix = "<!-- knomit:integration"
 	// blockHeading identifies a block whose marker is missing entirely —
 	// pre-marker installs, or a user who stripped the HTML comments.
 	blockHeading = "## Working with knomit memory"
+	// claudeMdBlockTemplate is the embedded block whose marker defines "current".
+	claudeMdBlockTemplate = "templates/CLAUDE-md-block.txt"
 )
+
+// blockMarkerCurrent is the marker of the block THIS build ships, read off the
+// embedded template rather than restated as a constant here. A hand-written copy
+// drifts silently in BOTH directions: bump the template to v3 and forget the
+// copy, and claudeMdBlockNote calls a freshly merged current block "from an
+// older version"; bump the copy and forget the template, and every install is
+// reported current forever. That is the same "the marker drifted because nothing
+// read it" failure the marker exists to prevent, moved one level up.
+//
+// Empty if the template has no marker line. That disables only the
+// already-current shortcut — claudeMdBlockNote guards against the empty string,
+// since strings.Contains(anything, "") is true and would report every CLAUDE.md
+// as current. TestBlockMarkerCurrent_ComesFromTemplate turns the condition into
+// a test failure rather than a silent degradation.
+var blockMarkerCurrent = templateBlockMarker()
+
+func templateBlockMarker() string {
+	data, err := templatesFS.ReadFile(claudeMdBlockTemplate)
+	if err != nil {
+		return ""
+	}
+	first, _, _ := strings.Cut(string(data), "\n")
+	first = strings.TrimSpace(first)
+	if !strings.HasPrefix(first, blockMarkerPrefix) {
+		return ""
+	}
+	return first
+}
 
 // claudeMdBlockNote reports how the CLAUDE.md already on disk compares to the
 // block this build ships, so the merge warning says WHAT to merge. Returns ""
@@ -311,7 +371,7 @@ func claudeMdBlockNote(path string) string {
 	}
 	content := string(data)
 	switch {
-	case strings.Contains(content, blockMarkerCurrent):
+	case blockMarkerCurrent != "" && strings.Contains(content, blockMarkerCurrent):
 		return ""
 	case strings.Contains(content, blockMarkerPrefix), strings.Contains(content, blockHeading):
 		// The heading is checked too: the template shipped without the HTML

--- a/tools/bridge/claude/init.go
+++ b/tools/bridge/claude/init.go
@@ -92,7 +92,11 @@ func runInit(args []string) error {
 		if err != nil {
 			return err
 		}
-		rendered, err := renderTemplate(string(data), map[string]string{"RepoName": repoName, "Lens": *lens})
+		rendered, err := renderTemplate(string(data), map[string]string{
+			"RepoName":  repoName,
+			"Lens":      *lens,
+			"ServerKey": serverKey(repoName, *lens),
+		})
 		if err != nil {
 			return fmt.Errorf("render %s: %w", srcPath, err)
 		}
@@ -137,6 +141,35 @@ func runInit(args []string) error {
 
 	printSummary(created, overwritten, conflicts)
 	return nil
+}
+
+// serverKey derives the `.mcp.json` mcpServers key — which Claude Code turns
+// into the tool-name prefix `mcp__<key>__knomit_learn`.
+//
+// It is DERIVED rather than the constant "knomit" because the constant made the
+// scaffolding structurally single-server: a second `claude init` in the same
+// project collided on the key, so two knomit servers could never coexist. A lens
+// scoping wins over a repo scoping because the two are mutually exclusive at the
+// flag layer and the lens is the thing actually being served.
+//
+// The "knomit-" prefix is skipped when the name already carries it, so a repo
+// literally named `knomit` keeps the key `knomit` rather than becoming
+// `knomit-knomit` — a name that is both ugly and, per the routing measurement,
+// carries no more routing signal than the bare one. That also makes the derived
+// key backward-compatible for every project already scoped to a knomit-prefixed
+// repo or lens.
+//
+// Callers must validate name/lens with repos.IsValidName first: the result is
+// interpolated into JSON, and this function does no escaping of its own.
+func serverKey(repoName, lens string) string {
+	name := repoName
+	if lens != "" {
+		name = lens
+	}
+	if strings.HasPrefix(name, "knomit") {
+		return name
+	}
+	return "knomit-" + name
 }
 
 // isOwnedByIntegration reports whether dstRel is a file that the integration

--- a/tools/bridge/claude/init.go
+++ b/tools/bridge/claude/init.go
@@ -270,10 +270,20 @@ func printSummary(created, overwritten, conflicts []string) {
 	}
 	for _, c := range conflicts {
 		fmt.Printf("WARNING: %s exists — merge from %s manually\n", c, companionRel(c))
-		if c == "CLAUDE.md" {
+		switch c {
+		case "CLAUDE.md":
 			if note := claudeMdBlockNote(c); note != "" {
 				fmt.Printf("         %s\n", note)
 			}
+		case ".mcp.json":
+			// Deriving the key makes two knomit servers MERGEABLE, and the
+			// obvious merge — both entries side by side — is exactly what
+			// disables the hooks, since there is then no single repo to bind
+			// to. Say so here; the user finds out otherwise only by noticing
+			// that knomit went quiet.
+			fmt.Println("         note: keep ONE knomit entry — a project with two knomit")
+			fmt.Println("         servers has no single repo to bind to, so the hooks disable")
+			fmt.Println("         themselves (the MCP tools still work for both).")
 		}
 	}
 }
@@ -286,6 +296,9 @@ func printSummary(created, overwritten, conflicts []string) {
 const (
 	blockMarkerPrefix  = "<!-- knomit:integration"
 	blockMarkerCurrent = "<!-- knomit:integration v2 -->"
+	// blockHeading identifies a block whose marker is missing entirely —
+	// pre-marker installs, or a user who stripped the HTML comments.
+	blockHeading = "## Working with knomit memory"
 )
 
 // claudeMdBlockNote reports how the CLAUDE.md already on disk compares to the
@@ -300,7 +313,10 @@ func claudeMdBlockNote(path string) string {
 	switch {
 	case strings.Contains(content, blockMarkerCurrent):
 		return ""
-	case strings.Contains(content, blockMarkerPrefix):
+	case strings.Contains(content, blockMarkerPrefix), strings.Contains(content, blockHeading):
+		// The heading is checked too: the template shipped without the HTML
+		// marker until c36015e7, and users strip comments. Calling such a block
+		// absent would advise appending a SECOND full copy.
 		return "its knomit block is from an older version — replace the whole block, not just parts"
 	default:
 		return "it has no knomit block yet — append the companion's contents"

--- a/tools/bridge/claude/init_test.go
+++ b/tools/bridge/claude/init_test.go
@@ -245,9 +245,9 @@ func TestRunInit_RepoMode_McpJsonArgsAreExactlyRepo(t *testing.T) {
 	}
 }
 
-// TestServerKey pins the derivation, including the no-stutter rule: a repo or
-// lens already carrying the knomit prefix keeps its own name, so this repo stays
-// on the key "knomit" rather than becoming "knomit-knomit".
+// TestServerKey pins the derivation. The prefix is unconditional: see
+// TestServerKey_IsInjective for why the tempting no-stutter special case is
+// wrong.
 func TestServerKey(t *testing.T) {
 	for _, tc := range []struct {
 		name, repo, lens, want string
@@ -255,10 +255,9 @@ func TestServerKey(t *testing.T) {
 		{"repo scoping prefixes", "team-kb", "", "knomit-team-kb"},
 		{"lens scoping prefixes", "team-kb", "eng", "knomit-eng"},
 		{"lens wins over repo", "team-kb", "eng", "knomit-eng"},
-		{"repo named knomit does not stutter", "knomit", "", "knomit"},
-		{"lens named knomit does not stutter", "team-kb", "knomit", "knomit"},
-		{"knomit-prefixed lens kept as-is", "team-kb", "knomit-dev", "knomit-dev"},
-		{"knomit-prefixed repo kept as-is", "knomit-web", "", "knomit-web"},
+		{"repo named knomit still prefixes", "knomit", "", "knomit-knomit"},
+		{"already-prefixed name prefixes again", "knomit-web", "", "knomit-knomit-web"},
+		{"knomit substring is not special", "knomitten", "", "knomit-knomitten"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := serverKey(tc.repo, tc.lens); got != tc.want {
@@ -268,41 +267,103 @@ func TestServerKey(t *testing.T) {
 	}
 }
 
-// TestRunInit_TwoScopesProduceDistinctKeys is the regression test for the whole
-// point of deriving the key: two knomit servers must be able to coexist in one
-// project. Before this, both scaffolds emitted "knomit" and the second clobbered
-// the first.
-func TestRunInit_TwoScopesProduceDistinctKeys(t *testing.T) {
-	keyOf := func(t *testing.T, args ...string) string {
-		t.Helper()
+// TestRunInit_ScaffoldedConfigBindsHooks is the test whose absence let a real
+// bug through: every mcpBinding test hand-builds .mcp.json with a literal key,
+// so none of them noticed when runInit stopped emitting that key. This pipes
+// runInit's actual output into mcpBinding.
+//
+// The failure it guards is silent: mcpBinding used to select the server by the
+// constant key "knomit", so a derived key made it fall through to the basename
+// fallback — repo mode against a directory-named repo, or (worse) a LENS-scoped
+// project demoted to a basename repo, which is the wrong-repo hazard
+// mcpBinding's contract says must never happen.
+func TestRunInit_ScaffoldedConfigBindsHooks(t *testing.T) {
+	t.Run("repo scope binds to the configured repo", func(t *testing.T) {
 		dir := t.TempDir()
 		chdir(t, dir)
-		if err := runInit(args); err != nil {
-			t.Fatalf("runInit %v: %v", args, err)
+		if err := runInit([]string{"--repo", "team-kb"}); err != nil {
+			t.Fatalf("runInit: %v", err)
 		}
-		raw, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
-		if err != nil {
-			t.Fatalf("read .mcp.json: %v", err)
+		repo, lens, ambiguous := mcpBinding(dir)
+		if ambiguous {
+			t.Fatal("single server reported as ambiguous")
 		}
-		var cfg struct {
-			McpServers map[string]json.RawMessage `json:"mcpServers"`
+		if lens != "" {
+			t.Errorf("lens = %q, want empty (repo scope)", lens)
 		}
-		if err := json.Unmarshal(raw, &cfg); err != nil {
-			t.Fatalf(".mcp.json does not parse: %v\n%s", err, raw)
+		if repo != "team-kb" {
+			t.Errorf("repo = %q, want %q — hooks would bind to the wrong repo", repo, "team-kb")
 		}
-		if len(cfg.McpServers) != 1 {
-			t.Fatalf("want exactly one server, got %d", len(cfg.McpServers))
+		if repo == filepath.Base(dir) {
+			t.Error("repo fell back to the directory basename; the --repo flag was ignored")
 		}
-		for k := range cfg.McpServers {
-			return k
-		}
-		return ""
-	}
+	})
 
-	a := keyOf(t, "--repo", "codebase")
-	b := keyOf(t, "--lens", "agentic")
-	if a == b {
-		t.Fatalf("both scopes produced the same mcpServers key %q — two knomit servers cannot coexist", a)
+	t.Run("lens scope never falls back to the basename", func(t *testing.T) {
+		dir := t.TempDir()
+		chdir(t, dir)
+		if err := runInit([]string{"--lens", "eng"}); err != nil {
+			t.Fatalf("runInit: %v", err)
+		}
+		repo, lens, ambiguous := mcpBinding(dir)
+		if ambiguous {
+			t.Fatal("single server reported as ambiguous")
+		}
+		if lens != "eng" {
+			t.Errorf("lens = %q, want %q", lens, "eng")
+		}
+		if repo != "" {
+			t.Errorf("repo = %q, want empty — a lens-scoped project must never "+
+				"resolve to a repo, least of all the directory basename", repo)
+		}
+	})
+}
+
+// TestMcpBinding_MultipleKnomitServers pins the fail-safe for the configuration
+// this PR makes possible for the first time. With two knomit servers there is no
+// principled answer to "which repo do the hooks bind to?", so binding must skip
+// with a stated reason rather than pick one and risk running post-edit against
+// the wrong repo.
+func TestMcpBinding_MultipleKnomitServers(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `{"mcpServers":{
+		"knomit-codebase":{"command":"knomit-bridge","args":["--repo","codebase"]},
+		"knomit-agentic":{"command":"knomit-bridge","args":["--lens","agentic"]}
+	}}`
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo, lens, ambiguous := mcpBinding(dir)
+	if !ambiguous {
+		t.Fatalf("two knomit servers not reported as ambiguous (repo=%q lens=%q)", repo, lens)
+	}
+	if repo != "" || lens != "" {
+		t.Errorf("ambiguous binding leaked a target: repo=%q lens=%q", repo, lens)
+	}
+	if got, want := mustSkipReason(t, dir), "multiple_knomit_servers"; got != want {
+		t.Errorf("skip reason = %q, want %q", got, want)
+	}
+}
+
+func mustSkipReason(t *testing.T, dir string) string {
+	t.Helper()
+	_, skip := resolveWriteRepo(dir)
+	return skip
+}
+
+// TestRunInit_RejectsOverlongDerivedKey guards the tool-name ceiling. The key
+// used to be a 6-char constant so this was unreachable; it now derives from a
+// repo name that defaults to the directory basename.
+func TestRunInit_RejectsOverlongDerivedKey(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	long := strings.Repeat("a", maxServerKeyRunes)
+	err := runInit([]string{"--repo", long})
+	if err == nil {
+		t.Fatalf("runInit accepted a repo name yielding a %d-char key", len(serverKey(long, "")))
+	}
+	if !strings.Contains(err.Error(), "server key") {
+		t.Errorf("error %q does not explain the key-length limit", err)
 	}
 }
 

--- a/tools/bridge/claude/init_test.go
+++ b/tools/bridge/claude/init_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -236,34 +237,74 @@ func TestRunInit_RepoMode_McpJsonArgsAreExactlyRepo(t *testing.T) {
 	// constant made a second `claude init` collide and is why two knomit
 	// servers could never coexist in one project.
 	if _, stale := cfg.McpServers["knomit"]; stale {
-		t.Errorf(`.mcp.json still uses the constant key "knomit"; want %q`, "knomit-team-kb")
+		t.Errorf(`.mcp.json still uses the constant key "knomit"; want %q`, "knomit-repo-team-kb")
 	}
-	got := cfg.McpServers["knomit-team-kb"].Args
+	got := cfg.McpServers["knomit-repo-team-kb"].Args
 	want := []string{"--repo", "team-kb"}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("knomit-team-kb args = %v, want %v", got, want)
+		t.Errorf("knomit-repo-team-kb args = %v, want %v", got, want)
 	}
 }
 
-// TestServerKey pins the derivation. The prefix is unconditional: see
-// TestServerKey_IsInjective for why the tempting no-stutter special case is
-// wrong.
+// TestServerKey pins the derivation. The prefix names the axis and is
+// unconditional: see TestServerKey_IsInjective for why both properties matter.
 func TestServerKey(t *testing.T) {
 	for _, tc := range []struct {
 		name, repo, lens, want string
 	}{
-		{"repo scoping prefixes", "team-kb", "", "knomit-team-kb"},
-		{"lens scoping prefixes", "team-kb", "eng", "knomit-eng"},
-		{"lens wins over repo", "team-kb", "eng", "knomit-eng"},
-		{"repo named knomit still prefixes", "knomit", "", "knomit-knomit"},
-		{"already-prefixed name prefixes again", "knomit-web", "", "knomit-knomit-web"},
-		{"knomit substring is not special", "knomitten", "", "knomit-knomitten"},
+		{"repo scoping prefixes", "team-kb", "", "knomit-repo-team-kb"},
+		{"lens scoping prefixes", "team-kb", "eng", "knomit-lens-eng"},
+		{"lens wins over repo", "team-kb", "eng", "knomit-lens-eng"},
+		{"repo named knomit still prefixes", "knomit", "", "knomit-repo-knomit"},
+		{"already-prefixed name prefixes again", "knomit-web", "", "knomit-repo-knomit-web"},
+		{"knomit substring is not special", "knomitten", "", "knomit-repo-knomitten"},
+		{"repo named after the other axis", "lens-eng", "", "knomit-repo-lens-eng"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := serverKey(tc.repo, tc.lens); got != tc.want {
 				t.Errorf("serverKey(%q, %q) = %q, want %q", tc.repo, tc.lens, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestServerKey_IsInjective pins the property the whole derivation exists for:
+// distinct scopes must never produce the same .mcp.json key. Duplicate keys in
+// one object silently drop an entry, which is exactly the clobbering the derived
+// key replaced — so a collision here is not cosmetic.
+//
+// Two tempting simplifications both break it, and both are covered:
+//
+//   - Sharing one `knomit-` prefix across the axes. Repos and lenses are
+//     separate namespaces validated by the same repos.IsValidName, so a repo and
+//     a lens may share a name; `--repo eng` and `--lens eng` would then collide.
+//   - Skipping the prefix when the name already carries it, to avoid
+//     `knomit-repo-knomit`. That is many-to-one by construction.
+//
+// The name set below is deliberately adversarial: names that already carry the
+// product prefix, and names that spell the OTHER axis marker.
+func TestServerKey_IsInjective(t *testing.T) {
+	names := []string{
+		"eng", "web", "knomit", "knomit-web", "knomitten",
+		"lens-eng", "repo-eng", "lens", "repo", "knomit-lens-eng",
+	}
+	type scope struct{ repo, lens string }
+	seen := make(map[string]scope, 2*len(names))
+	for _, n := range names {
+		for _, s := range []scope{{repo: n}, {repo: "unrelated", lens: n}} {
+			key := serverKey(s.repo, s.lens)
+			if prev, dup := seen[key]; dup {
+				t.Errorf("key %q derived from two distinct scopes: {repo:%q lens:%q} and {repo:%q lens:%q}",
+					key, prev.repo, prev.lens, s.repo, s.lens)
+				continue
+			}
+			seen[key] = s
+		}
+	}
+	// The specific collision the axis prefix exists to prevent, asserted
+	// directly so a regression names itself rather than surfacing as a map hit.
+	if repoKey, lensKey := serverKey("eng", ""), serverKey("eng", "eng"); repoKey == lensKey {
+		t.Errorf("repo %q and lens %q both derive %q", "eng", "eng", repoKey)
 	}
 }
 
@@ -357,7 +398,7 @@ func mustSkipReason(t *testing.T, dir string) string {
 func TestRunInit_RejectsOverlongDerivedKey(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
-	long := strings.Repeat("a", maxServerKeyRunes)
+	long := strings.Repeat("a", maxServerKeyLen)
 	err := runInit([]string{"--repo", long})
 	if err == nil {
 		t.Fatalf("runInit accepted a repo name yielding a %d-char key", len(serverKey(long, "")))
@@ -365,6 +406,112 @@ func TestRunInit_RejectsOverlongDerivedKey(t *testing.T) {
 	if !strings.Contains(err.Error(), "server key") {
 		t.Errorf("error %q does not explain the key-length limit", err)
 	}
+	// The remedy has to be actionable: repo mode can trip this with no flag at
+	// all (the name defaults to the directory basename), so the message must
+	// quote the name budget and say the repo need not match the directory.
+	for _, want := range []string{
+		fmt.Sprintf("max %d", maxScopeNameLen),
+		"--repo",
+		"need not match the directory",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestRunInit_AcceptsMaxLengthScopeName pins the other side of the boundary: a
+// name at exactly the budget must still scaffold. Without it, tightening the
+// prefix would silently shrink the accepted range with no test failing.
+func TestRunInit_AcceptsMaxLengthScopeName(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	name := strings.Repeat("a", maxScopeNameLen)
+	if err := runInit([]string{"--repo", name}); err != nil {
+		t.Fatalf("runInit rejected a %d-char repo name at the documented max: %v", len(name), err)
+	}
+	if got := len(serverKey(name, "")); got != maxServerKeyLen {
+		t.Errorf("key for a max-length name is %d chars, want exactly %d — "+
+			"maxScopeNameLen and the axis prefix have drifted apart", got, maxServerKeyLen)
+	}
+}
+
+// TestBlockMarkerCurrent_ComesFromTemplate ties "current" to the shipped
+// template. The constant it replaced was a hand-copy of the template's first
+// line, and nothing failed when the two drifted: bump the template alone and a
+// freshly merged block reports as stale forever, bump the copy alone and every
+// install reports as current. Both directions are silent, which is the same
+// failure the version marker exists to prevent.
+func TestBlockMarkerCurrent_ComesFromTemplate(t *testing.T) {
+	if blockMarkerCurrent == "" {
+		t.Fatalf("%s has no %q marker on its first line, so claudeMdBlockNote "+
+			"can no longer recognise a current block", claudeMdBlockTemplate, blockMarkerPrefix)
+	}
+	data, err := templatesFS.ReadFile(claudeMdBlockTemplate)
+	if err != nil {
+		t.Fatalf("read %s: %v", claudeMdBlockTemplate, err)
+	}
+	first, _, _ := strings.Cut(string(data), "\n")
+	if got := strings.TrimSpace(first); got != blockMarkerCurrent {
+		t.Errorf("blockMarkerCurrent = %q, template first line = %q", blockMarkerCurrent, got)
+	}
+	if !strings.HasPrefix(blockMarkerCurrent, blockMarkerPrefix) {
+		t.Errorf("marker %q does not start with %q, so the older-version arm "+
+			"of claudeMdBlockNote can never fire", blockMarkerCurrent, blockMarkerPrefix)
+	}
+}
+
+// TestClaudeMdBlockNote covers the merge advice, which had no test at all. The
+// three outcomes give materially different instructions — replace the block,
+// append it, or say nothing — so getting one wrong tells the user to duplicate
+// or to skip a needed merge.
+func TestClaudeMdBlockNote(t *testing.T) {
+	block, err := templatesFS.ReadFile(claudeMdBlockTemplate)
+	if err != nil {
+		t.Fatalf("read %s: %v", claudeMdBlockTemplate, err)
+	}
+	for _, tc := range []struct {
+		name, content, want string
+	}{
+		{"current block says nothing", "# Project\n\n" + string(block), ""},
+		{
+			"older marker asks for a whole-block replace",
+			"# Project\n\n<!-- knomit:integration v1 -->\n" + blockHeading + "\n\nold text\n",
+			"older version",
+		},
+		{
+			// The template shipped without the HTML marker until c36015e7, and
+			// users strip comments. Calling such a block absent would advise
+			// appending a SECOND full copy.
+			"marker-less block is recognised by its heading",
+			"# Project\n\n" + blockHeading + "\n\nold text\n",
+			"older version",
+		},
+		{"no block at all asks for an append", "# Project\n\nnothing knomit here\n", "no knomit block"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "CLAUDE.md")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			got := claudeMdBlockNote(path)
+			if tc.want == "" {
+				if got != "" {
+					t.Errorf("note = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("note = %q, want it to mention %q", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("unreadable file says nothing", func(t *testing.T) {
+		if got := claudeMdBlockNote(filepath.Join(t.TempDir(), "absent.md")); got != "" {
+			t.Errorf("note = %q, want empty for a missing file", got)
+		}
+	})
 }
 
 func TestRunInit_Lens_WritesLensScopedMcpJson(t *testing.T) {

--- a/tools/bridge/claude/init_test.go
+++ b/tools/bridge/claude/init_test.go
@@ -232,10 +232,77 @@ func TestRunInit_RepoMode_McpJsonArgsAreExactlyRepo(t *testing.T) {
 	if err := json.Unmarshal(mcp, &cfg); err != nil {
 		t.Fatalf(".mcp.json does not parse: %v\n%s", err, mcp)
 	}
-	got := cfg.McpServers["knomit"].Args
+	// The key is DERIVED from the scope, not the constant "knomit" — that
+	// constant made a second `claude init` collide and is why two knomit
+	// servers could never coexist in one project.
+	if _, stale := cfg.McpServers["knomit"]; stale {
+		t.Errorf(`.mcp.json still uses the constant key "knomit"; want %q`, "knomit-team-kb")
+	}
+	got := cfg.McpServers["knomit-team-kb"].Args
 	want := []string{"--repo", "team-kb"}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("knomit args = %v, want %v", got, want)
+		t.Errorf("knomit-team-kb args = %v, want %v", got, want)
+	}
+}
+
+// TestServerKey pins the derivation, including the no-stutter rule: a repo or
+// lens already carrying the knomit prefix keeps its own name, so this repo stays
+// on the key "knomit" rather than becoming "knomit-knomit".
+func TestServerKey(t *testing.T) {
+	for _, tc := range []struct {
+		name, repo, lens, want string
+	}{
+		{"repo scoping prefixes", "team-kb", "", "knomit-team-kb"},
+		{"lens scoping prefixes", "team-kb", "eng", "knomit-eng"},
+		{"lens wins over repo", "team-kb", "eng", "knomit-eng"},
+		{"repo named knomit does not stutter", "knomit", "", "knomit"},
+		{"lens named knomit does not stutter", "team-kb", "knomit", "knomit"},
+		{"knomit-prefixed lens kept as-is", "team-kb", "knomit-dev", "knomit-dev"},
+		{"knomit-prefixed repo kept as-is", "knomit-web", "", "knomit-web"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := serverKey(tc.repo, tc.lens); got != tc.want {
+				t.Errorf("serverKey(%q, %q) = %q, want %q", tc.repo, tc.lens, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunInit_TwoScopesProduceDistinctKeys is the regression test for the whole
+// point of deriving the key: two knomit servers must be able to coexist in one
+// project. Before this, both scaffolds emitted "knomit" and the second clobbered
+// the first.
+func TestRunInit_TwoScopesProduceDistinctKeys(t *testing.T) {
+	keyOf := func(t *testing.T, args ...string) string {
+		t.Helper()
+		dir := t.TempDir()
+		chdir(t, dir)
+		if err := runInit(args); err != nil {
+			t.Fatalf("runInit %v: %v", args, err)
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
+		if err != nil {
+			t.Fatalf("read .mcp.json: %v", err)
+		}
+		var cfg struct {
+			McpServers map[string]json.RawMessage `json:"mcpServers"`
+		}
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			t.Fatalf(".mcp.json does not parse: %v\n%s", err, raw)
+		}
+		if len(cfg.McpServers) != 1 {
+			t.Fatalf("want exactly one server, got %d", len(cfg.McpServers))
+		}
+		for k := range cfg.McpServers {
+			return k
+		}
+		return ""
+	}
+
+	a := keyOf(t, "--repo", "codebase")
+	b := keyOf(t, "--lens", "agentic")
+	if a == b {
+		t.Fatalf("both scopes produced the same mcpServers key %q — two knomit servers cannot coexist", a)
 	}
 }
 

--- a/tools/bridge/claude/templates/CLAUDE-md-block.txt
+++ b/tools/bridge/claude/templates/CLAUDE-md-block.txt
@@ -1,11 +1,11 @@
-<!-- knomit:integration -->
+<!-- knomit:integration v2 -->
 ## Working with knomit memory
 
 This project uses knomit as long-term memory. Eleven `/knomit-…` slash commands
 wrap knomit's MCP tools. Use them in these moments:
 
 **Before non-trivial work** — call `/knomit-recall <area>` before:
-- Editing or writing files under <KNOWN_INVARIANT_PATHS>
+- Editing or writing code in an area you have not already recalled for this session
 - Picking where new code goes
 - Implementing a pattern that may already exist
 - Answering "why does X work this way?"

--- a/tools/bridge/claude/templates/mcp.json.lens.tmpl
+++ b/tools/bridge/claude/templates/mcp.json.lens.tmpl
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "knomit": {
+    {{jsonStr .ServerKey}}: {
       "command": "knomit-bridge",
       "args": ["--lens", {{jsonStr .Lens}}]
     }

--- a/tools/bridge/claude/templates/mcp.json.tmpl
+++ b/tools/bridge/claude/templates/mcp.json.tmpl
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "knomit": {
+    {{jsonStr .ServerKey}}: {
       "command": "knomit-bridge",
       "args": ["--repo", {{jsonStr .RepoName}}]
     }

--- a/tools/bridge/claude/templates/skills/knomit-bootstrap/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-bootstrap/SKILL.md
@@ -51,7 +51,7 @@ Word every draft against the body authoring contract in /knomit-remember: name e
 
 Bootstrapping is high-leverage and high-blast-radius. Show drafts as a list (title + 1-line body summary + topic/category) and ask for approval before writing. **Don't write unilaterally.** A bad bootstrap pollutes the corpus and biases all future recall in the area.
 
-### Step 4 — Write approved facts via `mcp__knomit__knomit_learn`
+### Step 4 — Write approved facts via `knomit_learn`
 
 Single batched `knomit_learn` call with all approved facts. Suggested defaults:
 

--- a/tools/bridge/claude/templates/skills/knomit-decided/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-decided/SKILL.md
@@ -44,7 +44,7 @@ Before writing the code/edit the decision authorized, summarize into three parts
 3. **The choice** — concrete decision
 4. **Non-scope** (when foreseeable) — one line on what the decision does NOT authorize. Decisions compress into "we always do X" slogans; if the choice was conditional on context, name the boundary so it isn't stretched later.
 
-Then call `mcp__knomit__knomit_learn` with:
+Then call `knomit_learn` with:
 
 - `topic`: `decisions`
 - `category`: `<area>/<slug>` (e.g. `synthesize/sumproductnorm-default`)

--- a/tools/bridge/claude/templates/skills/knomit-hypothesize/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-hypothesize/SKILL.md
@@ -22,7 +22,7 @@ DON'T invoke:
 
 ## How
 
-Call `mcp__knomit__knomit_hypothesize` with no args to start a session. The tool returns one synthesis fact at a time with a `prompt` and `response_schema`.
+Call `knomit_hypothesize` with no args to start a session. The tool returns one synthesis fact at a time with a `prompt` and `response_schema`.
 
 For each item:
 

--- a/tools/bridge/claude/templates/skills/knomit-principle/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-principle/SKILL.md
@@ -21,7 +21,7 @@ Fire ONLY when the user runs `/knomit-principle` explicitly. Never invoke proact
    - An area path (e.g. `store/resolver`) — surfaces only when `/knomit-recall` touches that area or any parent.
 3. Ask the user for the **title** (short, imperative — the principle as a statement).
 4. Ask the user for the **body** (rationale, scope of applicability, examples of what NOT to do).
-5. Call `mcp__knomit__knomit_learn` with:
+5. Call `knomit_learn` with:
    - `topic`: `principles`
    - `category`: `<bucket>/<slug>` (where `<slug>` is the argument the user passed to `/knomit-principle`)
    - `title`: the user's title

--- a/tools/bridge/claude/templates/skills/knomit-recall/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-recall/SKILL.md
@@ -59,7 +59,7 @@ DON'T fire for:
 
 ## How
 
-Call `mcp__knomit__knomit_query` with:
+Call `knomit_query` with:
 
 - `text`: the user-supplied topic (or your own one-line summary of the area)
 - `entities`: any file paths currently open or about to be edited

--- a/tools/bridge/claude/templates/skills/knomit-remember/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-remember/SKILL.md
@@ -24,9 +24,9 @@ DON'T fire for:
 
 ## How
 
-1. Run `mcp__knomit__knomit_query` on the would-be title to surface similar or contradicting existing facts.
+1. Run `knomit_query` on the would-be title to surface similar or contradicting existing facts.
 2. If a contradicting fact exists: ASK the user whether to `/knomit-update`, `/knomit-retract`, or merge — don't write a duplicate.
-3. Otherwise call `mcp__knomit__knomit_learn` with: `topic`, `category`, `title`, `body`, `kind` (default epistemic), `type` (default observation; use `hypothesis` for predictions), `entities`, `refs`, `confidence` 0.85.
+3. Otherwise call `knomit_learn` with: `topic`, `category`, `title`, `body`, `kind` (default epistemic), `type` (default observation; use `hypothesis` for predictions), `entities`, `refs`, `confidence` 0.85.
 
 ## Body authoring contract — write it so it can't compress into a falsehood
 

--- a/tools/bridge/claude/templates/skills/knomit-retract/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-retract/SKILL.md
@@ -20,7 +20,7 @@ DON'T use for:
 
 ## How
 
-Call `mcp__knomit__knomit_retract` with:
+Call `knomit_retract` with:
 
 - `file`: the fact path (e.g. `kb/decisions/.../<uuid>.md`)
 - `moment_name`: short label explaining why (e.g. `"synthesize/recipes deleted in 0938d83"`)

--- a/tools/bridge/claude/templates/skills/knomit-review/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-review/SKILL.md
@@ -28,14 +28,14 @@ DON'T invoke:
 
 `knomit_review` is a **work-stealing session**, not an async task. The tool returns ONE work item at a time. The calling model burns its own cycles processing each item until the queue drains.
 
-1. First call: `mcp__knomit__knomit_review` with no args.
+1. First call: `knomit_review` with no args.
    - Returns `{session_id, work_item: {prompt, response_schema}}` for the first item, OR `{session_id, done: true}` if nothing dirty.
 2. Process the work item:
    - Read the `prompt` and produce a JSON response matching `response_schema`.
    - For prune items: decide which facts to merge (and the merged content) vs keep distinct.
    - For distill items: decide whether to synthesize a higher-level fact from the cluster, and write its content.
    - For reflect items: emit hypothesis transitions and optionally one methodology.
-3. Continue: `mcp__knomit__knomit_review` with `session_id` and `response`.
+3. Continue: `knomit_review` with `session_id` and `response`.
    - Server applies your decisions (writes new facts, retracts duplicates) and returns the next work item.
 4. Loop until response includes `done: true` — that completes the session and advances the watermark.
 

--- a/tools/bridge/claude/templates/skills/knomit-update/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-update/SKILL.md
@@ -20,7 +20,7 @@ DON'T use for:
 
 ## How
 
-Call `mcp__knomit__knomit_update` with:
+Call `knomit_update` with:
 
 - `file`: the fact path (e.g. `kb/decisions/synthesize/.../<uuid>.md`)
 - `moment_name`: short label (e.g. `"post-rename dirtyFacts → dirty"`)

--- a/tools/bridge/claude/templates/skills/knomit-why/SKILL.md
+++ b/tools/bridge/claude/templates/skills/knomit-why/SKILL.md
@@ -19,13 +19,13 @@ DON'T fire for:
 
 ## How
 
-Call `mcp__knomit__knomit_explain` with the fact path. The tool returns:
+Call `knomit_explain` with the fact path. The tool returns:
 
 - The fact's own body
 - Outgoing refs (what this fact references — both source files and other facts), classified as `local` (other fact paths) and `external` (URLs, src:// anchors)
 - All resolved at the fact's anchor commit, NOT at HEAD
 
-`knomit_explain` does NOT return incoming references (no backlink index). If you need to find facts that reference this one, use `mcp__knomit__knomit_query` with the fact path as a search term.
+`knomit_explain` does NOT return incoming references (no backlink index). If you need to find facts that reference this one, use `knomit_query` with the fact path as a search term.
 
 Walk the source-file refs:
 


### PR DESCRIPTION
## Problem

`claude init` was structurally single-server. Both mcp.json templates emitted the literal `mcpServers` key `"knomit"`, so a second `claude init` in the same project collided on that key — two knomit servers could never coexist, which is exactly the configuration a repo + lens setup wants.

Compounding it, ten of the eleven skills hardcoded the fully-qualified tool name `mcp__knomit__knomit_<tool>`, which only worked *because* that key was constant.

## Change

**Derive the key from the scope.** `serverKey(repoName, lens)` returns `knomit-<lens>` when a lens is given, `knomit-<repo>` otherwise. The prefix is applied **unconditionally** so the mapping is injective — distinct scopes can never collide.

**Nothing looks the server up by key any more.** `mcpBinding` selects by `command` basename `knomit-bridge`. The command is what identifies a knomit server; the key is now free to vary, which is the point.

**Skills use bare tool names.** `knomit_learn`, not `mcp__knomit__knomit_learn` — resolves under any key, cannot rot. 26 occurrences across 11 skills, in both `.claude/skills/` and the shipped templates.

**Ambiguity fails safe.** Two knomit servers in one project is newly possible and has no principled answer to "which repo do the hooks bind to?". `mcpBinding` reports ambiguity and `resolveWriteRepo` skips with `multiple_knomit_servers` rather than guessing and running post-edit against the wrong repo.

### Ordering matters

De-qualifying the skills had to land **before** the key change. The reverse order leaves a window where the key has changed but every skill names a tool that does not exist — and a model facing an unresolvable tool name invents a plausible one rather than asking.

### Existing installs are unaffected

`.mcp.json` is merge-required: when it already exists, `init` writes a `.mcp.json.knomit` companion and reports a conflict rather than overwriting. Nothing is rewritten in place; the user merges.

## Also

- `<KNOWN_INVARIANT_PATHS>` was a placeholder no Go code ever substituted. It shipped verbatim, leaving the most important recall trigger unactionable in every session. Replaced with a self-contained condition.
- The block marker is versioned (`knomit:integration v2`) **and consumed** — `init` now reports whether an existing `CLAUDE.md` has a current block, a stale one, or none. An unread version marker is how the block drifted in the first place ("Nine" installed vs "Eleven" in the template).
- Reject a derived key long enough to push `mcp__<key>__knomit_hypothesize` past the 64-char tool-name limit. Unreachable before (6-char constant); reachable now, since the repo name defaults to the directory basename.
- `tools/bridge/README.md` documented the old constant key.

## Review round

A high-effort review caught that the first commit **silently unbound every Claude Code hook**: `mcpBinding` still read `cfg.MCPServers["knomit"]`, so a derived key fell through to the basename fallback — `--repo` ignored, and a lens-scoped project demoted to repo mode, the exact wrong-repo hazard `mcpBinding`'s contract forbids. It went unnoticed because the only project dogfooding this is named `knomit`, and because every `mcpBinding` test hand-built `.mcp.json` with the literal key instead of going through `runInit`. There is now a test that pipes `runInit` output into `mcpBinding` for both scopes.

The review also flagged the original no-stutter rule as non-injective. It was worse than reported — even the suggested `knomit-` separator predicate still collided (`web` and `knomit-web` both → `knomit-web`), so the special case is gone entirely.

## Verification

- `go build ./...` clean; no failures across `./tools/...`, `./internal/mcp/...`, `./internal/repos/...`.
- New: `TestServerKey`, `TestServerKey_IsInjective`, `TestRunInit_ScaffoldedConfigBindsHooks` (the regression the review found), `TestMcpBinding_MultipleKnomitServers`, `TestRunInit_RejectsOverlongDerivedKey`.
- End-to-end: scaffolding `--repo` then `--lens` in one project yields two distinct keys; hooks bind correctly for both scopes; stale/missing/current `CLAUDE.md` blocks each report correctly.

## Context

First of several changes from a measurement session on knomit's Claude Code integration. Routing *between* connected knomit servers was measured to be correct already (zero misroutes in 630 calls), so this PR deliberately contains no tool-description work — the scaffolding collision was the whole multi-server blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)