### PR TITLE
feat(synthesize): cross-cluster restatement shortlist (motif phase 0)

### DIFF
--- a/internal/embeddings/embedder.go
+++ b/internal/embeddings/embedder.go
@@ -160,6 +160,27 @@ func (e *Embedder) EmbedDocuments(ctx context.Context, titles, bodies []string) 
 	return embedInBatches(ctx, texts, e.embedBatch)
 }
 
+// EmbedShortStrings embeds bare short strings — fact titles, and from Phase 2
+// of the motif work, motif names and name+definition strings — through the
+// model's ShortStringTemplate. Never the query or document template: see the
+// descriptor's comment for the measurement that settled this.
+//
+// ctx is checked before each batch, exactly as in EmbedDocuments.
+func (e *Embedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	rendered := make([]string, len(texts))
+	for i, t := range texts {
+		rendered[i] = e.shortStringText(t)
+	}
+	return embedInBatches(ctx, rendered, e.embedBatch)
+}
+
+// shortStringText renders one short string through the model's descriptor. The
+// string fills the {content} slot; {title} is empty, which for the title-hack
+// template is not reached at all.
+func (e *Embedder) shortStringText(s string) string {
+	return fillTemplate(e.model.ShortStringTemplate, "", s)
+}
+
 // embedInBatches splits texts into docBatchSize chunks and feeds each to run,
 // abandoning the remainder as soon as ctx is done. Split out from
 // EmbedDocuments (rather than inlined) so the cancellation checkpoint — the

--- a/internal/embeddings/model.go
+++ b/internal/embeddings/model.go
@@ -57,6 +57,19 @@ type Model struct {
 	MaxTokens     int
 	QueryTemplate string
 	DocTemplate   string
+	// ShortStringTemplate renders a BARE SHORT STRING (a fact title, a motif
+	// name, a name+definition) for embedding. It is deliberately the title slot
+	// with a literal "none" body — the "title-hack".
+	//
+	// This looks wrong and is right: the task sweep recorded in
+	// .claude/plans/motif/2026-08-20-motif-summarizer-experiment.md measured the
+	// model card's own task prompts WORSE than this rendering for strings of a
+	// few words on embeddinggemma, and every operating point calibrated in that
+	// work assumes this exact string. Do not "fix" it to a task prompt without
+	// re-running the sweep. New embedding axes get their own calibrated
+	// operating points; never reuse fact-embedding thresholds
+	// (decisions/embeddings/model-dependent-thresholds-on-descriptor).
+	ShortStringTemplate string
 	// Thresholds are this model's cosine cutoffs for dedup/search/graph/reflect.
 	// They are calibrated per model against the real corpus (tools/calibrate),
 	// because each model has a different cosine distribution.
@@ -78,6 +91,8 @@ var registry = map[string]Model{
 		MaxTokens:     2048, // EmbeddingGemma max position embeddings.
 		QueryTemplate: "task: search result | query: {content}",
 		DocTemplate:   "title: {title} | text: {content}",
+		// The title-hack — see the descriptor comment above.
+		ShortStringTemplate: "title: {content} | text: none",
 		// Calibrated against the real knomit corpus (712 facts, tools/calibrate).
 		// EmbeddingGemma's cosine distribution runs markedly cooler than nomic's
 		// (distinct same-category pairs: mean 0.48 vs 0.75), so every cutoff is
@@ -105,6 +120,10 @@ var registry = map[string]Model{
 		MaxTokens:     2048, // nomic-embed-text-v1.5 context window.
 		QueryTemplate: "search_query: {content}",
 		DocTemplate:   "search_document: {content}",
+		// Not swept on nomic: its document rendering has no title slot, so the
+		// title-hack has no analogue here. Re-measure before trusting any
+		// short-string operating point under this model.
+		ShortStringTemplate: "search_document: {content}",
 		// nomic was the original default; these are the historical literals the
 		// thresholds were implicitly tuned against (== params.Defaults()).
 		Thresholds: params.Defaults(),

--- a/internal/embeddings/short_string_template_test.go
+++ b/internal/embeddings/short_string_template_test.go
@@ -1,0 +1,50 @@
+package embeddings
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestShortStringTemplate_IsTheTitleHack pins the measured rendering for bare
+// short strings (fact titles now; motif names and name+definition strings from
+// Phase 2 of the motif work).
+//
+// It looks wrong — a title-slot template with a literal "none" body — and it is
+// right: the task sweep recorded in
+// .claude/plans/motif/2026-08-20-motif-summarizer-experiment.md measured the
+// model card's own task prompts WORSE than this rendering for strings of a few
+// words on embeddinggemma. Every operating point calibrated in that work
+// assumes this exact string, so changing it invalidates the calibration rather
+// than merely perturbing it.
+func TestShortStringTemplate_IsTheTitleHack(t *testing.T) {
+	m, err := Lookup("embeddinggemma")
+	require.NoError(t, err)
+	require.Equal(t, "title: {content} | text: none", m.ShortStringTemplate)
+	require.NotContains(t, m.ShortStringTemplate, "task:",
+		"short strings must never use the model card's task prompt")
+}
+
+// TestShortStringTemplate_EveryModelDefinesOne keeps the descriptor total: a
+// model with an empty short-string template would silently embed the bare
+// string, which is a third rendering nobody measured.
+func TestShortStringTemplate_EveryModelDefinesOne(t *testing.T) {
+	for _, id := range IDs() {
+		m, err := Lookup(id)
+		require.NoError(t, err)
+		require.NotEmpty(t, m.ShortStringTemplate, "model %s", id)
+		require.True(t, strings.Contains(m.ShortStringTemplate, "{content}"),
+			"model %s: short-string template must carry a {content} slot", id)
+	}
+}
+
+// TestShortStringText_RendersThroughTheDescriptor is the guard that every
+// short-string embedding site goes through the descriptor rather than
+// hand-rolling a template at the call site.
+func TestShortStringText_RendersThroughTheDescriptor(t *testing.T) {
+	m, err := Lookup("embeddinggemma")
+	require.NoError(t, err)
+	e := &Embedder{model: m}
+	require.Equal(t, "title: prune scope | text: none", e.shortStringText("prune scope"))
+}

--- a/internal/mcp/mock_batch_embedder_test.go
+++ b/internal/mcp/mock_batch_embedder_test.go
@@ -85,6 +85,21 @@ func (mr *MockBatchEmbedderMockRecorder) EmbedDocuments(ctx, titles, bodies any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmbedDocuments", reflect.TypeOf((*MockBatchEmbedder)(nil).EmbedDocuments), ctx, titles, bodies)
 }
 
+// EmbedShortStrings mocks base method.
+func (m *MockBatchEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EmbedShortStrings", ctx, texts)
+	ret0, _ := ret[0].([][]float32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EmbedShortStrings indicates an expected call of EmbedShortStrings.
+func (mr *MockBatchEmbedderMockRecorder) EmbedShortStrings(ctx, texts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmbedShortStrings", reflect.TypeOf((*MockBatchEmbedder)(nil).EmbedShortStrings), ctx, texts)
+}
+
 // EmbedQuery mocks base method.
 func (m *MockBatchEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
 	m.ctrl.T.Helper()

--- a/internal/mcp/query_federation_test.go
+++ b/internal/mcp/query_federation_test.go
@@ -661,3 +661,10 @@ func TestQueryFederation_RecentWithTextPreservesRelevanceOrder(t *testing.T) {
 		"newer weak match must come last despite its later commit")
 	require.NotContains(t, resp.Facts[0].File, federate.KBScheme, "lens-of-one rows must be bare (never kb://-qualified)")
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e rankedFedEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/repos/openone_background_test.go
+++ b/internal/repos/openone_background_test.go
@@ -225,3 +225,22 @@ func TestOpenOne_FailedBackgroundIndexReportsError(t *testing.T) {
 		return s == "error"
 	}, 10*time.Second, 50*time.Millisecond, "a failed background rebuild must report 'error', not 'ready'")
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *blockingEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e testEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}
+
+// EmbedShortStrings satisfies store.BatchEmbedder for the failing stub too.
+func (e failingEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/store/abstraction.go
+++ b/internal/store/abstraction.go
@@ -109,8 +109,27 @@ func (ax *abstractionIndex) TitleVectorCoverage(ctx context.Context, branch stri
 // that is what a prune work item talks in — and resolving them one id at a time
 // afterwards would be a query per changed fact.
 func (ax *abstractionIndex) LiveEpistemicFacts(ctx context.Context, branch string) (map[int64]string, error) {
-	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
-		`SELECT f.id, f.path`+epistemicLiveJoin, branch)
+	return ax.liveEpistemicFacts(ctx, branch, false)
+}
+
+// LiveEpistemicFactsOnAxis is LiveEpistemicFacts restricted to facts that
+// actually carry a title vector.
+//
+// The distinction is load-bearing during a partial backfill. A fact with no
+// vector has no neighbours to find, so treating it as "covered" would mark it
+// done in the cache state and its KNN would never run — permanently, because
+// the cache state is exactly what says "already covered". The refresh therefore
+// diffs against THIS set and leaves un-embedded facts for a later session.
+func (ax *abstractionIndex) LiveEpistemicFactsOnAxis(ctx context.Context, branch string) (map[int64]string, error) {
+	return ax.liveEpistemicFacts(ctx, branch, true)
+}
+
+func (ax *abstractionIndex) liveEpistemicFacts(ctx context.Context, branch string, onAxisOnly bool) (map[int64]string, error) {
+	query := `SELECT f.id, f.path` + epistemicLiveJoin
+	if onAxisOnly {
+		query += ` AND EXISTS (SELECT 1 FROM fact_titles_vec tv WHERE tv.rowid = f.id)`
+	}
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx, query, branch)
 	if err != nil {
 		return nil, fmt.Errorf("abstraction: live facts: %w", err)
 	}
@@ -264,6 +283,82 @@ func (ax *abstractionIndex) CachedPairFactIDs(ctx context.Context, branch string
 	return out, rows.Err()
 }
 
+// PartnersOfFacts returns the still-cached partners of the given facts — the
+// other endpoint of every standing pair that touches one of them.
+//
+// The refresh needs this because KNN is ASYMMETRIC: a pair can exist only
+// because B's top-K included A, never the other way round. Dropping every pair
+// that touches an edited fact and then re-running only that fact's KNN
+// therefore destroys pairs that nothing will rediscover. Requeuing the
+// surviving partners restores them, at a bounded cost of at most K partners per
+// dropped fact.
+func (ax *abstractionIndex) PartnersOfFacts(ctx context.Context, branch string, factIDs []int64) (map[int64]struct{}, error) {
+	out := map[int64]struct{}{}
+	if len(factIDs) == 0 {
+		return out, nil
+	}
+	branchID, err := ax.branchID(ctx, branch)
+	if err != nil {
+		return nil, err
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(factIDs)), ",")
+	args := make([]any, 0, len(factIDs)*2+1)
+	args = append(args, branchID)
+	for _, id := range factIDs {
+		args = append(args, id)
+	}
+	for _, id := range factIDs {
+		args = append(args, id)
+	}
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT a_fact_id, b_fact_id FROM restatement_pairs
+		  WHERE branch_id = ?
+		    AND (a_fact_id IN (`+placeholders+`) OR b_fact_id IN (`+placeholders+`))`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: partners of facts: %w", err)
+	}
+	defer rows.Close()
+
+	dropped := make(map[int64]struct{}, len(factIDs))
+	for _, id := range factIDs {
+		dropped[id] = struct{}{}
+	}
+	for rows.Next() {
+		var a, b int64
+		if err := rows.Scan(&a, &b); err != nil {
+			return nil, fmt.Errorf("abstraction: scan partner: %w", err)
+		}
+		for _, id := range []int64{a, b} {
+			if _, isDropped := dropped[id]; !isDropped {
+				out[id] = struct{}{}
+			}
+		}
+	}
+	return out, rows.Err()
+}
+
+// DeleteRestatementPair removes one standing pair.
+//
+// Called when the judge declines a pair: the verdict log keeps the record, and
+// leaving the pair standing would let it occupy the top of the ranking session
+// after session, saturating the selection window until nothing else could ever
+// be offered. An edit to either fact re-mints the pair through the ordinary KNN
+// path, which is the behaviour we want — the judge has not seen that version.
+func (ax *abstractionIndex) DeleteRestatementPair(ctx context.Context, branch string, aFactID, bFactID int64) error {
+	branchID, err := ax.branchID(ctx, branch)
+	if err != nil {
+		return err
+	}
+	if _, err := conn(ctx, ax.rh.db).ExecContext(ctx,
+		`DELETE FROM restatement_pairs
+		  WHERE branch_id = ?
+		    AND ((a_fact_id = ? AND b_fact_id = ?) OR (a_fact_id = ? AND b_fact_id = ?))`,
+		branchID, aFactID, bFactID, bFactID, aFactID); err != nil {
+		return fmt.Errorf("abstraction: delete pair: %w", err)
+	}
+	return nil
+}
+
 // ReplaceRestatementPairs applies one delta to the cache atomically: every pair
 // touching a dropped-or-changed fact goes, the new pairs land, and the cache
 // state records what the cache now covers.
@@ -289,17 +384,29 @@ func (ax *abstractionIndex) ReplaceRestatementPairs(ctx context.Context, branch 
 	}
 	db := conn(ctx, ax.rh.db)
 
-	for _, id := range dropFactIDs {
-		if _, err := db.ExecContext(ctx,
-			`DELETE FROM restatement_pairs
-			  WHERE branch_id = ? AND (a_fact_id = ? OR b_fact_id = ?)`,
-			branchID, id, id); err != nil {
-			return fmt.Errorf("abstraction: drop pairs for %d: %w", id, err)
+	if len(dropFactIDs) > 0 {
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(dropFactIDs)), ",")
+		args := make([]any, 0, len(dropFactIDs)*2+1)
+		args = append(args, branchID)
+		for _, id := range dropFactIDs {
+			args = append(args, id)
+		}
+		for _, id := range dropFactIDs {
+			args = append(args, id)
 		}
 		if _, err := db.ExecContext(ctx,
-			`DELETE FROM restatement_cache_state WHERE branch_id = ? AND fact_id = ?`,
-			branchID, id); err != nil {
-			return fmt.Errorf("abstraction: drop cache state for %d: %w", id, err)
+			`DELETE FROM restatement_pairs
+			  WHERE branch_id = ?
+			    AND (a_fact_id IN (`+placeholders+`) OR b_fact_id IN (`+placeholders+`))`,
+			args...); err != nil {
+			return fmt.Errorf("abstraction: drop pairs: %w", err)
+		}
+		stateArgs := append([]any{branchID}, args[1:len(dropFactIDs)+1]...)
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM restatement_cache_state
+			  WHERE branch_id = ? AND fact_id IN (`+placeholders+`)`,
+			stateArgs...); err != nil {
+			return fmt.Errorf("abstraction: drop cache state: %w", err)
 		}
 	}
 	for _, p := range add {
@@ -404,18 +511,13 @@ func (ax *abstractionIndex) pairQuantile(ctx context.Context, branch string, cou
 	return v, nil
 }
 
-// branchID resolves a branch name to its row id. A branch the registry has
-// never seen is an error rather than a silent no-op: writing shortlist state
-// under a phantom branch id would be invisible and permanent.
+// branchID resolves a branch name to its row id through repoHandler's cached
+// resolver, so this sub-service shares the cache and returns the same
+// ErrBranchNotFound every other caller matches on.
 func (ax *abstractionIndex) branchID(ctx context.Context, branch string) (int64, error) {
-	var id int64
-	err := conn(ctx, ax.rh.db).QueryRowContext(ctx,
-		`SELECT id FROM branches WHERE name = ?`, branch).Scan(&id)
-	if err == sql.ErrNoRows {
-		return 0, fmt.Errorf("abstraction: unknown branch %q", branch)
-	}
+	id, err := ax.rh.branchID(ctx, branch)
 	if err != nil {
-		return 0, fmt.Errorf("abstraction: branch id for %q: %w", branch, err)
+		return 0, fmt.Errorf("abstraction: %w", err)
 	}
 	return id, nil
 }
@@ -433,15 +535,15 @@ func (ax *abstractionIndex) RecordRestatementVerdict(ctx context.Context, branch
 	if err != nil {
 		return err
 	}
-	merged := 0
-	if v.Merged {
-		merged = 1
+	resolved := 0
+	if v.Resolved {
+		resolved = 1
 	}
 	if _, err := conn(ctx, ax.rh.db).ExecContext(ctx,
 		`INSERT INTO restatement_verdicts
-		     (branch_id, a_path, b_path, a_fact_id, b_fact_id, merged, judged_at)
+		     (branch_id, a_path, b_path, a_fact_id, b_fact_id, resolved, judged_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		branchID, v.APath, v.BPath, v.AFactID, v.BFactID, merged,
+		branchID, v.APath, v.BPath, v.AFactID, v.BFactID, resolved,
 		v.JudgedAt.UTC().Format(time.RFC3339)); err != nil {
 		return fmt.Errorf("abstraction: record verdict: %w", err)
 	}
@@ -454,7 +556,7 @@ func (ax *abstractionIndex) RecentRestatementVerdicts(ctx context.Context, branc
 		return nil, nil
 	}
 	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
-		`SELECT v.a_path, v.b_path, v.a_fact_id, v.b_fact_id, v.merged, v.judged_at
+		`SELECT v.a_path, v.b_path, v.a_fact_id, v.b_fact_id, v.resolved, v.judged_at
 		   FROM restatement_verdicts v
 		   JOIN branches b ON b.id = v.branch_id
 		  WHERE b.name = ?
@@ -468,12 +570,12 @@ func (ax *abstractionIndex) RecentRestatementVerdicts(ctx context.Context, branc
 	var out []RestatementVerdict
 	for rows.Next() {
 		var v RestatementVerdict
-		var merged int
+		var resolved int
 		var judged string
-		if err := rows.Scan(&v.APath, &v.BPath, &v.AFactID, &v.BFactID, &merged, &judged); err != nil {
+		if err := rows.Scan(&v.APath, &v.BPath, &v.AFactID, &v.BFactID, &resolved, &judged); err != nil {
 			return nil, fmt.Errorf("abstraction: scan verdict: %w", err)
 		}
-		v.Merged = merged == 1
+		v.Resolved = resolved == 1
 		if t, perr := time.Parse(time.RFC3339, judged); perr == nil {
 			v.JudgedAt = t
 		}
@@ -482,19 +584,21 @@ func (ax *abstractionIndex) RecentRestatementVerdicts(ctx context.Context, branc
 	return out, rows.Err()
 }
 
-// KeptPairFactIDs returns the id-pairs this branch's judge declined to merge,
-// as "a:b" keys with a < b.
+// KeptPairFactIDs returns the id-pairs this branch's judge declined to
+// resolve, as FactIDPairKey keys.
 //
-// Keyed by FACT ID rather than path on purpose. Ids are content-addressed, so
-// "the judge already looked at this and said keep" expires structurally the
-// moment either fact is edited — the pair becomes a new pair of ids and is
-// eligible again, with no hash comparison and no staleness rule to get wrong.
+// The refresh consults it when MINTING pairs, not the selector when choosing
+// them: a declined pair is deleted outright, and this set is what stops a later
+// neighbour rescan from minting it again. Keyed by FACT ID on purpose — ids are
+// content-addressed, so "the judge looked at this and kept both" expires
+// structurally the moment either fact is edited, with no staleness rule to get
+// wrong.
 func (ax *abstractionIndex) KeptPairFactIDs(ctx context.Context, branch string) (map[string]struct{}, error) {
 	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
 		`SELECT v.a_fact_id, v.b_fact_id
 		   FROM restatement_verdicts v
 		   JOIN branches b ON b.id = v.branch_id
-		  WHERE b.name = ? AND v.merged = 0`, branch)
+		  WHERE b.name = ? AND v.resolved = 0`, branch)
 	if err != nil {
 		return nil, fmt.Errorf("abstraction: kept pairs: %w", err)
 	}
@@ -519,4 +623,38 @@ func FactIDPairKey(a, b int64) string {
 		a, b = b, a
 	}
 	return fmt.Sprintf("%d:%d", a, b)
+}
+
+// ProbeSessionsWaited returns how many sessions this branch has waited since it
+// last spent a probe slot. Zero for a branch that has never been defunded.
+func (ax *abstractionIndex) ProbeSessionsWaited(ctx context.Context, branch string) (int, error) {
+	var n int
+	err := conn(ctx, ax.rh.db).QueryRowContext(ctx,
+		`SELECT s.sessions_since_probe
+		   FROM restatement_throttle_state s
+		   JOIN branches b ON b.id = s.branch_id
+		  WHERE b.name = ?`, branch).Scan(&n)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("abstraction: probe wait: %w", err)
+	}
+	return n, nil
+}
+
+// SetProbeSessionsWaited records the probe counter for this branch.
+func (ax *abstractionIndex) SetProbeSessionsWaited(ctx context.Context, branch string, n int) error {
+	branchID, err := ax.branchID(ctx, branch)
+	if err != nil {
+		return err
+	}
+	if _, err := conn(ctx, ax.rh.db).ExecContext(ctx,
+		`INSERT INTO restatement_throttle_state(branch_id, sessions_since_probe)
+		 VALUES (?, ?)
+		 ON CONFLICT(branch_id) DO UPDATE SET sessions_since_probe = excluded.sessions_since_probe`,
+		branchID, n); err != nil {
+		return fmt.Errorf("abstraction: set probe wait: %w", err)
+	}
+	return nil
 }

--- a/internal/store/abstraction.go
+++ b/internal/store/abstraction.go
@@ -8,6 +8,36 @@ import (
 	"time"
 )
 
+// sqlIDChunk is a SQL PARAMETER BUDGET: how many ids are bound into one
+// statement's IN clause.
+//
+// SQLite caps parameters per statement (32,766 on this build, 999 on older
+// ones). These queries bind one placeholder per fact id — and the session that
+// closes a backfill rescans the whole corpus, so it has every live id in hand
+// at once. Unchunked, the feature would stop working entirely somewhere past
+// ~16k facts, and would say so only in a health line. The value is deliberately
+// well under the smaller historical cap.
+const sqlIDChunk = 400
+
+// chunkIDs splits ids into batches no larger than sqlIDChunk.
+func chunkIDs(ids []int64) [][]int64 {
+	var out [][]int64
+	for start := 0; start < len(ids); start += sqlIDChunk {
+		end := min(start+sqlIDChunk, len(ids))
+		out = append(out, ids[start:end])
+	}
+	return out
+}
+
+// idPlaceholders renders "?,?,..." and the matching args for one chunk.
+func idPlaceholders(ids []int64) (string, []any) {
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", len(ids)), ","), args
+}
+
 // abstractionIndex implements AbstractionIndex: the title-embedding axis and
 // the restatement shortlist built on it.
 //
@@ -237,31 +267,34 @@ func (ax *abstractionIndex) BodyVectorsByFactID(ctx context.Context, ids []int64
 	if len(ids) == 0 {
 		return out, nil
 	}
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
-	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
-		`SELECT rowid, embedding FROM facts_vec WHERE rowid IN (`+placeholders+`)`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("abstraction: body vectors: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var id int64
-		var blob []byte
-		if err := rows.Scan(&id, &blob); err != nil {
-			return nil, fmt.Errorf("abstraction: scan body vector: %w", err)
-		}
-		vec, err := bytesToFloat32Slice(blob)
+	for _, chunk := range chunkIDs(ids) {
+		placeholders, args := idPlaceholders(chunk)
+		rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+			`SELECT rowid, embedding FROM facts_vec WHERE rowid IN (`+placeholders+`)`, args...)
 		if err != nil {
-			return nil, fmt.Errorf("abstraction: decode body vector %d: %w", id, err)
+			return nil, fmt.Errorf("abstraction: body vectors: %w", err)
 		}
-		out[id] = vec
+		for rows.Next() {
+			var id int64
+			var blob []byte
+			if err := rows.Scan(&id, &blob); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("abstraction: scan body vector: %w", err)
+			}
+			vec, err := bytesToFloat32Slice(blob)
+			if err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("abstraction: decode body vector %d: %w", id, err)
+			}
+			out[id] = vec
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("abstraction: body vectors: %w", err)
+		}
+		rows.Close()
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 // ── the standing restatement shortlist ────────────────────────────────────
@@ -306,27 +339,35 @@ func (ax *abstractionIndex) FactIDsByPath(ctx context.Context, branch string, pa
 	if len(paths) == 0 {
 		return out, nil
 	}
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(paths)), ",")
-	args := make([]any, 0, len(paths)+1)
-	args = append(args, branch)
-	for _, p := range paths {
-		args = append(args, p)
-	}
-	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
-		`SELECT f.id, f.path`+epistemicLiveJoin+` AND f.path IN (`+placeholders+`)`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("abstraction: fact ids by path: %w", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var id int64
-		var path string
-		if err := rows.Scan(&id, &path); err != nil {
-			return nil, fmt.Errorf("abstraction: scan fact id: %w", err)
+	for start := 0; start < len(paths); start += sqlIDChunk {
+		chunk := paths[start:min(start+sqlIDChunk, len(paths))]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(chunk)), ",")
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, branch)
+		for _, p := range chunk {
+			args = append(args, p)
 		}
-		out[path] = id
+		rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+			`SELECT f.id, f.path`+epistemicLiveJoin+` AND f.path IN (`+placeholders+`)`, args...)
+		if err != nil {
+			return nil, fmt.Errorf("abstraction: fact ids by path: %w", err)
+		}
+		for rows.Next() {
+			var id int64
+			var path string
+			if err := rows.Scan(&id, &path); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("abstraction: scan fact id: %w", err)
+			}
+			out[path] = id
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("abstraction: fact ids by path: %w", err)
+		}
+		rows.Close()
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 // PartnersOfFacts returns the still-cached partners of the given facts — the
@@ -347,40 +388,43 @@ func (ax *abstractionIndex) PartnersOfFacts(ctx context.Context, branch string, 
 	if err != nil {
 		return nil, err
 	}
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(factIDs)), ",")
-	args := make([]any, 0, len(factIDs)*2+1)
-	args = append(args, branchID)
-	for _, id := range factIDs {
-		args = append(args, id)
-	}
-	for _, id := range factIDs {
-		args = append(args, id)
-	}
-	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
-		`SELECT a_fact_id, b_fact_id FROM restatement_pairs
-		  WHERE branch_id = ?
-		    AND (a_fact_id IN (`+placeholders+`) OR b_fact_id IN (`+placeholders+`))`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("abstraction: partners of facts: %w", err)
-	}
-	defer rows.Close()
-
 	dropped := make(map[int64]struct{}, len(factIDs))
 	for _, id := range factIDs {
 		dropped[id] = struct{}{}
 	}
-	for rows.Next() {
-		var a, b int64
-		if err := rows.Scan(&a, &b); err != nil {
-			return nil, fmt.Errorf("abstraction: scan partner: %w", err)
+
+	for _, chunk := range chunkIDs(factIDs) {
+		placeholders, ids := idPlaceholders(chunk)
+		args := make([]any, 0, len(ids)*2+1)
+		args = append(args, branchID)
+		args = append(args, ids...)
+		args = append(args, ids...)
+		rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+			`SELECT a_fact_id, b_fact_id FROM restatement_pairs
+			  WHERE branch_id = ?
+			    AND (a_fact_id IN (`+placeholders+`) OR b_fact_id IN (`+placeholders+`))`, args...)
+		if err != nil {
+			return nil, fmt.Errorf("abstraction: partners of facts: %w", err)
 		}
-		for _, id := range []int64{a, b} {
-			if _, isDropped := dropped[id]; !isDropped {
-				out[id] = struct{}{}
+		for rows.Next() {
+			var a, b int64
+			if err := rows.Scan(&a, &b); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("abstraction: scan partner: %w", err)
+			}
+			for _, id := range []int64{a, b} {
+				if _, isDropped := dropped[id]; !isDropped {
+					out[id] = struct{}{}
+				}
 			}
 		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("abstraction: partners of facts: %w", err)
+		}
+		rows.Close()
 	}
-	return out, rows.Err()
+	return out, nil
 }
 
 // DeleteRestatementPair removes one standing pair.
@@ -430,24 +474,20 @@ func (ax *abstractionIndex) ReplaceRestatementPairs(ctx context.Context, branch 
 	}
 	db := conn(ctx, ax.rh.db)
 
-	if len(dropFactIDs) > 0 {
-		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(dropFactIDs)), ",")
-		args := make([]any, 0, len(dropFactIDs)*2+1)
-		args = append(args, branchID)
-		for _, id := range dropFactIDs {
-			args = append(args, id)
-		}
-		for _, id := range dropFactIDs {
-			args = append(args, id)
-		}
+	for _, chunk := range chunkIDs(dropFactIDs) {
+		placeholders, ids := idPlaceholders(chunk)
+		pairArgs := make([]any, 0, len(ids)*2+1)
+		pairArgs = append(pairArgs, branchID)
+		pairArgs = append(pairArgs, ids...)
+		pairArgs = append(pairArgs, ids...)
 		if _, err := db.ExecContext(ctx,
 			`DELETE FROM restatement_pairs
 			  WHERE branch_id = ?
 			    AND (a_fact_id IN (`+placeholders+`) OR b_fact_id IN (`+placeholders+`))`,
-			args...); err != nil {
+			pairArgs...); err != nil {
 			return fmt.Errorf("abstraction: drop pairs: %w", err)
 		}
-		stateArgs := append([]any{branchID}, args[1:len(dropFactIDs)+1]...)
+		stateArgs := append([]any{branchID}, ids...)
 		if _, err := db.ExecContext(ctx,
 			`DELETE FROM restatement_cache_state
 			  WHERE branch_id = ? AND fact_id IN (`+placeholders+`)`,

--- a/internal/store/abstraction.go
+++ b/internal/store/abstraction.go
@@ -70,6 +70,16 @@ func (ax *abstractionIndex) PutTitleVectors(ctx context.Context, vecs []TitleVec
 	if len(vecs) == 0 {
 		return nil
 	}
+	// One transaction for the batch: a backfill writes these 32 at a time, and
+	// under _txlock=immediate each implicit transaction is a process-wide write
+	// lock acquisition.
+	ctx, tx, owned, err := beginTxIfNeeded(ctx, ax.rh.db)
+	if err != nil {
+		return fmt.Errorf("abstraction: begin tx: %w", err)
+	}
+	if owned {
+		defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+	}
 	db := conn(ctx, ax.rh.db)
 	for _, v := range vecs {
 		if _, err := db.ExecContext(ctx,
@@ -81,6 +91,9 @@ func (ax *abstractionIndex) PutTitleVectors(ctx context.Context, vecs []TitleVec
 			v.FactID, float32SliceToBytes(v.Vec)); err != nil {
 			return fmt.Errorf("abstraction: put title vector %d: %w", v.FactID, err)
 		}
+	}
+	if owned {
+		return tx.Commit()
 	}
 	return nil
 }
@@ -279,6 +292,39 @@ func (ax *abstractionIndex) CachedPairFactIDs(ctx context.Context, branch string
 			return nil, fmt.Errorf("abstraction: scan cached fact id: %w", err)
 		}
 		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// FactIDsByPath resolves specific live paths to their current fact ids.
+//
+// Two paths, not the corpus: verdict attribution needs the ids of exactly the
+// pair it is recording, and scanning every live fact to find two of them is a
+// full table read on every judged item.
+func (ax *abstractionIndex) FactIDsByPath(ctx context.Context, branch string, paths []string) (map[string]int64, error) {
+	out := make(map[string]int64, len(paths))
+	if len(paths) == 0 {
+		return out, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(paths)), ",")
+	args := make([]any, 0, len(paths)+1)
+	args = append(args, branch)
+	for _, p := range paths {
+		args = append(args, p)
+	}
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT f.id, f.path`+epistemicLiveJoin+` AND f.path IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: fact ids by path: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		var path string
+		if err := rows.Scan(&id, &path); err != nil {
+			return nil, fmt.Errorf("abstraction: scan fact id: %w", err)
+		}
+		out[path] = id
 	}
 	return out, rows.Err()
 }

--- a/internal/store/abstraction.go
+++ b/internal/store/abstraction.go
@@ -1,0 +1,227 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// abstractionIndex implements AbstractionIndex: the title-embedding axis and
+// the restatement shortlist built on it.
+//
+// Both are derived state consumed EXCLUSIVELY by the review pipeline. Nothing
+// on the runtime paths (query / explain / learn) may reach them, which is why
+// this sub-service is exposed on its own accessor rather than folded into the
+// SearchIndex composite that mcp and web depend on.
+//
+// Like its siblings it holds only *repoHandler and never reaches sideways to
+// another sub-service (invariants/store/sub-index-up-not-sideways).
+type abstractionIndex struct{ rh *repoHandler }
+
+var _ AbstractionIndex = (*abstractionIndex)(nil)
+
+// epistemicLiveJoin is the join every query here shares: the version of each
+// path that `branch` currently sees, epistemic facts only.
+//
+// Epistemic-only is a CORRECTNESS filter, not a preference. Prune's decision
+// path does not carry Kind through mergedFact, so a pragmatic fact that reached
+// synthesis would be silently rewritten as epistemic — the same reason
+// reviewStrategy.AcceptSeed exists. A shortlist that offered one would corrupt
+// it. The cost is a known limitation: restatements among pragmatic facts stay
+// unjudged by this mechanism.
+const epistemicLiveJoin = `
+	FROM branch_facts bf
+	JOIN branches b ON b.id = bf.branch_id
+	JOIN facts f ON f.id = bf.fact_id
+	WHERE b.name = ? AND f.kind = 'epistemic'`
+
+// LiveFactsMissingTitleVector returns up to limit live epistemic facts with no
+// title vector, lowest fact id first.
+//
+// "Rows lacking a vector" IS the backfill delta: facts rows are content-
+// addressed, so editing a fact produces a new row that no vector points at.
+func (ax *abstractionIndex) LiveFactsMissingTitleVector(ctx context.Context, branch string, limit int) ([]TitleTarget, error) {
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT f.id, f.path, f.title`+epistemicLiveJoin+`
+		   AND NOT EXISTS (SELECT 1 FROM fact_titles_vec tv WHERE tv.rowid = f.id)
+		 ORDER BY f.id ASC
+		 LIMIT ?`, branch, limit)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: list missing title vectors: %w", err)
+	}
+	defer rows.Close()
+
+	var out []TitleTarget
+	for rows.Next() {
+		var t TitleTarget
+		if err := rows.Scan(&t.FactID, &t.Path, &t.Title); err != nil {
+			return nil, fmt.Errorf("abstraction: scan title target: %w", err)
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// PutTitleVectors stores title vectors by fact id. Delete-then-insert because
+// vec0 has no upsert.
+func (ax *abstractionIndex) PutTitleVectors(ctx context.Context, vecs []TitleVector) error {
+	if len(vecs) == 0 {
+		return nil
+	}
+	db := conn(ctx, ax.rh.db)
+	for _, v := range vecs {
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM fact_titles_vec WHERE rowid = ?`, v.FactID); err != nil {
+			return fmt.Errorf("abstraction: clear title vector %d: %w", v.FactID, err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO fact_titles_vec(rowid, embedding) VALUES (?, ?)`,
+			v.FactID, float32SliceToBytes(v.Vec)); err != nil {
+			return fmt.Errorf("abstraction: put title vector %d: %w", v.FactID, err)
+		}
+	}
+	return nil
+}
+
+// TitleVectorCoverage reports how much of the live epistemic corpus is on the
+// axis. Surfaced in review health output, because a time-budgeted backfill can
+// legitimately leave the axis partial for several sessions and silence would
+// read as "nothing to find".
+func (ax *abstractionIndex) TitleVectorCoverage(ctx context.Context, branch string) (int, int, error) {
+	var have, total int
+	err := conn(ctx, ax.rh.db).QueryRowContext(ctx,
+		`SELECT
+		     COUNT(CASE WHEN EXISTS (SELECT 1 FROM fact_titles_vec tv WHERE tv.rowid = f.id) THEN 1 END),
+		     COUNT(f.id)`+epistemicLiveJoin, branch).Scan(&have, &total)
+	if err != nil {
+		return 0, 0, fmt.Errorf("abstraction: title vector coverage: %w", err)
+	}
+	return have, total, nil
+}
+
+// LiveEpistemicFactIDs is the live set the pair cache is diffed against. The
+// symmetric difference with the cached set is the delta, which is why the
+// shortlist needs no watermark of its own.
+func (ax *abstractionIndex) LiveEpistemicFactIDs(ctx context.Context, branch string) (map[int64]struct{}, error) {
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT f.id`+epistemicLiveJoin, branch)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: live fact ids: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[int64]struct{}{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("abstraction: scan live fact id: %w", err)
+		}
+		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// titleKNNOverfetch is a STRUCTURAL BUDGET: how far past k the vec0 window
+// reaches so that post-filtering still yields k neighbours.
+//
+// It is load-bearing, not defensive. vec0 applies its k window BEFORE any WHERE
+// clause (the same trap RelevantMethodologyForFact documents), so a query
+// asking for exactly k and then filtering to live epistemic facts on this
+// branch would come back short — or empty on a repo whose axis carries many
+// superseded revisions. graphBuildSimilarityEdges pays the same tax as knnK+1.
+const titleKNNOverfetch = 4
+
+// TopTitleNeighbours returns up to k nearest live epistemic neighbours of
+// factID on the abstraction axis, self excluded, most similar first.
+//
+// A fact with no title vector yet returns nothing rather than an error: during
+// a partial backfill that is the common case, not a fault.
+func (ax *abstractionIndex) TopTitleNeighbours(ctx context.Context, branch string, factID int64, k int) ([]TitleNeighbour, error) {
+	if k <= 0 {
+		return nil, nil
+	}
+	var blob []byte
+	err := conn(ctx, ax.rh.db).QueryRowContext(ctx,
+		`SELECT embedding FROM fact_titles_vec WHERE rowid = ?`, factID).Scan(&blob)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: read title vector %d: %w", factID, err)
+	}
+
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT f.id, f.path, (1.0 - tv.distance) AS similarity
+		   FROM fact_titles_vec tv
+		   JOIN facts f ON f.id = tv.rowid
+		   JOIN branch_facts bf ON bf.fact_id = f.id
+		   JOIN branches b ON b.id = bf.branch_id
+		  WHERE tv.embedding MATCH ? AND tv.k = ?
+		    AND b.name = ? AND f.kind = 'epistemic' AND f.id != ?
+		  ORDER BY tv.distance ASC`,
+		blob, k*titleKNNOverfetch, branch, factID)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: title knn for %d: %w", factID, err)
+	}
+	defer rows.Close()
+
+	var out []TitleNeighbour
+	for rows.Next() {
+		if len(out) == k {
+			break
+		}
+		var n TitleNeighbour
+		var sim sql.NullFloat64
+		if err := rows.Scan(&n.FactID, &n.Path, &sim); err != nil {
+			return nil, fmt.Errorf("abstraction: scan title neighbour: %w", err)
+		}
+		// A zero-norm embedding has no meaningful similarity to anything, and
+		// its NULL sorts FIRST under "ORDER BY distance ASC" — skip, never
+		// treat as a perfect match.
+		v, ok := usableKNNSimilarity(sim)
+		if !ok {
+			continue
+		}
+		n.Similarity = v
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+// BodyVectorsByFactID returns the STORED blended (title+body) vectors for the
+// given facts. It reads facts_vec rather than re-embedding, for the same reason
+// dedupCluster does (conventions/synthesize/scoped-cluster-queryby-path): every
+// one of these facts is already indexed, and ONNX inference to recompute a
+// vector we already hold is pure waste.
+func (ax *abstractionIndex) BodyVectorsByFactID(ctx context.Context, ids []int64) (map[int64][]float32, error) {
+	out := make(map[int64][]float32, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT rowid, embedding FROM facts_vec WHERE rowid IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: body vectors: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		var blob []byte
+		if err := rows.Scan(&id, &blob); err != nil {
+			return nil, fmt.Errorf("abstraction: scan body vector: %w", err)
+		}
+		vec, err := bytesToFloat32Slice(blob)
+		if err != nil {
+			return nil, fmt.Errorf("abstraction: decode body vector %d: %w", id, err)
+		}
+		out[id] = vec
+	}
+	return out, rows.Err()
+}

--- a/internal/store/abstraction.go
+++ b/internal/store/abstraction.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // abstractionIndex implements AbstractionIndex: the title-embedding axis and
@@ -417,4 +418,105 @@ func (ax *abstractionIndex) branchID(ctx context.Context, branch string) (int64,
 		return 0, fmt.Errorf("abstraction: branch id for %q: %w", branch, err)
 	}
 	return id, nil
+}
+
+// ── judge verdicts ────────────────────────────────────────────────────────
+//
+// Two consumers, both of which make a corpus decide its own behaviour from its
+// own data: the trailing merge-rate that funds or defunds its shortlist, and
+// the kept-pair exclusion that stops one declined pair from occupying the
+// funded slots session after session.
+
+// RecordRestatementVerdict records what the judge did with one shortlist pair.
+func (ax *abstractionIndex) RecordRestatementVerdict(ctx context.Context, branch string, v RestatementVerdict) error {
+	branchID, err := ax.branchID(ctx, branch)
+	if err != nil {
+		return err
+	}
+	merged := 0
+	if v.Merged {
+		merged = 1
+	}
+	if _, err := conn(ctx, ax.rh.db).ExecContext(ctx,
+		`INSERT INTO restatement_verdicts
+		     (branch_id, a_path, b_path, a_fact_id, b_fact_id, merged, judged_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		branchID, v.APath, v.BPath, v.AFactID, v.BFactID, merged,
+		v.JudgedAt.UTC().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("abstraction: record verdict: %w", err)
+	}
+	return nil
+}
+
+// RecentRestatementVerdicts returns the last `window` verdicts, newest first.
+func (ax *abstractionIndex) RecentRestatementVerdicts(ctx context.Context, branch string, window int) ([]RestatementVerdict, error) {
+	if window <= 0 {
+		return nil, nil
+	}
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT v.a_path, v.b_path, v.a_fact_id, v.b_fact_id, v.merged, v.judged_at
+		   FROM restatement_verdicts v
+		   JOIN branches b ON b.id = v.branch_id
+		  WHERE b.name = ?
+		  ORDER BY v.id DESC
+		  LIMIT ?`, branch, window)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: recent verdicts: %w", err)
+	}
+	defer rows.Close()
+
+	var out []RestatementVerdict
+	for rows.Next() {
+		var v RestatementVerdict
+		var merged int
+		var judged string
+		if err := rows.Scan(&v.APath, &v.BPath, &v.AFactID, &v.BFactID, &merged, &judged); err != nil {
+			return nil, fmt.Errorf("abstraction: scan verdict: %w", err)
+		}
+		v.Merged = merged == 1
+		if t, perr := time.Parse(time.RFC3339, judged); perr == nil {
+			v.JudgedAt = t
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// KeptPairFactIDs returns the id-pairs this branch's judge declined to merge,
+// as "a:b" keys with a < b.
+//
+// Keyed by FACT ID rather than path on purpose. Ids are content-addressed, so
+// "the judge already looked at this and said keep" expires structurally the
+// moment either fact is edited — the pair becomes a new pair of ids and is
+// eligible again, with no hash comparison and no staleness rule to get wrong.
+func (ax *abstractionIndex) KeptPairFactIDs(ctx context.Context, branch string) (map[string]struct{}, error) {
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT v.a_fact_id, v.b_fact_id
+		   FROM restatement_verdicts v
+		   JOIN branches b ON b.id = v.branch_id
+		  WHERE b.name = ? AND v.merged = 0`, branch)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: kept pairs: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string]struct{}{}
+	for rows.Next() {
+		var a, b int64
+		if err := rows.Scan(&a, &b); err != nil {
+			return nil, fmt.Errorf("abstraction: scan kept pair: %w", err)
+		}
+		out[FactIDPairKey(a, b)] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// FactIDPairKey is the canonical key for an unordered pair of fact ids, shared
+// by the writer and the reader of the kept-pair set so the two can never
+// disagree about ordering.
+func FactIDPairKey(a, b int64) string {
+	if b < a {
+		a, b = b, a
+	}
+	return fmt.Sprintf("%d:%d", a, b)
 }

--- a/internal/store/abstraction.go
+++ b/internal/store/abstraction.go
@@ -100,24 +100,29 @@ func (ax *abstractionIndex) TitleVectorCoverage(ctx context.Context, branch stri
 	return have, total, nil
 }
 
-// LiveEpistemicFactIDs is the live set the pair cache is diffed against. The
-// symmetric difference with the cached set is the delta, which is why the
-// shortlist needs no watermark of its own.
-func (ax *abstractionIndex) LiveEpistemicFactIDs(ctx context.Context, branch string) (map[int64]struct{}, error) {
+// LiveEpistemicFacts is the live set the pair cache is diffed against, keyed by
+// fact id with its path. The symmetric difference with the cached set is the
+// delta, which is why the shortlist needs no watermark of its own.
+//
+// It carries paths as well as ids because a candidate pair is keyed by path —
+// that is what a prune work item talks in — and resolving them one id at a time
+// afterwards would be a query per changed fact.
+func (ax *abstractionIndex) LiveEpistemicFacts(ctx context.Context, branch string) (map[int64]string, error) {
 	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
-		`SELECT f.id`+epistemicLiveJoin, branch)
+		`SELECT f.id, f.path`+epistemicLiveJoin, branch)
 	if err != nil {
-		return nil, fmt.Errorf("abstraction: live fact ids: %w", err)
+		return nil, fmt.Errorf("abstraction: live facts: %w", err)
 	}
 	defer rows.Close()
 
-	out := map[int64]struct{}{}
+	out := map[int64]string{}
 	for rows.Next() {
 		var id int64
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("abstraction: scan live fact id: %w", err)
+		var path string
+		if err := rows.Scan(&id, &path); err != nil {
+			return nil, fmt.Errorf("abstraction: scan live fact: %w", err)
 		}
-		out[id] = struct{}{}
+		out[id] = path
 	}
 	return out, rows.Err()
 }
