### PR TITLE
feat(mcp): stamp the write destination on every write result

### DIFF
--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -450,6 +450,24 @@ func applyDedupMerge(
 	// commit that wrote them; the ref gate must not re-judge them just because
 	// a merge is rewriting the file that carries them.
 	priorRefs := make(map[string][]string)
+	// An existing fact absorbs at most ONE incoming fact per call. Search runs
+	// with Limit: 1, so two inputs in the same category directory can both come
+	// back pointing at the same existing fact — and without this set the second
+	// one retargets paths[i] onto a path the first already claimed, AFTER the
+	// duplicate-path guard in the handler has run and can no longer see it.
+	// That is the exact loss that guard describes: one file, two commit
+	// entries, one body silently gone, and a summary that reports both as
+	// written. It also double-lists a subsumed hypothesis in retract.
+	//
+	// A second matcher is SKIPPED rather than chained onto the in-progress
+	// merge — the same choice applyGreedyMerges makes with its `consumed` set
+	// ("each fact index participates in at most one merge"). Skipping writes
+	// the fact at its own freshly-minted path: two near-duplicates land instead
+	// of one, which a later review prune collapses. Chaining would instead pick
+	// a tiebreak winner among three bodies and drop two, silently, inside a
+	// call the caller thinks wrote everything it sent. A redundant fact is
+	// recoverable; a discarded one is not.
+	consumed := make(map[string]bool)
 
 	for i, f := range facts {
 		// Private-state facts are not knowledge and have no category
@@ -487,6 +505,10 @@ func applyDedupMerge(
 		}
 
 		match := results[0]
+		if consumed[match.Path] {
+			// Already absorbed an earlier fact in this call — see `consumed`.
+			continue
+		}
 		// Read existing fact to get its full metadata (refs, etc.)
 		readResult, readErr := s.facts.ReadFact(ctx, agentBranch, match.Path, nil)
 		if readErr != nil {
@@ -502,6 +524,7 @@ func applyDedupMerge(
 		// observation is written at its OWN path — it is a new fact, not a
 		// revision of the prediction it settles.
 		if existingFact.Type == fact.Hypothesis && f.Type != fact.Hypothesis {
+			consumed[match.Path] = true
 			f, retract = subsumeHypothesis(f, retract, match.Path)
 			facts[i] = f
 			if err := reserialize(files, paths[i], f); err != nil {
@@ -540,6 +563,7 @@ func applyDedupMerge(
 		// f.Path() here removed a key that was never inserted (the build stage
 		// keyed by the raw path), so the merge left the new-fact file in place
 		// and the commit wrote BOTH the original and the merged file.
+		consumed[match.Path] = true
 		delete(files, paths[i])
 		paths[i] = match.Path
 		priorRefs[match.Path] = existingFact.Refs

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -754,8 +754,11 @@ func LearnHandler(embedders ...store.BatchEmbedder) func(context.Context, mcpgo.
 			commits[i] = commitEntry{File: f.Path(), Hash: hash}
 		}
 
+		dest := describeWriteDestination(b)
 		result := map[string]interface{}{
-			"commits": commits,
+			"commits":    commits,
+			"written_to": dest,
+			"summary":    dest.summary(pluralFacts(len(facts))),
 		}
 		out, err := json.Marshal(result)
 		if err != nil {

--- a/internal/mcp/learn_test.go
+++ b/internal/mcp/learn_test.go
@@ -259,6 +259,61 @@ func TestLearnHandler_DedupMergePreservesKind(t *testing.T) {
 	require.Equal(t, 2, merged.Sources, "merge sums sources")
 }
 
+// TestLearnHandler_DedupMergeOneExistingFactAbsorbsOneIncoming regresses the
+// collision the handler's duplicate-path guard cannot see. That guard runs over
+// the freshly-minted paths; applyDedupMerge retargets paths[i] onto an existing
+// fact's path AFTERWARDS, so two inputs in one category that both match the
+// SAME existing fact used to land on one path — one file written, one body
+// silently gone, two commit entries emitted, and a summary asserting both were
+// written. An existing fact now absorbs at most one incoming fact per call; the
+// second is written at its own path, so nothing the caller sent disappears and
+// the reported count is a count that happened.
+func TestLearnHandler_DedupMergeOneExistingFactAbsorbsOneIncoming(t *testing.T) {
+	svc, ctx, emb := newPrinciplesTestRepo(t)
+
+	r1, err := LearnHandler(emb)(ctx, principleLearnReq("seed", 0.8, []any{"global"}))
+	require.NoError(t, err)
+	require.False(t, r1.IsError, "seed write must succeed: %s", resultText(t, r1))
+	seedPath := mergedFactPath(t, r1)
+
+	// Two facts in ONE call, both canonically identical to the seed, so both
+	// dedup-search back to the same existing fact.
+	req := principleLearnReq("collide", 0.9, []any{"global"})
+	facts := req.Params.Arguments.(map[string]any)["facts"].([]any)
+	req.Params.Arguments.(map[string]any)["facts"] = []any{facts[0], facts[0]}
+
+	r2, err := LearnHandler(emb)(ctx, req)
+	require.NoError(t, err)
+	require.False(t, r2.IsError, "colliding dedup matches must not fail the call: %s", resultText(t, r2))
+
+	var parsed struct {
+		Commits []struct {
+			File string `json:"file"`
+		} `json:"commits"`
+		Summary string `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, r2)), &parsed))
+	require.Len(t, parsed.Commits, 2, "both inputs are accounted for")
+
+	distinct := map[string]bool{}
+	for _, c := range parsed.Commits {
+		distinct[c.File] = true
+	}
+	require.Len(t, distinct, 2,
+		"two inputs collapsed onto one file while the response reported two: %v", parsed.Commits)
+	require.Contains(t, parsed.Summary, "2 facts",
+		"the summary must count what was actually written; got %q", parsed.Summary)
+
+	// One input merged into the seed; the other kept its own freshly-minted
+	// path. Every file the response names must actually carry a body.
+	require.True(t, distinct[seedPath], "one input must still have merged into the existing fact")
+	for file := range distinct {
+		res, rerr := svc.Facts().ReadFact(context.Background(), "agent/test", file, nil)
+		require.NoError(t, rerr, "response named %s but it is not on disk", file)
+		require.NotEmpty(t, res.Content, "%s was written empty", file)
+	}
+}
+
 // TestLearnHandler_DedupMergeReValidates regresses the re-validate step: a
 // merge can produce a rule violation even when both inputs were individually
 // valid. Here a [global] principle and an identically-worded [store]-scoped

--- a/internal/mcp/retract.go
+++ b/internal/mcp/retract.go
@@ -88,9 +88,12 @@ func RetractHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallT
 			return mcpgo.NewToolResultError(fmt.Sprintf("delete error: %v", err)), nil
 		}
 
+		dest := describeWriteDestination(b)
 		result := map[string]interface{}{
-			"file":   file,
-			"commit": hash,
+			"file":       file,
+			"commit":     hash,
+			"written_to": dest,
+			"summary":    dest.summary("1 retraction"),
 		}
 		out, err := json.Marshal(result)
 		if err != nil {

--- a/internal/mcp/update.go
+++ b/internal/mcp/update.go
@@ -232,9 +232,12 @@ func UpdateHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 			return mcpgo.NewToolResultError(fmt.Sprintf("write error: %v", err)), nil
 		}
 
+		dest := describeWriteDestination(b)
 		result := map[string]interface{}{
-			"file":   file,
-			"commit": writeRes.CommitHash,
+			"file":       file,
+			"commit":     writeRes.CommitHash,
+			"written_to": dest,
+			"summary":    dest.summary("1 fact revision"),
 		}
 		out, err := json.Marshal(result)
 		if err != nil {

--- a/internal/mcp/writedest.go
+++ b/internal/mcp/writedest.go
@@ -20,12 +20,27 @@ import (
 // observed bug — it is what makes such a write recoverable instead of silent if
 // one ever happens, and what lets a caller correct itself in the same turn.
 //
+// Identity note: `repo` is the display NAME and `repo_id` is the IDENTITY, and
+// the stamp needs both. A repo has three identifiers with different lifetimes,
+// and the name is the one that is neither stable nor globally unique — it is
+// per-machine, mutable, and unique only among the ACTIVE repos of ONE server.
+// Two connected knomit servers each holding a repo called "knomit" on
+// "agent/main" is the ordinary case, and it is exactly the case this stamp
+// exists to disambiguate: with the name alone, a write to the wrong server
+// renders byte-identically to a write to the right one and the stamp detects
+// nothing. RepoID is the 12-hex root-commit form (RepoInstance.ShortID) —
+// clone-stable, rename-safe, and the same identifier that already appears in
+// kb://<id>/… paths and the knomit_repos mount table. The name stays because
+// prose is what a caller reads; the id is what makes the prose discriminating,
+// and what keeps the stamp's meaning fixed across a rename.
+//
 // Lens shape note: `repo` is always the WRITE repo, never the lens. A lens reads
 // a union but writes to exactly one member, and reporting the lens name as the
 // destination would misdescribe where the bytes are — the lens is reported
 // alongside, as context for why that repo was chosen.
 type writeDestination struct {
 	Repo   string `json:"repo"`
+	RepoID string `json:"repo_id,omitempty"`
 	Branch string `json:"branch"`
 	Lens   string `json:"lens,omitempty"`
 }
@@ -33,10 +48,20 @@ type writeDestination struct {
 // describeWriteDestination reads the destination off the binding. Safe to call
 // only after the handler's WriteOK gate, which is where every write tool
 // resolves its binding.
+//
+// RepoID is omitempty because ShortID returns "" when the store is unavailable
+// and identity is genuinely unknown — an empty string there is honest, and
+// better than a field the caller would read as an id.
 func describeWriteDestination(b *repos.Binding) writeDestination {
 	ri := b.Write()
-	d := writeDestination{Repo: ri.Name(), Branch: ri.AgentBranch()}
-	if b.IsLens() {
+	d := writeDestination{Repo: ri.Name(), RepoID: ri.ShortID(), Branch: ri.AgentBranch()}
+	// FromLens, not IsLens. IsLens asks about federation BREADTH — whether the
+	// binding reads more than its own write repo — which a lens mounting a
+	// single member does not. But that caller still connected THROUGH a lens,
+	// and which connection a write went through is the one thing this stamp
+	// exists to let them confirm; dropping the lens there makes the result
+	// indistinguishable from a direct /repos/{repo}/… connection.
+	if b.FromLens() {
 		d.Lens = b.Name()
 	}
 	return d
@@ -48,11 +73,18 @@ func describeWriteDestination(b *repos.Binding) writeDestination {
 // the result, and the whole point of stamping the destination is that a caller
 // NOTICES an unintended one. Kept to one line so it cannot crowd the result.
 func (d writeDestination) summary(what string) string {
-	if d.Lens != "" {
-		return fmt.Sprintf("wrote %s to repo %q on branch %q — the write repo of lens %q",
-			what, d.Repo, d.Branch, d.Lens)
+	// The id rides in the prose, not only in the struct: a caller comparing two
+	// servers reads the sentence, and a sentence that names only the display
+	// name is the same sentence on both of them.
+	where := fmt.Sprintf("repo %q", d.Repo)
+	if d.RepoID != "" {
+		where = fmt.Sprintf("repo %q (%s)", d.Repo, d.RepoID)
 	}
-	return fmt.Sprintf("wrote %s to repo %q on branch %q", what, d.Repo, d.Branch)
+	if d.Lens != "" {
+		return fmt.Sprintf("wrote %s to %s on branch %q — the write repo of lens %q",
+			what, where, d.Branch, d.Lens)
+	}
+	return fmt.Sprintf("wrote %s to %s on branch %q", what, where, d.Branch)
 }
 
 // pluralFacts renders a fact count for the summary sentence.

--- a/internal/mcp/writedest.go
+++ b/internal/mcp/writedest.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"fmt"
+
+	"knomit/internal/repos"
+)
+
+// writeDestination describes where a write actually landed, so the caller can
+// SEE it rather than infer it.
+//
+// Why this exists: the write destination is a property of the connection, fixed
+// at process start and resolved from the request context — it is deliberately
+// not expressible in model output (a `repo:` parameter would relocate the choice
+// into tool arguments, which the corpus rejects on two separate grounds). That
+// is the right design, but it has a cost: the caller has no way to confirm where
+// a fact went, and a fact written to an unintended repo returns success exactly
+// like one written to the intended repo. Measurement across two connected knomit
+// servers never produced a wrong-server write, so this is not a fix for an
+// observed bug — it is what makes such a write recoverable instead of silent if
+// one ever happens, and what lets a caller correct itself in the same turn.
+//
+// Lens shape note: `repo` is always the WRITE repo, never the lens. A lens reads
+// a union but writes to exactly one member, and reporting the lens name as the
+// destination would misdescribe where the bytes are — the lens is reported
+// alongside, as context for why that repo was chosen.
+type writeDestination struct {
+	Repo   string `json:"repo"`
+	Branch string `json:"branch"`
+	Lens   string `json:"lens,omitempty"`
+}
+
+// describeWriteDestination reads the destination off the binding. Safe to call
+// only after the handler's WriteOK gate, which is where every write tool
+// resolves its binding.
+func describeWriteDestination(b *repos.Binding) writeDestination {
+	ri := b.Write()
+	d := writeDestination{Repo: ri.Name(), Branch: ri.AgentBranch()}
+	if b.IsLens() {
+		d.Lens = b.Name()
+	}
+	return d
+}
+
+// summary renders the destination as a sentence.
+//
+// The structured field alone is not enough: what a model reacts to is prose in
+// the result, and the whole point of stamping the destination is that a caller
+// NOTICES an unintended one. Kept to one line so it cannot crowd the result.
+func (d writeDestination) summary(what string) string {
+	if d.Lens != "" {
+		return fmt.Sprintf("wrote %s to repo %q on branch %q — the write repo of lens %q",
+			what, d.Repo, d.Branch, d.Lens)
+	}
+	return fmt.Sprintf("wrote %s to repo %q on branch %q", what, d.Repo, d.Branch)
+}
+
+// pluralFacts renders a fact count for the summary sentence.
+func pluralFacts(n int) string {
+	if n == 1 {
+		return "1 fact"
+	}
+	return fmt.Sprintf("%d facts", n)
+}

--- a/internal/mcp/writedest_test.go
+++ b/internal/mcp/writedest_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestWriteDestination_Summary pins the sentence the caller actually reads.
+// The structured field is the machine-readable half; this is the half a model
+// reacts to, and the whole point of the stamp is that an unintended
+// destination gets NOTICED rather than returning success indistinguishable
+// from an intended one.
+func TestWriteDestination_Summary(t *testing.T) {
+	t.Run("repo binding names no lens", func(t *testing.T) {
+		d := writeDestination{Repo: "knomit", Branch: "agent/main"}
+		got := d.summary("2 facts")
+		for _, want := range []string{"2 facts", `"knomit"`, `"agent/main"`} {
+			if !strings.Contains(got, want) {
+				t.Errorf("summary %q missing %q", got, want)
+			}
+		}
+		if strings.Contains(got, "lens") {
+			t.Errorf("repo binding mentioned a lens: %q", got)
+		}
+	})
+
+	t.Run("lens binding names the write repo, not the lens, as destination", func(t *testing.T) {
+		d := writeDestination{Repo: "knomit-kb", Branch: "agent/main", Lens: "knomit-dev"}
+		got := d.summary("1 fact")
+		// The repo is where the bytes land; the lens is context for why.
+		// Reporting the lens AS the destination would misdescribe a write, since
+		// a lens reads a union but writes to exactly one member.
+		repoAt := strings.Index(got, `"knomit-kb"`)
+		lensAt := strings.Index(got, `"knomit-dev"`)
+		if repoAt < 0 || lensAt < 0 {
+			t.Fatalf("summary %q must name both the repo and the lens", got)
+		}
+		if repoAt > lensAt {
+			t.Errorf("lens named before the write repo, which reads as the destination: %q", got)
+		}
+	})
+}
+
+// TestWriteDestination_JSONShape pins the wire shape. `lens` is omitempty so a
+// repo-bound write does not carry a misleading empty lens field.
+func TestWriteDestination_JSONShape(t *testing.T) {
+	raw, err := json.Marshal(writeDestination{Repo: "r", Branch: "agent/main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "lens") {
+		t.Errorf("repo-bound destination emitted a lens key: %s", raw)
+	}
+
+	raw, err = json.Marshal(writeDestination{Repo: "r", Branch: "agent/main", Lens: "l"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back writeDestination
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("round-trip: %v", err)
+	}
+	if back.Repo != "r" || back.Branch != "agent/main" || back.Lens != "l" {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+func TestPluralFacts(t *testing.T) {
+	for n, want := range map[int]string{0: "0 facts", 1: "1 fact", 2: "2 facts"} {
+		if got := pluralFacts(n); got != want {
+			t.Errorf("pluralFacts(%d) = %q, want %q", n, got, want)
+		}
+	}
+}

--- a/internal/mcp/writedest_test.go
+++ b/internal/mcp/writedest_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"knomit/internal/repos"
 )
 
 // TestWriteDestination_Summary pins the sentence the caller actually reads.
@@ -13,15 +15,41 @@ import (
 // from an intended one.
 func TestWriteDestination_Summary(t *testing.T) {
 	t.Run("repo binding names no lens", func(t *testing.T) {
-		d := writeDestination{Repo: "knomit", Branch: "agent/main"}
+		d := writeDestination{Repo: "knomit", RepoID: "3ec012f5b4d2", Branch: "agent/main"}
 		got := d.summary("2 facts")
-		for _, want := range []string{"2 facts", `"knomit"`, `"agent/main"`} {
+		for _, want := range []string{"2 facts", `"knomit"`, "3ec012f5b4d2", `"agent/main"`} {
 			if !strings.Contains(got, want) {
 				t.Errorf("summary %q missing %q", got, want)
 			}
 		}
 		if strings.Contains(got, "lens") {
 			t.Errorf("repo binding mentioned a lens: %q", got)
+		}
+	})
+
+	// The name alone does not identify a server: it is per-machine, mutable,
+	// and unique only among ONE server's active repos. Two connected knomit
+	// servers each holding a repo called "knomit" on "agent/main" is the
+	// ordinary case and precisely the one the stamp exists to disambiguate, so
+	// the sentence a caller reads must differ between them.
+	t.Run("same name on two servers reads differently", func(t *testing.T) {
+		a := writeDestination{Repo: "knomit", RepoID: "3ec012f5b4d2", Branch: "agent/main"}
+		b := writeDestination{Repo: "knomit", RepoID: "7b4887ce51d9", Branch: "agent/main"}
+		if a.summary("1 fact") == b.summary("1 fact") {
+			t.Errorf("two different repos produced an identical summary: %q", a.summary("1 fact"))
+		}
+	})
+
+	// ShortID returns "" when the store is unavailable and identity is
+	// genuinely unknown. The sentence must then read as an ordinary sentence,
+	// not one with an empty parenthetical in it.
+	t.Run("unknown id leaves no empty parenthetical", func(t *testing.T) {
+		got := writeDestination{Repo: "knomit", Branch: "agent/main"}.summary("1 fact")
+		if strings.Contains(got, "()") || strings.Contains(got, " ()") {
+			t.Errorf("empty id left a stray parenthetical: %q", got)
+		}
+		if !strings.Contains(got, `repo "knomit" on branch "agent/main"`) {
+			t.Errorf("summary %q lost its shape without an id", got)
 		}
 	})
 
@@ -42,8 +70,10 @@ func TestWriteDestination_Summary(t *testing.T) {
 	})
 }
 
-// TestWriteDestination_JSONShape pins the wire shape. `lens` is omitempty so a
-// repo-bound write does not carry a misleading empty lens field.
+// TestWriteDestination_JSONShape pins the wire shape. `lens` and `repo_id` are
+// omitempty so a repo-bound write carries no misleading empty lens field, and
+// an unresolvable identity is absent rather than an empty string a caller would
+// read as an id.
 func TestWriteDestination_JSONShape(t *testing.T) {
 	raw, err := json.Marshal(writeDestination{Repo: "r", Branch: "agent/main"})
 	if err != nil {
@@ -52,8 +82,11 @@ func TestWriteDestination_JSONShape(t *testing.T) {
 	if strings.Contains(string(raw), "lens") {
 		t.Errorf("repo-bound destination emitted a lens key: %s", raw)
 	}
+	if strings.Contains(string(raw), "repo_id") {
+		t.Errorf("unknown identity emitted a repo_id key: %s", raw)
+	}
 
-	raw, err = json.Marshal(writeDestination{Repo: "r", Branch: "agent/main", Lens: "l"})
+	raw, err = json.Marshal(writeDestination{Repo: "r", RepoID: "3ec012f5b4d2", Branch: "agent/main", Lens: "l"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,8 +94,37 @@ func TestWriteDestination_JSONShape(t *testing.T) {
 	if err := json.Unmarshal(raw, &back); err != nil {
 		t.Fatalf("round-trip: %v", err)
 	}
-	if back.Repo != "r" || back.Branch != "agent/main" || back.Lens != "l" {
+	if back.Repo != "r" || back.RepoID != "3ec012f5b4d2" || back.Branch != "agent/main" || back.Lens != "l" {
 		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+// TestDescribeWriteDestination_StampsRepoID pins that the id on the stamp is
+// the SAME identifier the caller already addresses facts with — the 12-hex
+// root-commit form that appears in kb://<id>/… paths and the knomit_repos mount
+// table — and not the registry uid or the display name, which are different
+// identifiers with different lifetimes.
+func TestDescribeWriteDestination_StampsRepoID(t *testing.T) {
+	svc, _, _ := newPrinciplesTestRepo(t)
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:        "stamped",
+		UID:         nextTestRepoUID(),
+		AgentBranch: "agent/test",
+		Svc:         svc,
+	})
+
+	d := describeWriteDestination(repos.NewBindingOfRepo(ri, ""))
+	if d.Repo != "stamped" || d.Branch != "agent/test" {
+		t.Fatalf("unexpected destination: %+v", d)
+	}
+	if d.RepoID != ri.ShortID() || len(d.RepoID) != 12 {
+		t.Errorf("repo_id = %q, want the 12-hex short id %q", d.RepoID, ri.ShortID())
+	}
+	if d.RepoID == ri.UID() {
+		t.Errorf("repo_id is the registry uid; a uid addresses nothing in a kb:// path")
+	}
+	if d.Lens != "" {
+		t.Errorf("a synthesized repo binding named a lens: %q", d.Lens)
 	}
 }
 

--- a/internal/repos/binding.go
+++ b/internal/repos/binding.go
@@ -100,6 +100,24 @@ func (b *Binding) IsLens() bool {
 	return false
 }
 
+// FromLens reports whether this binding was RESOLVED FROM a persisted lens
+// definition, rather than synthesized for a single repo (the /repos/{repo}/…
+// path). Read off PinID, which is prefixed exactly so the two provenances are
+// distinguishable without a name comparison.
+//
+// Distinct from IsLens, and the difference is load-bearing: IsLens asks about
+// federation BREADTH — does this binding read more than its own write repo —
+// and a lens that mounts a single member federates across nothing, so IsLens
+// says false about a binding that unambiguously came from a lens. Anything
+// reporting HOW THE CALLER CONNECTED wants FromLens; anything deciding whether
+// federation machinery has more than one mount to fan out over wants IsLens.
+//
+// A uid-less binding mints an empty PinID (pinOf fails closed) and therefore
+// reads as not-from-a-lens. That is the same four-barriers-unreachable case
+// PinID documents, and the safe direction to fail: a missing lens name is a
+// thinner report, not a wrong one.
+func (b *Binding) FromLens() bool { return strings.HasPrefix(b.pinID, "lens:") }
+
 // Reads returns the read mounts (the write repo is always among them).
 func (b *Binding) Reads() []ReadTarget { return b.reads }
 

--- a/internal/repos/binding_test.go
+++ b/internal/repos/binding_test.go
@@ -63,6 +63,38 @@ func TestBinding_IsLens(t *testing.T) {
 	require.True(t, lens.IsLens(), "write + distinct read mount is a lens")
 }
 
+// TestBinding_FromLens_IsProvenanceNotBreadth pins the distinction that makes
+// FromLens worth having separately from IsLens. A lens whose only read mount is
+// its own write repo federates across nothing, so IsLens is false about it —
+// but the caller unambiguously connected THROUGH a lens, and anything reporting
+// how a caller connected (the write-destination stamp) must still say so.
+// Reading IsLens there renders such a connection indistinguishable from a
+// direct /repos/{repo}/… one.
+func TestBinding_FromLens_IsProvenanceNotBreadth(t *testing.T) {
+	m := newLifecycleManager(t)
+	core := createRepo(t, m, testRepoName)
+
+	// A single-member lens: write repo is also its only read mount.
+	lens, err := m.LensRegistry().Create(Lens{
+		Name:     "solo-lens",
+		WriteUID: core.UID(),
+		Reads:    []LensRead{{RepoUID: core.UID()}},
+	})
+	require.NoError(t, err)
+	b, err := NewBindingOfLens(m, lens)
+	require.NoError(t, err)
+
+	require.False(t, b.IsLens(), "sanity: a lens of one member federates across nothing")
+	require.True(t, b.FromLens(), "provenance survives where breadth does not")
+	require.Equal(t, "solo-lens", b.Name())
+
+	// The lens-of-one synthesized for /repos/{repo}/… is the case FromLens must
+	// keep saying false about — it did not come from a lens definition.
+	direct := NewBindingOfRepo(core, "")
+	require.False(t, direct.FromLens(), "a synthesized repo binding is not from a lens")
+	require.False(t, direct.IsLens())
+}
+
 func TestBinding_WriteMountBranch(t *testing.T) {
 	// Lens-of-one bound to an explicit branch: WriteMountBranch is that branch.
 	ri := NewTestInstanceWithDeps(TestInstanceConfig{Name: "solo", AgentBranch: "agent/test"})


### PR DESCRIPTION
## Why

The write destination is a property of the *connection* — fixed at process start, resolved from the request context, and deliberately not expressible in model output. (A `repo:` tool argument would relocate the choice into tool arguments, which the corpus rejects on two grounds: models invent a plausible value rather than asking, and MCP 2026-07-28 removed protocol sessions specifically noting it relocated the same attack into tool arguments.)

That design is right, but it has a cost: the caller cannot confirm where a fact went, and **a fact written to an unintended repo returns success identical to one written to the intended repo.**

## What

`knomit_learn`, `knomit_update` and `knomit_retract` now report where the bytes landed:

```json
{
  "commits": [{"file": "kb/x/1.md", "hash": "abc123"}],
  "written_to": {"repo": "knomit-kb", "branch": "agent/main", "lens": "knomit-dev"},
  "summary": "wrote 2 facts to repo \"knomit-kb\" on branch \"agent/main\" — the write repo of lens \"knomit-dev\""
}
```

Repo-bound writes omit `lens` entirely (`omitempty`) rather than carry a misleading empty field.

### Two deliberate choices

**The sentence is not redundant with the struct.** What a caller reacts to is prose in the result; the point of stamping is that an unintended destination gets *noticed*. It is one line so it cannot crowd the payload.

**`repo` is always the WRITE repo, never the lens.** A lens reads a union but writes to exactly one member, so naming the lens as the destination would misdescribe where the bytes are. The lens is reported alongside, as context for *why* that repo was chosen. A test pins that ordering in the sentence.

## Scope

This is **not** a fix for an observed bug. Measurement across two connected knomit servers produced **zero wrong-server writes in 630 calls**. This is what makes such a write recoverable rather than silent if one ever happens, and what lets a caller correct itself in the same turn.

## Compatibility

No `outputSchema` is declared on these tools, so the result shape is not a binding contract (per `kb://…/mcp/schemas/ca3382bd` — declaring one *is* a contract) and the added fields are backward-compatible. The full `./internal/mcp` suite passes unchanged; no existing test asserted the exact result shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)