@@ -224,4 +229,192 @@ func (ax *abstractionIndex) BodyVectorsByFactID(ctx context.Context, ids []int64
 		out[id] = vec
 	}
 	return out, rows.Err()
+}
+
+// ── the standing restatement shortlist ────────────────────────────────────
+//
+// Candidate pairs live in the DB rather than being recomputed per session, for
+// the same reason SIMILAR_TO edges do: the structure is global, the change per
+// session is small, and rebuilding it every time would make a corpus-wide
+// question cost corpus-wide work forever. What a session pays is proportional
+// to what CHANGED.
+
+// CachedPairFactIDs returns the fact ids the pair cache was last built over.
+// Diffed against LiveEpistemicFactIDs, this IS the delta — no watermark.
+func (ax *abstractionIndex) CachedPairFactIDs(ctx context.Context, branch string) (map[int64]struct{}, error) {
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT s.fact_id
+		   FROM restatement_cache_state s
+		   JOIN branches b ON b.id = s.branch_id
+		  WHERE b.name = ?`, branch)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: cached pair fact ids: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[int64]struct{}{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("abstraction: scan cached fact id: %w", err)
+		}
+		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// ReplaceRestatementPairs applies one delta to the cache atomically: every pair
+// touching a dropped-or-changed fact goes, the new pairs land, and the cache
+// state records what the cache now covers.
+//
+// One transaction because a half-applied delta is worse than a stale cache: a
+// cache that lost its pairs but kept its state rows would never rebuild them,
+// since the state rows are what says "already covered".
+func (ax *abstractionIndex) ReplaceRestatementPairs(ctx context.Context, branch string, dropFactIDs []int64, add []RestatementPair, coveredNow []int64) error {
+	if len(dropFactIDs) == 0 && len(add) == 0 && len(coveredNow) == 0 {
+		return nil
+	}
+	branchID, err := ax.branchID(ctx, branch)
+	if err != nil {
+		return err
+	}
+
+	ctx, tx, owned, err := beginTxIfNeeded(ctx, ax.rh.db)
+	if err != nil {
+		return fmt.Errorf("abstraction: begin tx: %w", err)
+	}
+	if owned {
+		defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+	}
+	db := conn(ctx, ax.rh.db)
+
+	for _, id := range dropFactIDs {
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM restatement_pairs
+			  WHERE branch_id = ? AND (a_fact_id = ? OR b_fact_id = ?)`,
+			branchID, id, id); err != nil {
+			return fmt.Errorf("abstraction: drop pairs for %d: %w", id, err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM restatement_cache_state WHERE branch_id = ? AND fact_id = ?`,
+			branchID, id); err != nil {
+			return fmt.Errorf("abstraction: drop cache state for %d: %w", id, err)
+		}
+	}
+	for _, p := range add {
+		if _, err := db.ExecContext(ctx,
+			`INSERT OR REPLACE INTO restatement_pairs
+			     (branch_id, a_path, b_path, a_fact_id, b_fact_id, title_cos)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			branchID, p.APath, p.BPath, p.AFactID, p.BFactID, p.TitleCos); err != nil {
+			return fmt.Errorf("abstraction: insert pair %s|%s: %w", p.APath, p.BPath, err)
+		}
+	}
+	for _, id := range coveredNow {
+		if _, err := db.ExecContext(ctx,
+			`INSERT OR IGNORE INTO restatement_cache_state(branch_id, fact_id) VALUES (?, ?)`,
+			branchID, id); err != nil {
+			return fmt.Errorf("abstraction: record cache state for %d: %w", id, err)
+		}
+	}
+	if owned {
+		return tx.Commit()
+	}
+	return nil
+}
+
+// RestatementPairsByRank returns the top pairs by title cosine.
+//
+// Ranking is the whole selection mechanism: the "operating point" is whatever
+// absolute cosine the last selected pair happens to sit at IN THIS REPO, which
+// is why no cosine threshold appears anywhere in this file.
+func (ax *abstractionIndex) RestatementPairsByRank(ctx context.Context, branch string, limit int) ([]RestatementPair, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT p.a_path, p.b_path, p.a_fact_id, p.b_fact_id, p.title_cos
+		   FROM restatement_pairs p
+		   JOIN branches b ON b.id = p.branch_id
+		  WHERE b.name = ?
+		  ORDER BY p.title_cos DESC, p.a_path ASC, p.b_path ASC
+		  LIMIT ?`, branch, limit)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: rank pairs: %w", err)
+	}
+	defer rows.Close()
+
+	var out []RestatementPair
+	for rows.Next() {
+		var p RestatementPair
+		if err := rows.Scan(&p.APath, &p.BPath, &p.AFactID, &p.BFactID, &p.TitleCos); err != nil {
+			return nil, fmt.Errorf("abstraction: scan pair: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// RestatementPairStats describes the standing pair population. Every field is
+// OBSERVABILITY: reported in review health output, read by no branch. They are
+// descriptors of a corpus, and a corpus descriptor that decided anything would
+// be the corpus-property constant this design exists without.
+func (ax *abstractionIndex) RestatementPairStats(ctx context.Context, branch string) (RestatementPairStats, error) {
+	var st RestatementPairStats
+	if err := conn(ctx, ax.rh.db).QueryRowContext(ctx,
+		`SELECT COUNT(*)
+		   FROM restatement_pairs p
+		   JOIN branches b ON b.id = p.branch_id
+		  WHERE b.name = ?`, branch).Scan(&st.Count); err != nil {
+		return st, fmt.Errorf("abstraction: pair count: %w", err)
+	}
+	if st.Count == 0 {
+		return st, nil
+	}
+	var err error
+	if st.P99, err = ax.pairQuantile(ctx, branch, st.Count, 0.99); err != nil {
+		return st, err
+	}
+	if st.P999, err = ax.pairQuantile(ctx, branch, st.Count, 0.999); err != nil {
+		return st, err
+	}
+	return st, nil
+}
+
+// pairQuantile reads the title cosine at the given upper quantile by offsetting
+// into the descending ranking — cheap on the (branch_id, title_cos DESC) index
+// and exact, where a sampled estimate would wobble between sessions.
+func (ax *abstractionIndex) pairQuantile(ctx context.Context, branch string, count int, q float64) (float64, error) {
+	offset := int(float64(count) * (1 - q))
+	if offset >= count {
+		offset = count - 1
+	}
+	var v float64
+	err := conn(ctx, ax.rh.db).QueryRowContext(ctx,
+		`SELECT p.title_cos
+		   FROM restatement_pairs p
+		   JOIN branches b ON b.id = p.branch_id
+		  WHERE b.name = ?
+		  ORDER BY p.title_cos DESC
+		  LIMIT 1 OFFSET ?`, branch, offset).Scan(&v)
+	if err != nil {
+		return 0, fmt.Errorf("abstraction: pair quantile %.3f: %w", q, err)
+	}
+	return v, nil
+}
+
+// branchID resolves a branch name to its row id. A branch the registry has
+// never seen is an error rather than a silent no-op: writing shortlist state
+// under a phantom branch id would be invisible and permanent.
+func (ax *abstractionIndex) branchID(ctx context.Context, branch string) (int64, error) {
+	var id int64
+	err := conn(ctx, ax.rh.db).QueryRowContext(ctx,
+		`SELECT id FROM branches WHERE name = ?`, branch).Scan(&id)
+	if err == sql.ErrNoRows {
+		return 0, fmt.Errorf("abstraction: unknown branch %q", branch)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("abstraction: branch id for %q: %w", branch, err)
+	}
+	return id, nil
 }

--- a/internal/store/abstraction_helpers_test.go
+++ b/internal/store/abstraction_helpers_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -99,4 +100,12 @@ func (e *dim512Embedder) EmbedDocuments(ctx context.Context, titles, bodies []st
 
 func (e *dim512Embedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
 	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}
+
+func manyPaths(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = fmt.Sprintf("kb/p%d.md", i)
+	}
+	return out
 }

--- a/internal/store/abstraction_helpers_test.go
+++ b/internal/store/abstraction_helpers_test.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/embeddings/params"
+)
+
+// openAbstractionTestService opens a fresh repo with a stub embedder, ready for
+// abstraction-axis tests.
+func openAbstractionTestService(t *testing.T) *Service {
+	t.Helper()
+	return openAbstractionTestServiceAt(t, filepath.Join(t.TempDir(), "k.db"), &stub768Embedder{})
+}
+
+// openAbstractionTestServiceAt opens (or reopens) a repo at path under emb.
+// A repo that already exists is opened rather than initialised, so a test can
+// reopen the same file under a different embedder.
+func openAbstractionTestServiceAt(t *testing.T, path string, emb BatchEmbedder) *Service {
+	t.Helper()
+	_, statErr := os.Stat(path)
+	existed := statErr == nil
+	svc, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	svc.SetEmbedder(emb)
+	if existed {
+		require.NoError(t, svc.OpenRepo())
+	} else {
+		require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+	}
+	return svc
+}
+
+func writeTestFact(t *testing.T, svc *Service, path, title, body string) {
+	t.Helper()
+	_, err := svc.Facts().WriteFact(context.Background(), "agent/test", path,
+		"---\ntype: observation\n---\n# "+title+"\n\n"+body, "write "+path, "test")
+	require.NoError(t, err)
+}
+
+// unitVectorAt returns the dim-dimensional basis vector e_i.
+func unitVectorAt(i, dim int) []float32 {
+	v := make([]float32, dim)
+	v[i] = 1
+	return v
+}
+
+// ringVector places point i of n on a circle in the first two dimensions, so
+// cosine similarity between two points falls off with their index distance —
+// which gives a KNN test a known expected order.
+func ringVector(i, n, dim int) []float32 {
+	v := make([]float32, dim)
+	angle := 2 * math.Pi * float64(i) / float64(4*n) // spread over a quarter turn
+	v[0] = float32(math.Cos(angle))
+	v[1] = float32(math.Sin(angle))
+	return v
+}
+
+// otherIDEmbedder is stub768Embedder under a different model id, for testing
+// the embedding-identity heal.
+type otherIDEmbedder struct{ stub768Embedder }
+
+func (e *otherIDEmbedder) ID() string { return "stub768-other" }
+
+func (e *otherIDEmbedder) Thresholds() params.Thresholds { return params.Defaults() }

--- a/internal/store/abstraction_helpers_test.go
+++ b/internal/store/abstraction_helpers_test.go
@@ -70,3 +70,33 @@ type otherIDEmbedder struct{ stub768Embedder }
 func (e *otherIDEmbedder) ID() string { return "stub768-other" }
 
 func (e *otherIDEmbedder) Thresholds() params.Thresholds { return params.Defaults() }
+
+// dim512Embedder is a stub at a NON-default dimension, for testing that the vec
+// tables are created at the active model's width rather than the 768 the
+// tables are bootstrapped with at Open.
+type dim512Embedder struct{ stub768Embedder }
+
+func (e *dim512Embedder) Dim() int   { return 512 }
+func (e *dim512Embedder) ID() string { return "stub512" }
+
+func (e *dim512Embedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
+	return make([]float32, 512), nil
+}
+
+func (e *dim512Embedder) EmbedDocument(ctx context.Context, title, body string) ([]float32, error) {
+	v := make([]float32, 512)
+	v[0] = 1
+	return v, nil
+}
+
+func (e *dim512Embedder) EmbedDocuments(ctx context.Context, titles, bodies []string) ([][]float32, error) {
+	out := make([][]float32, len(titles))
+	for i := range titles {
+		out[i], _ = e.EmbedDocument(ctx, titles[i], bodies[i])
+	}
+	return out, nil
+}
+
+func (e *dim512Embedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/store/abstraction_test.go
+++ b/internal/store/abstraction_test.go
@@ -336,3 +336,62 @@ func TestAbstraction_TitleVecWidthFixedOnAnUpgradedDatabase(t *testing.T) {
 		FactID: targets[0].FactID, Vec: vec,
 	}}), "the axis must have been rebuilt at the active model's width")
 }
+
+// TestAbstraction_HandlesIdListsBeyondTheSQLVariableLimit — SQLite binds at most
+// 32,766 parameters per statement, and these queries build one placeholder per
+// fact id. The session that CLOSES a backfill rescans the whole corpus, so it
+// passes every live fact id at once: on a corpus past ~16k facts the delete
+// binds 2N parameters and the statement fails outright.
+//
+// It fails soft — the refresh degrades to "no candidates" with a health line —
+// which is exactly what makes it worth a test: a large corpus would simply
+// never get this feature, and would say so only in a line nobody reads.
+func TestAbstraction_HandlesIdListsBeyondTheSQLVariableLimit(t *testing.T) {
+	ctx := context.Background()
+	svc := openAbstractionTestService(t)
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+
+	// Well past the limit, and past 2x it for the two-list queries.
+	ids := make([]int64, 40_000)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+
+	require.NoError(t, svc.Abstraction().ReplaceRestatementPairs(ctx, "agent/test", ids, nil, ids),
+		"a whole-corpus rescan must not exceed the parameter limit")
+
+	_, err := svc.Abstraction().BodyVectorsByFactID(ctx, ids)
+	require.NoError(t, err, "scoring a whole corpus's pairs must not exceed the parameter limit")
+
+	_, err = svc.Abstraction().PartnersOfFacts(ctx, "agent/test", ids)
+	require.NoError(t, err, "a mass retraction must not exceed the parameter limit")
+
+	_, err = svc.Abstraction().FactIDsByPath(ctx, "agent/test", manyPaths(40_000))
+	require.NoError(t, err)
+}
+
+// TestCosineSim_OrthogonalIsZeroNotNull — the SQL function and the Go helper are
+// one formula now, and unifying them must not quietly change what either
+// returns. Orthogonal vectors have a defined similarity of 0; only a degenerate
+// (zero-norm) vector has none.
+func TestCosineSim_OrthogonalIsZeroNotNull(t *testing.T) {
+	svc := openAbstractionTestService(t)
+
+	a := make([]float32, 8)
+	b := make([]float32, 8)
+	a[0], b[1] = 1, 1
+
+	var sim *float64
+	require.NoError(t, svc.rh.db.QueryRow(`SELECT knomit_cosine_sim(?, ?)`,
+		float32SliceToBytes(a), float32SliceToBytes(b)).Scan(&sim))
+	require.NotNil(t, sim, "orthogonal vectors have a similarity, and it is 0")
+	require.InDelta(t, 0.0, *sim, 1e-9)
+
+	// A zero-norm vector genuinely has none.
+	require.NoError(t, svc.rh.db.QueryRow(`SELECT knomit_cosine_sim(?, ?)`,
+		float32SliceToBytes(a), float32SliceToBytes(make([]float32, 8))).Scan(&sim))
+	require.Nil(t, sim, "a degenerate vector has no similarity to anything")
+
+	require.InDelta(t, 0.0, CosineSim(a, b), 1e-9)
+	require.InDelta(t, 0.0, CosineSim(a, make([]float32, 8)), 1e-9)
+}

--- a/internal/store/abstraction_test.go
+++ b/internal/store/abstraction_test.go
@@ -1,0 +1,184 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAbstraction_TitleVectorLifecycle covers the whole of what makes the axis
+// watermark-incremental: coverage counts the live epistemic set, a stored
+// vector reads back, and EDITING a fact drops coverage because facts rows are
+// content-addressed — the edited fact is a new row with no vector, which is
+// exactly the delta a review session has to embed.
+func TestAbstraction_TitleVectorLifecycle(t *testing.T) {
+	ctx := context.Background()
+	svc := openAbstractionTestService(t)
+	ax := svc.Abstraction()
+
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+
+	have, total, err := ax.TitleVectorCoverage(ctx, "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, 0, have)
+	require.Equal(t, 1, total, "one live epistemic fact, no title vector yet")
+
+	targets, err := ax.LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, "kb/a.md", targets[0].Path)
+	require.Equal(t, "Alpha", targets[0].Title)
+
+	require.NoError(t, ax.PutTitleVectors(ctx, []TitleVector{{
+		FactID: targets[0].FactID,
+		Path:   targets[0].Path,
+		Vec:    unitVectorAt(0, 768),
+	}}))
+
+	have, total, err = ax.TitleVectorCoverage(ctx, "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, 1, have)
+	require.Equal(t, 1, total)
+
+	targets, err = ax.LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	require.Empty(t, targets, "a fact with a vector is not a backfill target")
+
+	writeTestFact(t, svc, "kb/a.md", "Alpha revised", "body-a-2")
+
+	have, total, err = ax.TitleVectorCoverage(ctx, "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, 0, have, "an edited fact is a new row, so the axis is stale by construction")
+	require.Equal(t, 1, total)
+}
+
+// TestAbstraction_PragmaticFactsAreNotOnTheAxis is a correctness filter, not a
+// preference: prune's decision path does not carry Kind through mergedFact, so
+// a pragmatic fact reaching synthesis would be silently rewritten as epistemic
+// (the reason reviewStrategy.AcceptSeed exists). A shortlist that offered one
+// would corrupt it, so pragmatic facts never join the axis.
+func TestAbstraction_PragmaticFactsAreNotOnTheAxis(t *testing.T) {
+	ctx := context.Background()
+	svc := openAbstractionTestService(t)
+
+	_, err := svc.Facts().WriteFact(ctx, "agent/test", "kb/policy.md",
+		"---\nkind: pragmatic\ntype: policy\n---\n# Policy\n\nbody", "add policy", "test")
+	require.NoError(t, err)
+
+	_, total, err := svc.Abstraction().TitleVectorCoverage(ctx, "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, 0, total)
+
+	targets, err := svc.Abstraction().LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	require.Empty(t, targets)
+}
+
+// TestAbstraction_TopTitleNeighbours proves the KNN over-fetch does its job:
+// the vec0 k window is applied BEFORE the branch/kind filter, so a naive k
+// would return short (or empty) once historical or pragmatic rows crowd the
+// window. Here five epistemic facts share the axis with a pragmatic one and a
+// superseded revision, and the query still returns live epistemic neighbours
+// only, self excluded, in descending similarity.
+func TestAbstraction_TopTitleNeighbours(t *testing.T) {
+	ctx := context.Background()
+	svc := openAbstractionTestService(t)
+	ax := svc.Abstraction()
+
+	for _, name := range []string{"a", "b", "c", "d", "e"} {
+		writeTestFact(t, svc, "kb/"+name+".md", "Title "+name, "body-"+name)
+	}
+	_, err := svc.Facts().WriteFact(ctx, "agent/test", "kb/pragmatic.md",
+		"---\nkind: pragmatic\ntype: policy\n---\n# Pragmatic\n\nbody", "add", "test")
+	require.NoError(t, err)
+
+	targets, err := ax.LiveFactsMissingTitleVector(ctx, "agent/test", 100)
+	require.NoError(t, err)
+	require.Len(t, targets, 5)
+
+	// Place the vectors on a ring so similarity order is known: index i sits at
+	// angle i, so neighbours of 0 are 1, then 2, then 3...
+	for i, tgt := range targets {
+		require.NoError(t, ax.PutTitleVectors(ctx, []TitleVector{{
+			FactID: tgt.FactID, Path: tgt.Path, Vec: ringVector(i, len(targets), 768),
+		}}))
+	}
+
+	got, err := ax.TopTitleNeighbours(ctx, "agent/test", targets[0].FactID, 2)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, n := range got {
+		require.NotEqual(t, targets[0].FactID, n.FactID, "self must be excluded")
+		require.NotEqual(t, "kb/pragmatic.md", n.Path)
+	}
+	require.GreaterOrEqual(t, got[0].Similarity, got[1].Similarity, "descending similarity")
+}
+
+// TestAbstraction_TopTitleNeighboursForUnembeddedFact returns nothing rather
+// than erroring: during a partial backfill most facts have no vector yet, and
+// the shortlist has to tolerate that quietly.
+func TestAbstraction_TopTitleNeighboursForUnembeddedFact(t *testing.T) {
+	ctx := context.Background()
+	svc := openAbstractionTestService(t)
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+
+	targets, err := svc.Abstraction().LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	got, err := svc.Abstraction().TopTitleNeighbours(ctx, "agent/test", targets[0].FactID, 5)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// TestAbstraction_BodyVectorsByFactID reads the EXISTING facts_vec rows. The
+// shortlist needs blended cosines and must never re-embed to get them
+// (conventions/synthesize/scoped-cluster-queryby-path).
+func TestAbstraction_BodyVectorsByFactID(t *testing.T) {
+	ctx := context.Background()
+	svc := openAbstractionTestService(t)
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+	writeTestFact(t, svc, "kb/b.md", "Beta", "body-b")
+
+	targets, err := svc.Abstraction().LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	ids := []int64{targets[0].FactID, targets[1].FactID}
+
+	vecs, err := svc.Abstraction().BodyVectorsByFactID(ctx, ids)
+	require.NoError(t, err)
+	require.Len(t, vecs, 2)
+	require.Len(t, vecs[ids[0]], 768)
+}
+
+// TestAbstraction_EmbedIdentityChangeClearsTheAxis — title vectors are model
+// vectors. When the embedding identity drifts, facts_vec is recreated empty and
+// the axis (and the caches derived from it) must go with it, or the next
+// session would compare cosines from two different models.
+func TestAbstraction_EmbedIdentityChangeClearsTheAxis(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.db")
+
+	svc := openAbstractionTestServiceAt(t, path, &stub768Embedder{})
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+	targets, err := svc.Abstraction().LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	require.NoError(t, svc.Abstraction().PutTitleVectors(ctx, []TitleVector{{
+		FactID: targets[0].FactID, Path: targets[0].Path, Vec: unitVectorAt(0, 768),
+	}}))
+	require.NoError(t, svc.Close())
+
+	// Reopen under a DIFFERENT model id and run the startup heal the repos
+	// layer runs: NeedsRebuild sees the embedding identity drift, and Rebuild
+	// recreates facts_vec empty. The axis must go the same way.
+	svc2 := openAbstractionTestServiceAt(t, path, &otherIDEmbedder{})
+	needs, err := svc2.IndexManager().NeedsRebuild(ctx, "agent/test")
+	require.NoError(t, err)
+	require.True(t, needs, "an embedding-identity change must demand a rebuild")
+	require.NoError(t, svc2.IndexManager().Rebuild(ctx, "agent/test", nil))
+
+	have, total, err := svc2.Abstraction().TitleVectorCoverage(ctx, "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, 1, total, "the fact is still there")
+	require.Equal(t, 0, have, "vectors from another model must not survive")
+}

--- a/internal/store/abstraction_test.go
+++ b/internal/store/abstraction_test.go
@@ -33,7 +33,6 @@ func TestAbstraction_TitleVectorLifecycle(t *testing.T) {
 
 	require.NoError(t, ax.PutTitleVectors(ctx, []TitleVector{{
 		FactID: targets[0].FactID,
-		Path:   targets[0].Path,
 		Vec:    unitVectorAt(0, 768),
 	}}))
 
@@ -102,7 +101,7 @@ func TestAbstraction_TopTitleNeighbours(t *testing.T) {
 	// angle i, so neighbours of 0 are 1, then 2, then 3...
 	for i, tgt := range targets {
 		require.NoError(t, ax.PutTitleVectors(ctx, []TitleVector{{
-			FactID: tgt.FactID, Path: tgt.Path, Vec: ringVector(i, len(targets), 768),
+			FactID: tgt.FactID, Vec: ringVector(i, len(targets), 768),
 		}}))
 	}
 
@@ -164,7 +163,7 @@ func TestAbstraction_EmbedIdentityChangeClearsTheAxis(t *testing.T) {
 	targets, err := svc.Abstraction().LiveFactsMissingTitleVector(ctx, "agent/test", 10)
 	require.NoError(t, err)
 	require.NoError(t, svc.Abstraction().PutTitleVectors(ctx, []TitleVector{{
-		FactID: targets[0].FactID, Path: targets[0].Path, Vec: unitVectorAt(0, 768),
+		FactID: targets[0].FactID, Vec: unitVectorAt(0, 768),
 	}}))
 	require.NoError(t, svc.Close())
 
@@ -181,4 +180,159 @@ func TestAbstraction_EmbedIdentityChangeClearsTheAxis(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, total, "the fact is still there")
 	require.Equal(t, 0, have, "vectors from another model must not survive")
+}
+
+// TestAbstraction_DropBranchClearsShortlistState — the restatement tables
+// reference branches(id) with no cascade, and foreign keys are enforced. Left
+// behind, they make DropBranch fail on the branches delete AFTER the git ref is
+// already gone: exactly the half-removed state DropBranch's ordering exists to
+// avoid.
+func TestAbstraction_DropBranchClearsShortlistState(t *testing.T) {
+	ctx := context.Background()
+	svc := openAbstractionTestService(t)
+	require.NoError(t, svc.Branches().CreateBranch(ctx, "agent/doomed", "agent/test"))
+
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+	targets, err := svc.Abstraction().LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, targets)
+
+	// Give the doomed branch a full set of shortlist state.
+	require.NoError(t, svc.Abstraction().ReplaceRestatementPairs(ctx, "agent/doomed", nil,
+		[]RestatementPair{{APath: "kb/a.md", BPath: "kb/b.md", AFactID: 1, BFactID: 2, TitleCos: 0.9}},
+		[]int64{1, 2}))
+	require.NoError(t, svc.Abstraction().RecordRestatementVerdict(ctx, "agent/doomed",
+		RestatementVerdict{APath: "kb/a.md", BPath: "kb/b.md", AFactID: 1, BFactID: 2}))
+	require.NoError(t, svc.Abstraction().SetProbeSessionsWaited(ctx, "agent/doomed", 3))
+
+	require.NoError(t, svc.Branches().DropBranch(ctx, "agent/doomed"),
+		"a branch carrying shortlist state must still drop cleanly")
+
+	branches, err := svc.Branches().ListBranches(ctx)
+	require.NoError(t, err)
+	for _, b := range branches {
+		require.NotEqual(t, "agent/doomed", b.Name)
+	}
+}
+
+// TestAbstraction_TitleVecWidthIsValidatedUnderEveryModel — fact_titles_vec is
+// created at the default 768 by Open (the delete trigger needs a table to
+// exist), and a vec0 table's width is fixed at CREATE. Under a model of any
+// other dimension the identity check would short-circuit before anyone noticed:
+// every insert would fail, the axis would stay empty, and the shortlist would
+// silently find nothing forever.
+func TestAbstraction_TitleVecWidthIsValidatedUnderEveryModel(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.db")
+
+	svc := openAbstractionTestServiceAt(t, path, &dim512Embedder{})
+	// Rebuild first: the vec tables are bootstrapped at the default width by
+	// Open, and it is the rebuild that recreates them at the ACTIVE model's
+	// dimension — which is the order the app startup path uses too.
+	require.NoError(t, svc.IndexManager().Rebuild(ctx, "agent/test", nil))
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+
+	targets, err := svc.Abstraction().LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+
+	vec := make([]float32, 512)
+	vec[0] = 1
+	require.NoError(t, svc.Abstraction().PutTitleVectors(ctx, []TitleVector{{
+		FactID: targets[0].FactID, Vec: vec,
+	}}), "the axis must accept vectors at the ACTIVE model's dimension")
+
+	have, _, err := svc.Abstraction().TitleVectorCoverage(ctx, "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, 1, have)
+}
+
+// TestAbstraction_EmbedIdentityChangeClearsVerdictsToo — a trailing
+// resolution-rate mixing judgements made under two embedding models is reading
+// evidence about pairs the new model may never propose. The schema says an
+// empty verdict window is safe, so a model change starts over.
+func TestAbstraction_EmbedIdentityChangeClearsVerdictsToo(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "k.db")
+
+	svc := openAbstractionTestServiceAt(t, path, &stub768Embedder{})
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+	require.NoError(t, svc.Abstraction().RecordRestatementVerdict(ctx, "agent/test",
+		RestatementVerdict{APath: "kb/a.md", BPath: "kb/b.md", AFactID: 1, BFactID: 2, Resolved: true}))
+	require.NoError(t, svc.Abstraction().SetProbeSessionsWaited(ctx, "agent/test", 4))
+	require.NoError(t, svc.Close())
+
+	svc2 := openAbstractionTestServiceAt(t, path, &otherIDEmbedder{})
+	require.NoError(t, svc2.IndexManager().Rebuild(ctx, "agent/test", nil))
+
+	verdicts, err := svc2.Abstraction().RecentRestatementVerdicts(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	require.Empty(t, verdicts, "verdicts from another model must not steer this one's throttle")
+
+	waited, err := svc2.Abstraction().ProbeSessionsWaited(ctx, "agent/test")
+	require.NoError(t, err)
+	require.Zero(t, waited)
+}
+
+// TestAbstraction_FactIDsByPathResolvesOnlyLiveVersions — verdict attribution
+// keys on ids, so a path that has been retracted must resolve to nothing rather
+// than to a stale id.
+func TestAbstraction_FactIDsByPathResolvesOnlyLiveVersions(t *testing.T) {
+	ctx := context.Background()
+	svc := openAbstractionTestService(t)
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+	writeTestFact(t, svc, "kb/b.md", "Beta", "body-b")
+
+	ids, err := svc.Abstraction().FactIDsByPath(ctx, "agent/test", []string{"kb/a.md", "kb/b.md"})
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+
+	_, err = svc.Facts().DeleteFact(ctx, "agent/test", "kb/b.md", "retract b")
+	require.NoError(t, err)
+
+	ids, err = svc.Abstraction().FactIDsByPath(ctx, "agent/test", []string{"kb/a.md", "kb/b.md"})
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	require.NotContains(t, ids, "kb/b.md")
+}
+
+// TestAbstraction_TitleVecWidthFixedOnAnUpgradedDatabase is the actual latent
+// case, and the one the width check exists for.
+//
+// A database indexed under a non-768 model, upgraded from a version that
+// predates the axis: Open bootstraps fact_titles_vec at the DEFAULT 768 so the
+// delete trigger has a table, and then the embedding identity MATCHES — same
+// model, same dim — so the rebuild has every reason to return early. Without a
+// width check that runs before that short-circuit, the axis keeps the wrong
+// width permanently: every insert fails, coverage never rises, and the
+// shortlist reports "no candidates" forever on a corpus full of them.
+func TestAbstraction_TitleVecWidthFixedOnAnUpgradedDatabase(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "k.db")
+
+	svc := openAbstractionTestServiceAt(t, path, &dim512Embedder{})
+	require.NoError(t, svc.IndexManager().Rebuild(ctx, "agent/test", nil))
+	writeTestFact(t, svc, "kb/a.md", "Alpha", "body-a")
+
+	// Simulate the pre-axis database: the titles table simply is not there.
+	_, err := svc.rh.db.ExecContext(ctx, `DROP TABLE fact_titles_vec`)
+	require.NoError(t, err)
+	require.NoError(t, svc.Close())
+
+	// Reopen: Open recreates it at the default width, and the identity check
+	// has nothing to complain about.
+	svc2 := openAbstractionTestServiceAt(t, path, &dim512Embedder{})
+	require.NoError(t, svc2.IndexManager().Rebuild(ctx, "agent/test", nil))
+
+	targets, err := svc2.Abstraction().LiveFactsMissingTitleVector(ctx, "agent/test", 10)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+
+	vec := make([]float32, 512)
+	vec[0] = 1
+	require.NoError(t, svc2.Abstraction().PutTitleVectors(ctx, []TitleVector{{
+		FactID: targets[0].FactID, Vec: vec,
+	}}), "the axis must have been rebuilt at the active model's width")
 }

--- a/internal/store/branch.go
+++ b/internal/store/branch.go
@@ -254,6 +254,17 @@ func (rh *repoHandler) DropBranch(ctx context.Context, name string) error {
 	if _, err := conn(ctx, rh.db).ExecContext(ctx, `DELETE FROM branch_facts WHERE branch_id = ?`, id); err != nil {
 		return fmt.Errorf("drop branch_facts: %w", err)
 	}
+	// 2b. Delete the branch's restatement-shortlist state. These tables
+	// reference branches(id) WITHOUT a cascade, and foreign keys are enforced
+	// (_foreign_keys=1), so leaving them would fail step 3 — after the git ref
+	// is already gone, which is the half-removed state step 1 exists to avoid.
+	// Derived state either way: the next review session rebuilds it.
+	for _, table := range []string{"restatement_pairs", "restatement_cache_state", "restatement_verdicts", "restatement_throttle_state"} {
+		if _, err := conn(ctx, rh.db).ExecContext(ctx,
+			`DELETE FROM `+table+` WHERE branch_id = ?`, id); err != nil {
+			return fmt.Errorf("drop %s: %w", table, err)
+		}
+	}
 	// 3. Delete the branches row. This cascades into branch_commits via
 	// the FK defined in migration 000004.
 	if _, err := conn(ctx, rh.db).ExecContext(ctx, `DELETE FROM branches WHERE id = ?`, id); err != nil {

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -193,9 +193,6 @@ type PipelineIndex interface {
 	CreatePipelineSession(ctx context.Context, tool, branch string) (*PipelineSession, error)
 	GetPipelineSession(ctx context.Context, id string) (*PipelineSession, error)
 	MarkPipelineSessionScoped(ctx context.Context, id string) error
-	// SetPipelineSessionHealth stores corpus-health descriptor lines for the
-	// session. Observability that rides back to the caller on the result.
-	SetPipelineSessionHealth(ctx context.Context, id, health string) error
 	AdvancePipelineSessionPhase(ctx context.Context, id, from, to string) (advanced bool, err error)
 	CompletePipelineSession(ctx context.Context, id string) error
 	InsertPipelineWorkItem(ctx context.Context, item PipelineWorkItem) error
@@ -250,9 +247,12 @@ type AbstractionIndex interface {
 	PutTitleVectors(ctx context.Context, vecs []TitleVector) error
 	// TitleVectorCoverage reports (embedded, total) over live epistemic facts.
 	TitleVectorCoverage(ctx context.Context, branch string) (have, total int, err error)
-	// LiveEpistemicFacts is the live set the pair cache is diffed against,
-	// keyed by fact id with its path.
+	// LiveEpistemicFacts is the live set, keyed by fact id with its path.
 	LiveEpistemicFacts(ctx context.Context, branch string) (map[int64]string, error)
+	// LiveEpistemicFactsOnAxis is the same set restricted to facts that carry a
+	// title vector — what the pair cache is diffed against, so a partial
+	// backfill cannot mark un-embedded facts as covered.
+	LiveEpistemicFactsOnAxis(ctx context.Context, branch string) (map[int64]string, error)
 	// TopTitleNeighbours returns up to k live epistemic neighbours of factID on
 	// the axis, self excluded, most similar first. A fact with no vector yet
 	// returns nothing rather than an error.
@@ -279,10 +279,28 @@ type AbstractionIndex interface {
 	// first — the input to the throttle.
 	RecentRestatementVerdicts(ctx context.Context, branch string, window int) ([]RestatementVerdict, error)
 	// KeptPairFactIDs returns pairs the judge declined, keyed by FactIDPairKey.
+	// Consulted when MINTING pairs, so a declined pair is not re-created by a
+	// later neighbour rescan.
 	KeptPairFactIDs(ctx context.Context, branch string) (map[string]struct{}, error)
+	// PartnersOfFacts returns the still-cached partners of the given facts, so
+	// an asymmetric KNN discovery is not lost when its owner is re-scanned.
+	PartnersOfFacts(ctx context.Context, branch string, factIDs []int64) (map[int64]struct{}, error)
+	// DeleteRestatementPair removes one standing pair (the judge declined it).
+	DeleteRestatementPair(ctx context.Context, branch string, aFactID, bFactID int64) error
+	// ProbeSessionsWaited returns how many sessions this branch has waited
+	// since its last throttle probe, and ResetProbeWait / BumpProbeWait move it.
+	// The counter is what keeps a defunded corpus recoverable.
+	ProbeSessionsWaited(ctx context.Context, branch string) (int, error)
+	SetProbeSessionsWaited(ctx context.Context, branch string, n int) error
 }
 
 // RestatementVerdict is one judge outcome on a shortlist-originated pair.
+//
+// Resolved, not Merged: a judge that consolidates a restatement by RETRACTING
+// the redundant half has done exactly the work this mechanism exists to buy.
+// Counting only merges would defund a corpus that is consolidating
+// successfully by another route — which is the failure mode a throttle can
+// least afford, since it looks identical to "the shortlist finds nothing".
 //
 // It carries fact ids as well as paths because ids are content-addressed: a
 // "keep" applies to the exact pair of versions that was judged, and editing
@@ -292,7 +310,7 @@ type RestatementVerdict struct {
 	BPath    string
 	AFactID  int64
 	BFactID  int64
-	Merged   bool
+	Resolved bool
 	JudgedAt time.Time
 }
 

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -210,6 +210,53 @@ type PipelineIndex interface {
 	SetPipelineWatermark(ctx context.Context, tool, branch, hash string) error
 }
 
+// TitleTarget is a fact whose title still needs embedding onto the abstraction
+// axis.
+type TitleTarget struct {
+	FactID int64
+	Path   string
+	Title  string
+}
+
+// TitleVector is one fact's title embedding.
+type TitleVector struct {
+	FactID int64
+	Path   string
+	Vec    []float32
+}
+
+// TitleNeighbour is one KNN hit on the abstraction axis.
+type TitleNeighbour struct {
+	FactID     int64
+	Path       string
+	Similarity float64
+}
+
+// AbstractionIndex is the title-embedding axis ("the abstraction axis") and the
+// restatement shortlist built on it. Implemented by *abstractionIndex, exposed
+// on Service via Abstraction().
+//
+// REVIEW PIPELINE ONLY. It is deliberately not part of the SearchIndex
+// composite: nothing on the runtime paths (query / explain / learn) may consume
+// it, and keeping it off the composite makes that structural rather than a rule
+// somebody has to remember.
+type AbstractionIndex interface {
+	// LiveFactsMissingTitleVector returns up to limit live epistemic facts on
+	// branch that have no title vector yet, lowest fact id first.
+	LiveFactsMissingTitleVector(ctx context.Context, branch string, limit int) ([]TitleTarget, error)
+	PutTitleVectors(ctx context.Context, vecs []TitleVector) error
+	// TitleVectorCoverage reports (embedded, total) over live epistemic facts.
+	TitleVectorCoverage(ctx context.Context, branch string) (have, total int, err error)
+	// LiveEpistemicFactIDs is the live set the pair cache is diffed against.
+	LiveEpistemicFactIDs(ctx context.Context, branch string) (map[int64]struct{}, error)
+	// TopTitleNeighbours returns up to k live epistemic neighbours of factID on
+	// the axis, self excluded, most similar first. A fact with no vector yet
+	// returns nothing rather than an error.
+	TopTitleNeighbours(ctx context.Context, branch string, factID int64, k int) ([]TitleNeighbour, error)
+	// BodyVectorsByFactID returns STORED blended vectors from facts_vec.
+	BodyVectorsByFactID(ctx context.Context, ids []int64) (map[int64][]float32, error)
+}
+
 // Embedder computes vector embeddings. Roles differ because retrieval models
 // embed queries and documents with different prompts.
 //

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -218,10 +218,10 @@ type TitleTarget struct {
 	Title  string
 }
 
-// TitleVector is one fact's title embedding.
+// TitleVector is one fact's title embedding, keyed by fact id — the same
+// content-addressed key facts_vec uses.
 type TitleVector struct {
 	FactID int64
-	Path   string
 	Vec    []float32
 }
 
@@ -282,6 +282,8 @@ type AbstractionIndex interface {
 	// Consulted when MINTING pairs, so a declined pair is not re-created by a
 	// later neighbour rescan.
 	KeptPairFactIDs(ctx context.Context, branch string) (map[string]struct{}, error)
+	// FactIDsByPath resolves specific live paths to their current fact ids.
+	FactIDsByPath(ctx context.Context, branch string, paths []string) (map[string]int64, error)
 	// PartnersOfFacts returns the still-cached partners of the given facts, so
 	// an asymmetric KNN discovery is not lost when its owner is re-scanned.
 	PartnersOfFacts(ctx context.Context, branch string, factIDs []int64) (map[int64]struct{}, error)

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -253,4 +253,10 @@ func EmbedderThresholds(emb Embedder) params.Thresholds {
 type BatchEmbedder interface {
 	Embedder
 	EmbedDocuments(ctx context.Context, titles, bodies []string) ([][]float32, error)
+	// EmbedShortStrings embeds bare short strings (fact titles today, motif
+	// names later) through the model's short-string template. Separate from
+	// EmbedDocuments because the RENDERING differs, not the batching: a few
+	// words in the document template embed measurably worse than the same words
+	// in the title slot (see embeddings.Model.ShortStringTemplate).
+	EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error)
 }

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -193,6 +193,9 @@ type PipelineIndex interface {
 	CreatePipelineSession(ctx context.Context, tool, branch string) (*PipelineSession, error)
 	GetPipelineSession(ctx context.Context, id string) (*PipelineSession, error)
 	MarkPipelineSessionScoped(ctx context.Context, id string) error
+	// SetPipelineSessionHealth stores corpus-health descriptor lines for the
+	// session. Observability that rides back to the caller on the result.
+	SetPipelineSessionHealth(ctx context.Context, id, health string) error
 	AdvancePipelineSessionPhase(ctx context.Context, id, from, to string) (advanced bool, err error)
 	CompletePipelineSession(ctx context.Context, id string) error
 	InsertPipelineWorkItem(ctx context.Context, item PipelineWorkItem) error
@@ -268,6 +271,29 @@ type AbstractionIndex interface {
 	// RestatementPairStats describes the standing population. Observability
 	// only — no branch reads these values.
 	RestatementPairStats(ctx context.Context, branch string) (RestatementPairStats, error)
+
+	// RecordRestatementVerdict records what the judge did with one
+	// shortlist-originated pair.
+	RecordRestatementVerdict(ctx context.Context, branch string, v RestatementVerdict) error
+	// RecentRestatementVerdicts returns the last `window` verdicts, newest
+	// first — the input to the throttle.
+	RecentRestatementVerdicts(ctx context.Context, branch string, window int) ([]RestatementVerdict, error)
+	// KeptPairFactIDs returns pairs the judge declined, keyed by FactIDPairKey.
+	KeptPairFactIDs(ctx context.Context, branch string) (map[string]struct{}, error)
+}
+
+// RestatementVerdict is one judge outcome on a shortlist-originated pair.
+//
+// It carries fact ids as well as paths because ids are content-addressed: a
+// "keep" applies to the exact pair of versions that was judged, and editing
+// either fact makes the pair eligible again with no staleness rule needed.
+type RestatementVerdict struct {
+	APath    string
+	BPath    string
+	AFactID  int64
+	BFactID  int64
+	Merged   bool
+	JudgedAt time.Time
 }
 
 // RestatementPair is one standing candidate: two facts whose TITLES are close

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -247,14 +247,46 @@ type AbstractionIndex interface {
 	PutTitleVectors(ctx context.Context, vecs []TitleVector) error
 	// TitleVectorCoverage reports (embedded, total) over live epistemic facts.
 	TitleVectorCoverage(ctx context.Context, branch string) (have, total int, err error)
-	// LiveEpistemicFactIDs is the live set the pair cache is diffed against.
-	LiveEpistemicFactIDs(ctx context.Context, branch string) (map[int64]struct{}, error)
+	// LiveEpistemicFacts is the live set the pair cache is diffed against,
+	// keyed by fact id with its path.
+	LiveEpistemicFacts(ctx context.Context, branch string) (map[int64]string, error)
 	// TopTitleNeighbours returns up to k live epistemic neighbours of factID on
 	// the axis, self excluded, most similar first. A fact with no vector yet
 	// returns nothing rather than an error.
 	TopTitleNeighbours(ctx context.Context, branch string, factID int64, k int) ([]TitleNeighbour, error)
 	// BodyVectorsByFactID returns STORED blended vectors from facts_vec.
 	BodyVectorsByFactID(ctx context.Context, ids []int64) (map[int64][]float32, error)
+
+	// CachedPairFactIDs returns the fact ids the standing pair cache covers.
+	CachedPairFactIDs(ctx context.Context, branch string) (map[int64]struct{}, error)
+	// ReplaceRestatementPairs applies one cache delta atomically: pairs touching
+	// dropFactIDs are removed, add is inserted, and coveredNow is recorded as
+	// covered.
+	ReplaceRestatementPairs(ctx context.Context, branch string, dropFactIDs []int64, add []RestatementPair, coveredNow []int64) error
+	// RestatementPairsByRank returns the top `limit` pairs by title cosine.
+	RestatementPairsByRank(ctx context.Context, branch string, limit int) ([]RestatementPair, error)
+	// RestatementPairStats describes the standing population. Observability
+	// only — no branch reads these values.
+	RestatementPairStats(ctx context.Context, branch string) (RestatementPairStats, error)
+}
+
+// RestatementPair is one standing candidate: two facts whose TITLES are close
+// on the abstraction axis while their bodies are not close enough for the
+// mechanical dedup gate to have merged them. Canonical order: APath < BPath.
+type RestatementPair struct {
+	APath    string
+	BPath    string
+	AFactID  int64
+	BFactID  int64
+	TitleCos float64
+}
+
+// RestatementPairStats describes the standing pair population for health
+// output: how many pairs stand, and where the top of the distribution sits.
+type RestatementPairStats struct {
+	Count int
+	P99   float64
+	P999  float64
 }
 
 // Embedder computes vector embeddings. Roles differ because retrieval models

--- a/internal/store/migrate/repo/000018_abstraction_axis.down.sql
+++ b/internal/store/migrate/repo/000018_abstraction_axis.down.sql
@@ -1,4 +1,5 @@
 DROP TRIGGER IF EXISTS facts_after_delete_title_vecs;
+DROP TABLE IF EXISTS restatement_throttle_state;
 DROP TABLE IF EXISTS restatement_verdicts;
 DROP TABLE IF EXISTS restatement_cache_state;
 DROP TABLE IF EXISTS restatement_pairs;

--- a/internal/store/migrate/repo/000018_abstraction_axis.down.sql
+++ b/internal/store/migrate/repo/000018_abstraction_axis.down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER IF EXISTS facts_after_delete_title_vecs;
+DROP TABLE IF EXISTS restatement_verdicts;
+DROP TABLE IF EXISTS restatement_cache_state;
+DROP TABLE IF EXISTS restatement_pairs;
+-- fact_titles_vec is code-managed (ensureFactTitlesVec), so it is dropped here
+-- rather than by a CREATE this file never issued.
+DROP TABLE IF EXISTS fact_titles_vec;

--- a/internal/store/migrate/repo/000018_abstraction_axis.up.sql
+++ b/internal/store/migrate/repo/000018_abstraction_axis.up.sql
@@ -91,5 +91,3 @@ CREATE TABLE IF NOT EXISTS restatement_throttle_state (
 );
 CREATE INDEX IF NOT EXISTS restatement_verdicts_recent
     ON restatement_verdicts(branch_id, id DESC);
-CREATE INDEX IF NOT EXISTS restatement_verdicts_pair
-    ON restatement_verdicts(branch_id, a_fact_id, b_fact_id);

--- a/internal/store/migrate/repo/000018_abstraction_axis.up.sql
+++ b/internal/store/migrate/repo/000018_abstraction_axis.up.sql
@@ -51,13 +51,19 @@ CREATE TABLE IF NOT EXISTS restatement_cache_state (
 );
 
 -- Judge outcomes for shortlist-originated prune items — the ONLY enforcement
--- input in this design. Two consumers: the trailing merge-rate that funds or
--- defunds a corpus's shortlist, and the kept-pair exclusion that stops one
--- declined pair from occupying the funded slots forever.
+-- input in this design. Two consumers: the trailing resolution-rate that funds
+-- or defunds a corpus's shortlist, and the kept-pair guard that stops a
+-- declined pair from being re-minted by a later neighbour rescan.
+--
+-- `resolved`, not `merged`: a judge that consolidates a restatement by
+-- RETRACTING the redundant half has done exactly the work this mechanism
+-- exists to buy, and counting only merges would defund a corpus that is
+-- consolidating successfully by another route.
 --
 -- Fact ids, not just paths, because ids are content-addressed: "the judge kept
 -- this pair" expires structurally the moment either fact is edited, with no
--- hash comparison and no staleness.
+-- hash comparison and no staleness. Paths ride along because every human and
+-- log line that reads these rows thinks in paths.
 --
 -- Losing these rows is safe. An empty window reads as "optimistic", which is
 -- the cold-start posture anyway.
@@ -68,8 +74,20 @@ CREATE TABLE IF NOT EXISTS restatement_verdicts (
     b_path    TEXT NOT NULL,
     a_fact_id INTEGER NOT NULL,
     b_fact_id INTEGER NOT NULL,
-    merged    INTEGER NOT NULL,
+    resolved  INTEGER NOT NULL,
     judged_at TEXT NOT NULL
+);
+
+-- How many sessions a defunded corpus has waited since its last probe.
+--
+-- Without this the throttle is a LATCH, not a governor: a defunded corpus
+-- emits nothing, so it produces no verdicts, so nothing can ever restore it.
+-- The counter buys back the missing feedback at a bounded price — one probe
+-- pair every Nth session — so recovery stays data-driven rather than
+-- configured.
+CREATE TABLE IF NOT EXISTS restatement_throttle_state (
+    branch_id            INTEGER PRIMARY KEY REFERENCES branches(id),
+    sessions_since_probe INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS restatement_verdicts_recent
     ON restatement_verdicts(branch_id, id DESC);

--- a/internal/store/migrate/repo/000018_abstraction_axis.up.sql
+++ b/internal/store/migrate/repo/000018_abstraction_axis.up.sql
@@ -1,0 +1,77 @@
+-- The abstraction axis (title-only embeddings) and the restatement shortlist
+-- built on it. Both exist to close gotchas/synthesize/prune-scope/c40d6748:
+-- prune's judge only ever sees facts that landed in the same cluster, so a
+-- restatement whose halves cluster apart is judged by nothing.
+--
+-- Derived index state: rebuilt from git, no data backfill here. Deliberately NO
+-- GraphSchemaVersion bump — the bump exists to force regeneration of state a
+-- rebuild would otherwise leave stale, and EMPTY is the correct state for
+-- everything below: the review pipeline fills the axis lazily under its own
+-- latency budget, and the pair cache is derived from whatever the axis holds
+-- (architecture/store/f6db3a49 — "USUALLY a bump ... but NOT ALWAYS").
+--
+-- fact_titles_vec (the axis itself) is NOT created here. A vec0 table fixes its
+-- dimension at CREATE and cannot be ALTERed, so like facts_vec it is
+-- code-managed at the active model's dimension (ensureFactTitlesVec in
+-- vec_table.go; the 000009 precedent). This file ships the plain tables and the
+-- delete trigger only.
+--
+-- The axis is keyed by facts.id, which is content-addressed
+-- (UNIQUE(path, blob_hash)), so an edited fact is a NEW row with no vector.
+-- "Rows lacking a vector" is therefore exactly the delta, and the cache is
+-- watermark-incremental with no bookkeeping of its own.
+CREATE TRIGGER IF NOT EXISTS facts_after_delete_title_vecs AFTER DELETE ON facts
+BEGIN
+    DELETE FROM fact_titles_vec WHERE rowid = OLD.id;
+END;
+
+-- Standing candidate pairs, per branch. Canonical order: a_path < b_path, with
+-- the ids ordered to match, so the primary key collapses A-B and B-A.
+CREATE TABLE IF NOT EXISTS restatement_pairs (
+    branch_id  INTEGER NOT NULL REFERENCES branches(id),
+    a_path     TEXT NOT NULL,
+    b_path     TEXT NOT NULL,
+    a_fact_id  INTEGER NOT NULL,
+    b_fact_id  INTEGER NOT NULL,
+    title_cos  REAL NOT NULL,
+    PRIMARY KEY (branch_id, a_path, b_path)
+);
+CREATE INDEX IF NOT EXISTS restatement_pairs_rank
+    ON restatement_pairs(branch_id, title_cos DESC);
+CREATE INDEX IF NOT EXISTS restatement_pairs_a ON restatement_pairs(branch_id, a_fact_id);
+CREATE INDEX IF NOT EXISTS restatement_pairs_b ON restatement_pairs(branch_id, b_fact_id);
+
+-- Which fact ids the pair cache was last built over, per branch. The symmetric
+-- difference against the live set IS the delta: no watermark column, and
+-- nothing to migrate when the corpus changes shape.
+CREATE TABLE IF NOT EXISTS restatement_cache_state (
+    branch_id INTEGER NOT NULL REFERENCES branches(id),
+    fact_id   INTEGER NOT NULL,
+    PRIMARY KEY (branch_id, fact_id)
+);
+
+-- Judge outcomes for shortlist-originated prune items — the ONLY enforcement
+-- input in this design. Two consumers: the trailing merge-rate that funds or
+-- defunds a corpus's shortlist, and the kept-pair exclusion that stops one
+-- declined pair from occupying the funded slots forever.
+--
+-- Fact ids, not just paths, because ids are content-addressed: "the judge kept
+-- this pair" expires structurally the moment either fact is edited, with no
+-- hash comparison and no staleness.
+--
+-- Losing these rows is safe. An empty window reads as "optimistic", which is
+-- the cold-start posture anyway.
+CREATE TABLE IF NOT EXISTS restatement_verdicts (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    branch_id INTEGER NOT NULL REFERENCES branches(id),
+    a_path    TEXT NOT NULL,
+    b_path    TEXT NOT NULL,
+    a_fact_id INTEGER NOT NULL,
+    b_fact_id INTEGER NOT NULL,
+    merged    INTEGER NOT NULL,
+    judged_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS restatement_verdicts_recent
+    ON restatement_verdicts(branch_id, id DESC);
+CREATE INDEX IF NOT EXISTS restatement_verdicts_pair
+    ON restatement_verdicts(branch_id, a_fact_id, b_fact_id);

--- a/internal/store/mock_batch_embedder_test.go
+++ b/internal/store/mock_batch_embedder_test.go
@@ -85,6 +85,21 @@ func (mr *MockBatchEmbedderMockRecorder) EmbedDocuments(ctx, titles, bodies any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmbedDocuments", reflect.TypeOf((*MockBatchEmbedder)(nil).EmbedDocuments), ctx, titles, bodies)
 }
 
+// EmbedShortStrings mocks base method.
+func (m *MockBatchEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EmbedShortStrings", ctx, texts)
+	ret0, _ := ret[0].([][]float32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EmbedShortStrings indicates an expected call of EmbedShortStrings.
+func (mr *MockBatchEmbedderMockRecorder) EmbedShortStrings(ctx, texts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmbedShortStrings", reflect.TypeOf((*MockBatchEmbedder)(nil).EmbedShortStrings), ctx, texts)
+}
+
 // EmbedQuery mocks base method.
 func (m *MockBatchEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
 	m.ctrl.T.Helper()

--- a/internal/store/pipeline_index.go
+++ b/internal/store/pipeline_index.go
@@ -18,13 +18,16 @@ import (
 // Phase is what makes the reviewer stateless across MCP calls — see
 // AdvancePipelineSessionPhase for the CAS guarantee.
 type PipelineSession struct {
-	ID        string
-	Tool      string
-	Branch    string
-	Status    string // "active", "completed", "abandoned"
-	Phase     string // "work", "reflect", "done"
-	Scoped    bool   // true when session was started with a scope filter active
-	Stats     PipelineSessionStats
+	ID     string
+	Tool   string
+	Branch string
+	Status string // "active", "completed", "abandoned"
+	Phase  string // "work", "reflect", "done"
+	Scoped bool   // true when session was started with a scope filter active
+	Stats  PipelineSessionStats
+	// Health carries corpus-health descriptor lines recorded while planning the
+	// session, as a JSON array. Observability only.
+	Health    string
 	CreatedAt string
 	UpdatedAt string
 }
@@ -155,11 +158,11 @@ func (pi *pipelineIndex) GetPipelineSession(ctx context.Context, id string) (*Pi
 	err := pi.sessionDB.QueryRowContext(ctx,
 		`SELECT id, tool, branch, status, phase, scoped,
 		        stat_pruned, stat_merged, stat_updated, stat_synthesized,
-		        created_at, updated_at
+		        health, created_at, updated_at
 		 FROM pipeline_sessions WHERE id = ?`, id,
 	).Scan(&s.ID, &s.Tool, &s.Branch, &s.Status, &s.Phase, &scoped,
 		&s.Stats.Pruned, &s.Stats.Merged, &s.Stats.Updated, &s.Stats.Synthesized,
-		&s.CreatedAt, &s.UpdatedAt)
+		&s.Health, &s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -168,6 +171,21 @@ func (pi *pipelineIndex) GetPipelineSession(ctx context.Context, id string) (*Pi
 	}
 	s.Scoped = scoped != 0
 	return &s, nil
+}
+
+// SetPipelineSessionHealth stores the session's health descriptor lines.
+//
+// On the session row rather than in memory for the same reason the stat
+// counters are: the engine is per-call stateless, so anything held on the
+// Reviewer between the plan and the result is discarded
+// (invariants/synthesize/per-call-objects-no-session-state).
+func (pi *pipelineIndex) SetPipelineSessionHealth(ctx context.Context, id, health string) error {
+	if _, err := pi.sessionDB.ExecContext(ctx,
+		`UPDATE pipeline_sessions SET health = ?, updated_at = ? WHERE id = ?`,
+		health, time.Now().UTC().Format(time.RFC3339), id); err != nil {
+		return fmt.Errorf("SetPipelineSessionHealth: %w", err)
+	}
+	return nil
 }
 
 // MarkPipelineSessionScoped marks a session as having been started with a

--- a/internal/store/pipeline_index.go
+++ b/internal/store/pipeline_index.go
@@ -26,8 +26,10 @@ type PipelineSession struct {
 	Scoped bool   // true when session was started with a scope filter active
 	Stats  PipelineSessionStats
 	// Health carries corpus-health descriptor lines recorded while planning the
-	// session, as a JSON array. Observability only.
-	Health    string
+	// session. IN MEMORY ONLY — it is written and read inside the same
+	// StartSession call, so it is deliberately not a column: nothing needs it
+	// after the turn that produced it.
+	Health    []string
 	CreatedAt string
 	UpdatedAt string
 }
@@ -158,11 +160,11 @@ func (pi *pipelineIndex) GetPipelineSession(ctx context.Context, id string) (*Pi
 	err := pi.sessionDB.QueryRowContext(ctx,
 		`SELECT id, tool, branch, status, phase, scoped,
 		        stat_pruned, stat_merged, stat_updated, stat_synthesized,
-		        health, created_at, updated_at
+		        created_at, updated_at
 		 FROM pipeline_sessions WHERE id = ?`, id,
 	).Scan(&s.ID, &s.Tool, &s.Branch, &s.Status, &s.Phase, &scoped,
 		&s.Stats.Pruned, &s.Stats.Merged, &s.Stats.Updated, &s.Stats.Synthesized,
-		&s.Health, &s.CreatedAt, &s.UpdatedAt)
+		&s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -171,21 +173,6 @@ func (pi *pipelineIndex) GetPipelineSession(ctx context.Context, id string) (*Pi
 	}
 	s.Scoped = scoped != 0
 	return &s, nil
-}
-
-// SetPipelineSessionHealth stores the session's health descriptor lines.
-//
-// On the session row rather than in memory for the same reason the stat
-// counters are: the engine is per-call stateless, so anything held on the
-// Reviewer between the plan and the result is discarded
-// (invariants/synthesize/per-call-objects-no-session-state).
-func (pi *pipelineIndex) SetPipelineSessionHealth(ctx context.Context, id, health string) error {
-	if _, err := pi.sessionDB.ExecContext(ctx,
-		`UPDATE pipeline_sessions SET health = ?, updated_at = ? WHERE id = ?`,
-		health, time.Now().UTC().Format(time.RFC3339), id); err != nil {
-		return fmt.Errorf("SetPipelineSessionHealth: %w", err)
-	}
-	return nil
 }
 
 // MarkPipelineSessionScoped marks a session as having been started with a

--- a/internal/store/rebuild_concurrency_test.go
+++ b/internal/store/rebuild_concurrency_test.go
@@ -211,3 +211,17 @@ func TestRebuild_SerializedWithConcurrentSyncLocked(t *testing.T) {
 		t.Fatal("SyncLocked never resumed after Rebuild released the branch lock")
 	}
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *blockingBatchEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *shortBatchEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/store/rebuild_title_threading_test.go
+++ b/internal/store/rebuild_title_threading_test.go
@@ -92,3 +92,10 @@ func TestRebuildEmbeddings_ThreadsTitleIntoDocuments(t *testing.T) {
 	require.NotContains(t, pairedBody, "Unique-Title-Marker",
 		"the title must not be concatenated into the body argument")
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *recordingEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/store/remote_migration_test.go
+++ b/internal/store/remote_migration_test.go
@@ -70,7 +70,7 @@ func TestMigration017_UpgradesPreMigrationDatabase(t *testing.T) {
 	var dirty bool
 	require.NoError(t, svc2.rh.db.QueryRow(
 		`SELECT version, dirty FROM schema_migrations`).Scan(&v, &dirty))
-	require.Equal(t, 17, v, "the store must have migrated forward")
+	require.Equal(t, 18, v, "the store must have migrated forward")
 	require.False(t, dirty)
 
 	// The connection columns are gone...

--- a/internal/store/search_graph_knn_test.go
+++ b/internal/store/search_graph_knn_test.go
@@ -60,3 +60,10 @@ func TestGraphBuildSimilarityEdges_SkipsNeighborWithNullDistance(t *testing.T) {
 	err = svc.si.graphBuildSimilarityEdges(ctx, "kb/x/src.md", blobHash)
 	require.NoError(t, err, "NULL-distance neighbors must be skipped, not fail the edge build")
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *zeroForMarkerEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/store/search_index_test.go
+++ b/internal/store/search_index_test.go
@@ -283,3 +283,10 @@ func TestUpsert_DuplicateEntitiesAndDomains_NoError(t *testing.T) {
 	// Domains are stored canonicalised (de-hyphenized): "machine-learning" → "machine learning".
 	require.Equal(t, []string{"ai", "machine learning"}, domains)
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *configurableEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/store/search_query_test.go
+++ b/internal/store/search_query_test.go
@@ -189,3 +189,10 @@ func TestRecentFacts_PopulatesCommitHash(t *testing.T) {
 	require.NotEmpty(t, searchEntries)
 	require.Equal(t, commit, searchEntries[0].CommitHash, "text-search RecentFacts must populate CommitHash")
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *rankedEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/store/service.go
+++ b/internal/store/service.go
@@ -50,10 +50,14 @@ type Service struct {
 	// The four query sub-services carved out of searchIndex (P1.3). searchIndex
 	// (si) keeps IndexManager + the write/rebuild path; these own the read
 	// surface. search composes all four for the Search() composite.
-	fq     *factQuery
-	gq     *graphStore
-	hq     *historyQuery
-	mq     *methodologyMatcher
+	fq *factQuery
+	gq *graphStore
+	hq *historyQuery
+	mq *methodologyMatcher
+	// ax is the abstraction axis + restatement shortlist. Kept OFF the search
+	// facade on purpose: it is review-pipeline state, and composing it would
+	// hand it to every mcp/web consumer of Search().
+	ax     *abstractionIndex
 	search *searchFacade
 	pi     *pipelineIndex
 	ti     *toolIndex
@@ -154,6 +158,7 @@ func Open(path string) (*Service, error) {
 	gq := &graphStore{rh: rh}
 	hq := &historyQuery{rh: rh}
 	mq := &methodologyMatcher{rh: rh}
+	ax := &abstractionIndex{rh: rh}
 	search := &searchFacade{factQuery: fq, graphStore: gq, historyQuery: hq, methodologyMatcher: mq}
 	canonPath := canonicalizePath(path)
 
@@ -176,6 +181,7 @@ func Open(path string) (*Service, error) {
 		gq:            gq,
 		hq:            hq,
 		mq:            mq,
+		ax:            ax,
 		search:        search,
 		pi:            &pipelineIndex{rh: rh, sessionDB: sessionDB},
 		ti:            &toolIndex{db: sessionDB},
@@ -354,6 +360,10 @@ func (s *Service) HistoryQuery() HistoryQuery { return s.hq }
 
 // Methodology returns the methodology-matching query sub-service.
 func (s *Service) Methodology() MethodologyMatcher { return s.mq }
+
+// Abstraction returns the title-embedding axis and the restatement shortlist
+// built on it. REVIEW PIPELINE ONLY — no runtime path may consume it.
+func (s *Service) Abstraction() AbstractionIndex { return s.ax }
 
 // IndexManager returns the IndexManager for search index lifecycle operations.
 func (s *Service) IndexManager() IndexManager { return s.si }

--- a/internal/store/session_schema.sql
+++ b/internal/store/session_schema.sql
@@ -59,10 +59,6 @@ CREATE TABLE pipeline_sessions (
     stat_merged      INTEGER NOT NULL DEFAULT 0,
     stat_updated     INTEGER NOT NULL DEFAULT 0,
     stat_synthesized INTEGER NOT NULL DEFAULT 0,
-    -- Corpus-health descriptors produced while planning this session (one line
-    -- per entry, JSON array). Observability that travels back to the calling
-    -- agent on the session result; nothing in the engine reads it back.
-    health       TEXT NOT NULL DEFAULT '',
     created_at   TEXT NOT NULL,
     updated_at   TEXT NOT NULL,
     last_used_at TEXT NOT NULL              -- idle-reap heartbeat (bumped on work-item access)

--- a/internal/store/session_schema.sql
+++ b/internal/store/session_schema.sql
@@ -59,6 +59,10 @@ CREATE TABLE pipeline_sessions (
     stat_merged      INTEGER NOT NULL DEFAULT 0,
     stat_updated     INTEGER NOT NULL DEFAULT 0,
     stat_synthesized INTEGER NOT NULL DEFAULT 0,
+    -- Corpus-health descriptors produced while planning this session (one line
+    -- per entry, JSON array). Observability that travels back to the calling
+    -- agent on the session result; nothing in the engine reads it back.
+    health       TEXT NOT NULL DEFAULT '',
     created_at   TEXT NOT NULL,
     updated_at   TEXT NOT NULL,
     last_used_at TEXT NOT NULL              -- idle-reap heartbeat (bumped on work-item access)

--- a/internal/store/sqlfuncs.go
+++ b/internal/store/sqlfuncs.go
@@ -3,9 +3,7 @@
 package store
 
 import (
-	"encoding/binary"
 	"encoding/json"
-	"math"
 
 	"knomit/internal/fact"
 
@@ -78,21 +76,21 @@ func sqlParseFact(data []byte) interface{} {
 // Both inputs must be little-endian float32 arrays of equal length.
 // Returns a REAL in [-1, 1] or NULL on invalid input.
 func sqlCosineSim(a, b []byte) interface{} {
-	if len(a) == 0 || len(b) == 0 || len(a) != len(b) || len(a)%4 != 0 {
+	va, err := bytesToFloat32Slice(a)
+	if err != nil || len(va) == 0 {
 		return nil
 	}
-	n := len(a) / 4
-	var dot, normA, normB float64
-	for i := 0; i < n; i++ {
-		va := float64(math.Float32frombits(binary.LittleEndian.Uint32(a[i*4:])))
-		vb := float64(math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:])))
-		dot += va * vb
-		normA += va * va
-		normB += vb * vb
-	}
-	denom := math.Sqrt(normA) * math.Sqrt(normB)
-	if denom == 0 {
+	vb, err := bytesToFloat32Slice(b)
+	if err != nil || len(vb) != len(va) {
 		return nil
 	}
-	return dot / denom
+	sim := CosineSim(va, vb)
+	if sim == 0 {
+		// CosineSim folds "degenerate" into 0; SQL callers want NULL for a
+		// vector that has no meaningful similarity, and a genuine 0 is
+		// indistinguishable from it at this boundary. Orthogonality is
+		// vanishingly rare in practice and NULL is the safer answer.
+		return nil
+	}
+	return sim
 }

--- a/internal/store/sqlfuncs.go
+++ b/internal/store/sqlfuncs.go
@@ -84,12 +84,11 @@ func sqlCosineSim(a, b []byte) interface{} {
 	if err != nil || len(vb) != len(va) {
 		return nil
 	}
-	sim := CosineSim(va, vb)
-	if sim == 0 {
-		// CosineSim folds "degenerate" into 0; SQL callers want NULL for a
-		// vector that has no meaningful similarity, and a genuine 0 is
-		// indistinguishable from it at this boundary. Orthogonality is
-		// vanishingly rare in practice and NULL is the safer answer.
+	sim, ok := cosineSim(va, vb)
+	if !ok {
+		// NULL only for a vector with no defined similarity. Orthogonal vectors
+		// are not that case: their similarity is 0, and reporting NULL for it
+		// would change what this function has always answered.
 		return nil
 	}
 	return sim

--- a/internal/store/threshold_wiring_test.go
+++ b/internal/store/threshold_wiring_test.go
@@ -120,3 +120,10 @@ func pathSet(results []SearchResult) map[string]bool {
 	}
 	return out
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *floorEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/store/vec.go
+++ b/internal/store/vec.go
@@ -79,3 +79,28 @@ func bytesToFloat32Slice(b []byte) ([]float32, error) {
 	}
 	return v, nil
 }
+
+// CosineSim is the cosine similarity of two vectors, and the single definition
+// of that formula in this package: the SQL function knomit_cosine_sim decodes
+// its blobs and calls straight through to it, so a change here cannot leave the
+// two disagreeing.
+//
+// Returns 0 for mismatched lengths or a degenerate (zero-norm) vector, which
+// has no meaningful similarity to anything.
+func CosineSim(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		va, vb := float64(a[i]), float64(b[i])
+		dot += va * vb
+		normA += va * va
+		normB += vb * vb
+	}
+	denom := math.Sqrt(normA) * math.Sqrt(normB)
+	if denom == 0 {
+		return 0
+	}
+	return dot / denom
+}

--- a/internal/store/vec.go
+++ b/internal/store/vec.go
@@ -82,14 +82,25 @@ func bytesToFloat32Slice(b []byte) ([]float32, error) {
 
 // CosineSim is the cosine similarity of two vectors, and the single definition
 // of that formula in this package: the SQL function knomit_cosine_sim decodes
-// its blobs and calls straight through to it, so a change here cannot leave the
-// two disagreeing.
+// its blobs and calls straight through to cosineSim, so a change here cannot
+// leave the two disagreeing.
 //
-// Returns 0 for mismatched lengths or a degenerate (zero-norm) vector, which
-// has no meaningful similarity to anything.
+// Returns 0 when there is no defined similarity — mismatched lengths, or a
+// degenerate (zero-norm) vector. Callers that must distinguish "no similarity"
+// from a genuine 0 (orthogonal vectors have a perfectly good similarity, and it
+// is 0) use cosineSim instead.
 func CosineSim(a, b []float32) float64 {
+	sim, _ := cosineSim(a, b)
+	return sim
+}
+
+// cosineSim reports the similarity and whether it is DEFINED. The bool is the
+// distinction the SQL function needs and the shortlist does not: SQL answers
+// NULL for a degenerate vector, while a threshold comparison treats "undefined"
+// and "far apart" the same way.
+func cosineSim(a, b []float32) (float64, bool) {
 	if len(a) != len(b) || len(a) == 0 {
-		return 0
+		return 0, false
 	}
 	var dot, normA, normB float64
 	for i := range a {
@@ -100,7 +111,7 @@ func CosineSim(a, b []float32) float64 {
 	}
 	denom := math.Sqrt(normA) * math.Sqrt(normB)
 	if denom == 0 {
-		return 0
+		return 0, false
 	}
-	return dot / denom
+	return dot / denom, true
 }

--- a/internal/store/vec_table.go
+++ b/internal/store/vec_table.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 // defaultVecDim is the dimension facts_vec is created at when no embedder is
@@ -81,29 +82,79 @@ func (si *searchIndex) ensureFactsVec(ctx context.Context, modelID string, dim i
 	if err != nil {
 		return err
 	}
-	exists, err := si.vecTableExists(ctx, factsVecTable)
+	// Width is validated on EVERY path, before the identity short-circuit.
+	// fact_titles_vec is created at defaultVecDim by Open (the table must exist
+	// for the delete trigger), so under a model of any other dimension it would
+	// otherwise keep that wrong width forever: inserts would fail, the axis
+	// would stay empty, and the shortlist would silently find nothing. The
+	// identity check below governs RE-EMBEDDING; it cannot govern shape.
+	titlesOK, err := si.vecTableHasDim(ctx, titlesVecTable, dim)
 	if err != nil {
 		return err
 	}
-	if exists && curID == modelID && curDim == dim {
+	if !titlesOK {
+		if err := si.recreateVecTable(ctx, titlesVecTable, dim); err != nil {
+			return err
+		}
+		if err := si.clearRestatementState(ctx); err != nil {
+			return err
+		}
+	}
+
+	factsOK, err := si.vecTableHasDim(ctx, factsVecTable, dim)
+	if err != nil {
+		return err
+	}
+	if factsOK && curID == modelID && curDim == dim {
 		return nil
 	}
 	// The abstraction axis is embedded by the same model at the same dimension,
 	// so it drifts with facts_vec and is recreated by the same mechanism. The
-	// restatement caches are derived from the axis — title cosines computed
-	// under another model are not comparable — so they go with it.
+	// restatement state is derived from the axis — title cosines computed under
+	// another model are not comparable — so it goes with it.
 	if err := si.recreateVecTable(ctx, factsVecTable, dim); err != nil {
 		return err
 	}
 	if err := si.recreateVecTable(ctx, titlesVecTable, dim); err != nil {
 		return err
 	}
-	for _, table := range []string{"restatement_pairs", "restatement_cache_state"} {
+	return si.clearRestatementState(ctx)
+}
+
+// clearRestatementState drops everything derived from the abstraction axis.
+//
+// The VERDICTS go too, which is easy to miss: a trailing resolution-rate that
+// mixed judgements made under two different embedding models would be reading
+// evidence about pairs the new model may never propose. The schema says an
+// empty verdict window is safe — it reads as "optimistic", the cold-start
+// posture — so the honest move on a model change is to start over.
+func (si *searchIndex) clearRestatementState(ctx context.Context) error {
+	for _, table := range []string{
+		"restatement_pairs",
+		"restatement_cache_state",
+		"restatement_verdicts",
+		"restatement_throttle_state",
+	} {
 		if _, err := conn(ctx, si.rh.db).ExecContext(ctx, `DELETE FROM `+table); err != nil {
 			return fmt.Errorf("clear %s on embed-identity change: %w", table, err)
 		}
 	}
 	return nil
+}
+
+// vecTableHasDim reports whether table exists AND was created at exactly dim,
+// read back from its stored DDL.
+func (si *searchIndex) vecTableHasDim(ctx context.Context, table string, dim int) (bool, error) {
+	var ddl sql.NullString
+	err := conn(ctx, si.rh.db).QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name = ?`, table).Scan(&ddl)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s ddl: %w", table, err)
+	}
+	return strings.Contains(ddl.String, fmt.Sprintf("FLOAT[%d]", dim)), nil
 }
 
 // recreateVecTable drops table if present and creates it empty at dim.

--- a/internal/store/vec_table.go
+++ b/internal/store/vec_table.go
@@ -16,6 +16,19 @@ import (
 // dimension.
 const defaultVecDim = 768
 
+// The two code-managed vec0 tables. Both are keyed by facts.id and both are
+// created at the ACTIVE model's dimension, which is why neither can be a static
+// migration: a vec0 table fixes its width at CREATE and cannot be ALTERed.
+//
+//   - factsVecTable holds the blended (title+body) document vector every fact
+//     is indexed with.
+//   - titlesVecTable holds the ABSTRACTION AXIS: the title embedded alone. It
+//     is filled lazily by the review pipeline, never by the write path.
+const (
+	factsVecTable  = "facts_vec"
+	titlesVecTable = "fact_titles_vec"
+)
+
 // ensureFactsVecDefault creates facts_vec at defaultVecDim if it does not
 // already exist, without consulting or writing the embed identity meta. Called
 // from Open so the table is present from the moment the DB is migrated (the
@@ -23,26 +36,32 @@ const defaultVecDim = 768
 // embedder is ever configured. A no-op when the table already exists, so it
 // never clobbers a table that ensureFactsVec created at a real model dim.
 func (si *searchIndex) ensureFactsVecDefault(ctx context.Context) error {
-	exists, err := si.factsVecExists(ctx)
-	if err != nil {
-		return err
+	for _, table := range []string{factsVecTable, titlesVecTable} {
+		exists, err := si.vecTableExists(ctx, table)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		if err := si.createVecTable(ctx, table, defaultVecDim); err != nil {
+			return err
+		}
 	}
-	if exists {
-		return nil
-	}
-	return si.createFactsVec(ctx, defaultVecDim)
+	return nil
 }
 
-// createFactsVec creates the facts_vec vec0 table at exactly `dim`. It is the
-// single source of the table's DDL, shared by ensureFactsVecDefault and
+// createVecTable creates one code-managed vec0 table at exactly `dim`. It is
+// the single source of their DDL, shared by ensureFactsVecDefault and
 // ensureFactsVec so the column spec (width, distance metric) can never drift
-// between the create-on-Open and recreate-on-rebuild paths. `dim` comes from the
-// trusted model registry (or defaultVecDim), so formatting it into DDL is safe.
-func (si *searchIndex) createFactsVec(ctx context.Context, dim int) error {
+// between the create-on-Open and recreate-on-rebuild paths. `table` is one of
+// the constants above and `dim` comes from the trusted model registry (or
+// defaultVecDim), so formatting both into DDL is safe.
+func (si *searchIndex) createVecTable(ctx context.Context, table string, dim int) error {
 	if _, err := conn(ctx, si.rh.db).ExecContext(ctx,
-		fmt.Sprintf(`CREATE VIRTUAL TABLE facts_vec USING vec0(embedding FLOAT[%d] distance_metric=cosine)`, dim),
+		fmt.Sprintf(`CREATE VIRTUAL TABLE %s USING vec0(embedding FLOAT[%d] distance_metric=cosine)`, table, dim),
 	); err != nil {
-		return fmt.Errorf("create facts_vec[%d]: %w", dim, err)
+		return fmt.Errorf("create %s[%d]: %w", table, dim, err)
 	}
 	return nil
 }
@@ -62,30 +81,54 @@ func (si *searchIndex) ensureFactsVec(ctx context.Context, modelID string, dim i
 	if err != nil {
 		return err
 	}
-	exists, err := si.factsVecExists(ctx)
+	exists, err := si.vecTableExists(ctx, factsVecTable)
 	if err != nil {
 		return err
 	}
 	if exists && curID == modelID && curDim == dim {
 		return nil
 	}
+	// The abstraction axis is embedded by the same model at the same dimension,
+	// so it drifts with facts_vec and is recreated by the same mechanism. The
+	// restatement caches are derived from the axis — title cosines computed
+	// under another model are not comparable — so they go with it.
+	if err := si.recreateVecTable(ctx, factsVecTable, dim); err != nil {
+		return err
+	}
+	if err := si.recreateVecTable(ctx, titlesVecTable, dim); err != nil {
+		return err
+	}
+	for _, table := range []string{"restatement_pairs", "restatement_cache_state"} {
+		if _, err := conn(ctx, si.rh.db).ExecContext(ctx, `DELETE FROM `+table); err != nil {
+			return fmt.Errorf("clear %s on embed-identity change: %w", table, err)
+		}
+	}
+	return nil
+}
+
+// recreateVecTable drops table if present and creates it empty at dim.
+func (si *searchIndex) recreateVecTable(ctx context.Context, table string, dim int) error {
+	exists, err := si.vecTableExists(ctx, table)
+	if err != nil {
+		return err
+	}
 	if exists {
-		if err := si.dropFactsVec(ctx); err != nil {
+		if err := si.dropVecTable(ctx, table); err != nil {
 			return err
 		}
 	}
-	return si.createFactsVec(ctx, dim)
+	return si.createVecTable(ctx, table, dim)
 }
 
-func (si *searchIndex) factsVecExists(ctx context.Context) (bool, error) {
+func (si *searchIndex) vecTableExists(ctx context.Context, table string) (bool, error) {
 	var n int
 	err := conn(ctx, si.rh.db).QueryRowContext(ctx,
-		`SELECT count(*) FROM sqlite_master WHERE type='table' AND name='facts_vec'`).Scan(&n)
+		`SELECT count(*) FROM sqlite_master WHERE type='table' AND name = ?`, table).Scan(&n)
 	return n > 0, err
 }
 
-func (si *searchIndex) dropFactsVec(ctx context.Context) error {
-	_, err := conn(ctx, si.rh.db).ExecContext(ctx, `DROP TABLE IF EXISTS facts_vec`)
+func (si *searchIndex) dropVecTable(ctx context.Context, table string) error {
+	_, err := conn(ctx, si.rh.db).ExecContext(ctx, `DROP TABLE IF EXISTS `+table)
 	return err
 }
 

--- a/internal/store/vec_table_test.go
+++ b/internal/store/vec_table_test.go
@@ -66,7 +66,7 @@ func TestEnsureFactsVecCreatesAtDim(t *testing.T) {
 	// Open created facts_vec at the default dim; recreate at 1024.
 	require.NoError(t, si.ensureFactsVec(ctx, "m", 1024))
 
-	exists, err := si.factsVecExists(ctx)
+	exists, err := si.vecTableExists(ctx, factsVecTable)
 	require.NoError(t, err)
 	require.True(t, exists, "facts_vec must exist after ensureFactsVec")
 

--- a/internal/store/verify_test.go
+++ b/internal/store/verify_test.go
@@ -392,3 +392,10 @@ func TestVerify_DetectsMissingGraphFactNode(t *testing.T) {
 	}
 	require.True(t, found, "expected graph-coherence Error for kb/x.md, got: %v", report.Issues)
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *stub768Embedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -174,13 +174,10 @@ func (p *Pipeline) StartSession(ctx context.Context) (*PipelineResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Health descriptors recorded during Plan ride the FIRST result: the
-	// session row is the only place they could survive planning (the engine is
-	// per-call stateless), and the start turn is the one the agent reads before
-	// deciding how much of this session to work through.
-	if fresh, ferr := d.Pipeline.GetPipelineSession(ctx, sess.ID); ferr == nil {
-		res.Health = sessionHealthLines(fresh)
-	}
+	// Health descriptors recorded during Plan ride the FIRST result — the turn
+	// the agent reads before deciding how much of this session to work through.
+	// Plan hung them on the same session object this call is holding.
+	res.Health = sess.Health
 	return res, nil
 }
 

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -82,34 +82,37 @@ func errf(tool string, format string, args ...any) error {
 }
 
 // storeIndices returns the store indices under the repo read lock.
-func (p *Pipeline) storeIndices() (store.FactIndex, SearchQuery, store.PipelineIndex, store.BranchIndex) {
+func (p *Pipeline) storeIndices() (store.FactIndex, SearchQuery, store.PipelineIndex, store.BranchIndex, store.AbstractionIndex) {
 	var gs store.FactIndex
 	var idx SearchQuery
 	var pipelineIdx store.PipelineIndex
 	var branches store.BranchIndex
+	var abstraction store.AbstractionIndex
 	p.ri.WithRead(func(svc *store.Service) {
 		gs = svc.Facts()
 		idx = svc.Search()
 		pipelineIdx = svc.Pipeline()
 		branches = svc.Branches()
+		abstraction = svc.Abstraction()
 	})
-	return gs, idx, pipelineIdx, branches
+	return gs, idx, pipelineIdx, branches, abstraction
 }
 
 // deps resolves the per-call dependency bundle handed to Strategy methods.
 // Resolved once per engine entry point (and once per dispatch hop) rather than
 // cached on the struct, so a store swap between turns is picked up.
 func (p *Pipeline) deps() Deps {
-	gs, idx, pipelineIdx, branches := p.storeIndices()
+	gs, idx, pipelineIdx, branches, abstraction := p.storeIndices()
 	return Deps{
-		RI:         p.ri,
-		Facts:      gs,
-		Search:     idx,
-		Pipeline:   pipelineIdx,
-		Branches:   branches,
-		Effort:     p.effort,
-		Scope:      p.scope,
-		OnProgress: p.onProgress,
+		RI:          p.ri,
+		Facts:       gs,
+		Search:      idx,
+		Pipeline:    pipelineIdx,
+		Branches:    branches,
+		Abstraction: abstraction,
+		Effort:      p.effort,
+		Scope:       p.scope,
+		OnProgress:  p.onProgress,
 	}
 }
 
@@ -671,7 +674,7 @@ func (p *Pipeline) handlePhase(ctx context.Context, sess *store.PipelineSession,
 // fetched row, so no caller needs a defensive re-read of its own.
 func (p *Pipeline) refetchAndDispatch(ctx context.Context, sessionID string) (*PipelineResult, error) {
 	tool := p.strategy.Tool()
-	_, _, pipelineIdx, _ := p.storeIndices()
+	_, _, pipelineIdx, _, _ := p.storeIndices()
 	fresh, err := pipelineIdx.GetPipelineSession(ctx, sessionID)
 	if err != nil {
 		return nil, wrapf(tool, err, "refetch session")

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -170,7 +170,18 @@ func (p *Pipeline) StartSession(ctx context.Context) (*PipelineResult, error) {
 		Str("effort", string(p.effort)).Dur("total", time.Since(totalStart)).
 		Msg("pipeline: session started")
 
-	return p.nextItem(ctx, sess)
+	res, err := p.nextItem(ctx, sess)
+	if err != nil {
+		return nil, err
+	}
+	// Health descriptors recorded during Plan ride the FIRST result: the
+	// session row is the only place they could survive planning (the engine is
+	// per-call stateless), and the start turn is the one the agent reads before
+	// deciding how much of this session to work through.
+	if fresh, ferr := d.Pipeline.GetPipelineSession(ctx, sess.ID); ferr == nil {
+		res.Health = sessionHealthLines(fresh)
+	}
+	return res, nil
 }
 
 // ContinueSession processes the model's response for the current work item and

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"slices"
 	"strings"
 	"time"
@@ -85,7 +84,7 @@ func ensureTitleVectors(ctx context.Context, d Deps, branch string, budget time.
 		}
 		out := make([]store.TitleVector, 0, len(targets))
 		for i, t := range targets {
-			out = append(out, store.TitleVector{FactID: t.FactID, Path: t.Path, Vec: vecs[i]})
+			out = append(out, store.TitleVector{FactID: t.FactID, Vec: vecs[i]})
 		}
 		if err := d.Abstraction.PutTitleVectors(ctx, out); err != nil {
 			return 0, 0, wrapf(reviewTool, err, "title backfill: store")
@@ -312,32 +311,12 @@ func filterByBlendedCosine(ctx context.Context, d Deps, pairs []store.Restatemen
 			}
 			continue
 		}
-		if cosine(a, b) >= dedupThreshold {
+		if store.CosineSim(a, b) >= dedupThreshold {
 			continue
 		}
 		out = append(out, p)
 	}
 	return out, unscorable, nil
-}
-
-// cosine of two stored vectors. They are L2-normalized at embed time, so this
-// is a dot product; the norms are recomputed anyway rather than assumed,
-// because a donated vector (WithPrecomputedEmbeddings) is only validated for
-// dimension.
-func cosine(a, b []float32) float64 {
-	if len(a) != len(b) {
-		return 0
-	}
-	var dot, na, nb float64
-	for i := range a {
-		dot += float64(a[i]) * float64(b[i])
-		na += float64(a[i]) * float64(a[i])
-		nb += float64(b[i]) * float64(b[i])
-	}
-	if na <= 1e-12 || nb <= 1e-12 {
-		return 0
-	}
-	return dot / (math.Sqrt(na) * math.Sqrt(nb))
 }
 
 // ── selection ─────────────────────────────────────────────────────────────
@@ -769,14 +748,10 @@ func resolveShortlistPair(ctx context.Context, d Deps, sess *store.PipelineSessi
 	if err != nil || len(paths) != 2 {
 		return nil
 	}
-	live, err := d.Abstraction.LiveEpistemicFacts(ctx, sess.Branch)
+	ids, err := d.Abstraction.FactIDsByPath(ctx, sess.Branch, paths)
 	if err != nil {
 		log.Warn().Err(err).Str("session", sess.ID).Msg("review: could not resolve shortlist verdict ids")
 		return nil
-	}
-	ids := map[string]int64{}
-	for id, path := range live {
-		ids[path] = id
 	}
 	return &judgedPair{
 		APath: paths[0], BPath: paths[1],

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -462,17 +462,18 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	h.ResolutionRate, h.ThrottleState = throttleState(verdicts)
 
 	budget := shortlistBudget(n)
+	probing := false
 	if h.ThrottleState == throttleDefunded {
 		// Defunded corpora still probe, or they could never recover.
-		probeBudget, err := probeAllowance(ctx, d, branch)
+		allowed, err := probeAllowed(ctx, d, branch)
 		if err != nil {
 			return nil, h, err
 		}
-		if probeBudget == 0 {
+		if !allowed {
 			return nil, h, nil
 		}
-		h.Probing = true
-		budget = probeBudget
+		probing = true
+		budget = 1
 	} else if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, 0); err != nil {
 		// A funded corpus owes no probe; reset so a later defunding starts its
 		// wait from now rather than inheriting an ancient count.
@@ -502,6 +503,16 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 		out = append(out, p)
 		if len(out) == budget {
 			break
+		}
+	}
+	if probing && len(out) > 0 {
+		// The probe is spent only if it actually put something in front of the
+		// judge. A session that found nothing to offer produced no evidence,
+		// and charging it a probe would buy another full interval of silence
+		// for nothing.
+		h.Probing = true
+		if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, 0); err != nil {
+			return nil, h, wrapf(reviewTool, err, "shortlist: consume probe")
 		}
 	}
 	if len(out) > 0 {
@@ -837,26 +848,29 @@ func pairCovered(mergePaths []string, a, b string) bool {
 	return sawA && sawB
 }
 
-// probeAllowance is how many slots a DEFUNDED corpus may spend this session:
-// one, every throttleProbeInterval sessions, and zero otherwise.
+// probeAllowed reports whether a DEFUNDED corpus may spend a probe slot this
+// session: one every throttleProbeInterval sessions.
 //
 // This is the whole of the recovery path. A defunded corpus produces no
 // verdicts, so its own evidence can never change without someone spending a
 // slot to generate more — the probe spends exactly one, on a schedule, and the
 // ordinary throttle takes over the moment a probe resolves.
-func probeAllowance(ctx context.Context, d Deps, branch string) (int, error) {
+//
+// The waiting counter is advanced here but CONSUMED by the caller, and only
+// when a pair was actually emitted: a probe that found nothing to offer has
+// bought no information and must not cost an interval.
+func probeAllowed(ctx context.Context, d Deps, branch string) (bool, error) {
 	waited, err := d.Abstraction.ProbeSessionsWaited(ctx, branch)
 	if err != nil {
-		return 0, wrapf(reviewTool, err, "shortlist: probe wait")
+		return false, wrapf(reviewTool, err, "shortlist: probe wait")
 	}
 	if waited+1 < throttleProbeInterval {
 		if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, waited+1); err != nil {
-			return 0, wrapf(reviewTool, err, "shortlist: bump probe wait")
+			return false, wrapf(reviewTool, err, "shortlist: bump probe wait")
 		}
-		return 0, nil
+		return false, nil
 	}
-	if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, 0); err != nil {
-		return 0, wrapf(reviewTool, err, "shortlist: reset probe wait")
-	}
-	return 1, nil
+	// At the interval: hold the counter here so every subsequent session is
+	// also eligible until one of them actually emits.
+	return true, nil
 }

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -2,10 +2,14 @@ package synthesize
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"math"
 	"slices"
 	"sync/atomic"
 	"time"
+
+	"github.com/rs/zerolog/log"
 
 	"knomit/internal/store"
 )
@@ -240,4 +244,354 @@ func cosine(a, b []float32) float64 {
 		return 0
 	}
 	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+// ── selection ─────────────────────────────────────────────────────────────
+//
+// What a session spends is decided entirely by the corpus's own data: the
+// ranking is a percentile of its own pair-similarity distribution, and the
+// budget is funded or defunded by its own judge's verdicts. There is no
+// threshold here to configure, and no constant that claims a fact about any
+// corpus (MN13).
+
+// maxShortlistItems is a JUDGE-SLOT BUDGET: the most restatement pairs one
+// review session will ever put in front of the judge, whatever the corpus
+// looks like. It bounds what a corpus where title similarity does not
+// discriminate can waste before its own verdicts defund it.
+const maxShortlistItems = 8
+
+// shortlistPerMille scales that budget to corpus size — five slots per thousand
+// facts. Also a JUDGE-SLOT BUDGET: it allocates spend, it does not claim a
+// restatement RATE. At small N it evaluates to 0-1, which is the cold-start
+// posture: a brand-new corpus risks a slot or two before any mechanism here has
+// learned anything about it.
+const shortlistPerMille = 5
+
+// throttleWindow is how many shortlist verdicts the trailing merge-rate is
+// measured over; throttleMinVerdicts is how much evidence must accumulate
+// before a corpus may defund itself. Both are PATIENCE BUDGETS, trading wasted
+// judge slots against how fast a corpus can turn its own shortlist off.
+const (
+	throttleWindow      = 10
+	throttleMinVerdicts = 5
+)
+
+// Throttle states, reported in health output.
+const (
+	throttleOptimistic = "optimistic" // no history yet — the cap bounds the downside
+	throttleFunded     = "funded"     // the judge has merged something recently
+	throttleDefunded   = "defunded"   // enough judged, none merged: stop spending
+)
+
+// restatementClusterKeyPrefix marks a prune work item as shortlist-originated.
+// Verdict attribution reads it, so an ordinary cluster prune can never be
+// mistaken for evidence that the shortlist is earning its slots.
+const restatementClusterKeyPrefix = "restate-"
+
+// restatementPriority places shortlist items inside prune's positive band but
+// below every real cluster (a prune cluster always has at least two facts, so
+// its priority is >= 2). Ordinary cluster consolidation — the bulk of the work
+// and the part that never needed this mechanism — therefore always runs first.
+const restatementPriority = 1.5
+
+// restatementHealth is what a session reports about the axis and the shortlist.
+// Every field is OBSERVABILITY: descriptors of this corpus, read by no branch.
+// A corpus descriptor that decided anything would be the corpus-property
+// constant this design exists without.
+type restatementHealth struct {
+	Coverage       float64 // fraction of live epistemic facts on the axis
+	StandingPairs  int
+	TailP99        float64
+	TailP999       float64
+	OperatingPoint float64 // title-cos of the last selected pair, in THIS repo
+	Emitted        int
+	MergeRate      float64
+	ThrottleState  string
+}
+
+// shortlistBudget is how many judge slots this session may spend.
+func shortlistBudget(n int) int {
+	b := n * shortlistPerMille / 1000
+	if b > maxShortlistItems {
+		return maxShortlistItems
+	}
+	return b
+}
+
+// throttleState reads the corpus's own verdict history: optimistic with no
+// history, defunded once enough shortlist pairs have been judged and none
+// merged, funded again the moment one merges.
+func throttleState(verdicts []store.RestatementVerdict) (float64, string) {
+	if len(verdicts) == 0 {
+		return 0, throttleOptimistic
+	}
+	merges := 0
+	for _, v := range verdicts {
+		if v.Merged {
+			merges++
+		}
+	}
+	rate := float64(merges) / float64(len(verdicts))
+	if merges == 0 && len(verdicts) >= throttleMinVerdicts {
+		return rate, throttleDefunded
+	}
+	return rate, throttleFunded
+}
+
+// selectRestatementCandidates picks this session's pairs off the standing
+// shortlist.
+//
+// clusters is what dedupCluster produced for THIS session — used as a
+// membership check, never re-clustered: a pair already sitting in one cluster
+// is a pair prune sees anyway, so spending a shortlist slot on it is spending
+// twice for one judgement.
+func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clusters [][]factForLLM, n int) ([]store.RestatementPair, restatementHealth, error) {
+	var h restatementHealth
+
+	stats, err := d.Abstraction.RestatementPairStats(ctx, branch)
+	if err != nil {
+		return nil, h, wrapf(reviewTool, err, "shortlist: stats")
+	}
+	h.StandingPairs, h.TailP99, h.TailP999 = stats.Count, stats.P99, stats.P999
+
+	verdicts, err := d.Abstraction.RecentRestatementVerdicts(ctx, branch, throttleWindow)
+	if err != nil {
+		return nil, h, wrapf(reviewTool, err, "shortlist: verdicts")
+	}
+	h.MergeRate, h.ThrottleState = throttleState(verdicts)
+
+	budget := shortlistBudget(n)
+	if h.ThrottleState == throttleDefunded || budget == 0 {
+		return nil, h, nil
+	}
+
+	kept, err := d.Abstraction.KeptPairFactIDs(ctx, branch)
+	if err != nil {
+		return nil, h, wrapf(reviewTool, err, "shortlist: kept pairs")
+	}
+
+	// Over-fetch: the exclusions below are decided per candidate, and cutting to
+	// the budget first would let one excluded pair silently shrink a batch the
+	// throttle had funded.
+	raw, err := d.Abstraction.RestatementPairsByRank(ctx, branch, budget*shortlistOverfetch)
+	if err != nil {
+		return nil, h, wrapf(reviewTool, err, "shortlist: rank")
+	}
+
+	coGrouped := clusterCoMembership(clusters)
+	var out []store.RestatementPair
+	for _, p := range raw {
+		if _, ok := coGrouped[pathPairKey(p.APath, p.BPath)]; ok {
+			continue
+		}
+		if _, ok := kept[store.FactIDPairKey(p.AFactID, p.BFactID)]; ok {
+			continue
+		}
+		if !d.Scope.IsEmpty() && !pairTouchesScope(ctx, d, branch, p) {
+			continue
+		}
+		out = append(out, p)
+		if len(out) == budget {
+			break
+		}
+	}
+	if len(out) > 0 {
+		// The operating point is not a threshold anyone chose: it is whatever
+		// absolute cosine the last funded pair happens to sit at in THIS repo.
+		// Reported because it is a corpus fingerprint — the same code on
+		// another corpus prints a different number.
+		h.OperatingPoint = out[len(out)-1].TitleCos
+	}
+	h.Emitted = len(out)
+	return out, h, nil
+}
+
+// shortlistOverfetch is how many ranked pairs are considered per funded slot,
+// so per-candidate exclusions cannot silently shrink a funded batch. A
+// RESOURCE BUDGET on a SQL read, nothing more.
+const shortlistOverfetch = 4
+
+// clusterCoMembership is the set of pairs this session's own dedupCluster
+// already places in one cluster — the exact "prune already sees them together"
+// exclusion. A membership check over clusters the caller already computed; no
+// clustering runs here.
+func clusterCoMembership(clusters [][]factForLLM) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, c := range clusters {
+		for i := range c {
+			for j := i + 1; j < len(c); j++ {
+				out[pathPairKey(c[i].File, c[j].File)] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+// pathPairKey is the canonical key for an unordered pair of paths.
+func pathPairKey(a, b string) string {
+	if b < a {
+		a, b = b, a
+	}
+	return a + "\x00" + b
+}
+
+// pairTouchesScope reports whether either endpoint falls inside a scoped
+// session's filter.
+//
+// The standing shortlist stays corpus-wide — that is the whole point, since the
+// target population is pairs a scoped view never co-presents — but a session
+// asked to work on one area should not spend its judge slots on two facts that
+// are both somewhere else. A fully out-of-scope pair simply waits for an
+// unscoped session.
+func pairTouchesScope(ctx context.Context, d Deps, branch string, p store.RestatementPair) bool {
+	for _, path := range []string{p.APath, p.BPath} {
+		f, err := d.Search.GetByPath(ctx, branch, path)
+		if err != nil || f == nil {
+			continue
+		}
+		if d.Scope.Matches(f.Domain, f.Entities) {
+			return true
+		}
+	}
+	return false
+}
+
+// enqueueRestatementItems turns selected pairs into ordinary prune work items.
+//
+// Ordinary is the point: the prune prompt ships facts beside itself rather than
+// interpolating them, so a two-fact item is shape-identical to a cluster item
+// and needs no prompt, schema, or apply-path change. The judge that already
+// knows how to merge under a fidelity contract gets to apply it to pairs it
+// previously never saw.
+func enqueueRestatementItems(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, pairs []store.RestatementPair) error {
+	for i, p := range pairs {
+		facts := make([]factForLLM, 0, 2)
+		for _, path := range []string{p.APath, p.BPath} {
+			f, err := d.Search.GetByPath(ctx, branch, path)
+			if err != nil {
+				return wrapf(reviewTool, err, "shortlist: read %s", path)
+			}
+			if f == nil {
+				break // raced a retraction; drop the pair rather than half-ship it
+			}
+			facts = append(facts, factForLLM{
+				File:       f.Path,
+				Title:      f.Title,
+				Body:       f.Body,
+				Type:       f.Type,
+				Domain:     f.Domain,
+				Entities:   f.Entities,
+				Confidence: f.Confidence,
+				Sources:    f.Sources,
+				Origin:     f.Origin,
+			})
+		}
+		if len(facts) != 2 {
+			continue
+		}
+		factsJSON, err := json.Marshal(facts)
+		if err != nil {
+			return wrapf(reviewTool, err, "shortlist: marshal pair %d", i)
+		}
+		if err := d.Pipeline.InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+			SessionID:  sess.ID,
+			StepType:   "prune",
+			ClusterKey: fmt.Sprintf("%s%d", restatementClusterKeyPrefix, i),
+			FactsJSON:  string(factsJSON),
+			Priority:   restatementPriority,
+		}); err != nil {
+			return wrapf(reviewTool, err, "shortlist: insert item %d", i)
+		}
+	}
+	return nil
+}
+
+// planRestatementShortlist runs the whole phase-0 sequence for one session:
+// top up the axis, refresh the standing pair cache, select what this corpus's
+// own history says it may spend, and enqueue the result as prune items.
+//
+// Only an enqueue failure is fatal. Everything upstream of it degrades to "no
+// candidates and a health line saying so": this mechanism is an ADDITION to
+// consolidation, and a corpus whose axis cannot be built should still get its
+// ordinary review rather than an error.
+func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, clusters [][]factForLLM, seeds int) error {
+	have, total, err := ensureTitleVectors(ctx, d, branch, titleBackfillBudget)
+	if err != nil {
+		log.Warn().Err(err).Str("session", sess.ID).
+			Msg("review: title backfill failed; skipping restatement shortlist")
+		return nil
+	}
+	if total == 0 {
+		return nil // empty corpus: every ratio is zero and there is nothing to do
+	}
+
+	dedupThreshold := store.EmbedderThresholds(d.RI.Embedder()).Dedup
+	if err := refreshRestatementShortlist(ctx, d, branch, dedupThreshold); err != nil {
+		log.Warn().Err(err).Str("session", sess.ID).
+			Msg("review: restatement shortlist refresh failed; continuing without candidates")
+		return nil
+	}
+
+	pairs, health, err := selectRestatementCandidates(ctx, d, branch, clusters, seeds)
+	if err != nil {
+		log.Warn().Err(err).Str("session", sess.ID).
+			Msg("review: restatement selection failed; continuing without candidates")
+		return nil
+	}
+	health.Coverage = float64(have) / float64(total)
+
+	if err := enqueueRestatementItems(ctx, d, sess, branch, pairs); err != nil {
+		return err
+	}
+	recordRestatementHealth(ctx, d, sess.ID, health)
+	return nil
+}
+
+// ── health ────────────────────────────────────────────────────────────────
+
+// healthLines renders the phase-0 observability block.
+//
+// Every line is a DESCRIPTOR derived from this corpus's own data, and no line
+// is read by any branch in this package. The operating point in particular is
+// printed precisely because it is a fingerprint: the same code on two corpora
+// prints two different cosines, which is what it means for the selection to be
+// a percentile of each repo's own distribution rather than a threshold someone
+// picked (MN13).
+func healthLines(h restatementHealth) []string {
+	return []string{
+		fmt.Sprintf("abstraction coverage: %.0f%% of live epistemic facts", h.Coverage*100),
+		fmt.Sprintf("standing restatement pairs: %d (title-cos p99 %.3f, p99.9 %.3f)",
+			h.StandingPairs, h.TailP99, h.TailP999),
+		fmt.Sprintf("operating point: title-cos %.3f (this corpus, this session)", h.OperatingPoint),
+		fmt.Sprintf("restatement candidates emitted: %d", h.Emitted),
+		fmt.Sprintf("shortlist throttle: %s (trailing merge-rate %.0f%% over last %d judged)",
+			h.ThrottleState, h.MergeRate*100, throttleWindow),
+	}
+}
+
+// recordRestatementHealth stores the session's health lines so the result the
+// caller receives can carry them. The engine is per-call stateless, so this
+// cannot be kept in memory between planning and responding.
+func recordRestatementHealth(ctx context.Context, d Deps, sessionID string, h restatementHealth) {
+	encoded, err := json.Marshal(healthLines(h))
+	if err != nil {
+		return
+	}
+	if err := d.Pipeline.SetPipelineSessionHealth(ctx, sessionID, string(encoded)); err != nil {
+		// Informational, like recordStats: losing a health line costs
+		// visibility, never correctness.
+		log.Warn().Err(err).Str("session", sessionID).Msg("review: could not record health lines")
+	}
+}
+
+// sessionHealthLines decodes what recordRestatementHealth stored.
+func sessionHealthLines(sess *store.PipelineSession) []string {
+	if sess == nil || sess.Health == "" {
+		return nil
+	}
+	var lines []string
+	if err := json.Unmarshal([]byte(sess.Health), &lines); err != nil {
+		return nil
+	}
+	return lines
 }

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -354,6 +354,13 @@ func throttleState(verdicts []store.RestatementVerdict) (float64, string) {
 func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clusters [][]factForLLM, n int) ([]store.RestatementPair, restatementHealth, error) {
 	var h restatementHealth
 
+	// Coverage is read here rather than passed in, so every caller that builds
+	// health gets a complete one. A health block that silently reports 0%
+	// because its caller forgot to fill a field is worse than no health block.
+	if have, total, cerr := d.Abstraction.TitleVectorCoverage(ctx, branch); cerr == nil && total > 0 {
+		h.Coverage = float64(have) / float64(total)
+	}
+
 	stats, err := d.Abstraction.RestatementPairStats(ctx, branch)
 	if err != nil {
 		return nil, h, wrapf(reviewTool, err, "shortlist: stats")
@@ -516,7 +523,7 @@ func enqueueRestatementItems(ctx context.Context, d Deps, sess *store.PipelineSe
 // consolidation, and a corpus whose axis cannot be built should still get its
 // ordinary review rather than an error.
 func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, clusters [][]factForLLM, seeds int) error {
-	have, total, err := ensureTitleVectors(ctx, d, branch, titleBackfillBudget)
+	_, total, err := ensureTitleVectors(ctx, d, branch, titleBackfillBudget)
 	if err != nil {
 		log.Warn().Err(err).Str("session", sess.ID).
 			Msg("review: title backfill failed; skipping restatement shortlist")
@@ -539,7 +546,6 @@ func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineS
 			Msg("review: restatement selection failed; continuing without candidates")
 		return nil
 	}
-	health.Coverage = float64(have) / float64(total)
 
 	if err := enqueueRestatementItems(ctx, d, sess, branch, pairs); err != nil {
 		return err

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"slices"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -101,9 +100,15 @@ func ensureTitleVectors(ctx context.Context, d Deps, branch string, budget time.
 // standing cache at K·N rows and per-session work at O(Δ·K).
 const pairNeighbourK = 10
 
-// neighbourQueryCount counts KNN lookups so tests can assert that per-session
-// work is proportional to what CHANGED rather than to corpus size.
-var neighbourQueryCount atomic.Int64
+// refreshStats reports what one refresh actually did. Returned rather than
+// counted in a package variable: test instrumentation does not belong in
+// production state, and a caller that wants to log the cost should be handed it.
+type refreshStats struct {
+	NeighbourQueries int // KNN lookups — the per-session work
+	PairsAdded       int
+	FactsRequeued    int  // partners re-scanned so an asymmetric discovery is not lost
+	AxisComplete     bool // false while the backfill is still filling the axis
+}
 
 // refreshRestatementShortlist brings the standing candidate cache up to date.
 //
@@ -116,21 +121,35 @@ var neighbourQueryCount atomic.Int64
 //
 // NO clustering runs in this path. The neighbour lookup is the same KNN the
 // similarity graph uses.
-func refreshRestatementShortlist(ctx context.Context, d Deps, branch string, dedupThreshold float64) error {
+func refreshRestatementShortlist(ctx context.Context, d Deps, branch string, dedupThreshold float64) (refreshStats, error) {
+	var stats refreshStats
+
+	// Diff against facts that are actually ON THE AXIS. A fact with no title
+	// vector has no neighbours to find, so counting it as covered would mark it
+	// done and its KNN would never run — permanently, because the cache state
+	// is what says "already covered". During a partial backfill that would
+	// freeze the cache at whatever the first session managed.
+	onAxis, err := d.Abstraction.LiveEpistemicFactsOnAxis(ctx, branch)
+	if err != nil {
+		return stats, wrapf(reviewTool, err, "shortlist: live facts on axis")
+	}
 	live, err := d.Abstraction.LiveEpistemicFacts(ctx, branch)
 	if err != nil {
-		return wrapf(reviewTool, err, "shortlist: live facts")
+		return stats, wrapf(reviewTool, err, "shortlist: live facts")
 	}
 	cached, err := d.Abstraction.CachedPairFactIDs(ctx, branch)
 	if err != nil {
-		return wrapf(reviewTool, err, "shortlist: cached fact ids")
+		return stats, wrapf(reviewTool, err, "shortlist: cached fact ids")
 	}
 
-	// The delta is the symmetric difference. An edit shows up as one added id
-	// and one dropped id, because facts rows are content-addressed — which is
-	// why nothing here needs a watermark.
+	// While the axis is incomplete, every on-axis fact is in play: see the
+	// coverage note where the cache state is written.
+	complete := len(onAxis) == len(live)
+
+	// An edit shows up as one added id and one dropped id, because facts rows
+	// are content-addressed — which is why nothing here needs a watermark.
 	var added []int64
-	for id := range live {
+	for id := range onAxis {
 		if _, ok := cached[id]; !ok {
 			added = append(added, id)
 		}
@@ -142,30 +161,96 @@ func refreshRestatementShortlist(ctx context.Context, d Deps, branch string, ded
 		}
 	}
 	if len(added) == 0 && len(dropped) == 0 {
-		return nil
+		return stats, nil
+	}
+	stats.AxisComplete = complete
+
+	// KNN is ASYMMETRIC: a standing pair may exist only because B's top-K
+	// included A, and never the reverse. Dropping every pair that touches a
+	// departed fact and re-scanning only the arrivals would therefore destroy
+	// discoveries that nothing rediscovers. Re-scan the surviving partners too
+	// — bounded at K per dropped fact.
+	partners, err := d.Abstraction.PartnersOfFacts(ctx, branch, dropped)
+	if err != nil {
+		return stats, wrapf(reviewTool, err, "shortlist: partners of dropped facts")
+	}
+	requeue := append([]int64(nil), added...)
+	for id := range partners {
+		if _, stillOnAxis := onAxis[id]; stillOnAxis {
+			requeue = append(requeue, id)
+			stats.FactsRequeued++
+		}
 	}
 	// Deterministic order so two runs over the same delta produce the same
 	// cache, and so a test can talk about "the first fact".
-	slices.Sort(added)
-	slices.Sort(dropped)
+	slices.Sort(requeue)
+	requeue = slices.Compact(requeue)
+
+	// Pairs the judge already declined must not be re-minted by this rescan.
+	// The pair itself was deleted when the verdict landed; this is what keeps
+	// it gone until one of its facts is edited (which makes it a new pair of
+	// content-addressed ids, and therefore genuinely unseen).
+	declined, err := d.Abstraction.KeptPairFactIDs(ctx, branch)
+	if err != nil {
+		return stats, wrapf(reviewTool, err, "shortlist: declined pairs")
+	}
 
 	var candidates []store.RestatementPair
-	for _, id := range added {
-		neighbourQueryCount.Add(1)
+	for _, id := range requeue {
+		stats.NeighbourQueries++
 		neighbours, err := d.Abstraction.TopTitleNeighbours(ctx, branch, id, pairNeighbourK)
 		if err != nil {
-			return wrapf(reviewTool, err, "shortlist: neighbours for fact %d", id)
+			return stats, wrapf(reviewTool, err, "shortlist: neighbours for fact %d", id)
 		}
 		for _, n := range neighbours {
-			candidates = append(candidates, newRestatementPair(id, live[id], n))
+			if _, ok := declined[store.FactIDPairKey(id, n.FactID)]; ok {
+				continue
+			}
+			candidates = append(candidates, newRestatementPair(id, onAxis[id], n))
 		}
 	}
 
-	kept, err := filterByBlendedCosine(ctx, d, candidates, dedupThreshold)
+	kept, unscorable, err := filterByBlendedCosine(ctx, d, candidates, dedupThreshold)
 	if err != nil {
-		return err
+		return stats, err
 	}
-	return d.Abstraction.ReplaceRestatementPairs(ctx, branch, append(dropped, added...), kept, added)
+	stats.PairsAdded = len(kept)
+
+	// Nothing is recorded as covered until the axis is COMPLETE.
+	//
+	// The cache state means "scanned against the whole corpus", and during a
+	// backfill that is a lie: a fact scanned while half the corpus had no title
+	// vector cannot have seen the partners embedded later, and KNN asymmetry
+	// means the later fact's own scan may not find it either. Marking it
+	// covered would make that a permanent hole rather than a delay. So while
+	// coverage is partial, every on-axis fact is rescanned each session — the
+	// pairs found so far are still offered, they are just not treated as final.
+	// The cost is bounded to the fill period and vanishes the session coverage
+	// closes.
+	//
+	// A fact whose blended vector could not be read was not really scanned
+	// either, for the same reason and with the same consequence.
+	var covered []int64
+	if complete {
+		covered = make([]int64, 0, len(requeue))
+		for _, id := range requeue {
+			if _, bad := unscorable[id]; !bad {
+				covered = append(covered, id)
+			}
+		}
+	}
+	// Pairs are deleted for departed facts and for facts being scanned for the
+	// first time — never for requeued partners, whose existing pairs are
+	// exactly the asymmetric discoveries the requeue exists to preserve.
+	//
+	// "First time" is a no-op during ordinary operation (a new fact version has
+	// new ids and therefore no pairs), and does the necessary cleanup in one
+	// case: the session where the backfill finally completes. Nothing was
+	// marked covered while the axis was partial, so that session rescans the
+	// whole corpus — and its pairs should describe the finished axis, not the
+	// union of every half-filled state it passed through on the way.
+	return stats, d.Abstraction.ReplaceRestatementPairs(ctx, branch,
+		append(dropped, added...), kept, covered)
 }
 
 // newRestatementPair canonicalises a pair so A-B and B-A are one row.
@@ -192,9 +277,10 @@ func newRestatementPair(id int64, path string, n store.TitleNeighbour) store.Res
 // contributes no absolute cosine of its own.
 //
 // Vectors come from the stored facts_vec rows. Nothing is re-embedded.
-func filterByBlendedCosine(ctx context.Context, d Deps, pairs []store.RestatementPair, dedupThreshold float64) ([]store.RestatementPair, error) {
+func filterByBlendedCosine(ctx context.Context, d Deps, pairs []store.RestatementPair, dedupThreshold float64) ([]store.RestatementPair, map[int64]struct{}, error) {
+	unscorable := map[int64]struct{}{}
 	if len(pairs) == 0 {
-		return nil, nil
+		return nil, unscorable, nil
 	}
 	idSet := map[int64]struct{}{}
 	for _, p := range pairs {
@@ -207,7 +293,7 @@ func filterByBlendedCosine(ctx context.Context, d Deps, pairs []store.Restatemen
 	}
 	vecs, err := d.Abstraction.BodyVectorsByFactID(ctx, ids)
 	if err != nil {
-		return nil, wrapf(reviewTool, err, "shortlist: body vectors")
+		return nil, unscorable, wrapf(reviewTool, err, "shortlist: body vectors")
 	}
 
 	out := make([]store.RestatementPair, 0, len(pairs))
@@ -215,8 +301,15 @@ func filterByBlendedCosine(ctx context.Context, d Deps, pairs []store.Restatemen
 		a, aok := vecs[p.AFactID]
 		b, bok := vecs[p.BFactID]
 		if !aok || !bok {
-			// A fact with no stored vector cannot be scored. Keeping it would
-			// mean guessing whether dedup would already have caught the pair.
+			// A fact with no stored vector cannot be scored — keeping the pair
+			// would mean guessing whether dedup already caught it. Report the
+			// missing side so the caller does not record it as covered.
+			if !aok {
+				unscorable[p.AFactID] = struct{}{}
+			}
+			if !bok {
+				unscorable[p.BFactID] = struct{}{}
+			}
 			continue
 		}
 		if cosine(a, b) >= dedupThreshold {
@@ -224,7 +317,7 @@ func filterByBlendedCosine(ctx context.Context, d Deps, pairs []store.Restatemen
 		}
 		out = append(out, p)
 	}
-	return out, nil
+	return out, unscorable, nil
 }
 
 // cosine of two stored vectors. They are L2-normalized at embed time, so this
@@ -268,13 +361,22 @@ const maxShortlistItems = 8
 // learned anything about it.
 const shortlistPerMille = 5
 
-// throttleWindow is how many shortlist verdicts the trailing merge-rate is
+// throttleWindow is how many shortlist verdicts the trailing resolution-rate is
 // measured over; throttleMinVerdicts is how much evidence must accumulate
-// before a corpus may defund itself. Both are PATIENCE BUDGETS, trading wasted
-// judge slots against how fast a corpus can turn its own shortlist off.
+// before a corpus may defund itself; throttleProbeInterval is how many sessions
+// a defunded corpus waits before spending ONE slot to test whether it is still
+// right to be defunded. All three are PATIENCE BUDGETS, trading wasted judge
+// slots against how fast a corpus can change its own mind.
+//
+// The probe is not a nicety. Without it the throttle is a LATCH: defunded means
+// no emission, no emission means no verdicts, and no verdicts means the "a
+// resolution restores it" clause can never fire. A corpus that briefly looked
+// unproductive would be switched off permanently by evidence it is then
+// forbidden from updating.
 const (
-	throttleWindow      = 10
-	throttleMinVerdicts = 5
+	throttleWindow        = 10
+	throttleMinVerdicts   = 5
+	throttleProbeInterval = 5
 )
 
 // shortlistOverfetch is how many ranked pairs are considered per funded slot,
@@ -311,8 +413,15 @@ type restatementHealth struct {
 	TailP999       float64
 	OperatingPoint float64 // title-cos of the last selected pair, in THIS repo
 	Emitted        int
-	MergeRate      float64
+	ResolutionRate float64
 	ThrottleState  string
+	// Probing is true when a defunded corpus spent its periodic probe slot —
+	// the one path by which its own evidence can change.
+	Probing bool
+	// Failure names the step that failed, when one did. The shortlist degrades
+	// to "no candidates" rather than failing a session, so without this line a
+	// broken axis and a clean corpus look identical from outside.
+	Failure string
 }
 
 // shortlistBudget is how many judge slots this session may spend.
@@ -331,14 +440,14 @@ func throttleState(verdicts []store.RestatementVerdict) (float64, string) {
 	if len(verdicts) == 0 {
 		return 0, throttleOptimistic
 	}
-	merges := 0
+	resolved := 0
 	for _, v := range verdicts {
-		if v.Merged {
-			merges++
+		if v.Resolved {
+			resolved++
 		}
 	}
-	rate := float64(merges) / float64(len(verdicts))
-	if merges == 0 && len(verdicts) >= throttleMinVerdicts {
+	rate := float64(resolved) / float64(len(verdicts))
+	if resolved == 0 && len(verdicts) >= throttleMinVerdicts {
 		return rate, throttleDefunded
 	}
 	return rate, throttleFunded
@@ -371,16 +480,27 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	if err != nil {
 		return nil, h, wrapf(reviewTool, err, "shortlist: verdicts")
 	}
-	h.MergeRate, h.ThrottleState = throttleState(verdicts)
+	h.ResolutionRate, h.ThrottleState = throttleState(verdicts)
 
 	budget := shortlistBudget(n)
-	if h.ThrottleState == throttleDefunded || budget == 0 {
-		return nil, h, nil
+	if h.ThrottleState == throttleDefunded {
+		// Defunded corpora still probe, or they could never recover.
+		probeBudget, err := probeAllowance(ctx, d, branch)
+		if err != nil {
+			return nil, h, err
+		}
+		if probeBudget == 0 {
+			return nil, h, nil
+		}
+		h.Probing = true
+		budget = probeBudget
+	} else if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, 0); err != nil {
+		// A funded corpus owes no probe; reset so a later defunding starts its
+		// wait from now rather than inheriting an ancient count.
+		return nil, h, wrapf(reviewTool, err, "shortlist: reset probe wait")
 	}
-
-	kept, err := d.Abstraction.KeptPairFactIDs(ctx, branch)
-	if err != nil {
-		return nil, h, wrapf(reviewTool, err, "shortlist: kept pairs")
+	if budget == 0 {
+		return nil, h, nil
 	}
 
 	// Over-fetch: the exclusions below are decided per candidate, and cutting to
@@ -395,9 +515,6 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	var out []store.RestatementPair
 	for _, p := range raw {
 		if _, ok := coGrouped[pathPairKey(p.APath, p.BPath)]; ok {
-			continue
-		}
-		if _, ok := kept[store.FactIDPairKey(p.AFactID, p.BFactID)]; ok {
 			continue
 		}
 		if !d.Scope.IsEmpty() && !pairTouchesScope(ctx, d, branch, p) {
@@ -522,9 +639,17 @@ func enqueueRestatementItems(ctx context.Context, d Deps, sess *store.PipelineSe
 // candidates and a health line saying so": this mechanism is an ADDITION to
 // consolidation, and a corpus whose axis cannot be built should still get its
 // ordinary review rather than an error.
-func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, clusters [][]factForLLM, seeds int) error {
-	_, total, err := ensureTitleVectors(ctx, d, branch, titleBackfillBudget)
+func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, clusters [][]factForLLM) error {
+	// health is emitted on EVERY path, including the failures below. The error
+	// path is exactly where "the shortlist found nothing" has to stay
+	// distinguishable from "the shortlist could not run" — a silent skip on a
+	// corpus with 2,000 standing pairs reads as a clean bill of health.
+	var health restatementHealth
+	defer func() { recordRestatementHealth(sess, health) }()
+
+	have, total, err := ensureTitleVectors(ctx, d, branch, titleBackfillBudget)
 	if err != nil {
+		health.Failure = "title backfill failed"
 		log.Warn().Err(err).Str("session", sess.ID).
 			Msg("review: title backfill failed; skipping restatement shortlist")
 		return nil
@@ -532,25 +657,40 @@ func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineS
 	if total == 0 {
 		return nil // empty corpus: every ratio is zero and there is nothing to do
 	}
+	health.Coverage = float64(have) / float64(total)
 
 	dedupThreshold := store.EmbedderThresholds(d.RI.Embedder()).Dedup
-	if err := refreshRestatementShortlist(ctx, d, branch, dedupThreshold); err != nil {
+	refresh, err := refreshRestatementShortlist(ctx, d, branch, dedupThreshold)
+	if err != nil {
+		health.Failure = "shortlist refresh failed"
 		log.Warn().Err(err).Str("session", sess.ID).
 			Msg("review: restatement shortlist refresh failed; continuing without candidates")
 		return nil
 	}
+	log.Debug().Str("session", sess.ID).
+		Int("knn_queries", refresh.NeighbourQueries).
+		Int("pairs_added", refresh.PairsAdded).
+		Int("facts_requeued", refresh.FactsRequeued).
+		Msg("review: restatement shortlist refreshed")
 
-	pairs, health, err := selectRestatementCandidates(ctx, d, branch, clusters, seeds)
+	// The budget scales with the CORPUS, not with this session's dirty seeds.
+	// Seeds would make the feature a first-scan special case: every incremental
+	// session sees a handful of changed facts, and a handful times 5-per-1000
+	// is zero — so the shortlist would emit nothing for the entire life of a
+	// repo after its first review, with a full pair cache sitting unread.
+	pairs, selectHealth, err := selectRestatementCandidates(ctx, d, branch, clusters, total)
 	if err != nil {
+		health.Failure = "shortlist selection failed"
 		log.Warn().Err(err).Str("session", sess.ID).
 			Msg("review: restatement selection failed; continuing without candidates")
 		return nil
 	}
+	selectHealth.Coverage = health.Coverage
+	health = selectHealth
 
 	if err := enqueueRestatementItems(ctx, d, sess, branch, pairs); err != nil {
 		return err
 	}
-	recordRestatementHealth(ctx, d, sess.ID, health)
 	return nil
 }
 
@@ -565,42 +705,44 @@ func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineS
 // a percentile of each repo's own distribution rather than a threshold someone
 // picked (MN13).
 func healthLines(h restatementHealth) []string {
+	if h.Failure != "" {
+		return []string{
+			fmt.Sprintf("restatement shortlist unavailable this session: %s "+
+				"(no candidates — this is NOT a statement about the corpus)", h.Failure),
+			fmt.Sprintf("abstraction coverage: %.0f%% of live epistemic facts", h.Coverage*100),
+		}
+	}
 	return []string{
 		fmt.Sprintf("abstraction coverage: %.0f%% of live epistemic facts", h.Coverage*100),
 		fmt.Sprintf("standing restatement pairs: %d (title-cos p99 %.3f, p99.9 %.3f)",
 			h.StandingPairs, h.TailP99, h.TailP999),
 		fmt.Sprintf("operating point: title-cos %.3f (this corpus, this session)", h.OperatingPoint),
 		fmt.Sprintf("restatement candidates emitted: %d", h.Emitted),
-		fmt.Sprintf("shortlist throttle: %s (trailing merge-rate %.0f%% over last %d judged)",
-			h.ThrottleState, h.MergeRate*100, throttleWindow),
+		fmt.Sprintf("shortlist throttle: %s%s (trailing resolution-rate %.0f%% over last %d judged)",
+			h.ThrottleState, probeSuffix(h), h.ResolutionRate*100, throttleWindow),
 	}
 }
 
-// recordRestatementHealth stores the session's health lines so the result the
-// caller receives can carry them. The engine is per-call stateless, so this
-// cannot be kept in memory between planning and responding.
-func recordRestatementHealth(ctx context.Context, d Deps, sessionID string, h restatementHealth) {
-	encoded, err := json.Marshal(healthLines(h))
-	if err != nil {
+func probeSuffix(h restatementHealth) string {
+	if h.Probing {
+		return " (probing)"
+	}
+	return ""
+}
+
+// recordRestatementHealth hangs the session's health lines on the session
+// object StartSession is holding.
+//
+// In memory, not in the session row: planning and responding happen inside the
+// SAME StartSession call, on the same *PipelineSession pointer, so a database
+// round trip would buy nothing. Health is read once, by the turn that produced
+// it (invariants/synthesize/per-call-objects-no-session-state is about state
+// that must SURVIVE a call — this deliberately does not).
+func recordRestatementHealth(sess *store.PipelineSession, h restatementHealth) {
+	if sess == nil {
 		return
 	}
-	if err := d.Pipeline.SetPipelineSessionHealth(ctx, sessionID, string(encoded)); err != nil {
-		// Informational, like recordStats: losing a health line costs
-		// visibility, never correctness.
-		log.Warn().Err(err).Str("session", sessionID).Msg("review: could not record health lines")
-	}
-}
-
-// sessionHealthLines decodes what recordRestatementHealth stored.
-func sessionHealthLines(sess *store.PipelineSession) []string {
-	if sess == nil || sess.Health == "" {
-		return nil
-	}
-	var lines []string
-	if err := json.Unmarshal([]byte(sess.Health), &lines); err != nil {
-		return nil
-	}
-	return lines
+	sess.Health = healthLines(h)
 }
 
 // ── verdict attribution ───────────────────────────────────────────────────
@@ -642,31 +784,67 @@ func resolveShortlistPair(ctx context.Context, d Deps, sess *store.PipelineSessi
 	}
 }
 
-// recordShortlistVerdict records what the judge did with a shortlist pair.
+// recordShortlistVerdict records what the judge did with a shortlist pair, and
+// retires the pair when the judge declined it.
 //
-// "Merged" means the judge merged THE PAIR the shortlist put in front of it,
-// not merely that the item produced some merge — on a two-fact item those
-// coincide, but saying it precisely keeps the throttle measuring what it
-// claims to measure.
+// RESOLVED, not merged. A judge that consolidates a restatement by retracting
+// the redundant half has done exactly the work this mechanism exists to buy, so
+// counting only merges would defund a corpus that is consolidating
+// successfully by another route — and a wrongly defunded corpus looks
+// identical, from outside, to one where the shortlist genuinely finds nothing.
+//
+// A confidence "update" is deliberately NOT a resolution: it leaves both facts
+// standing, so the redundancy this pair was offered for is still there.
 func recordShortlistVerdict(ctx context.Context, d Deps, sess *store.PipelineSession, judged *judgedPair, res *PruneResult) {
 	if judged == nil || res == nil {
 		return
 	}
-	merged := false
+	if judged.AFactID == 0 || judged.BFactID == 0 {
+		// An endpoint could not be resolved to a live fact — it was merged or
+		// retracted earlier in this same session, so this item was judging a
+		// pair that no longer exists. Recording it would write a zero id into
+		// the declined set (matching every other unresolved pair) and spend a
+		// slot of the throttle window on a non-event.
+		log.Debug().Str("session", sess.ID).
+			Str("a", judged.APath).Str("b", judged.BPath).
+			Msg("review: shortlist pair no longer live at judgement; not recording a verdict")
+		return
+	}
+
+	resolved := false
 	for _, m := range res.Merges {
 		if pairCovered(m.Paths, judged.APath, judged.BPath) {
-			merged = true
+			resolved = true
 			break
 		}
 	}
+	for _, dec := range res.Decisions {
+		if dec.Action == "retract" && (dec.Path == judged.APath || dec.Path == judged.BPath) {
+			resolved = true
+			break
+		}
+	}
+
 	if err := d.Abstraction.RecordRestatementVerdict(ctx, sess.Branch, store.RestatementVerdict{
 		APath: judged.APath, BPath: judged.BPath,
 		AFactID: judged.AFactID, BFactID: judged.BFactID,
-		Merged: merged, JudgedAt: time.Now().UTC(),
+		Resolved: resolved, JudgedAt: time.Now().UTC(),
 	}); err != nil {
 		// Informational, like recordStats: the mutations are already committed,
 		// and a lost verdict only makes the throttle slightly more optimistic.
 		log.Warn().Err(err).Str("session", sess.ID).Msg("review: could not record shortlist verdict")
+		return
+	}
+
+	// Retire the pair either way. A resolved pair no longer exists as written;
+	// a declined pair must not keep its place at the top of the ranking, or
+	// after a few declining sessions the whole selection window would be
+	// standing pairs the judge has already refused and nothing new could ever
+	// be offered. The verdict log remains the record, and an edit to either
+	// fact re-mints the pair through the ordinary KNN path — at which point it
+	// is genuinely unseen, because a new version is a new id.
+	if err := d.Abstraction.DeleteRestatementPair(ctx, sess.Branch, judged.AFactID, judged.BFactID); err != nil {
+		log.Warn().Err(err).Str("session", sess.ID).Msg("review: could not retire judged shortlist pair")
 	}
 }
 
@@ -682,4 +860,28 @@ func pairCovered(mergePaths []string, a, b string) bool {
 		}
 	}
 	return sawA && sawB
+}
+
+// probeAllowance is how many slots a DEFUNDED corpus may spend this session:
+// one, every throttleProbeInterval sessions, and zero otherwise.
+//
+// This is the whole of the recovery path. A defunded corpus produces no
+// verdicts, so its own evidence can never change without someone spending a
+// slot to generate more — the probe spends exactly one, on a schedule, and the
+// ordinary throttle takes over the moment a probe resolves.
+func probeAllowance(ctx context.Context, d Deps, branch string) (int, error) {
+	waited, err := d.Abstraction.ProbeSessionsWaited(ctx, branch)
+	if err != nil {
+		return 0, wrapf(reviewTool, err, "shortlist: probe wait")
+	}
+	if waited+1 < throttleProbeInterval {
+		if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, waited+1); err != nil {
+			return 0, wrapf(reviewTool, err, "shortlist: bump probe wait")
+		}
+		return 0, nil
+	}
+	if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, 0); err != nil {
+		return 0, wrapf(reviewTool, err, "shortlist: reset probe wait")
+	}
+	return 1, nil
 }

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -277,6 +277,11 @@ const (
 	throttleMinVerdicts = 5
 )
 
+// shortlistOverfetch is how many ranked pairs are considered per funded slot,
+// so per-candidate exclusions cannot silently shrink a funded batch. A
+// RESOURCE BUDGET on a SQL read, nothing more.
+const shortlistOverfetch = 4
+
 // Throttle states, reported in health output.
 const (
 	throttleOptimistic = "optimistic" // no history yet — the cap bounds the downside
@@ -406,11 +411,6 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	h.Emitted = len(out)
 	return out, h, nil
 }
-
-// shortlistOverfetch is how many ranked pairs are considered per funded slot,
-// so per-candidate exclusions cannot silently shrink a funded batch. A
-// RESOURCE BUDGET on a SQL read, nothing more.
-const shortlistOverfetch = 4
 
 // clusterCoMembership is the set of pairs this session's own dedupCluster
 // already places in one cluster — the exact "prune already sees them together"

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -2,6 +2,9 @@ package synthesize
 
 import (
 	"context"
+	"math"
+	"slices"
+	"sync/atomic"
 	"time"
 
 	"knomit/internal/store"
@@ -85,4 +88,156 @@ func ensureTitleVectors(ctx context.Context, d Deps, branch string, budget time.
 		}
 	}
 	return d.Abstraction.TitleVectorCoverage(ctx, branch)
+}
+
+// pairNeighbourK is how many title-neighbours are retained per fact — a
+// STRUCTURAL BUDGET with system precedent (store.knnK = 10 for SIMILAR_TO),
+// never a claim about how many restatements a corpus contains. It bounds the
+// standing cache at K·N rows and per-session work at O(Δ·K).
+const pairNeighbourK = 10
+
+// neighbourQueryCount counts KNN lookups so tests can assert that per-session
+// work is proportional to what CHANGED rather than to corpus size.
+var neighbourQueryCount atomic.Int64
+
+// refreshRestatementShortlist brings the standing candidate cache up to date.
+//
+// Pairing is CORPUS-WIDE and session-independent: the session's scope and the
+// session's clusters play no part here (scope is applied at emission,
+// cluster co-membership at selection). That separation is the point — the
+// target population is precisely the pairs a scoped view never co-presents, so
+// restricting the pairing to a session's own view would rebuild the blindness
+// this exists to fix.
+//
+// NO clustering runs in this path. The neighbour lookup is the same KNN the
+// similarity graph uses.
+func refreshRestatementShortlist(ctx context.Context, d Deps, branch string, dedupThreshold float64) error {
+	live, err := d.Abstraction.LiveEpistemicFacts(ctx, branch)
+	if err != nil {
+		return wrapf(reviewTool, err, "shortlist: live facts")
+	}
+	cached, err := d.Abstraction.CachedPairFactIDs(ctx, branch)
+	if err != nil {
+		return wrapf(reviewTool, err, "shortlist: cached fact ids")
+	}
+
+	// The delta is the symmetric difference. An edit shows up as one added id
+	// and one dropped id, because facts rows are content-addressed — which is
+	// why nothing here needs a watermark.
+	var added []int64
+	for id := range live {
+		if _, ok := cached[id]; !ok {
+			added = append(added, id)
+		}
+	}
+	var dropped []int64
+	for id := range cached {
+		if _, ok := live[id]; !ok {
+			dropped = append(dropped, id)
+		}
+	}
+	if len(added) == 0 && len(dropped) == 0 {
+		return nil
+	}
+	// Deterministic order so two runs over the same delta produce the same
+	// cache, and so a test can talk about "the first fact".
+	slices.Sort(added)
+	slices.Sort(dropped)
+
+	var candidates []store.RestatementPair
+	for _, id := range added {
+		neighbourQueryCount.Add(1)
+		neighbours, err := d.Abstraction.TopTitleNeighbours(ctx, branch, id, pairNeighbourK)
+		if err != nil {
+			return wrapf(reviewTool, err, "shortlist: neighbours for fact %d", id)
+		}
+		for _, n := range neighbours {
+			candidates = append(candidates, newRestatementPair(id, live[id], n))
+		}
+	}
+
+	kept, err := filterByBlendedCosine(ctx, d, candidates, dedupThreshold)
+	if err != nil {
+		return err
+	}
+	return d.Abstraction.ReplaceRestatementPairs(ctx, branch, append(dropped, added...), kept, added)
+}
+
+// newRestatementPair canonicalises a pair so A-B and B-A are one row.
+func newRestatementPair(id int64, path string, n store.TitleNeighbour) store.RestatementPair {
+	p := store.RestatementPair{
+		APath: path, BPath: n.Path,
+		AFactID: id, BFactID: n.FactID,
+		TitleCos: n.Similarity,
+	}
+	if p.BPath < p.APath {
+		p.APath, p.BPath = p.BPath, p.APath
+		p.AFactID, p.BFactID = p.BFactID, p.AFactID
+	}
+	return p
+}
+
+// filterByBlendedCosine drops pairs whose BLENDED (title+body) vectors already
+// sit at or above the model's calibrated dedup threshold.
+//
+// Those pairs are not restatements the judge needs to see: mergeFacts already
+// merges them mechanically, so spending a judge slot on one is pure waste. The
+// threshold is the active model's own calibrated value
+// (internal/embeddings/params), not a constant invented here — the shortlist
+// contributes no absolute cosine of its own.
+//
+// Vectors come from the stored facts_vec rows. Nothing is re-embedded.
+func filterByBlendedCosine(ctx context.Context, d Deps, pairs []store.RestatementPair, dedupThreshold float64) ([]store.RestatementPair, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	idSet := map[int64]struct{}{}
+	for _, p := range pairs {
+		idSet[p.AFactID] = struct{}{}
+		idSet[p.BFactID] = struct{}{}
+	}
+	ids := make([]int64, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	vecs, err := d.Abstraction.BodyVectorsByFactID(ctx, ids)
+	if err != nil {
+		return nil, wrapf(reviewTool, err, "shortlist: body vectors")
+	}
+
+	out := make([]store.RestatementPair, 0, len(pairs))
+	for _, p := range pairs {
+		a, aok := vecs[p.AFactID]
+		b, bok := vecs[p.BFactID]
+		if !aok || !bok {
+			// A fact with no stored vector cannot be scored. Keeping it would
+			// mean guessing whether dedup would already have caught the pair.
+			continue
+		}
+		if cosine(a, b) >= dedupThreshold {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// cosine of two stored vectors. They are L2-normalized at embed time, so this
+// is a dot product; the norms are recomputed anyway rather than assumed,
+// because a donated vector (WithPrecomputedEmbeddings) is only validated for
+// dimension.
+func cosine(a, b []float32) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na <= 1e-12 || nb <= 1e-12 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
 }

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -594,4 +595,85 @@ func sessionHealthLines(sess *store.PipelineSession) []string {
 		return nil
 	}
 	return lines
+}
+
+// ── verdict attribution ───────────────────────────────────────────────────
+
+// judgedPair is a shortlist pair as it stood when the judge was shown it: the
+// two paths, and the fact ids of the exact versions.
+type judgedPair struct {
+	APath, BPath     string
+	AFactID, BFactID int64
+}
+
+// resolveShortlistPair identifies the pair a shortlist-originated prune item
+// put in front of the judge, capturing the fact ids of the versions shown.
+// Returns nil for ordinary cluster items — those say nothing about whether the
+// shortlist is earning its slots.
+//
+// Called BEFORE the decisions are applied, because applying them can rewrite a
+// fact, and a rewritten fact is a new row with a new id.
+func resolveShortlistPair(ctx context.Context, d Deps, sess *store.PipelineSession, item *store.PipelineWorkItem) *judgedPair {
+	if !strings.HasPrefix(item.ClusterKey, restatementClusterKeyPrefix) {
+		return nil
+	}
+	paths, err := itemInputPaths(item)
+	if err != nil || len(paths) != 2 {
+		return nil
+	}
+	live, err := d.Abstraction.LiveEpistemicFacts(ctx, sess.Branch)
+	if err != nil {
+		log.Warn().Err(err).Str("session", sess.ID).Msg("review: could not resolve shortlist verdict ids")
+		return nil
+	}
+	ids := map[string]int64{}
+	for id, path := range live {
+		ids[path] = id
+	}
+	return &judgedPair{
+		APath: paths[0], BPath: paths[1],
+		AFactID: ids[paths[0]], BFactID: ids[paths[1]],
+	}
+}
+
+// recordShortlistVerdict records what the judge did with a shortlist pair.
+//
+// "Merged" means the judge merged THE PAIR the shortlist put in front of it,
+// not merely that the item produced some merge — on a two-fact item those
+// coincide, but saying it precisely keeps the throttle measuring what it
+// claims to measure.
+func recordShortlistVerdict(ctx context.Context, d Deps, sess *store.PipelineSession, judged *judgedPair, res *PruneResult) {
+	if judged == nil || res == nil {
+		return
+	}
+	merged := false
+	for _, m := range res.Merges {
+		if pairCovered(m.Paths, judged.APath, judged.BPath) {
+			merged = true
+			break
+		}
+	}
+	if err := d.Abstraction.RecordRestatementVerdict(ctx, sess.Branch, store.RestatementVerdict{
+		APath: judged.APath, BPath: judged.BPath,
+		AFactID: judged.AFactID, BFactID: judged.BFactID,
+		Merged: merged, JudgedAt: time.Now().UTC(),
+	}); err != nil {
+		// Informational, like recordStats: the mutations are already committed,
+		// and a lost verdict only makes the throttle slightly more optimistic.
+		log.Warn().Err(err).Str("session", sess.ID).Msg("review: could not record shortlist verdict")
+	}
+}
+
+// pairCovered reports whether a merge entry covers both halves of the pair.
+func pairCovered(mergePaths []string, a, b string) bool {
+	var sawA, sawB bool
+	for _, p := range mergePaths {
+		switch p {
+		case a:
+			sawA = true
+		case b:
+			sawB = true
+		}
+	}
+	return sawA && sawB
 }

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -1,0 +1,88 @@
+package synthesize
+
+import (
+	"context"
+	"time"
+
+	"knomit/internal/store"
+)
+
+// The consolidation-scope fix.
+//
+// Prune IS consolidation with a judge — it replaces N facts with one newly
+// authored body under an explicit fidelity contract — but its judge only ever
+// sees facts that landed in the same cluster. Restatements whose halves cluster
+// apart are judged by nothing and live forever
+// (gotchas/synthesize/prune-scope/c40d6748).
+//
+// This file gives that judge a bounded, CORPUS-WIDE shortlist of candidate
+// pairs, built on the abstraction axis (title-only embeddings) rather than on
+// clustering. Nothing here is configurable: what a corpus spends is decided by
+// its own data — the ranking is a percentile of its own pair-similarity
+// distribution, and the budget is funded or defunded by its own judge's
+// verdicts.
+
+// titleBackfillBudget is a LATENCY BUDGET (a resource constant, not a claim
+// about any corpus): the wall-clock one review session will spend embedding
+// fact titles before getting on with the work the caller actually asked for.
+//
+// A large corpus therefore reaches full coverage across several sessions rather
+// than stalling the first one for a minute. Partial coverage is reported in the
+// session's health output, because a silently partial axis reads as "nothing to
+// find" — the failure mode this area keeps hitting is caps that nothing reports.
+const titleBackfillBudget = 15 * time.Second
+
+// titleBackfillBatch is a THROUGHPUT BUDGET: how many titles go to the embedder
+// per call. Batching amortizes ONNX setup, and since the clock is only checked
+// between batches it also bounds how far a session can overrun the latency
+// budget above.
+const titleBackfillBatch = 32
+
+// ensureTitleVectors fills the abstraction axis for live epistemic facts that
+// lack a title vector, bounded by budget. It returns coverage (have, total)
+// after the attempt, whether or not the budget ran out.
+//
+// Watermark-incremental BY CONSTRUCTION: facts rows are content-addressed, so
+// an edited fact is a new row with no vector, and "rows lacking a vector" is
+// exactly the delta. There is no watermark column here and nothing to migrate.
+//
+// A repo with no embedder (read-only tooling, tests) is a no-op rather than an
+// error: the axis simply stays empty and the shortlist finds nothing.
+func ensureTitleVectors(ctx context.Context, d Deps, branch string, budget time.Duration) (int, int, error) {
+	emb := d.RI.Embedder()
+	if emb == nil {
+		return 0, 0, nil
+	}
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		targets, err := d.Abstraction.LiveFactsMissingTitleVector(ctx, branch, titleBackfillBatch)
+		if err != nil {
+			return 0, 0, wrapf(reviewTool, err, "title backfill: list missing")
+		}
+		if len(targets) == 0 {
+			break
+		}
+		titles := make([]string, len(targets))
+		for i, t := range targets {
+			titles[i] = t.Title
+		}
+		// EmbedShortStrings, never EmbedDocument: a title is a few words, and
+		// the short-string template is the rendering those were measured under
+		// (embeddings.Model.ShortStringTemplate).
+		vecs, err := emb.EmbedShortStrings(ctx, titles)
+		if err != nil {
+			return 0, 0, wrapf(reviewTool, err, "title backfill: embed")
+		}
+		if len(vecs) != len(targets) {
+			return 0, 0, errf(reviewTool, "title backfill: embedder returned %d vectors for %d titles", len(vecs), len(targets))
+		}
+		out := make([]store.TitleVector, 0, len(targets))
+		for i, t := range targets {
+			out = append(out, store.TitleVector{FactID: t.FactID, Path: t.Path, Vec: vecs[i]})
+		}
+		if err := d.Abstraction.PutTitleVectors(ctx, out); err != nil {
+			return 0, 0, wrapf(reviewTool, err, "title backfill: store")
+		}
+	}
+	return d.Abstraction.TitleVectorCoverage(ctx, branch)
+}

--- a/internal/synthesize/restatement_acceptance_test.go
+++ b/internal/synthesize/restatement_acceptance_test.go
@@ -93,9 +93,11 @@ func TestAcceptance_RealCorpusShortlist(t *testing.T) {
 	t.Logf("coverage complete: %d/%d", have, total)
 
 	seeded := time.Now()
-	require.NoError(t, refreshRestatementShortlist(ctx, d, branch,
-		store.EmbedderThresholds(emb).Dedup))
-	t.Logf("shortlist seeded in %s", time.Since(seeded).Round(time.Millisecond))
+	refresh, err := refreshRestatementShortlist(ctx, d, branch, store.EmbedderThresholds(emb).Dedup)
+	require.NoError(t, err)
+	t.Logf("shortlist seeded in %s (%d KNN queries, %d pairs, %d partners requeued)",
+		time.Since(seeded).Round(time.Millisecond),
+		refresh.NeighbourQueries, refresh.PairsAdded, refresh.FactsRequeued)
 
 	pairs, health, err := selectRestatementCandidates(ctx, d, branch, nil, total)
 	require.NoError(t, err)

--- a/internal/synthesize/restatement_acceptance_test.go
+++ b/internal/synthesize/restatement_acceptance_test.go
@@ -2,7 +2,6 @@ package synthesize
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -109,9 +108,9 @@ func TestAcceptance_RealCorpusShortlist(t *testing.T) {
 		"whatever the corpus looks like, a session's spend is bounded")
 
 	for i, p := range pairs {
-		t.Log(fmt.Sprintf("candidate %d (title-cos %.3f)", i, p.TitleCos))
-		t.Log("  A " + p.APath)
-		t.Log("  B " + p.BPath)
+		t.Logf("candidate %d (title-cos %.3f)", i, p.TitleCos)
+		t.Logf("  A %s", p.APath)
+		t.Logf("  B %s", p.BPath)
 	}
 
 	// The whole standing population, for corpora small enough to read.

--- a/internal/synthesize/restatement_acceptance_test.go
+++ b/internal/synthesize/restatement_acceptance_test.go
@@ -1,0 +1,122 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/embeddings"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// TestAcceptance_RealCorpusShortlist runs the consolidation-scope fix against a
+// REAL knomit repo database with the REAL embedding model, and prints what the
+// shortlist did with it.
+//
+// Skipped unless KNOMIT_PHASE0_DB names a copy of a repo DB, because it needs
+// both a corpus and the ONNX model, and because it is a measurement rather than
+// a contract — the assertions below are deliberately weak (it must not crash,
+// and it must produce a bounded batch). What makes it worth keeping is the
+// output: coverage, the standing pair population, this corpus's operating
+// point, and the pairs it chose to spend judge slots on.
+//
+//	cp ~/.knomit/repos/<uid>.db /tmp/accept.db
+//	KNOMIT_PHASE0_DB=/tmp/accept.db go test ./internal/synthesize/ \
+//	    -run TestAcceptance_RealCorpusShortlist -v -timeout 30m
+//
+// Work on a COPY. The run migrates the schema and writes derived state.
+func TestAcceptance_RealCorpusShortlist(t *testing.T) {
+	dbPath := os.Getenv("KNOMIT_PHASE0_DB")
+	if dbPath == "" {
+		t.Skip("set KNOMIT_PHASE0_DB to a COPY of a repo database to run the acceptance measurement")
+	}
+	ctx := context.Background()
+
+	svc, err := store.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+
+	model, err := embeddings.Lookup(embeddings.DefaultModelID)
+	require.NoError(t, err)
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	emb, err := embeddings.NewEmbedder(ctx, model, filepath.Join(home, ".knomit", "models"))
+	require.NoError(t, err)
+	t.Cleanup(emb.Close)
+	svc.SetEmbedder(emb)
+	require.NoError(t, svc.OpenRepo())
+
+	branch := os.Getenv("KNOMIT_PHASE0_BRANCH")
+	if branch == "" {
+		branch, err = svc.Branches().DefaultBranch(ctx)
+		require.NoError(t, err)
+	}
+
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:         "acceptance",
+		AgentBranch:  branch,
+		Svc:          svc,
+		Embedder:     emb,
+		OntologyRoot: "kb",
+	})
+	d := Deps{
+		RI:          ri,
+		Facts:       svc.Facts(),
+		Search:      svc.Search(),
+		Pipeline:    svc.Pipeline(),
+		Branches:    svc.Branches(),
+		Abstraction: svc.Abstraction(),
+		Effort:      EffortNormal,
+		OnProgress:  func(ProgressEvent) {},
+	}
+
+	// Fill the axis. In production this spreads over sessions under the latency
+	// budget; here we keep going so the measurement sees full coverage, and
+	// report what a first session would actually have cost.
+	firstSession := time.Now()
+	have, total, err := ensureTitleVectors(ctx, d, branch, titleBackfillBudget)
+	require.NoError(t, err)
+	t.Logf("first session backfill: %d/%d titles in %s", have, total, time.Since(firstSession).Round(time.Millisecond))
+
+	for have < total {
+		before := have
+		have, total, err = ensureTitleVectors(ctx, d, branch, titleBackfillBudget)
+		require.NoError(t, err)
+		require.Greater(t, have, before, "backfill stalled at %d/%d", have, total)
+	}
+	t.Logf("coverage complete: %d/%d", have, total)
+
+	seeded := time.Now()
+	require.NoError(t, refreshRestatementShortlist(ctx, d, branch,
+		store.EmbedderThresholds(emb).Dedup))
+	t.Logf("shortlist seeded in %s", time.Since(seeded).Round(time.Millisecond))
+
+	pairs, health, err := selectRestatementCandidates(ctx, d, branch, nil, total)
+	require.NoError(t, err)
+
+	for _, line := range healthLines(health) {
+		t.Log(line)
+	}
+	require.LessOrEqual(t, len(pairs), maxShortlistItems,
+		"whatever the corpus looks like, a session's spend is bounded")
+
+	for i, p := range pairs {
+		t.Log(fmt.Sprintf("candidate %d (title-cos %.3f)", i, p.TitleCos))
+		t.Log("  A " + p.APath)
+		t.Log("  B " + p.BPath)
+	}
+
+	// The whole standing population, for corpora small enough to read.
+	standing, err := svc.Abstraction().RestatementPairsByRank(ctx, branch, 25)
+	require.NoError(t, err)
+	t.Logf("top standing pairs (%d shown of %d):", len(standing), health.StandingPairs)
+	for _, p := range standing {
+		t.Logf("  %.3f  %s | %s", p.TitleCos, p.APath, p.BPath)
+	}
+}

--- a/internal/synthesize/restatement_conformance_test.go
+++ b/internal/synthesize/restatement_conformance_test.go
@@ -1,0 +1,140 @@
+package synthesize
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// budgetLiterals are the float literals the consolidation-scope fix is allowed
+// to contain, each with the reason it is a RESOURCE constant rather than a
+// claim about a corpus.
+//
+// The distinction is the whole design (roadmap MN13). A corpus-property
+// constant — an absolute cosine, a "restatements should be under X% of facts"
+// rate — encodes somebody's guess about a corpus into code that then applies it
+// to every corpus. A resource constant allocates OUR spend and is honest about
+// it. The first kind is forbidden; the second has to say what it budgets.
+var budgetLiterals = map[string]string{
+	"1.5":   "restatementPriority: ordering within prune's band, below every real cluster",
+	"1e-12": "degenerate-norm guard in cosine; a numerical floor, not a similarity threshold",
+}
+
+// TestConformance_NoCorpusPropertyConstants fails if a float literal appears in
+// the shortlist path without being declared a budget above.
+//
+// This is a real gate, not decoration: an absolute cosine is exactly what this
+// mechanism kept growing in every earlier draft, and it looks reasonable every
+// single time.
+func TestConformance_NoCorpusPropertyConstants(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "restatement.go", nil, 0)
+	require.NoError(t, err)
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != token.FLOAT {
+			return true
+		}
+		_, allowed := budgetLiterals[lit.Value]
+		require.True(t, allowed,
+			"float literal %s at %s is not a declared budget: absolute cosines and "+
+				"corpus rates must be derived from the repo's own data, never hard-coded (MN13)",
+			lit.Value, fset.Position(lit.Pos()))
+		return true
+	})
+}
+
+// TestConformance_BudgetConstantsSayWhatTheyBudget — a number that allocates
+// spend has to say so where it is defined, or the next reader cannot tell it
+// from a threshold somebody measured.
+func TestConformance_BudgetConstantsSayWhatTheyBudget(t *testing.T) {
+	src := readSourceFile(t, "restatement.go")
+	for _, want := range []struct{ name, classification string }{
+		{"titleBackfillBudget", "LATENCY BUDGET"},
+		{"titleBackfillBatch", "THROUGHPUT BUDGET"},
+		{"pairNeighbourK", "STRUCTURAL BUDGET"},
+		{"maxShortlistItems", "JUDGE-SLOT BUDGET"},
+		{"shortlistPerMille", "JUDGE-SLOT BUDGET"},
+		{"throttleWindow", "PATIENCE BUDGET"},
+		{"shortlistOverfetch", "RESOURCE BUDGET"},
+	} {
+		idx := strings.Index(src, want.name)
+		require.Positive(t, idx, "constant %s not found", want.name)
+		// The classification has to sit in the comment that introduces the
+		// constant. A doc comment opens by naming it, so look forward from the
+		// first mention rather than backward.
+		window := src[idx:min(idx+700, len(src))]
+		require.Contains(t, window, want.classification,
+			"%s must be documented as a %s where it is defined", want.name, want.classification)
+	}
+}
+
+// TestConformance_ReviewPipelineOnly — the runtime paths are untouched by this
+// phase. The abstraction axis is review-time derived state, and a query or
+// learn call that consulted it would be paying review's costs on the hot path.
+//
+// Structurally enforced as well as asserted: AbstractionIndex is deliberately
+// NOT part of the SearchIndex composite that mcp and web depend on.
+func TestConformance_ReviewPipelineOnly(t *testing.T) {
+	runtimeFiles := []string{
+		"../mcp/query.go",
+		"../mcp/explain.go",
+		"../mcp/learn.go",
+		"../store/search_query.go",
+		"../store/search_crud.go",
+	}
+	for _, rel := range runtimeFiles {
+		if _, err := os.Stat(rel); err != nil {
+			continue // file renamed; the greps below still cover the packages
+		}
+		src := readSourceFile(t, rel)
+		require.NotContains(t, src, "Abstraction()", "%s must not reach the abstraction axis", rel)
+		require.NotContains(t, src, "Restatement", "%s must not reach the restatement shortlist", rel)
+		require.NotContains(t, src, "restatement", "%s must not reach the restatement shortlist", rel)
+	}
+}
+
+// TestConformance_NoConfigSurface — enablement is COMPUTED, never configured.
+// A repo owner cannot know whether title similarity discriminates on their
+// corpus, so asking them is asking for a guess that then looks like a decision.
+func TestConformance_NoConfigSurface(t *testing.T) {
+	for _, rel := range []string{"../config/config.go", "../repos/instance.go"} {
+		src := strings.ToLower(readSourceFile(t, rel))
+		for _, forbidden := range []string{"restatement", "shortlist", "title_vector", "titlevector", "abstraction"} {
+			require.NotContains(t, src, forbidden,
+				"%s must carry no setting for the consolidation-scope fix", rel)
+		}
+	}
+}
+
+// TestConformance_BridgeFilesUntouched — phase 0 is independent of motifs and
+// of the bridge engine. Nothing here may reach into bridge*.go, and the
+// EffortNormal contract test must not need adjusting to accommodate it.
+func TestConformance_BridgeFilesUntouched(t *testing.T) {
+	src := readSourceFile(t, "restatement.go")
+	for _, forbidden := range []string{"BridgeSeedSet", "bridgeQ", "buildScoredBridges", "BridgeKind"} {
+		require.NotContains(t, src, forbidden,
+			"the consolidation-scope fix is independent of the bridge engine")
+	}
+	// The EffortNormal contract is that normal spends nothing on DISCOVERY.
+	// Consolidation is not discovery, so the shortlist runs at every level —
+	// which is only legitimate because it is applied uniformly.
+	require.NotContains(t, src, "EffortMedium")
+	require.NotContains(t, src, "EffortHigh")
+	require.NotContains(t, src, "d.Effort",
+		"the shortlist is review machinery, not a discovery spend, and must not branch on effort")
+}
+
+func readSourceFile(t *testing.T, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Clean(rel))
+	require.NoError(t, err)
+	return string(b)
+}

--- a/internal/synthesize/restatement_conformance_test.go
+++ b/internal/synthesize/restatement_conformance_test.go
@@ -5,6 +5,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,6 +25,17 @@ import (
 var budgetLiterals = map[string]string{
 	"1.5":   "restatementPriority: ordering within prune's band, below every real cluster",
 	"1e-12": "degenerate-norm guard in cosine; a numerical floor, not a similarity threshold",
+	"0.99":  "p99 of the standing pair distribution — a REPORTED quantile of this repo's own data",
+	"0.999": "p99.9 of the standing pair distribution — reported, read by no branch",
+}
+
+// phase0Files are every file the consolidation-scope fix owns. The audit covers
+// all of them: an absolute cosine is no less a corpus-property constant for
+// being in the store layer, and the first version of this test only looked at
+// one file.
+var phase0Files = []string{
+	"restatement.go",
+	"../store/abstraction.go",
 }
 
 // TestConformance_NoCorpusPropertyConstants fails if a float literal appears in
@@ -33,29 +45,31 @@ var budgetLiterals = map[string]string{
 // mechanism kept growing in every earlier draft, and it looks reasonable every
 // single time.
 func TestConformance_NoCorpusPropertyConstants(t *testing.T) {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "restatement.go", nil, 0)
-	require.NoError(t, err)
+	for _, rel := range phase0Files {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, rel, nil, 0)
+		require.NoError(t, err, "parse %s", rel)
 
-	ast.Inspect(file, func(n ast.Node) bool {
-		lit, ok := n.(*ast.BasicLit)
-		if !ok || lit.Kind != token.FLOAT {
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.FLOAT {
+				return true
+			}
+			_, allowed := budgetLiterals[lit.Value]
+			require.True(t, allowed,
+				"float literal %s at %s is not a declared budget: absolute cosines and "+
+					"corpus rates must be derived from the repo's own data, never hard-coded (MN13)",
+				lit.Value, fset.Position(lit.Pos()))
 			return true
-		}
-		_, allowed := budgetLiterals[lit.Value]
-		require.True(t, allowed,
-			"float literal %s at %s is not a declared budget: absolute cosines and "+
-				"corpus rates must be derived from the repo's own data, never hard-coded (MN13)",
-			lit.Value, fset.Position(lit.Pos()))
-		return true
-	})
+		})
+	}
 }
 
 // TestConformance_BudgetConstantsSayWhatTheyBudget — a number that allocates
 // spend has to say so where it is defined, or the next reader cannot tell it
 // from a threshold somebody measured.
 func TestConformance_BudgetConstantsSayWhatTheyBudget(t *testing.T) {
-	src := readSourceFile(t, "restatement.go")
+	src := readSourceFile(t, "restatement.go") + readSourceFile(t, "../store/abstraction.go")
 	for _, want := range []struct{ name, classification string }{
 		{"titleBackfillBudget", "LATENCY BUDGET"},
 		{"titleBackfillBatch", "THROUGHPUT BUDGET"},
@@ -64,6 +78,8 @@ func TestConformance_BudgetConstantsSayWhatTheyBudget(t *testing.T) {
 		{"shortlistPerMille", "JUDGE-SLOT BUDGET"},
 		{"throttleWindow", "PATIENCE BUDGET"},
 		{"shortlistOverfetch", "RESOURCE BUDGET"},
+		{"throttleProbeInterval", "PATIENCE BUDGET"},
+		{"titleKNNOverfetch", "STRUCTURAL BUDGET"},
 	} {
 		idx := strings.Index(src, want.name)
 		require.Positive(t, idx, "constant %s not found", want.name)
@@ -83,22 +99,37 @@ func TestConformance_BudgetConstantsSayWhatTheyBudget(t *testing.T) {
 // Structurally enforced as well as asserted: AbstractionIndex is deliberately
 // NOT part of the SearchIndex composite that mcp and web depend on.
 func TestConformance_ReviewPipelineOnly(t *testing.T) {
-	runtimeFiles := []string{
-		"../mcp/query.go",
-		"../mcp/explain.go",
-		"../mcp/learn.go",
-		"../store/search_query.go",
-		"../store/search_crud.go",
-	}
-	for _, rel := range runtimeFiles {
-		if _, err := os.Stat(rel); err != nil {
-			continue // file renamed; the greps below still cover the packages
+	// Whole packages, not a list of filenames. The first version of this test
+	// named five files and skipped any that had been renamed, so it would have
+	// gone quietly green on the very refactor most likely to break it.
+	scanned := 0
+	for _, pkg := range []string{"../mcp", "../web", "../store"} {
+		files, err := filepath.Glob(filepath.Join(pkg, "*.go"))
+		require.NoError(t, err)
+		require.NotEmpty(t, files, "package %s has no Go files — the scan is not covering what it claims", pkg)
+
+		for _, path := range files {
+			base := filepath.Base(path)
+			if strings.HasSuffix(base, "_test.go") {
+				continue
+			}
+			// The axis lives in the store, so its own implementation and the
+			// interface that declares it are the two legitimate mentions.
+			if pkg == "../store" && (base == "abstraction.go" || base == "interfaces.go" ||
+				base == "vec_table.go" || base == "branch.go" || base == "service.go") {
+				continue
+			}
+			src := readSourceFile(t, path)
+			require.NotContains(t, src, "Abstraction()",
+				"%s must not reach the abstraction axis — it is review-time derived state", path)
+			require.NotContains(t, src, "restatement",
+				"%s must not reach the restatement shortlist", path)
+			require.NotContains(t, src, "Restatement",
+				"%s must not reach the restatement shortlist", path)
+			scanned++
 		}
-		src := readSourceFile(t, rel)
-		require.NotContains(t, src, "Abstraction()", "%s must not reach the abstraction axis", rel)
-		require.NotContains(t, src, "Restatement", "%s must not reach the restatement shortlist", rel)
-		require.NotContains(t, src, "restatement", "%s must not reach the restatement shortlist", rel)
 	}
+	require.Greater(t, scanned, 50, "the reachability scan must actually be reading files")
 }
 
 // TestConformance_NoConfigSurface — enablement is COMPUTED, never configured.
@@ -114,22 +145,79 @@ func TestConformance_NoConfigSurface(t *testing.T) {
 	}
 }
 
-// TestConformance_BridgeFilesUntouched — phase 0 is independent of motifs and
-// of the bridge engine. Nothing here may reach into bridge*.go, and the
-// EffortNormal contract test must not need adjusting to accommodate it.
+// TestConformance_BridgeFilesUntouched enforces two roadmap constraints that
+// only a DIFF can see: no change under internal/synthesize/bridge*.go, and the
+// EffortNormal contract test left byte-identical (MN5).
+//
+// It runs git, because that is what the constraint is about. An earlier version
+// of this test replaced the diff with identifier greps over the source — which
+// reads like the same check and is not one: greps cannot see an edit to the
+// EffortNormal test at all, so MN5 was being enforced by nothing.
 func TestConformance_BridgeFilesUntouched(t *testing.T) {
+	base := baseRefOrSkip(t)
+	// Diff the WORKING TREE against the merge base, not HEAD against it. The
+	// first attempt used base...HEAD and let an uncommitted edit to a bridge
+	// file pass — which is the state the check most needs to catch, since that
+	// is what a developer is looking at when they run the suite.
+	mergeBase, err := exec.Command("git", "merge-base", base, "HEAD").Output()
+	require.NoError(t, err, "git merge-base %s HEAD", base)
+	out, err := exec.Command("git", "diff", "--name-only", strings.TrimSpace(string(mergeBase))).Output()
+	require.NoError(t, err, "git diff against %s", base)
+
+	// A conformance check that examines an empty list is not a check. This work
+	// touches many files, so an empty diff means the base ref is wrong, not
+	// that the constraint holds.
+	changed := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) != "" {
+			changed++
+		}
+	}
+	require.Positive(t, changed,
+		"diff against %s is empty — this check would pass vacuously", base)
+
+	for _, line := range strings.Split(string(out), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		require.NotRegexp(t, `^internal/synthesize/bridge.*\.go$`, name,
+			"phase 0 is independent of the bridge engine")
+		require.NotEqual(t, "internal/synthesize/review_effort_normal_test.go", name,
+			"MN5: the EffortNormal contract test stays byte-identical")
+	}
+}
+
+// baseRefOrSkip resolves the branch this work sits on top of. It SKIPS with a
+// loud reason when the ref is genuinely absent (a shallow CI clone, a fork
+// without the upstream ref) rather than passing silently — a conformance test
+// that cannot run must say so, not report success.
+func baseRefOrSkip(t *testing.T) string {
+	t.Helper()
+	for _, ref := range []string{"dev", "origin/dev", "master", "origin/master"} {
+		if err := exec.Command("git", "rev-parse", "--verify", "--quiet", ref).Run(); err == nil {
+			return ref
+		}
+	}
+	t.Skip("no base ref (dev/master) available in this checkout: the diff-based " +
+		"bridge/MN5 conformance check cannot run here and is NOT being enforced")
+	return ""
+}
+
+// TestConformance_ShortlistDoesNotBranchOnEffort — consolidation is not
+// discovery, so the shortlist runs at every effort level. That is only
+// legitimate because it is applied UNIFORMLY, which is what
+// invariants/synthesize/effort-normal-byte-identical actually permits.
+func TestConformance_ShortlistDoesNotBranchOnEffort(t *testing.T) {
 	src := readSourceFile(t, "restatement.go")
+	require.NotContains(t, src, "EffortMedium")
+	require.NotContains(t, src, "EffortHigh")
+	require.NotContains(t, src, "d.Effort",
+		"the shortlist is review machinery, not a discovery spend")
 	for _, forbidden := range []string{"BridgeSeedSet", "bridgeQ", "buildScoredBridges", "BridgeKind"} {
 		require.NotContains(t, src, forbidden,
 			"the consolidation-scope fix is independent of the bridge engine")
 	}
-	// The EffortNormal contract is that normal spends nothing on DISCOVERY.
-	// Consolidation is not discovery, so the shortlist runs at every level —
-	// which is only legitimate because it is applied uniformly.
-	require.NotContains(t, src, "EffortMedium")
-	require.NotContains(t, src, "EffortHigh")
-	require.NotContains(t, src, "d.Effort",
-		"the shortlist is review machinery, not a discovery spend, and must not branch on effort")
 }
 
 func readSourceFile(t *testing.T, rel string) string {

--- a/internal/synthesize/restatement_dynamics_test.go
+++ b/internal/synthesize/restatement_dynamics_test.go
@@ -260,3 +260,67 @@ func (e *restatementEnv) standingPairSet() map[string]bool {
 	}
 	return out
 }
+
+// TestDynamics_ProbeIsNotConsumedWhenNothingIsEmitted — the probe is the only
+// path by which a defunded corpus can change its own evidence, so spending one
+// on a session that emits nothing costs a full interval of silence for no
+// information.
+//
+// This is the repair's own recursion: the probe fix restored recovery, and this
+// asks what the repair does when the thing it funds turns out to be empty.
+func TestDynamics_ProbeIsNotConsumedWhenNothingIsEmitted(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 600)
+	env.seedShortlist()
+
+	// Decline until defunded.
+	for range throttleWindow {
+		pairs, health, err := selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+		require.NoError(t, err)
+		if health.ThrottleState == throttleDefunded {
+			break
+		}
+		for _, p := range pairs {
+			env.recordVerdict(p.APath, p.BPath, false)
+		}
+	}
+
+	// Retire every remaining standing pair, so a probe has nothing to offer.
+	standing, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100_000)
+	require.NoError(t, err)
+	for _, p := range standing {
+		require.NoError(t, env.svc.Abstraction().DeleteRestatementPair(ctx, env.branch, p.AFactID, p.BFactID))
+	}
+
+	// Run well past a probe interval. No pair can be emitted, so no probe may
+	// be marked as spent.
+	for range throttleProbeInterval * 2 {
+		pairs, health, err := selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+		require.NoError(t, err)
+		require.Empty(t, pairs)
+		require.False(t, health.Probing, "a session that emits nothing has not probed")
+	}
+
+	// Put the pairs back. Re-running the refresh alone would not do it — every
+	// fact is already marked covered — so evict the cache state the way a
+	// partner requeue does, which forces a rescan.
+	ids := env.liveFactIDs()
+	all := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		all = append(all, id)
+	}
+	require.NoError(t, env.svc.Abstraction().ReplaceRestatementPairs(ctx, env.branch, all, nil, nil))
+	env.seedShortlist()
+	require.Positive(t, env.standingPairCount(), "the corpus has pairs to offer again")
+	probed := false
+	for range throttleProbeInterval {
+		pairs, health, err := selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+		require.NoError(t, err)
+		if health.Probing {
+			probed = true
+			require.NotEmpty(t, pairs)
+			break
+		}
+	}
+	require.True(t, probed, "the probe budget was still owed, not burned on empty sessions")
+}

--- a/internal/synthesize/restatement_dynamics_test.go
+++ b/internal/synthesize/restatement_dynamics_test.go
@@ -1,0 +1,262 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// Multi-session dynamics.
+//
+// Every defect that made it past the first round of review lived here rather
+// than in any single function: each component was correct on its own, and the
+// system failed on the SECOND session, or the fifth, or the one after an edit.
+// A unit test that calls a function once cannot see any of that.
+//
+// These tests therefore drive whole sessions in sequence — with partial
+// backfill budgets, judge verdicts, and fact edits in between — and assert on
+// what the corpus does over time.
+
+// TestDynamics_IncrementalSessionsStillEmit is the regression for the defect
+// that would have shipped: the budget was scaled by the session's DIRTY SEED
+// count, not by corpus size. The first review of a repo full-scans, so seeds ≈
+// corpus and everything looked right; every session after it sees a handful of
+// changed facts, and a handful times five-per-thousand is zero. The feature
+// would have emitted nothing for the entire life of every repo, with a full
+// pair cache sitting unread.
+func TestDynamics_IncrementalSessionsStillEmit(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+	env.writeFact("kb/restate-a.md", "Cache invalidation on write", "one account of it")
+	env.writeFact("kb/restate-b.md", "Cache invalidation on write", "a different account, at length, of the same thing")
+	for i := range 400 {
+		env.writeFact(fmt.Sprintf("kb/filler%d.md", i), fmt.Sprintf("Filler %d", i), fmt.Sprintf("filler body %d", i))
+	}
+
+	// Session 1: the full scan. This is the session that always worked.
+	first := env.runSession()
+	require.NotEmpty(t, first.restatementItems, "the full-scan session emits")
+
+	// Session 2: one fact edited, so the seed pool is a single fact.
+	env.writeFact("kb/filler7.md", "Filler 7 revised", "a revised filler body")
+	second := env.runSession()
+	require.NotEmpty(t, second.restatementItems,
+		"an incremental session must still spend from the CORPUS budget — "+
+			"scaling by dirty seeds makes this zero forever after the first review")
+	require.Contains(t, strings.Join(second.health, "\n"), "standing restatement pairs")
+}
+
+// TestDynamics_PartialBackfillClosesOverSessions is the regression for the
+// frozen-cache defect. Facts were marked "covered" by the pair cache whether or
+// not their titles had actually been embedded, so on any corpus too large to
+// backfill in one session the un-embedded majority was recorded as done and
+// their neighbours were never searched — permanently, because the cache state
+// is exactly what says "already covered".
+func TestDynamics_PartialBackfillClosesOverSessions(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 120)
+	env.emb.perBatchDelay = 15 * time.Millisecond // forces a partial first pass
+
+	// A deliberately tiny backfill budget: a few batches per session.
+	const tinyBudget = 40 * time.Millisecond
+
+	have, total, err := ensureTitleVectors(ctx, env.deps(), env.branch, tinyBudget)
+	require.NoError(t, err)
+	require.Less(t, have, total, "the first session covers only part of the corpus")
+
+	_, err = refreshRestatementShortlist(ctx, env.deps(), env.branch, env.dedupThreshold())
+	require.NoError(t, err)
+	firstPairs := env.standingPairCount()
+
+	// Sessions continue until coverage closes. Pair growth must continue with
+	// it: a frozen cache would keep returning the same count forever.
+	for range 40 {
+		have, total, err = ensureTitleVectors(ctx, env.deps(), env.branch, tinyBudget)
+		require.NoError(t, err)
+		_, err = refreshRestatementShortlist(ctx, env.deps(), env.branch, env.dedupThreshold())
+		require.NoError(t, err)
+		if have == total {
+			break
+		}
+	}
+	require.Equal(t, total, have, "coverage closes")
+	require.Greater(t, env.standingPairCount(), firstPairs,
+		"pairs keep being discovered as the axis fills — a cache that stops growing "+
+			"has marked un-embedded facts as covered")
+
+	// And the finished corpus matches what a single-session backfill would have
+	// produced: partial coverage delays discovery, it does not lose it.
+	full := newRestatementEnv(t, 120)
+	full.seedShortlist()
+	require.Equal(t, full.standingPairCount(), env.standingPairCount(),
+		"a corpus backfilled across sessions ends up with the same pairs as one backfilled at once")
+}
+
+// TestDynamics_PairsSurviveAnUnrelatedEdit is the regression for asymmetric-KNN
+// delta loss. A standing pair can exist only because B's top-K included A and
+// never the reverse; dropping every pair that touches an edited fact and then
+// re-running only that fact's KNN destroys such pairs with nothing to
+// rediscover them.
+func TestDynamics_PairsSurviveAnUnrelatedEdit(t *testing.T) {
+	env := newRestatementEnv(t, 60)
+	env.seedShortlist()
+	before := env.standingPairSet()
+	require.NotEmpty(t, before)
+
+	// Edit facts one at a time, refreshing between each, and require the pair
+	// population never to erode. Each edit legitimately retires the pairs of the
+	// edited fact and re-mints them; what must not happen is a net loss of pairs
+	// between OTHER facts.
+	for _, i := range []int{3, 17, 42} {
+		path := fmt.Sprintf("kb/f%d.md", i)
+		env.writeFact(path, fmt.Sprintf("F%d", i), fmt.Sprintf("rewritten body %d", i))
+		env.seedShortlist()
+
+		after := env.standingPairSet()
+		for key := range before {
+			if strings.Contains(key, path) {
+				continue // the edited fact's own pairs are re-minted, not preserved
+			}
+			require.Contains(t, after, key,
+				"pair %s disappeared after editing %s — an asymmetric KNN discovery was lost", key, path)
+		}
+		before = after
+	}
+}
+
+// TestDynamics_DefundAndProbeRecoveryOverSessions walks the throttle's whole
+// life cycle through the paths production actually takes: decline until the
+// corpus defunds itself, wait out the probe interval, spend the probe, resolve
+// it, and be funded again.
+//
+// The earlier version of this suite "restored" funding by writing a resolution
+// verdict directly — a state a defunded corpus can never reach on its own,
+// which is exactly why the latch went unnoticed.
+func TestDynamics_DefundAndProbeRecoveryOverSessions(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 600)
+	env.seedShortlist()
+
+	// Decline everything offered until the corpus stops offering. How many
+	// sessions that takes depends on the batch size, which is the corpus's
+	// business, not this test's — what matters is that it happens, bounded.
+	declined := map[string]bool{}
+	var health restatementHealth
+	var pairs []store.RestatementPair
+	var err error
+	sessions := 0
+	for ; sessions < throttleWindow; sessions++ {
+		pairs, health, err = selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+		require.NoError(t, err)
+		if health.ThrottleState == throttleDefunded {
+			break
+		}
+		require.NotEmpty(t, pairs, "a funded corpus keeps offering work")
+		for _, p := range pairs {
+			key := pathPairKey(p.APath, p.BPath)
+			require.False(t, declined[key], "a declined pair must never be offered twice")
+			declined[key] = true
+			env.recordVerdict(p.APath, p.BPath, false)
+		}
+	}
+	require.Equal(t, throttleDefunded, health.ThrottleState,
+		"declining everything must eventually stop the spending")
+	require.Empty(t, pairs)
+	require.GreaterOrEqual(t, len(declined), throttleMinVerdicts)
+
+	// Quiet sessions, then exactly one probe.
+	probed := 0
+	var probePair store.RestatementPair
+	for range throttleProbeInterval + 1 {
+		pairs, health, err = selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+		require.NoError(t, err)
+		if health.Probing {
+			probed++
+			require.Len(t, pairs, 1, "a probe is one slot, not a batch")
+			probePair = pairs[0]
+		} else {
+			require.Empty(t, pairs, "a defunded corpus is silent between probes")
+		}
+	}
+	require.Equal(t, 1, probed, "exactly one probe per interval")
+
+	// Resolve the probe: the corpus funds itself again from evidence only the
+	// probe could have produced.
+	env.recordVerdict(probePair.APath, probePair.BPath, true)
+	pairs, health, err = selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+	require.NoError(t, err)
+	require.Equal(t, throttleFunded, health.ThrottleState)
+	require.NotEmpty(t, pairs)
+}
+
+// TestDynamics_DecliningSessionsKeepOfferingNewPairs is the regression for
+// window saturation: with declined pairs left standing at the top of the
+// ranking, a handful of declining sessions filled the entire selection window
+// with pairs the judge had already refused, and a funded corpus went silent.
+func TestDynamics_DecliningSessionsKeepOfferingNewPairs(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 600)
+	env.seedShortlist()
+
+	seen := map[string]bool{}
+	for session := range throttleMinVerdicts - 1 {
+		pairs, _, err := selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+		require.NoError(t, err)
+		require.NotEmpty(t, pairs, "session %d went silent while still funded", session)
+		for _, p := range pairs {
+			key := pathPairKey(p.APath, p.BPath)
+			require.False(t, seen[key], "session %d re-offered %s", session, key)
+			seen[key] = true
+			// Decline, but resolve one so the corpus stays funded throughout.
+			env.recordVerdict(p.APath, p.BPath, session == 0)
+		}
+	}
+	require.GreaterOrEqual(t, len(seen), throttleMinVerdicts-1)
+}
+
+// ── session harness ───────────────────────────────────────────────────────
+
+type sessionOutcome struct {
+	sessionID        string
+	restatementItems []store.PipelineWorkItem
+	health           []string
+}
+
+// runSession drives one real review session through the engine and reports what
+// the shortlist contributed to it.
+func (e *restatementEnv) runSession() sessionOutcome {
+	e.t.Helper()
+	res, err := NewReviewerWithOptions(e.ri, nil, EffortNormal, ScopeFilter{}).StartSession(context.Background())
+	require.NoError(e.t, err)
+
+	out := sessionOutcome{sessionID: res.SessionID, health: res.Health}
+	for _, item := range e.workItems(res.SessionID) {
+		if strings.HasPrefix(item.ClusterKey, restatementClusterKeyPrefix) {
+			out.restatementItems = append(out.restatementItems, item)
+		}
+	}
+	return out
+}
+
+func (e *restatementEnv) standingPairCount() int {
+	e.t.Helper()
+	stats, err := e.svc.Abstraction().RestatementPairStats(context.Background(), e.branch)
+	require.NoError(e.t, err)
+	return stats.Count
+}
+
+func (e *restatementEnv) standingPairSet() map[string]bool {
+	e.t.Helper()
+	pairs, err := e.svc.Abstraction().RestatementPairsByRank(context.Background(), e.branch, 100_000)
+	require.NoError(e.t, err)
+	out := make(map[string]bool, len(pairs))
+	for _, p := range pairs {
+		out[pathPairKey(p.APath, p.BPath)] = true
+	}
+	return out
+}

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -222,11 +222,12 @@ func (e *restatementEnv) seedShortlist() {
 	ctx := context.Background()
 	_, _, err := ensureTitleVectors(ctx, e.deps(), e.branch, titleBackfillBudget)
 	require.NoError(e.t, err)
-	require.NoError(e.t, refreshRestatementShortlist(ctx, e.deps(), e.branch, e.dedupThreshold()))
+	_, err = refreshRestatementShortlist(ctx, e.deps(), e.branch, e.dedupThreshold())
+	require.NoError(e.t, err)
 }
 
 // recordVerdict stores a judge outcome for a pair, resolving the fact ids the
-// way the apply path does.
+// way the apply path does, and retires the pair the way the apply path does.
 func (e *restatementEnv) recordVerdict(aPath, bPath string, merged bool) {
 	e.t.Helper()
 	ctx := context.Background()
@@ -234,8 +235,9 @@ func (e *restatementEnv) recordVerdict(aPath, bPath string, merged bool) {
 	require.NoError(e.t, e.svc.Abstraction().RecordRestatementVerdict(ctx, e.branch, store.RestatementVerdict{
 		APath: aPath, BPath: bPath,
 		AFactID: ids[aPath], BFactID: ids[bPath],
-		Merged: merged, JudgedAt: time.Now(),
+		Resolved: merged, JudgedAt: time.Now(),
 	}))
+	require.NoError(e.t, e.svc.Abstraction().DeleteRestatementPair(ctx, e.branch, ids[aPath], ids[bPath]))
 }
 
 // liveFactIDs maps live paths to their current fact ids.

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -214,3 +214,109 @@ func containsPair(pairs []store.RestatementPair, a, b string) bool {
 	}
 	return false
 }
+
+// seedShortlist runs the backfill + refresh the way a review session does.
+func (e *restatementEnv) seedShortlist() {
+	e.t.Helper()
+	ctx := context.Background()
+	_, _, err := ensureTitleVectors(ctx, e.deps(), e.branch, titleBackfillBudget)
+	require.NoError(e.t, err)
+	require.NoError(e.t, refreshRestatementShortlist(ctx, e.deps(), e.branch, e.dedupThreshold()))
+}
+
+// recordVerdict stores a judge outcome for a pair, resolving the fact ids the
+// way the apply path does.
+func (e *restatementEnv) recordVerdict(aPath, bPath string, merged bool) {
+	e.t.Helper()
+	ctx := context.Background()
+	ids := e.liveFactIDs()
+	require.NoError(e.t, e.svc.Abstraction().RecordRestatementVerdict(ctx, e.branch, store.RestatementVerdict{
+		APath: aPath, BPath: bPath,
+		AFactID: ids[aPath], BFactID: ids[bPath],
+		Merged: merged, JudgedAt: time.Now(),
+	}))
+}
+
+// liveFactIDs maps live paths to their current fact ids.
+func (e *restatementEnv) liveFactIDs() map[string]int64 {
+	e.t.Helper()
+	facts, err := e.svc.Abstraction().LiveEpistemicFacts(context.Background(), e.branch)
+	require.NoError(e.t, err)
+	out := make(map[string]int64, len(facts))
+	for id, path := range facts {
+		out[path] = id
+	}
+	return out
+}
+
+func (e *restatementEnv) titleOf(path string) string {
+	e.t.Helper()
+	f, err := e.svc.Search().GetByPath(context.Background(), e.branch, path)
+	require.NoError(e.t, err)
+	require.NotNil(e.t, f)
+	return f.Title
+}
+
+func (e *restatementEnv) writeFactWithDomain(path, title, body, domain string) {
+	e.t.Helper()
+	_, err := e.svc.Facts().WriteFact(context.Background(), e.branch, path,
+		"---\ntype: observation\ndomain: ["+domain+"]\n---\n# "+title+"\n\n"+body,
+		"write "+path, "test")
+	require.NoError(e.t, err)
+}
+
+// keepVerdicts is n judge outcomes that all said "keep".
+func keepVerdicts(n int) []store.RestatementVerdict {
+	out := make([]store.RestatementVerdict, 0, n)
+	for i := range n {
+		out = append(out, store.RestatementVerdict{
+			APath: fmt.Sprintf("kb/a%d.md", i), BPath: fmt.Sprintf("kb/b%d.md", i),
+			AFactID: int64(i * 2), BFactID: int64(i*2 + 1),
+		})
+	}
+	return out
+}
+
+// newRestatementEnvOnAxis builds a corpus whose TITLES sit at a controlled
+// spacing on the abstraction axis, so a test can compare what two differently
+// shaped corpora do under identical code. spacing is the angular gap in
+// radians between consecutive titles: small spacing means a corpus whose titles
+// all look alike.
+func newRestatementEnvOnAxis(t *testing.T, n int, spacing float64) *restatementEnv {
+	t.Helper()
+	titleAngles := map[string]float64{}
+	emb := &restatementEmbedder{}
+	emb.vectorFor = func(text string) []float32 {
+		angle, ok := titleAngles[text]
+		if !ok {
+			return nil // bodies keep the default hash placement
+		}
+		return axisVector(angle)
+	}
+	env := newRestatementEnvWith(t, 0, emb)
+	for i := range n {
+		title := fmt.Sprintf("Title %d", i)
+		titleAngles[title] = float64(i) * spacing
+		env.writeFact(fmt.Sprintf("kb/f%d.md", i), title, fmt.Sprintf("body %d with its own distinct wording", i))
+	}
+	return env
+}
+
+// workItems drains the session's queue for inspection.
+func (e *restatementEnv) workItems(sessionID string) []store.PipelineWorkItem {
+	e.t.Helper()
+	var out []store.PipelineWorkItem
+	seen := map[int64]bool{}
+	for range 5000 {
+		item, err := e.svc.Pipeline().NextPipelineWorkItem(context.Background(), sessionID)
+		require.NoError(e.t, err)
+		if item == nil || seen[item.ID] {
+			break
+		}
+		seen[item.ID] = true
+		out = append(out, *item)
+		_, err = e.svc.Pipeline().AnswerPipelineWorkItem(context.Background(), item.ID, "{}")
+		require.NoError(e.t, err)
+	}
+	return out
+}

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -1,0 +1,201 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/embeddings/params"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// restatementEmbedder is a deterministic stand-in for the ONNX embedder that
+// counts what it was asked to do, so tests can assert on the SHAPE of the
+// backfill (how many titles, through which rendering) rather than on vectors.
+//
+// vectorFor lets a test place facts at chosen positions on the axis; the
+// default is a stable hash of the text, which gives unrelated strings low
+// similarity and identical strings similarity 1.
+type restatementEmbedder struct {
+	titles           atomic.Int64
+	shortStringCalls atomic.Int64
+	documentCalls    atomic.Int64
+	perBatchDelay    time.Duration
+	vectorFor        func(text string) []float32
+}
+
+const testVecDim = 768
+
+func (e *restatementEmbedder) vec(text string) []float32 {
+	if e.vectorFor != nil {
+		if v := e.vectorFor(text); v != nil {
+			return v
+		}
+	}
+	return hashVector(text)
+}
+
+func (e *restatementEmbedder) EmbedQuery(_ context.Context, text string) ([]float32, error) {
+	return e.vec(text), nil
+}
+
+func (e *restatementEmbedder) EmbedDocument(_ context.Context, title, body string) ([]float32, error) {
+	e.documentCalls.Add(1)
+	return e.vec(title + " " + body), nil
+}
+
+func (e *restatementEmbedder) EmbedDocuments(_ context.Context, titles, bodies []string) ([][]float32, error) {
+	e.documentCalls.Add(1)
+	out := make([][]float32, len(titles))
+	for i := range titles {
+		out[i] = e.vec(titles[i] + " " + bodies[i])
+	}
+	return out, nil
+}
+
+func (e *restatementEmbedder) EmbedShortStrings(_ context.Context, texts []string) ([][]float32, error) {
+	e.shortStringCalls.Add(1)
+	e.titles.Add(int64(len(texts)))
+	if e.perBatchDelay > 0 {
+		time.Sleep(e.perBatchDelay)
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = e.vec(t)
+	}
+	return out, nil
+}
+
+func (e *restatementEmbedder) Dim() int                      { return testVecDim }
+func (e *restatementEmbedder) ID() string                    { return "restatement-stub" }
+func (e *restatementEmbedder) Thresholds() params.Thresholds { return params.Defaults() }
+
+// hashVector maps text onto a stable unit vector. Distinct texts land far
+// apart; identical texts land on top of each other.
+func hashVector(text string) []float32 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(text))
+	seed := h.Sum64()
+	v := make([]float32, testVecDim)
+	for i := range v {
+		seed = seed*6364136223846793005 + 1442695040888963407
+		v[i] = float32(int64(seed>>33)%2000-1000) / 1000
+	}
+	normalize(v)
+	return v
+}
+
+// axisVector places a point at `angle` radians in the first two dimensions, so
+// a test can dial the exact title-cosine between two facts.
+func axisVector(angle float64) []float32 {
+	v := make([]float32, testVecDim)
+	v[0] = float32(math.Cos(angle))
+	v[1] = float32(math.Sin(angle))
+	return v
+}
+
+func normalize(v []float32) {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	if sum <= 1e-12 {
+		return
+	}
+	inv := float32(1 / math.Sqrt(sum))
+	for i := range v {
+		v[i] *= inv
+	}
+}
+
+// restatementEnv is a repo with n facts, wired the way the review pipeline
+// wires itself, so tests can call the phase-0 functions directly with a real
+// store behind them.
+type restatementEnv struct {
+	t      *testing.T
+	svc    *store.Service
+	ri     *repos.RepoInstance
+	emb    *restatementEmbedder
+	branch string
+}
+
+func newRestatementEnv(t *testing.T, n int) *restatementEnv {
+	t.Helper()
+	return newRestatementEnvWith(t, n, &restatementEmbedder{})
+}
+
+func newRestatementEnvWithoutEmbedder(t *testing.T, n int) *restatementEnv {
+	t.Helper()
+	return newRestatementEnvWith(t, n, nil)
+}
+
+func newRestatementEnvWith(t *testing.T, n int, emb *restatementEmbedder) *restatementEnv {
+	t.Helper()
+	branch := "agent/test"
+	svc, err := store.Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	if emb != nil {
+		svc.SetEmbedder(emb)
+	}
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+
+	cfg := repos.TestInstanceConfig{
+		Name:         "test",
+		AgentBranch:  branch,
+		Svc:          svc,
+		OntologyRoot: "kb",
+	}
+	if emb != nil {
+		cfg.Embedder = emb
+	}
+	env := &restatementEnv{t: t, svc: svc, ri: repos.NewTestInstanceWithDeps(cfg), emb: emb, branch: branch}
+
+	for i := range n {
+		env.writeFact(fmt.Sprintf("kb/f%d.md", i), fmt.Sprintf("F%d", i), fmt.Sprintf("body-%d", i))
+	}
+	return env
+}
+
+func (e *restatementEnv) writeFact(path, title, body string) {
+	e.t.Helper()
+	_, err := e.svc.Facts().WriteFact(context.Background(), e.branch, path,
+		"---\ntype: observation\n---\n# "+title+"\n\n"+body, "write "+path, "test")
+	require.NoError(e.t, err)
+}
+
+// deps mirrors Pipeline.deps for a test that drives the phase-0 functions
+// directly rather than through a session.
+func (e *restatementEnv) deps() Deps {
+	return Deps{
+		RI:          e.ri,
+		Facts:       e.svc.Facts(),
+		Search:      e.svc.Search(),
+		Pipeline:    e.svc.Pipeline(),
+		Branches:    e.svc.Branches(),
+		Abstraction: e.svc.Abstraction(),
+		Effort:      EffortNormal,
+		OnProgress:  func(ProgressEvent) {},
+	}
+}
+
+// factIDs returns the live fact ids keyed by path, for tests that need to talk
+// about facts the way the axis does.
+func (e *restatementEnv) factIDs() map[string]int64 {
+	e.t.Helper()
+	targets, err := e.svc.Abstraction().LiveFactsMissingTitleVector(context.Background(), e.branch, 10_000)
+	require.NoError(e.t, err)
+	out := make(map[string]int64, len(targets))
+	for _, t := range targets {
+		out[t.Path] = t.FactID
+	}
+	return out
+}

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -2,6 +2,7 @@ package synthesize
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -319,4 +320,19 @@ func (e *restatementEnv) workItems(sessionID string) []store.PipelineWorkItem {
 		require.NoError(e.t, err)
 	}
 	return out
+}
+
+// factsJSON renders the two named facts the way a prune work item carries them.
+func (e *restatementEnv) factsJSON(paths ...string) string {
+	e.t.Helper()
+	facts := make([]factForLLM, 0, len(paths))
+	for _, p := range paths {
+		f, err := e.svc.Search().GetByPath(context.Background(), e.branch, p)
+		require.NoError(e.t, err)
+		require.NotNil(e.t, f)
+		facts = append(facts, factForLLM{File: f.Path, Title: f.Title, Body: f.Body, Type: f.Type})
+	}
+	out, err := json.Marshal(facts)
+	require.NoError(e.t, err)
+	return string(out)
 }

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -199,3 +199,18 @@ func (e *restatementEnv) factIDs() map[string]int64 {
 	}
 	return out
 }
+
+// dedupThreshold is the active model's calibrated near-duplicate floor, the
+// same value reviewStrategy.Plan hands to dedupCluster.
+func (e *restatementEnv) dedupThreshold() float64 {
+	return store.EmbedderThresholds(e.ri.Embedder()).Dedup
+}
+
+func containsPair(pairs []store.RestatementPair, a, b string) bool {
+	for _, p := range pairs {
+		if (p.APath == a && p.BPath == b) || (p.APath == b && p.BPath == a) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/synthesize/restatement_test.go
+++ b/internal/synthesize/restatement_test.go
@@ -2,10 +2,15 @@ package synthesize
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
 )
 
 // TestEnsureTitleVectors_WatermarkIncremental is the conformance test for
@@ -203,4 +208,276 @@ func TestRefreshShortlist_KeepsSimilarToNeighbours(t *testing.T) {
 	require.Len(t, pairs, 1)
 	require.Equal(t, "kb/adjacent-a.md", pairs[0].APath)
 	require.Equal(t, "kb/adjacent-b.md", pairs[0].BPath)
+}
+
+// TestShortlistBudget_ScalesWithCorpusAndCapsOut — the cap is also the
+// cold-start guard: a brand-new corpus risks a slot or two before any mechanism
+// here has learned anything about it.
+func TestShortlistBudget_ScalesWithCorpusAndCapsOut(t *testing.T) {
+	require.Equal(t, 0, shortlistBudget(0))
+	require.Equal(t, 0, shortlistBudget(150), "a tiny corpus spends nothing")
+	require.Equal(t, 1, shortlistBudget(300))
+	require.Equal(t, 4, shortlistBudget(800))
+	require.Equal(t, maxShortlistItems, shortlistBudget(50_000), "capped however large the corpus")
+}
+
+// TestThrottleState_StartsOptimisticDefundsOnAllKeepRestoresOnMerge is the
+// SOLE enforcement mechanism in phase 0: a corpus decides from its own judge's
+// verdicts whether the shortlist is worth funding.
+func TestThrottleState_StartsOptimisticDefundsOnAllKeepRestoresOnMerge(t *testing.T) {
+	rate, state := throttleState(nil)
+	require.Equal(t, throttleOptimistic, state, "no history means try it")
+	require.Zero(t, rate)
+
+	// Not enough evidence yet: a couple of keeps must not defund a corpus.
+	_, state = throttleState(keepVerdicts(throttleMinVerdicts - 1))
+	require.Equal(t, throttleFunded, state)
+
+	_, state = throttleState(keepVerdicts(throttleMinVerdicts))
+	require.Equal(t, throttleDefunded, state, "enough judged, none merged")
+
+	withMerge := append(keepVerdicts(throttleMinVerdicts), store.RestatementVerdict{Merged: true})
+	rate, state = throttleState(withMerge)
+	require.Equal(t, throttleFunded, state, "one merge restores funding")
+	require.Positive(t, rate)
+}
+
+// TestSelect_ThrottleDefundsAndAMergeRestores drives the throttle through the
+// real store rather than the pure function above.
+func TestSelect_ThrottleDefundsAndAMergeRestores(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 400)
+	d := env.deps()
+	env.seedShortlist()
+
+	pairs, health, err := selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	require.NotEmpty(t, pairs, "a fresh corpus is funded")
+	require.Equal(t, throttleOptimistic, health.ThrottleState)
+	require.Equal(t, len(pairs), health.Emitted)
+	require.Positive(t, health.OperatingPoint, "the cut is reported as a cosine")
+
+	for i := range throttleMinVerdicts {
+		env.recordVerdict(fmt.Sprintf("kb/f%d.md", i), "kb/f399.md", false)
+	}
+	pairs, health, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	require.Empty(t, pairs, "all-keep history zeroes the corpus's shortlist budget")
+	require.Equal(t, throttleDefunded, health.ThrottleState)
+	require.Positive(t, health.StandingPairs, "the pairs still stand; the corpus just stops paying to judge them")
+
+	env.recordVerdict("kb/f1.md", "kb/f2.md", true)
+	pairs, health, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	require.NotEmpty(t, pairs, "a merge restores funding")
+	require.Equal(t, throttleFunded, health.ThrottleState)
+}
+
+// TestSelect_ExcludesPairsCoGroupedByThisSessionsClusters — the exact "prune
+// already sees them together" exclusion, done as a membership check over
+// clusters the caller already computed.
+func TestSelect_ExcludesPairsCoGroupedByThisSessionsClusters(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 400)
+	d := env.deps()
+	env.seedShortlist()
+
+	pairs, _, err := selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	require.NotEmpty(t, pairs)
+	top := pairs[0]
+
+	// Put the top pair in one cluster and it stops being worth a slot.
+	clusters := [][]factForLLM{{{File: top.APath}, {File: top.BPath}}}
+	pairs, _, err = selectRestatementCandidates(ctx, d, env.branch, clusters, 400)
+	require.NoError(t, err)
+	require.False(t, containsPair(pairs, top.APath, top.BPath),
+		"a pair prune already sees in one cluster must not also cost a shortlist slot")
+}
+
+// TestSelect_KeptPairIsNotReOffered — the throttle defunds a CORPUS; this is
+// what stops one declined pair from occupying the funded slots forever.
+func TestSelect_KeptPairIsNotReOffered(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 400)
+	d := env.deps()
+	env.seedShortlist()
+
+	pairs, _, err := selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	require.NotEmpty(t, pairs)
+	top := pairs[0]
+
+	env.recordVerdict(top.APath, top.BPath, false)
+
+	pairs, _, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	require.False(t, containsPair(pairs, top.APath, top.BPath),
+		"the judge already looked at this pair and said keep")
+	require.NotEmpty(t, pairs, "and the slot goes to the next-ranked pair instead")
+}
+
+// TestSelect_EditingEitherFactReEligibilizesTheKeptPair — the exclusion is
+// keyed by fact id, and ids are content-addressed, so a keep expires
+// structurally when either fact changes rather than by any staleness rule.
+func TestSelect_EditingEitherFactReEligibilizesTheKeptPair(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 400)
+	d := env.deps()
+	env.seedShortlist()
+
+	pairs, _, err := selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	top := pairs[0]
+	env.recordVerdict(top.APath, top.BPath, false)
+
+	pairs, _, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	require.False(t, containsPair(pairs, top.APath, top.BPath))
+
+	// Rewrite one endpoint with the same title (so it stays a candidate pair)
+	// but a different body: new blob, new facts row, new id.
+	env.writeFact(top.APath, env.titleOf(top.APath), "a materially rewritten body for the same claim")
+	env.seedShortlist()
+
+	pairs, _, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	require.True(t, containsPair(pairs, top.APath, top.BPath),
+		"an edited fact is a new version, and the judge has not seen this one")
+}
+
+// TestSelect_ScopedSessionEmitsOnlyPairsTouchingScope — the standing shortlist
+// stays corpus-wide (that is the whole point), but a session asked to work on
+// one area does not spend its slots on two facts that are both elsewhere.
+func TestSelect_ScopedSessionEmitsOnlyPairsTouchingScope(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	env.writeFactWithDomain("kb/auth-a.md", "Token refresh", "one body", "auth")
+	env.writeFactWithDomain("kb/auth-b.md", "Token refresh", "another body entirely, worded differently", "auth")
+	env.writeFactWithDomain("kb/store-a.md", "Row locking", "one body", "store")
+	env.writeFactWithDomain("kb/store-b.md", "Row locking", "another body entirely, worded differently", "store")
+
+	d := env.deps()
+	env.seedShortlist()
+
+	// Corpus-wide: both pairs stand.
+	all, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100)
+	require.NoError(t, err)
+	require.True(t, containsPair(all, "kb/auth-a.md", "kb/auth-b.md"))
+	require.True(t, containsPair(all, "kb/store-a.md", "kb/store-b.md"))
+
+	// Scoped emission: only the pair touching the scope is offered.
+	scoped := d
+	scoped.Scope = ScopeFilter{Domain: []string{"auth"}}
+	pairs, _, err := selectRestatementCandidates(ctx, scoped, env.branch, nil, 4000)
+	require.NoError(t, err)
+	require.True(t, containsPair(pairs, "kb/auth-a.md", "kb/auth-b.md"))
+	require.False(t, containsPair(pairs, "kb/store-a.md", "kb/store-b.md"),
+		"a scoped session does not spend its slots outside its scope")
+}
+
+// TestSelect_OperatingPointIsPercentileDerivedPerCorpus — same code, two
+// corpora, two different absolute cosines. This is what MN13 buys: nothing here
+// encodes a claim about what a restatement looks like.
+func TestSelect_OperatingPointIsPercentileDerivedPerCorpus(t *testing.T) {
+	ctx := context.Background()
+
+	// Two corpora of the same size whose TITLES are shaped differently: in one
+	// they crowd together, in the other they stand apart. The seed count passed
+	// to the selector is the same for both, so any difference in the reported
+	// cut comes from the corpora, not from the budget.
+	tight := newRestatementEnvOnAxis(t, 20, 0.01)
+	tight.seedShortlist()
+	_, tightHealth, err := selectRestatementCandidates(ctx, tight.deps(), tight.branch, nil, 400)
+	require.NoError(t, err)
+
+	loose := newRestatementEnvOnAxis(t, 20, 0.25)
+	loose.seedShortlist()
+	_, looseHealth, err := selectRestatementCandidates(ctx, loose.deps(), loose.branch, nil, 400)
+	require.NoError(t, err)
+
+	require.Positive(t, tightHealth.OperatingPoint)
+	require.Positive(t, looseHealth.OperatingPoint)
+	require.Greater(t, tightHealth.OperatingPoint, looseHealth.OperatingPoint+0.01,
+		"the cut is a percentile of each repo's own distribution, not a fixed cosine")
+}
+
+// TestPlan_EmitsRestatementItemsAsOrdinaryPruneItems — shape parity with
+// cluster items is what lets the existing prompt, schema, and apply path serve
+// these unchanged.
+func TestPlan_EmitsRestatementItemsAsOrdinaryPruneItems(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	// Two facts with near-identical titles and unrelated bodies, plus filler so
+	// the corpus is large enough to fund a slot.
+	env.writeFact("kb/restate-a.md", "Cache invalidation on write", "one account of it")
+	env.writeFact("kb/restate-b.md", "Cache invalidation on write", "a different account, at length, of the same thing")
+	for i := range 400 {
+		env.writeFact(fmt.Sprintf("kb/filler%d.md", i), fmt.Sprintf("Filler %d", i), fmt.Sprintf("filler body %d", i))
+	}
+
+	res, err := NewReviewerWithOptions(env.ri, nil, EffortNormal, ScopeFilter{}).StartSession(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.SessionID)
+
+	items := env.workItems(res.SessionID)
+	var restatement []store.PipelineWorkItem
+	for _, it := range items {
+		if strings.HasPrefix(it.ClusterKey, restatementClusterKeyPrefix) {
+			restatement = append(restatement, it)
+		}
+	}
+	require.NotEmpty(t, restatement, "the shortlist put something in front of the judge")
+	for _, it := range restatement {
+		require.Equal(t, "prune", it.StepType, "a restatement item IS a prune item")
+		var facts []factForLLM
+		require.NoError(t, json.Unmarshal([]byte(it.FactsJSON), &facts))
+		require.Len(t, facts, 2, "exactly the pair")
+		require.NotEmpty(t, facts[0].Body, "with the bodies the judge needs")
+	}
+}
+
+// TestPlan_HealthLinesReachTheCaller — a partial axis or a defunded shortlist
+// has to be visible, or "no candidates" reads as "nothing to find".
+func TestPlan_HealthLinesReachTheCaller(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 30)
+
+	res, err := NewReviewerWithOptions(env.ri, nil, EffortNormal, ScopeFilter{}).StartSession(ctx)
+	require.NoError(t, err)
+
+	joined := strings.Join(res.Health, "\n")
+	require.Contains(t, joined, "abstraction coverage")
+	require.Contains(t, joined, "standing restatement pairs")
+	require.Contains(t, joined, "operating point")
+	require.Contains(t, joined, "restatement candidates emitted")
+	require.Contains(t, joined, "shortlist throttle")
+}
+
+// TestPlan_FloodCorpusIsBoundedByTheBudgetNotSuppressed — the design has no
+// density cut: a corpus where title similarity does not discriminate still gets
+// a cap-sized batch, and it is that corpus's OWN verdicts that defund it.
+func TestPlan_FloodCorpusIsBoundedByTheBudgetNotSuppressed(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	// Every title identical: on this corpus the axis says everything restates
+	// everything.
+	for i := range 600 {
+		env.writeFact(fmt.Sprintf("kb/flood%d.md", i), "Same headline every time",
+			fmt.Sprintf("body %d, quite different in wording from the others", i))
+	}
+
+	res, err := NewReviewerWithOptions(env.ri, nil, EffortNormal, ScopeFilter{}).StartSession(ctx)
+	require.NoError(t, err)
+
+	emitted := 0
+	for _, it := range env.workItems(res.SessionID) {
+		if strings.HasPrefix(it.ClusterKey, restatementClusterKeyPrefix) {
+			emitted++
+		}
+	}
+	require.LessOrEqual(t, emitted, maxShortlistItems,
+		"bounded by the judge-slot budget, never by a rate anyone hard-coded")
+	require.Contains(t, strings.Join(res.Health, "\n"), "standing restatement pairs",
+		"and the flood is visible in the health output")
 }

--- a/internal/synthesize/restatement_test.go
+++ b/internal/synthesize/restatement_test.go
@@ -96,3 +96,111 @@ func TestEnsureTitleVectors_NoEmbedderIsANoOp(t *testing.T) {
 	require.Zero(t, have)
 	require.Zero(t, total)
 }
+
+// TestRefreshShortlist_SeedsThenGoesIncremental is the performance contract:
+// the first refresh covers the whole corpus, a second over an unchanged corpus
+// does no work at all, and one edit costs one fact's worth of lookups — not the
+// corpus's.
+func TestRefreshShortlist_SeedsThenGoesIncremental(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 40)
+	d := env.deps()
+	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+
+	before := neighbourQueryCount.Load()
+	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+	require.Equal(t, int64(40), neighbourQueryCount.Load()-before, "first refresh seeds every fact")
+
+	stats, err := env.svc.Abstraction().RestatementPairStats(ctx, env.branch)
+	require.NoError(t, err)
+	require.Positive(t, stats.Count, "the cache is populated")
+
+	before = neighbourQueryCount.Load()
+	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+	require.Equal(t, before, neighbourQueryCount.Load(), "unchanged corpus does no work")
+
+	env.writeFact("kb/f7.md", "F7 revised", "body-7-v2")
+	_, _, err = ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+
+	before = neighbourQueryCount.Load()
+	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+	require.Equal(t, int64(1), neighbourQueryCount.Load()-before, "one edited fact, one lookup")
+}
+
+// TestRefreshShortlist_DropsPairsOfDepartedFacts — a stale pair naming a fact
+// that no longer exists would be offered to the judge and fail to resolve.
+func TestRefreshShortlist_DropsPairsOfDepartedFacts(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 6)
+	d := env.deps()
+	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+
+	_, err = env.svc.Facts().DeleteFact(ctx, env.branch, "kb/f3.md", "retract f3")
+	require.NoError(t, err)
+	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+
+	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 1000)
+	require.NoError(t, err)
+	for _, p := range pairs {
+		require.NotEqual(t, "kb/f3.md", p.APath)
+		require.NotEqual(t, "kb/f3.md", p.BPath)
+	}
+}
+
+// TestRefreshShortlist_ExcludesPairsAtOrAboveDedup — the one absolute cosine in
+// play is the model's OWN calibrated dedup threshold, and pairs at or above it
+// are mergeFacts's business, not the judge's.
+func TestRefreshShortlist_ExcludesPairsAtOrAboveDedup(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	// Two facts with identical text: identical blended vectors, cosine 1.
+	env.writeFact("kb/twin-a.md", "Twin", "identical body")
+	env.writeFact("kb/twin-b.md", "Twin", "identical body")
+	// ...and two whose titles are close while their bodies are not.
+	env.writeFact("kb/near-a.md", "Near", "body one is about a thing")
+	env.writeFact("kb/near-b.md", "Near two", "body two is about something else entirely")
+
+	d := env.deps()
+	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+
+	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100)
+	require.NoError(t, err)
+	for _, p := range pairs {
+		require.False(t, p.APath == "kb/twin-a.md" && p.BPath == "kb/twin-b.md",
+			"a pair the mechanical dedup gate already catches must never reach the judge")
+	}
+	// ...while the sub-dedup pair still stands, so the assertion above is about
+	// the filter rather than about the shortlist finding nothing.
+	require.True(t, containsPair(pairs, "kb/near-a.md", "kb/near-b.md"),
+		"a pair below the dedup floor is exactly what the judge should see")
+}
+
+// TestRefreshShortlist_KeepsSimilarToNeighbours is the roadmap's explicit trap.
+// Genuine cross-cluster restatements are frequently top-K neighbours of each
+// other, so "not SIMILAR_TO-adjacent" is NOT a substitute for the removed
+// community condition — an adjacency exclusion would delete the target
+// population. Here two facts are each other's nearest neighbours on both axes
+// and must still be candidates.
+func TestRefreshShortlist_KeepsSimilarToNeighbours(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	env.writeFact("kb/adjacent-a.md", "Adjacent restatement", "one body about the mechanism")
+	env.writeFact("kb/adjacent-b.md", "Adjacent restatement", "another body about the same mechanism, worded differently and at greater length so the blended vectors diverge")
+
+	d := env.deps()
+	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+
+	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100)
+	require.NoError(t, err)
+	require.Len(t, pairs, 1)
+	require.Equal(t, "kb/adjacent-a.md", pairs[0].APath)
+	require.Equal(t, "kb/adjacent-b.md", pairs[0].BPath)
+}

--- a/internal/synthesize/restatement_test.go
+++ b/internal/synthesize/restatement_test.go
@@ -113,25 +113,27 @@ func TestRefreshShortlist_SeedsThenGoesIncremental(t *testing.T) {
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
 
-	before := neighbourQueryCount.Load()
-	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
-	require.Equal(t, int64(40), neighbourQueryCount.Load()-before, "first refresh seeds every fact")
+	refresh, err := refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	require.NoError(t, err)
+	require.Equal(t, 40, refresh.NeighbourQueries, "first refresh seeds every fact")
 
 	stats, err := env.svc.Abstraction().RestatementPairStats(ctx, env.branch)
 	require.NoError(t, err)
 	require.Positive(t, stats.Count, "the cache is populated")
 
-	before = neighbourQueryCount.Load()
-	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
-	require.Equal(t, before, neighbourQueryCount.Load(), "unchanged corpus does no work")
+	refresh, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	require.NoError(t, err)
+	require.Zero(t, refresh.NeighbourQueries, "unchanged corpus does no work")
 
 	env.writeFact("kb/f7.md", "F7 revised", "body-7-v2")
 	_, _, err = ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
 
-	before = neighbourQueryCount.Load()
-	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
-	require.Equal(t, int64(1), neighbourQueryCount.Load()-before, "one edited fact, one lookup")
+	refresh, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	require.NoError(t, err)
+	require.LessOrEqual(t, refresh.NeighbourQueries, 1+pairNeighbourK,
+		"one edited fact costs its own lookup plus at most its partners'")
+	require.Positive(t, refresh.NeighbourQueries)
 }
 
 // TestRefreshShortlist_DropsPairsOfDepartedFacts — a stale pair naming a fact
@@ -142,11 +144,13 @@ func TestRefreshShortlist_DropsPairsOfDepartedFacts(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	require.NoError(t, err)
 
 	_, err = env.svc.Facts().DeleteFact(ctx, env.branch, "kb/f3.md", "retract f3")
 	require.NoError(t, err)
-	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	require.NoError(t, err)
 
 	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 1000)
 	require.NoError(t, err)
@@ -172,7 +176,8 @@ func TestRefreshShortlist_ExcludesPairsAtOrAboveDedup(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	require.NoError(t, err)
 
 	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100)
 	require.NoError(t, err)
@@ -201,7 +206,8 @@ func TestRefreshShortlist_KeepsSimilarToNeighbours(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	require.NoError(t, refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold()))
+	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	require.NoError(t, err)
 
 	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100)
 	require.NoError(t, err)
@@ -221,10 +227,10 @@ func TestShortlistBudget_ScalesWithCorpusAndCapsOut(t *testing.T) {
 	require.Equal(t, maxShortlistItems, shortlistBudget(50_000), "capped however large the corpus")
 }
 
-// TestThrottleState_StartsOptimisticDefundsOnAllKeepRestoresOnMerge is the
+// TestThrottleState_StartsOptimisticDefundsOnAllKeepRestoresOnResolution is the
 // SOLE enforcement mechanism in phase 0: a corpus decides from its own judge's
 // verdicts whether the shortlist is worth funding.
-func TestThrottleState_StartsOptimisticDefundsOnAllKeepRestoresOnMerge(t *testing.T) {
+func TestThrottleState_StartsOptimisticDefundsOnAllKeepRestoresOnResolution(t *testing.T) {
 	rate, state := throttleState(nil)
 	require.Equal(t, throttleOptimistic, state, "no history means try it")
 	require.Zero(t, rate)
@@ -234,43 +240,60 @@ func TestThrottleState_StartsOptimisticDefundsOnAllKeepRestoresOnMerge(t *testin
 	require.Equal(t, throttleFunded, state)
 
 	_, state = throttleState(keepVerdicts(throttleMinVerdicts))
-	require.Equal(t, throttleDefunded, state, "enough judged, none merged")
+	require.Equal(t, throttleDefunded, state, "enough judged, none resolved")
 
-	withMerge := append(keepVerdicts(throttleMinVerdicts), store.RestatementVerdict{Merged: true})
-	rate, state = throttleState(withMerge)
-	require.Equal(t, throttleFunded, state, "one merge restores funding")
+	withResolution := append(keepVerdicts(throttleMinVerdicts), store.RestatementVerdict{Resolved: true})
+	rate, state = throttleState(withResolution)
+	require.Equal(t, throttleFunded, state, "one resolution restores funding")
 	require.Positive(t, rate)
 }
 
-// TestSelect_ThrottleDefundsAndAMergeRestores drives the throttle through the
-// real store rather than the pure function above.
-func TestSelect_ThrottleDefundsAndAMergeRestores(t *testing.T) {
+// TestSelect_DefundedCorpusProbesAndRecovers is the test the earlier version of
+// this suite got wrong. It used to "restore" funding by writing a resolution
+// verdict directly — a state production can never reach, because a defunded
+// corpus emits nothing, so it produces no verdicts, so its evidence can never
+// change. Recovery has to come from a path the system can actually walk.
+func TestSelect_DefundedCorpusProbesAndRecovers(t *testing.T) {
 	ctx := context.Background()
 	env := newRestatementEnv(t, 400)
 	d := env.deps()
 	env.seedShortlist()
 
+	// Decline enough pairs to defund the corpus.
+	for range throttleMinVerdicts {
+		pairs, _, err := selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+		require.NoError(t, err)
+		require.NotEmpty(t, pairs)
+		env.recordVerdict(pairs[0].APath, pairs[0].BPath, false)
+	}
 	pairs, health, err := selectRestatementCandidates(ctx, d, env.branch, nil, 400)
 	require.NoError(t, err)
-	require.NotEmpty(t, pairs, "a fresh corpus is funded")
-	require.Equal(t, throttleOptimistic, health.ThrottleState)
-	require.Equal(t, len(pairs), health.Emitted)
-	require.Positive(t, health.OperatingPoint, "the cut is reported as a cosine")
-
-	for i := range throttleMinVerdicts {
-		env.recordVerdict(fmt.Sprintf("kb/f%d.md", i), "kb/f399.md", false)
-	}
-	pairs, health, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
-	require.NoError(t, err)
-	require.Empty(t, pairs, "all-keep history zeroes the corpus's shortlist budget")
+	require.Empty(t, pairs, "an all-keep history stops the spending")
 	require.Equal(t, throttleDefunded, health.ThrottleState)
-	require.Positive(t, health.StandingPairs, "the pairs still stand; the corpus just stops paying to judge them")
 
-	env.recordVerdict("kb/f1.md", "kb/f2.md", true)
+	// Quiet sessions while the probe interval elapses.
+	for range throttleProbeInterval - 2 {
+		pairs, health, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+		require.NoError(t, err)
+		require.Empty(t, pairs)
+		require.False(t, health.Probing)
+	}
+
+	// Then one probe slot, unprompted.
 	pairs, health, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
 	require.NoError(t, err)
-	require.NotEmpty(t, pairs, "a merge restores funding")
+	require.Len(t, pairs, 1, "a defunded corpus spends exactly one slot to test its own verdict")
+	require.True(t, health.Probing)
+	require.Equal(t, throttleDefunded, health.ThrottleState)
+
+	// The probe resolves — and the corpus funds itself again, from evidence it
+	// could only have generated by probing.
+	env.recordVerdict(pairs[0].APath, pairs[0].BPath, true)
+	pairs, health, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
 	require.Equal(t, throttleFunded, health.ThrottleState)
+	require.NotEmpty(t, pairs, "funding restored")
+	require.False(t, health.Probing)
 }
 
 // TestSelect_ExcludesPairsCoGroupedByThisSessionsClusters — the exact "prune
@@ -295,9 +318,12 @@ func TestSelect_ExcludesPairsCoGroupedByThisSessionsClusters(t *testing.T) {
 		"a pair prune already sees in one cluster must not also cost a shortlist slot")
 }
 
-// TestSelect_KeptPairIsNotReOffered — the throttle defunds a CORPUS; this is
-// what stops one declined pair from occupying the funded slots forever.
-func TestSelect_KeptPairIsNotReOffered(t *testing.T) {
+// TestSelect_DeclinedPairIsRetiredNotJustSkipped — a declined pair leaves the
+// standing set entirely. Filtering it at selection time was not enough: the
+// pair kept its place at the top of the ranking, so after a few declining
+// sessions the whole selection window was pairs the judge had already refused
+// and nothing new could be offered.
+func TestSelect_DeclinedPairIsRetiredNotJustSkipped(t *testing.T) {
 	ctx := context.Background()
 	env := newRestatementEnv(t, 400)
 	d := env.deps()
@@ -310,17 +336,21 @@ func TestSelect_KeptPairIsNotReOffered(t *testing.T) {
 
 	env.recordVerdict(top.APath, top.BPath, false)
 
+	standing, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 10_000)
+	require.NoError(t, err)
+	require.False(t, containsPair(standing, top.APath, top.BPath),
+		"the declined pair is gone from the standing set, not merely skipped")
+
 	pairs, _, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
 	require.NoError(t, err)
-	require.False(t, containsPair(pairs, top.APath, top.BPath),
-		"the judge already looked at this pair and said keep")
-	require.NotEmpty(t, pairs, "and the slot goes to the next-ranked pair instead")
+	require.NotEmpty(t, pairs, "and the slot goes to the next-ranked pair")
+	require.False(t, containsPair(pairs, top.APath, top.BPath))
 }
 
-// TestSelect_EditingEitherFactReEligibilizesTheKeptPair — the exclusion is
-// keyed by fact id, and ids are content-addressed, so a keep expires
-// structurally when either fact changes rather than by any staleness rule.
-func TestSelect_EditingEitherFactReEligibilizesTheKeptPair(t *testing.T) {
+// TestRefresh_DeclinedPairIsNotReMintedByALaterRescan — retiring the pair is
+// only half the job. A later neighbour rescan (triggered by an unrelated edit
+// elsewhere) would happily rediscover it, so the verdict log gates minting too.
+func TestRefresh_DeclinedPairIsNotReMintedByALaterRescan(t *testing.T) {
 	ctx := context.Background()
 	env := newRestatementEnv(t, 400)
 	d := env.deps()
@@ -331,9 +361,31 @@ func TestSelect_EditingEitherFactReEligibilizesTheKeptPair(t *testing.T) {
 	top := pairs[0]
 	env.recordVerdict(top.APath, top.BPath, false)
 
-	pairs, _, err = selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	// Force both endpoints back through KNN by evicting them from the cache
+	// state — exactly what a partner requeue does.
+	require.NoError(t, env.svc.Abstraction().ReplaceRestatementPairs(ctx, env.branch,
+		[]int64{env.liveFactIDs()[top.APath], env.liveFactIDs()[top.BPath]}, nil, nil))
+	env.seedShortlist()
+
+	standing, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 10_000)
 	require.NoError(t, err)
-	require.False(t, containsPair(pairs, top.APath, top.BPath))
+	require.False(t, containsPair(standing, top.APath, top.BPath),
+		"a rescan must not resurrect a pair the judge has already refused")
+}
+
+// TestSelect_EditingEitherFactReEligibilizesTheDeclinedPair — the guard is
+// keyed by fact id, and ids are content-addressed, so a decline expires
+// structurally when either fact changes rather than by any staleness rule.
+func TestSelect_EditingEitherFactReEligibilizesTheDeclinedPair(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 400)
+	d := env.deps()
+	env.seedShortlist()
+
+	pairs, _, err := selectRestatementCandidates(ctx, d, env.branch, nil, 400)
+	require.NoError(t, err)
+	top := pairs[0]
+	env.recordVerdict(top.APath, top.BPath, false)
 
 	// Rewrite one endpoint with the same title (so it stays a candidate pair)
 	// but a different body: new blob, new facts row, new id.
@@ -527,14 +579,65 @@ func TestApply_AttributesOnlyShortlistVerdicts(t *testing.T) {
 	verdicts, err = env.svc.Abstraction().RecentRestatementVerdicts(ctx, env.branch, throttleWindow)
 	require.NoError(t, err)
 	require.Len(t, verdicts, 1)
-	require.False(t, verdicts[0].Merged)
+	require.False(t, verdicts[0].Resolved)
 
-	// The same item answered with a merge OF THAT PAIR is attributed as merged.
+	// The same item answered with a merge OF THAT PAIR is attributed as resolved.
 	recordShortlistVerdict(ctx, d, sess, judged, &PruneResult{
 		Merges: []MergeEntry{{Paths: []string{"kb/pair-a.md", "kb/pair-b.md"}}},
 	})
 	verdicts, err = env.svc.Abstraction().RecentRestatementVerdicts(ctx, env.branch, throttleWindow)
 	require.NoError(t, err)
 	require.Len(t, verdicts, 2)
-	require.True(t, verdicts[0].Merged, "newest first")
+	require.True(t, verdicts[0].Resolved, "newest first")
+
+	// ...and so is a RETRACT of either half. A judge that consolidates by
+	// retracting the redundant fact has done the work this mechanism buys;
+	// counting only merges would defund a corpus that is succeeding.
+	recordShortlistVerdict(ctx, d, sess, judged, &PruneResult{
+		Decisions: []PruneDecision{{Path: "kb/pair-b.md", Action: "retract"}},
+	})
+	verdicts, err = env.svc.Abstraction().RecentRestatementVerdicts(ctx, env.branch, throttleWindow)
+	require.NoError(t, err)
+	require.True(t, verdicts[0].Resolved, "a retract of one half resolves the pair")
+
+	// A confidence update does NOT: both facts still stand, so the redundancy
+	// the pair was offered for is still there.
+	recordShortlistVerdict(ctx, d, sess, judged, &PruneResult{
+		Decisions: []PruneDecision{{Path: "kb/pair-a.md", Action: "update", Confidence: 0.9}},
+	})
+	verdicts, err = env.svc.Abstraction().RecentRestatementVerdicts(ctx, env.branch, throttleWindow)
+	require.NoError(t, err)
+	require.False(t, verdicts[0].Resolved, "an update leaves the redundancy in place")
+}
+
+// TestApply_SkipsVerdictWhenAnEndpointIsAlreadyGone — a pair whose halves were
+// merged or retracted earlier in the same session is judging something that no
+// longer exists. Recording it would write fact id 0 into the declined set,
+// where it matches every other unresolved pair, and would spend a slot of the
+// throttle window on a non-event.
+func TestApply_SkipsVerdictWhenAnEndpointIsAlreadyGone(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 4)
+	d := env.deps()
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	require.NoError(t, err)
+
+	item := &store.PipelineWorkItem{
+		SessionID: sess.ID, StepType: "prune", ClusterKey: restatementClusterKeyPrefix + "0",
+		FactsJSON: env.factsJSON("kb/f0.md", "kb/f1.md"),
+	}
+	judged := resolveShortlistPair(ctx, d, sess, item)
+	require.NotNil(t, judged)
+
+	// f1 is retracted before the verdict is recorded — the earlier-item case.
+	_, err = env.svc.Facts().DeleteFact(ctx, env.branch, "kb/f1.md", "retract f1")
+	require.NoError(t, err)
+	gone := resolveShortlistPair(ctx, d, sess, item)
+	require.NotNil(t, gone)
+	require.Zero(t, gone.BFactID, "the retracted endpoint no longer resolves")
+
+	recordShortlistVerdict(ctx, d, sess, gone, &PruneResult{})
+	verdicts, err := env.svc.Abstraction().RecentRestatementVerdicts(ctx, env.branch, throttleWindow)
+	require.NoError(t, err)
+	require.Empty(t, verdicts, "no verdict is recorded for a pair that no longer exists")
 }

--- a/internal/synthesize/restatement_test.go
+++ b/internal/synthesize/restatement_test.go
@@ -1,0 +1,98 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureTitleVectors_WatermarkIncremental is the conformance test for
+// "a second review session on an unchanged corpus embeds ZERO titles, and a
+// session after one fact edit embeds exactly one".
+//
+// Both are measured AFTER coverage completes, because a time-budgeted backfill
+// legitimately continues across sessions until then — see
+// TestEnsureTitleVectors_StopsAtTheLatencyBudget for that half.
+func TestEnsureTitleVectors_WatermarkIncremental(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 3)
+
+	have, total, err := ensureTitleVectors(ctx, env.deps(), env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+	require.Equal(t, 3, have)
+	require.Equal(t, 3, total, "coverage completes in one session at this size")
+	require.Equal(t, int64(3), env.emb.titles.Load())
+
+	env.emb.titles.Store(0)
+	have, _, err = ensureTitleVectors(ctx, env.deps(), env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+	require.Equal(t, 3, have)
+	require.Equal(t, int64(0), env.emb.titles.Load(), "unchanged corpus embeds ZERO titles")
+
+	env.writeFact("kb/f1.md", "F1 revised", "body-1-v2")
+
+	env.emb.titles.Store(0)
+	have, total, err = ensureTitleVectors(ctx, env.deps(), env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+	require.Equal(t, 3, have)
+	require.Equal(t, 3, total)
+	require.Equal(t, int64(1), env.emb.titles.Load(), "one edited fact embeds exactly one title")
+}
+
+// TestEnsureTitleVectors_UsesTheShortStringTemplate — MN9's guard on this side
+// of the seam. Titles are short strings; embedding them as documents would put
+// them through a rendering nothing in the motif work was calibrated under.
+func TestEnsureTitleVectors_UsesTheShortStringTemplate(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 2)
+
+	// Writing the facts embeds their bodies through the document path, which is
+	// the write path's business — snapshot that counter so this test speaks
+	// only about what the BACKFILL does.
+	docsBefore := env.emb.documentCalls.Load()
+
+	_, _, err := ensureTitleVectors(ctx, env.deps(), env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+
+	require.Positive(t, env.emb.shortStringCalls.Load(), "titles embed as short strings")
+	require.Equal(t, docsBefore, env.emb.documentCalls.Load(),
+		"the backfill never embeds a title through the document path")
+}
+
+// TestEnsureTitleVectors_StopsAtTheLatencyBudget proves the budget is honoured
+// and that partial coverage is REPORTED rather than hidden — a silently partial
+// axis reads as "nothing to find".
+func TestEnsureTitleVectors_StopsAtTheLatencyBudget(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 200)
+	env.emb.perBatchDelay = 20 * time.Millisecond
+
+	have, total, err := ensureTitleVectors(ctx, env.deps(), env.branch, 50*time.Millisecond)
+	require.NoError(t, err)
+	require.Greater(t, have, 0, "it makes progress")
+	require.Less(t, have, total, "and stops before coverage completes")
+
+	// Coverage completes over subsequent sessions rather than being abandoned.
+	for range 20 {
+		have, total, err = ensureTitleVectors(ctx, env.deps(), env.branch, 50*time.Millisecond)
+		require.NoError(t, err)
+		if have == total {
+			break
+		}
+	}
+	require.Equal(t, total, have, "later sessions finish the backfill")
+}
+
+// TestEnsureTitleVectors_NoEmbedderIsANoOp — read-only tooling and tests run
+// without an embedder; the axis stays empty and nothing errors.
+func TestEnsureTitleVectors_NoEmbedderIsANoOp(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnvWithoutEmbedder(t, 2)
+
+	have, total, err := ensureTitleVectors(ctx, env.deps(), env.branch, titleBackfillBudget)
+	require.NoError(t, err)
+	require.Zero(t, have)
+	require.Zero(t, total)
+}

--- a/internal/synthesize/restatement_test.go
+++ b/internal/synthesize/restatement_test.go
@@ -481,3 +481,60 @@ func TestPlan_FloodCorpusIsBoundedByTheBudgetNotSuppressed(t *testing.T) {
 	require.Contains(t, strings.Join(res.Health, "\n"), "standing restatement pairs",
 		"and the flood is visible in the health output")
 }
+
+// TestApply_AttributesOnlyShortlistVerdicts — the throttle is only as good as
+// its attribution. If an ordinary cluster prune counted, a healthy corpus's
+// cluster merges would keep a useless shortlist funded forever.
+func TestApply_AttributesOnlyShortlistVerdicts(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	env.writeFact("kb/pair-a.md", "Shared headline", "one account")
+	env.writeFact("kb/pair-b.md", "Shared headline", "a different account of the same thing, longer")
+	for i := range 400 {
+		env.writeFact(fmt.Sprintf("kb/filler%d.md", i), fmt.Sprintf("Filler %d", i), fmt.Sprintf("filler body %d", i))
+	}
+
+	d := env.deps()
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	require.NoError(t, err)
+	env.seedShortlist()
+
+	// An ordinary cluster item, answered with a merge: must NOT be attributed.
+	clusterItem := &store.PipelineWorkItem{
+		SessionID: sess.ID, StepType: "prune", ClusterKey: "cluster-0",
+		FactsJSON: env.factsJSON("kb/filler0.md", "kb/filler1.md"),
+	}
+	judged := resolveShortlistPair(ctx, d, sess, clusterItem)
+	require.Nil(t, judged, "a cluster item is not a shortlist outcome")
+	recordShortlistVerdict(ctx, d, sess, judged, &PruneResult{
+		Merges: []MergeEntry{{Paths: []string{"kb/filler0.md", "kb/filler1.md"}}},
+	})
+
+	verdicts, err := env.svc.Abstraction().RecentRestatementVerdicts(ctx, env.branch, throttleWindow)
+	require.NoError(t, err)
+	require.Empty(t, verdicts)
+
+	// A shortlist item, answered with keep: attributed, and not merged.
+	restateItem := &store.PipelineWorkItem{
+		SessionID: sess.ID, StepType: "prune", ClusterKey: restatementClusterKeyPrefix + "0",
+		FactsJSON: env.factsJSON("kb/pair-a.md", "kb/pair-b.md"),
+	}
+	judged = resolveShortlistPair(ctx, d, sess, restateItem)
+	require.NotNil(t, judged)
+	require.NotZero(t, judged.AFactID, "the versions the judge saw are captured by id")
+	recordShortlistVerdict(ctx, d, sess, judged, &PruneResult{})
+
+	verdicts, err = env.svc.Abstraction().RecentRestatementVerdicts(ctx, env.branch, throttleWindow)
+	require.NoError(t, err)
+	require.Len(t, verdicts, 1)
+	require.False(t, verdicts[0].Merged)
+
+	// The same item answered with a merge OF THAT PAIR is attributed as merged.
+	recordShortlistVerdict(ctx, d, sess, judged, &PruneResult{
+		Merges: []MergeEntry{{Paths: []string{"kb/pair-a.md", "kb/pair-b.md"}}},
+	})
+	verdicts, err = env.svc.Abstraction().RecentRestatementVerdicts(ctx, env.branch, throttleWindow)
+	require.NoError(t, err)
+	require.Len(t, verdicts, 2)
+	require.True(t, verdicts[0].Merged, "newest first")
+}

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -253,7 +253,8 @@ func reviewResultPage(res *PipelineResult, page int) (*ReviewResult, error) {
 
 // storeIndices returns the store indices under the repo read lock.
 func (r *Reviewer) storeIndices() (store.FactIndex, SearchQuery, store.PipelineIndex, store.BranchIndex) {
-	return r.p.storeIndices()
+	gs, idx, pipelineIdx, branches, _ := r.p.storeIndices()
+	return gs, idx, pipelineIdx, branches
 }
 
 // dirtyFacts returns the review seed facts (changed since watermark, or the

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -167,6 +167,7 @@ func reviewResultPage(res *PipelineResult, page int) (*ReviewResult, error) {
 		Done:      res.Done,
 		Summary:   res.Summary,
 		Progress:  res.Progress,
+		Health:    res.Health,
 	}
 	if res.Item == nil {
 		return out, nil

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -151,7 +151,7 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	// Every step degrades to "no candidates" rather than failing the session:
 	// this is an addition to consolidation, and a corpus that cannot embed its
 	// titles or read its own cache should still get its ordinary review.
-	if err := planRestatementShortlist(ctx, d, sess, branch, clusters, len(llmSeeds)); err != nil {
+	if err := planRestatementShortlist(ctx, d, sess, branch, clusters); err != nil {
 		return err
 	}
 

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -141,6 +141,20 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 		}
 	}
 
+	// The consolidation-scope fix. Prune's judge only ever sees facts that
+	// landed in the same cluster, so restatements whose halves cluster apart are
+	// judged by nothing and live forever
+	// (gotchas/synthesize/prune-scope/c40d6748). The shortlist below is
+	// corpus-wide and cached; the only session-dependent input is the
+	// co-membership check against the clusters computed above.
+	//
+	// Every step degrades to "no candidates" rather than failing the session:
+	// this is an addition to consolidation, and a corpus that cannot embed its
+	// titles or read its own cache should still get its ordinary review.
+	if err := planRestatementShortlist(ctx, d, sess, branch, clusters, len(llmSeeds)); err != nil {
+		return err
+	}
+
 	// Store distill work items if >1 seed (lower priority than prune).
 	//
 	// Grouped by cluster, then chunked. Depth-0 distill used to pass the whole

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -610,11 +610,22 @@ func (reviewStrategy) Apply(ctx context.Context, d Deps, sess *store.PipelineSes
 		}
 
 	case "prune":
+		// Resolve the shortlist pair BEFORE applying: an "update" decision
+		// rewrites a fact, and a rewritten fact is a new row with a new id, so
+		// ids read afterwards would not be the versions the judge saw.
+		// Returns nil for ordinary cluster items.
+		judged := resolveShortlistPair(ctx, d, sess, item)
+
 		stats, err := ApplyPruneDecisions(ctx, d.Facts, d.Search, dec.prune.Decisions, dec.prune.Merges, reviewTool, d.OnProgress, branch, fact.ID12(d.RI.ID()), d.RI.OntologyRoot())
 		if err != nil {
 			return wrapf(reviewTool, err, "apply prune")
 		}
 		recordStats(ctx, reviewTool, d, sess, stats)
+		// Attribution for the judge-outcome throttle. ONLY shortlist-originated
+		// items count: a cluster prune's merges say nothing about whether the
+		// shortlist is earning its slots, and counting them would keep a
+		// useless shortlist funded forever on any healthy corpus.
+		recordShortlistVerdict(ctx, d, sess, judged, dec.prune)
 
 	case "distill":
 		stats, writtenFacts, err := ApplyDistillDecisions(ctx, d.Facts, d.Search, dec.distill.Synthesize, dec.distill.Retract, reviewTool, d.OnProgress, branch, fact.ID12(d.RI.ID()), d.RI.OntologyRoot())

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -150,6 +150,16 @@ type PipelineResult struct {
 	// the name is review-flavoured but the counters are not.
 	Summary  *ReviewStats
 	Progress *ReviewProgress
+	// Health carries corpus-health descriptor lines recorded while planning the
+	// session — coverage of the abstraction axis, the standing pair population
+	// and where its top sits, what this session was funded to spend and why.
+	//
+	// Observability only: nothing in the engine reads it back, and no branch
+	// anywhere depends on a value in it. It rides the session RESULT because
+	// that is the one carrier that always reaches the calling agent — reflect
+	// items exist only when a session found hypothesis transitions, and
+	// progress events go to the server log.
+	Health []string
 }
 
 // Strategy is the per-tool half of a synthesis pipeline.

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -55,14 +55,17 @@ type SearchQuery interface {
 // invariants/synthesize/session-branch-binding — nothing below StartSession
 // may consult RI.AgentBranch().
 type Deps struct {
-	RI         *repos.RepoInstance
-	Facts      store.FactIndex
-	Search     SearchQuery
-	Pipeline   store.PipelineIndex
-	Branches   store.BranchIndex
-	Effort     Effort
-	Scope      ScopeFilter
-	OnProgress func(ProgressEvent)
+	RI       *repos.RepoInstance
+	Facts    store.FactIndex
+	Search   SearchQuery
+	Pipeline store.PipelineIndex
+	Branches store.BranchIndex
+	// Abstraction is the title-embedding axis and the restatement shortlist
+	// built on it (the consolidation-scope fix). Review-pipeline only.
+	Abstraction store.AbstractionIndex
+	Effort      Effort
+	Scope       ScopeFilter
+	OnProgress  func(ProgressEvent)
 }
 
 // pagedStrategy is the optional half of Strategy: implemented only by

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -255,6 +255,9 @@ type ReviewResult struct {
 	Done      bool            `json:"done,omitempty"`
 	Summary   *ReviewStats    `json:"summary,omitempty"`
 	Progress  *ReviewProgress `json:"progress,omitempty"`
+	// Health carries corpus-health descriptors for this session. Read by the
+	// agent, by nothing in the engine.
+	Health []string `json:"health,omitempty"`
 }
 
 // ReviewItem describes a single work item for the hosting model.

--- a/test/testenv/embedder_stub.go
+++ b/test/testenv/embedder_stub.go
@@ -90,3 +90,10 @@ func (e *DeterministicEmbedder) vectorFor(text string) []float32 {
 	}
 	return out
 }
+
+// EmbedShortStrings satisfies store.BatchEmbedder. Short strings render
+// through the model's short-string template in production; a stub has no
+// template, so it embeds each string as a title-only document.
+func (e *DeterministicEmbedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	return e.EmbedDocuments(ctx, texts, make([]string, len(texts)))
+}


### PR DESCRIPTION
## The gap this closes

Prune **is** consolidation with a judge: `MergeEntry` replaces N facts with one
newly authored body under an explicit fidelity contract. But its judge only ever
sees facts that landed in the same cluster, so a restatement whose halves
cluster apart is judged by nothing and lives forever
(`gotchas/synthesize/prune-scope/c40d6748`).

This gives that judge a bounded, corpus-wide shortlist of the pairs it never
sees.

## How

A new **abstraction axis**: one title-only embedding per fact version, in a
`vec0` table keyed by `facts.id`. That key is content-addressed, so the cache is
watermark-incremental by construction — an edited fact is a new row with no
vector, and "rows lacking a vector" *is* the delta. No watermark column, nothing
to migrate.

Inside review sessions only:

1. **Backfill** tops up the axis under a named latency budget (~15s/session), so
   a large corpus reaches coverage across sessions instead of stalling the first
   one. Partial coverage is reported, never silent.
2. **A standing pair cache** is maintained SIMILAR_TO-style — top-K title
   neighbours per fact, delta-updated — so a corpus-wide question costs
   per-session work proportional to what changed.
3. **Selection** ranks by title cosine and takes what the corpus's own history
   says it may spend. Pairs at or above the model's calibrated dedup threshold
   are dropped (those are `mergeFacts`'s business), as are pairs this session's
   clusters already co-present.
4. **Emission** as ordinary `prune` work items. The prune prompt ships facts
   beside itself rather than interpolating them, so a two-fact item is
   shape-identical to a cluster item — no prompt, schema, or apply-path change.

## No number here claims a fact about a corpus

The operating point is whatever absolute cosine the last funded pair happens to
sit at *in this repo* — printed in the health output because it is a
fingerprint, not a setting. Identical code prints **0.783** on knomit-kb and
**0.884** on core.

Enforcement is entirely data-derived: enough shortlist pairs judged with none
resolved defunds a corpus; a defunded corpus still spends one probe slot every
fifth session, so recovery cannot latch shut; a resolution refunds it. A
declined pair is retired outright, so the selection window keeps advancing.

Every float literal in the phase-0 path is either a declared resource budget or
the test fails — see `TestConformance_NoCorpusPropertyConstants`.

## Measured on real corpora

`TestAcceptance_RealCorpusShortlist` (env-gated) against copies of two research
corpora, with the real embeddinggemma model:

| | knomit-kb (326 facts) | core (1 693 facts) |
|---|---|---|
| standing pairs | 2 449 (p99 0.697, p99.9 0.771) | 14 130 (p99 0.816, p99.9 0.869) |
| operating point | 0.783 | 0.884 |
| emitted | 1 | 8 (the judge-slot cap) |
| second run, unchanged corpus | 326/326 in **2 ms**, 0 embedder calls, 0 KNN lookups | — |

The research harness put knomit-kb's top pair at title-cos **0.784**; production
says **0.783**. That transfer is why the short-string template ships as measured
rather than as the doc path rendered it.

A flood corpus is **bounded, not suppressed**: core's high candidate rate costs
at most 8 judge slots per session, after which that corpus's own verdicts
decide.

## Tests worth knowing about

- `restatement_dynamics_test.go` — the class that matters. Five scenarios
  driving 4–6 sessions with partial backfill budgets, verdicts, and edits in
  between. Every defect found in review lived in cross-session behaviour, not in
  any single function; three of them were caught by this suite while it was
  being written.
- `restatement_conformance_test.go` — MN13 constant audit, review-pipeline-only
  reachability (package-scoped, fail-closed), no config surface, and a
  working-tree diff proving no `bridge*.go` change and MN5 intact. The diff check
  was verified to *fail* when a bridge file is touched.

## Scope

No motifs. No bridge-engine change. `review_effort_normal_test.go` is
byte-identical. The runtime paths (query/explain/learn) are untouched, enforced
by test rather than by intent.

**Known limitation:** the axis is epistemic-only, so restatements among
pragmatic facts stay unjudged. That is forced — prune's decision path does not
carry `Kind` through `mergedFact`, so a pragmatic fact reaching synthesis would
be silently rewritten as epistemic. Lifting it means fixing that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
