### PR TITLE
feat(motif): phase 1 — the field

### DIFF
--- a/internal/fact/format.go
+++ b/internal/fact/format.go
@@ -362,9 +362,15 @@ func SerializeFact(f Fact) (string, error) {
 	if err := ValidateRefs(f.Refs); err != nil {
 		return "", fmt.Errorf("SerializeFact %q: %w", f.path, err)
 	}
+	// Order is load-bearing: VALIDATE first, then strip. A malformed motif is
+	// a misunderstanding of the field and the caller is told; a subject motif
+	// is an ordinary miss and is dropped in silence. Stripping first would let
+	// "antigravity" (one word AND a subject word) vanish without the caller
+	// ever learning that one-word motifs are not a thing.
 	if err := ValidateMotifs(f.Motifs); err != nil {
 		return "", fmt.Errorf("SerializeFact %q: %w", f.path, err)
 	}
+	motifs := StripSubjectMotifs(f)
 	// Origin is held to the same standard as (kind, type): both
 	// well-formedness and the origin×type pairing. Without this a fact with
 	// `origin: distilled` on `type: observation` serialized cleanly and then
@@ -445,8 +451,8 @@ func SerializeFact(f Fact) (string, error) {
 	// Emitted only when non-empty. `motifs: []` on the thousands of facts
 	// that predate the field would churn every file in the corpus for no
 	// information.
-	if len(f.Motifs) > 0 {
-		add("motifs", flowSeq(f.Motifs))
+	if len(motifs) > 0 {
+		add("motifs", flowSeq(motifs))
 	}
 	add("refs", flowSeq(f.Refs))
 

--- a/internal/fact/format.go
+++ b/internal/fact/format.go
@@ -12,15 +12,22 @@ import (
 // Fact represents a single knomit fact file (YAML frontmatter + Markdown body).
 // path is private and always lowercase — use NewFact to construct, Path() to read.
 type Fact struct {
-	path           string   // private — always lowercase
-	Title          string   `json:"title"`
-	Body           string   `json:"body"`
-	Kind           Kind     `json:"kind,omitempty"`
-	Type           Type     `json:"type"`
-	Domain         []string `json:"domain"`
-	Confidence     float64  `json:"confidence"`
-	Sources        int      `json:"sources"`
-	Entities       []string `json:"entities"`
+	path       string   // private — always lowercase
+	Title      string   `json:"title"`
+	Body       string   `json:"body"`
+	Kind       Kind     `json:"kind,omitempty"`
+	Type       Type     `json:"type"`
+	Domain     []string `json:"domain"`
+	Confidence float64  `json:"confidence"`
+	Sources    int      `json:"sources"`
+	Entities   []string `json:"entities"`
+	// Motifs names the general regularities this fact is an instance of —
+	// the ASPECT axis, orthogonal to Entities (subject) and Domain (area).
+	// Optional and capped at MaxMotifs; see motif.go for the rules and
+	// blueprint §1 for the contract. omitempty is load-bearing: the entire
+	// pre-motif corpus must round-trip byte-identically, so an absent list
+	// and an empty list are the same thing at every boundary.
+	Motifs         []string `json:"motifs,omitempty"`
 	Refs           []string `json:"refs"`
 	EvidenceWeight float64  `json:"evidence_weight,omitempty"`
 	Origin         Origin   `json:"origin,omitempty"`
@@ -56,6 +63,7 @@ func (f Fact) MarshalJSON() ([]byte, error) {
 		Confidence     float64  `json:"confidence"`
 		Sources        int      `json:"sources"`
 		Entities       []string `json:"entities"`
+		Motifs         []string `json:"motifs,omitempty"`
 		Refs           []string `json:"refs"`
 		EvidenceWeight float64  `json:"evidence_weight,omitempty"`
 		Origin         Origin   `json:"origin,omitempty"`
@@ -78,6 +86,7 @@ func (f Fact) MarshalJSON() ([]byte, error) {
 		Confidence:     f.Confidence,
 		Sources:        f.Sources,
 		Entities:       f.Entities,
+		Motifs:         f.Motifs,
 		Refs:           f.Refs,
 		EvidenceWeight: f.EvidenceWeight,
 		Origin:         origin,
@@ -97,6 +106,7 @@ func (f *Fact) UnmarshalJSON(data []byte) error {
 		Confidence     float64  `json:"confidence"`
 		Sources        int      `json:"sources"`
 		Entities       []string `json:"entities"`
+		Motifs         []string `json:"motifs,omitempty"`
 		Refs           []string `json:"refs"`
 		EvidenceWeight float64  `json:"evidence_weight,omitempty"`
 		Origin         Origin   `json:"origin,omitempty"`
@@ -117,6 +127,7 @@ func (f *Fact) UnmarshalJSON(data []byte) error {
 	f.Confidence = p.Confidence
 	f.Sources = p.Sources
 	f.Entities = p.Entities
+	f.Motifs = p.Motifs
 	f.Refs = p.Refs
 	f.EvidenceWeight = p.EvidenceWeight
 	f.Origin = p.Origin
@@ -134,6 +145,7 @@ type frontmatter struct {
 	Confidence     float64  `yaml:"confidence"`
 	Sources        int      `yaml:"sources"`
 	Entities       []string `yaml:"entities"`
+	Motifs         []string `yaml:"motifs,omitempty"`
 	Refs           []string `yaml:"refs"`
 	EvidenceWeight float64  `yaml:"evidence_weight,omitempty"`
 	Origin         string   `yaml:"origin"`
@@ -280,6 +292,10 @@ func ParseFact(path, content string) (Fact, error) {
 	f.Confidence = fm.Confidence
 	f.Sources = fm.Sources
 	f.Entities = fm.Entities
+	// Deliberately NOT normalized to []string{} when absent: motifs is the
+	// only elided list field, so nil and empty must remain indistinguishable
+	// all the way through, or a round trip changes the bytes.
+	f.Motifs = fm.Motifs
 	f.Refs = fm.Refs
 	f.EvidenceWeight = fm.EvidenceWeight
 	f.Origin = origin
@@ -418,6 +434,12 @@ func SerializeFact(f Fact) (string, error) {
 		add("origin", strScalar(string(f.Origin)))
 	}
 	add("entities", flowSeq(f.Entities))
+	// Emitted only when non-empty. `motifs: []` on the thousands of facts
+	// that predate the field would churn every file in the corpus for no
+	// information.
+	if len(f.Motifs) > 0 {
+		add("motifs", flowSeq(f.Motifs))
+	}
 	add("refs", flowSeq(f.Refs))
 
 	var buf bytes.Buffer

--- a/internal/fact/format.go
+++ b/internal/fact/format.go
@@ -295,7 +295,12 @@ func ParseFact(path, content string) (Fact, error) {
 	// Deliberately NOT normalized to []string{} when absent: motifs is the
 	// only elided list field, so nil and empty must remain indistinguishable
 	// all the way through, or a round trip changes the bytes.
-	f.Motifs = fm.Motifs
+	//
+	// Lenient on read for the same reason refs and origin above are lenient:
+	// a fact must never become unloadable because of a field nothing's
+	// correctness depends on. Same helper as the write gate, so there is one
+	// definition of a well-formed motif, not two.
+	f.Motifs = DropInvalidMotifs(fm.Motifs)
 	f.Refs = fm.Refs
 	f.EvidenceWeight = fm.EvidenceWeight
 	f.Origin = origin
@@ -355,6 +360,9 @@ func SerializeFact(f Fact) (string, error) {
 		return "", fmt.Errorf("SerializeFact %q: %w", f.path, err)
 	}
 	if err := ValidateRefs(f.Refs); err != nil {
+		return "", fmt.Errorf("SerializeFact %q: %w", f.path, err)
+	}
+	if err := ValidateMotifs(f.Motifs); err != nil {
 		return "", fmt.Errorf("SerializeFact %q: %w", f.path, err)
 	}
 	// Origin is held to the same standard as (kind, type): both

--- a/internal/fact/format.go
+++ b/internal/fact/format.go
@@ -41,6 +41,12 @@ type Fact struct {
 	// invisible either, or the corpus quietly accumulates citations nobody can
 	// follow. SerializeFact still refuses to write one.
 	RefWarnings []string `json:"ref_warnings,omitempty"`
+
+	// MotifWarnings describes motifs ParseFact DROPPED, for the same reason
+	// RefWarnings exists and on the same terms: derived on read, never stored,
+	// absent from the frontmatter struct. SerializeFact still refuses to write
+	// a motif that would earn one.
+	MotifWarnings []string `json:"motif_warnings,omitempty"`
 }
 
 // NewFact is the sole constructor. path is always lowercased.
@@ -301,6 +307,7 @@ func ParseFact(path, content string) (Fact, error) {
 	// correctness depends on. Same helper as the write gate, so there is one
 	// definition of a well-formed motif, not two.
 	f.Motifs = DropInvalidMotifs(fm.Motifs)
+	f.MotifWarnings = motifShapeWarnings(fm.Motifs)
 	f.Refs = fm.Refs
 	f.EvidenceWeight = fm.EvidenceWeight
 	f.Origin = origin

--- a/internal/fact/format_motif_test.go
+++ b/internal/fact/format_motif_test.go
@@ -1,0 +1,96 @@
+package fact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMotifs_RoundTrip: a fact carrying motifs serializes them and parses
+// them back identically, in authored order.
+func TestMotifs_RoundTrip(t *testing.T) {
+	f := NewFact("kb/gotchas/build/x.md")
+	f.Title = "A title"
+	f.Body = "A body."
+	f.Type = Observation
+	f.Domain = []string{"build"}
+	f.Entities = []string{"Bazel"}
+	f.Refs = []string{}
+	f.Confidence = 0.9
+	f.Sources = 1
+	f.Motifs = []string{"silent-fallback", "config-drift"}
+
+	out, err := SerializeFact(f)
+	require.NoError(t, err)
+	require.Contains(t, out, "motifs: [silent-fallback, config-drift]")
+
+	back, err := ParseFact("kb/gotchas/build/x.md", out)
+	require.NoError(t, err)
+	require.Equal(t, []string{"silent-fallback", "config-drift"}, back.Motifs)
+}
+
+// TestMotifs_AbsentIsByteIdentical: the entire pre-motif corpus must
+// serialize to exactly the bytes it does today. A fact with no motifs emits
+// no motifs key at all — not `motifs: []`.
+func TestMotifs_AbsentIsByteIdentical(t *testing.T) {
+	f := NewFact("kb/gotchas/build/x.md")
+	f.Title = "A title"
+	f.Body = "A body."
+	f.Type = Observation
+	f.Domain = []string{"build"}
+	f.Entities = []string{"Bazel"}
+	f.Refs = []string{}
+	f.Confidence = 0.9
+	f.Sources = 1
+
+	out, err := SerializeFact(f)
+	require.NoError(t, err)
+	require.NotContains(t, out, "motifs")
+
+	back, err := ParseFact("kb/gotchas/build/x.md", out)
+	require.NoError(t, err)
+	require.Nil(t, back.Motifs, "absent motifs must parse back as nil, not []string{}")
+}
+
+// TestMotifs_EmptySliceElides: an explicitly empty list is the same as
+// absent. "Omit entirely ... an empty list is a correct answer" (Block A) —
+// both spellings must produce the same bytes, or two writers of the same
+// fact disagree on its blob hash.
+func TestMotifs_EmptySliceElides(t *testing.T) {
+	f := NewFact("kb/gotchas/build/x.md")
+	f.Title = "A title"
+	f.Body = "A body."
+	f.Type = Observation
+	f.Domain = []string{}
+	f.Entities = []string{}
+	f.Refs = []string{}
+	f.Confidence = 0.9
+	f.Sources = 1
+	f.Motifs = []string{}
+
+	withEmpty, err := SerializeFact(f)
+	require.NoError(t, err)
+
+	f.Motifs = nil
+	withNil, err := SerializeFact(f)
+	require.NoError(t, err)
+
+	require.Equal(t, withNil, withEmpty)
+}
+
+// TestMotifs_JSONRoundTrip: Fact's custom (Un)MarshalJSON must carry motifs,
+// or every JSON boundary in the repo silently drops them.
+func TestMotifs_JSONRoundTrip(t *testing.T) {
+	f := NewFact("kb/gotchas/build/x.md")
+	f.Title = "A title"
+	f.Type = Observation
+	f.Motifs = []string{"silent-fallback"}
+
+	data, err := f.MarshalJSON()
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"motifs":["silent-fallback"]`)
+
+	var back Fact
+	require.NoError(t, back.UnmarshalJSON(data))
+	require.Equal(t, []string{"silent-fallback"}, back.Motifs)
+}

--- a/internal/fact/motif.go
+++ b/internal/fact/motif.go
@@ -118,6 +118,76 @@ func DropInvalidMotifs(motifs []string) []string {
 	return out
 }
 
+// MergeMotifs is the mechanical motif union every fact-merging path uses:
+// the winner's motifs first, then whatever the loser adds, trimmed to
+// MaxMotifs (blueprint §2.1).
+//
+// Winner-first, NOT incoming-first like the domain and entity unions beside
+// the call sites. Those are uncapped, so their order is cosmetic — every value
+// survives whichever way round they go. Motifs are capped, so order decides
+// what SURVIVES, and handing the loser's naming of the regularity priority
+// because it happened to arrive in a particular argument slot would contradict
+// the tiebreak philosophy every other merged field follows: the winner
+// contributes the identity.
+//
+// Trimming here rather than letting SerializeFact reject an over-cap list is
+// what keeps a routine merge from failing the whole operation that triggered
+// it — a learn call, or a review session's consolidation.
+//
+// It lives here, with one definition and two callers, because there are two
+// merge sites: learn-time dedup (internal/mcp) and review-session
+// consolidation (internal/synthesize). They are the same operation in two
+// places, and the second one silently dropped the loser's motifs until a
+// review caught it — which is what a second copy of a rule buys you.
+//
+// Returns nil when both sides are empty, so a merge of two motif-less facts
+// stays motif-less rather than becoming an empty list (see Fact.Motifs).
+//
+// Cross-parent phrasing duplicates that are not string-equal ride along and
+// cost a slot until alias resolution collapses them in derived state; that is
+// the accepted price of resolving this mechanically at merge time.
+func MergeMotifs(winner, loser []string) []string {
+	merged := UnionStrings(winner, loser)
+	if len(merged) > MaxMotifs {
+		merged = merged[:MaxMotifs]
+	}
+	return merged
+}
+
+// motifShapeWarnings describes the motifs DropInvalidMotifs would discard, as
+// ParseFact found them. It is the motif counterpart of refShapeWarnings, and it
+// exists for the reason stated on Fact.RefWarnings: ParseFact is deliberately
+// lenient, but the leniency must not be INVISIBLE, or a caller cannot tell a
+// fact that never had a motif from one whose motif was silently thrown away.
+//
+// It is also load-bearing, not merely informational. The REST PUT path stores
+// the client's bytes verbatim unless a gate changed something, and it has no
+// other way to learn that the parse dropped anything — the parsed fact is clean
+// while the bytes on the wire are not.
+func motifShapeWarnings(motifs []string) []string {
+	var problems []string
+	seen := map[string]struct{}{}
+	kept := 0
+	for _, m := range motifs {
+		if err := validateMotifShape(m); err != nil {
+			problems = append(problems, err.Error())
+			continue
+		}
+		if _, dup := seen[m]; dup {
+			problems = append(problems, fmt.Sprintf("motif %q: duplicate entry, dropped", m))
+			continue
+		}
+		seen[m] = struct{}{}
+		if kept == MaxMotifs {
+			problems = append(problems, fmt.Sprintf(
+				"motif %q: dropped — a fact carries at most %d", m, MaxMotifs))
+			continue
+		}
+		kept++
+	}
+	return problems
+}
+
 // StripSubjectMotifs returns f's motifs with every SUBJECT motif removed: one
 // whose stemmed token set is a subset of the fact's own subject tokens
 // (entities ∪ domain ∪ path). It never errors and never reports — a motif

--- a/internal/fact/motif.go
+++ b/internal/fact/motif.go
@@ -1,0 +1,117 @@
+package fact
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// MaxMotifs is the per-fact cap from the field contract (blueprint §1).
+//
+// CONSTANT CLASSIFICATION (roadmap MN13): this is a WRITE-DISCIPLINE BUDGET,
+// not a corpus-property constant. It asserts nothing about any corpus's
+// distribution — no cosine, no density, no frequency. It exists because the
+// value of a motif is that it TRANSFERS, and an author allowed unlimited
+// motifs stops choosing; three forces the choice. Changing it changes what we
+// ask of authors, never what we claim about a repo.
+const MaxMotifs = 3
+
+// A motif is a 2–4 word kebab-case noun phrase. Both bounds are contract, not
+// calibration: below two words a phrase is a bare noun that cannot name a
+// mechanism, and above four it has become a sentence — which is the title's
+// job, not the motif's. The upper bound is measured ground (designer ruling
+// 2026-08-21); do not widen it to accommodate a phrasing.
+const (
+	minMotifWords = 2
+	maxMotifWords = 4
+)
+
+// motifWord is one kebab segment: lowercase alphanumeric, at least one
+// character. Digits are allowed so protocol- and version-shaped regularities
+// ("http2-head-of-line") can be named.
+var motifWord = regexp.MustCompile(`^[a-z0-9]+$`)
+
+// ValidateMotifs enforces the two REJECTING halves of the motif contract:
+// at most MaxMotifs entries, each a well-formed 2–4 word kebab-case phrase,
+// no duplicates. It is called from SerializeFact and nowhere else — that is
+// the a63ff254 single-entry-point pattern, and it is what makes every write
+// path (learn, update, dedup-merge, prune, distill, discover) covered with no
+// per-path code.
+//
+// The SILENT half of the contract — the subject-word strip — is deliberately
+// NOT here: see StripSubjectMotifs. A caller writing a motif that merely
+// renames its fact's subject has made an ordinary mistake and gets a quieter
+// correction; a caller writing "onlyoneword" has misunderstood the field and
+// should be told, and is an agent mid-call that can retry.
+func ValidateMotifs(motifs []string) error {
+	if len(motifs) > MaxMotifs {
+		return fmt.Errorf("motifs: %d entries exceeds the maximum of %d", len(motifs), MaxMotifs)
+	}
+	seen := make(map[string]struct{}, len(motifs))
+	for _, m := range motifs {
+		if err := validateMotifShape(m); err != nil {
+			return err
+		}
+		if _, dup := seen[m]; dup {
+			return fmt.Errorf("motifs: duplicate entry %q", m)
+		}
+		seen[m] = struct{}{}
+	}
+	return nil
+}
+
+// validMotifShape reports whether m is a well-formed motif string.
+func validMotifShape(m string) bool { return validateMotifShape(m) == nil }
+
+func validateMotifShape(m string) error {
+	if m == "" {
+		return fmt.Errorf("motifs: empty entry")
+	}
+	if m != strings.TrimSpace(m) {
+		return fmt.Errorf("motif %q: leading or trailing whitespace", m)
+	}
+	words := strings.Split(m, "-")
+	if len(words) < minMotifWords || len(words) > maxMotifWords {
+		return fmt.Errorf("motif %q: %d kebab-case words, want %d–%d",
+			m, len(words), minMotifWords, maxMotifWords)
+	}
+	for _, w := range words {
+		if !motifWord.MatchString(w) {
+			return fmt.Errorf("motif %q: segment %q is not lowercase alphanumeric — motifs are kebab-case", m, w)
+		}
+	}
+	return nil
+}
+
+// DropInvalidMotifs is the READ-side counterpart to ValidateMotifs: it drops
+// what ValidateMotifs would reject instead of failing, preserving order.
+//
+// The asymmetry is the same one ParseFact already applies to refs and to
+// origin, for the same reason stated there: this is a historical graph, and a
+// version that was legal when it was committed must stay readable forever. A
+// malformed motif costs a reader nothing — nothing consumes motifs yet, and
+// later phases treat an unknown motif as a candidate that finds no partner.
+// Losing the field beats losing the fact. SerializeFact still rejects, which
+// is what stops the corpus accumulating more of them.
+//
+// Returns nil (not an empty slice) when nothing survives, so an all-invalid
+// list is indistinguishable from an absent one — see Fact.Motifs on why nil
+// and empty must stay the same thing.
+func DropInvalidMotifs(motifs []string) []string {
+	var out []string
+	seen := make(map[string]struct{}, len(motifs))
+	for _, m := range motifs {
+		if !validMotifShape(m) {
+			continue
+		}
+		if _, dup := seen[m]; dup {
+			continue
+		}
+		seen[m] = struct{}{}
+		out = append(out, m)
+		if len(out) == MaxMotifs {
+			break
+		}
+	}
+	return out
+}

--- a/internal/fact/motif.go
+++ b/internal/fact/motif.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"knomit/internal/textnorm"
 )
 
 // MaxMotifs is the per-fact cap from the field contract (blueprint §1).
@@ -114,4 +116,78 @@ func DropInvalidMotifs(motifs []string) []string {
 		}
 	}
 	return out
+}
+
+// StripSubjectMotifs returns f's motifs with every SUBJECT motif removed: one
+// whose stemmed token set is a subset of the fact's own subject tokens
+// (entities ∪ domain ∪ path). It never errors and never reports — a motif
+// that merely renames its fact's subject is structurally impossible to store,
+// and blueprint §2's Block B tells authors so up front, which is where that
+// correction belongs.
+//
+// The SUBSET test, not equality, is the point.
+// "antigravity-plugin-resolution" on a fact at
+// kb/.../antigravity/plugin-dir-resolution/ contributes nothing a reader
+// could not get from the path; "antigravity-shadowing" adds "shadowing", a
+// shape another fact could carry, and survives. The question the test asks
+// is: does this phrase say anything this fact has not already said about
+// ITSELF?
+//
+// Returns nil when nothing survives, so an all-stripped list is
+// indistinguishable from an absent one (see Fact.Motifs).
+func StripSubjectMotifs(f Fact) []string {
+	subject := subjectTokens(f)
+	var out []string
+	for _, m := range f.Motifs {
+		if isSubjectMotif(m, subject) {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// subjectTokens is the stemmed token set of everything the fact already says
+// about its own subject: authored entities, domain tags, and path segments.
+//
+// The path is included because a fact's location IS a subject claim — the
+// ontology category is chosen to describe what the fact is about — and
+// because the most common subject motif in the wild is the category slug
+// re-typed. The ontology root and the uuid segment ride along harmlessly:
+// they are stemmed tokens like any other, and no motif of 2+ words is a
+// subset of {kb} or of a hex id.
+func subjectTokens(f Fact) map[string]struct{} {
+	set := make(map[string]struct{})
+	add := func(s string) {
+		for _, tok := range textnorm.Tokens(textnorm.Canonicalize(s)) {
+			set[tok] = struct{}{}
+		}
+	}
+	for _, e := range f.Entities {
+		add(e)
+	}
+	for _, d := range f.Domain {
+		add(d)
+	}
+	// Trim the extension first so "e5d04257.md" does not contribute a
+	// spurious "md" token — that describes the file format, not the fact.
+	// Canonicalize de-hyphenizes and Tokens splits on '/', so path segments
+	// and their words arrive already separated.
+	add(strings.TrimSuffix(f.path, ".md"))
+	return set
+}
+
+// isSubjectMotif reports whether every stemmed token of motif is already in
+// the fact's subject set.
+func isSubjectMotif(motif string, subject map[string]struct{}) bool {
+	toks := textnorm.Tokens(textnorm.Canonicalize(motif))
+	if len(toks) == 0 {
+		return false
+	}
+	for _, t := range toks {
+		if _, ok := subject[t]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -97,10 +97,16 @@ func TestMN4_MotifValidationHasOneCallSite(t *testing.T) {
 	}
 }
 
-// TestMN6_NoMotifConsumers — motifs are stored and counted this phase and
-// consumed by nothing. Not by dedup thresholds, not by clustering, not by
-// search ranking, and not by the bridge engine, which is phase 3.
-func TestMN6_NoMotifConsumers(t *testing.T) {
+// TestMN6_MotifsDoNotDriveMechanics — MN6 as clarified by the designer on
+// 2026-08-21: the restriction is about MECHANICS, not visibility.
+//
+// Motifs may be READ by anyone — UI, query/explain output, the ontology rule
+// sandbox, serialization. None of those is a "consumer" in this rule's sense,
+// and this test deliberately does not police them. What motifs must never do
+// is influence the engine's mechanical decisions: dedup thresholds, clustering,
+// search ranking, or anything that spawns work outside the §4/§5/§7 synthesis
+// paths designed for them. The files below are those decision paths.
+func TestMN6_MotifsDoNotDriveMechanics(t *testing.T) {
 	sources := goSources(t)
 	for _, rel := range []string{
 		"internal/synthesize/dedup.go",
@@ -117,7 +123,7 @@ func TestMN6_NoMotifConsumers(t *testing.T) {
 		require.Truef(t, ok,
 			"MN6 target %s is missing — update this list, do not let the check lapse", rel)
 		require.NotContainsf(t, strings.ToLower(src), "motif",
-			"MN6: %s must not consume motifs in phase 1", rel)
+			"MN6: %s is a mechanical decision path and must not read motifs", rel)
 	}
 }
 

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -1,6 +1,9 @@
 package fact
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -56,9 +59,38 @@ func goSources(t *testing.T) map[string]string {
 	return out
 }
 
-// motifRuleNames are the helpers that define the motif contract. Any use of
-// one outside internal/fact is a second place the rules are applied.
-var motifRuleNames = regexp.MustCompile(`\b(ValidateMotifs|StripSubjectMotifs|DropInvalidMotifs|MaxMotifs)\b`)
+// motifGateNames are the helpers that DECIDE what a valid motif is. Any use of
+// one outside internal/fact is a second place the rules are applied, which is
+// exactly what MN4 forbids.
+//
+// fact.MergeMotifs and fact.MaxMotifs are deliberately NOT here. They are
+// writer plumbing, not gate logic: MergeMotifs unions two already-validated
+// lists and MaxMotifs is the cap it trims to, and every fact-merging path needs
+// them by construction. Policing them as if they were validation is what pushed
+// the review-session merge into dropping the loser's motifs to stay "clean".
+var motifGateNames = regexp.MustCompile(`\b(ValidateMotifs|StripSubjectMotifs|DropInvalidMotifs)\b`)
+
+// motifGateCallSites are the write paths permitted to invoke the gate helpers
+// directly, with the reason each needs to.
+//
+// Calling the shared gate is not what MN4 forbids — RE-IMPLEMENTING it is. A
+// path that asks fact.StripSubjectMotifs what to drop is using the single
+// definition, not inventing a second one. The list exists so that a new direct
+// caller has to be justified, because needing one usually means the path is not
+// reaching SerializeFact, which is the actual defect.
+var motifGateCallSites = map[string]string{
+	"internal/web/handlers_fact_write.go": "the REST PUT path commits the client's bytes verbatim, so it must " +
+		"apply the gate itself and reserialize when the gate changes anything; it is the one write " +
+		"path that does not reach SerializeFact on its own",
+}
+
+// motifMergeSites are the fact-merging paths permitted to call fact.MergeMotifs.
+// Both are the SAME operation in two locations; the list exists so a third one
+// cannot appear unnoticed.
+var motifMergeSites = map[string]string{
+	"internal/mcp/learn.go":        "learn-time dedup merge",
+	"internal/synthesize/dedup.go": "review-session consolidation merge",
+}
 
 // TestMN4_MotifValidationHasOneCallSite is the roadmap's MN4 grep, as a test.
 //
@@ -67,64 +99,137 @@ var motifRuleNames = regexp.MustCompile(`\b(ValidateMotifs|StripSubjectMotifs|Dr
 // DEFINED once and still be re-applied by a handler that "just checks the
 // count first", which is exactly how per-path validation grows back.
 func TestMN4_MotifValidationHasOneCallSite(t *testing.T) {
-	callers := map[string][]string{}
+	offenders := map[string][]string{}
+	mergeCallers := map[string]bool{}
 	for rel, src := range goSources(t) {
 		if strings.HasPrefix(rel, "internal/fact/") {
 			continue // the definition site
 		}
-		if hits := motifRuleNames.FindAllString(src, -1); len(hits) > 0 {
-			callers[rel] = hits
+		if hits := motifGateNames.FindAllString(src, -1); len(hits) > 0 {
+			offenders[rel] = hits
+		}
+		if callsFunc(t, rel, "MergeMotifs") {
+			mergeCallers[rel] = true
 		}
 	}
 
-	// internal/mcp/learn.go references MaxMotifs to TRIM the dedup-merge union.
-	// That is blueprint §2.1's mechanical rule, not a second validation site,
-	// and it is the sole permitted reference.
-	permitted := callers["internal/mcp/learn.go"]
-	delete(callers, "internal/mcp/learn.go")
-	require.Empty(t, callers,
-		"MN4: the motif rules are defined AND applied in internal/fact only")
-
-	// Pin WHAT the exception may name, not how many times it says it: the trim
-	// is one rule spelled over two lines (a bound check and a slice), and
-	// re-spelling it must not fail this. What must never appear there is a
-	// rule HELPER — that would be learn.go deciding for itself what a valid
-	// motif is, which is the failure MN4 exists to prevent.
-	require.NotEmpty(t, permitted, "the trim in learn.go must still reference MaxMotifs")
-	for _, hit := range permitted {
-		require.Equalf(t, "MaxMotifs", hit,
-			"internal/mcp/learn.go may reference MaxMotifs to trim the merge union, never %s", hit)
+	for rel, hits := range offenders {
+		require.Containsf(t, motifGateCallSites, rel,
+			"MN4: %s invokes the motif gate %v outside internal/fact. Route the fact "+
+				"through SerializeFact instead — or, if this path genuinely commits bytes "+
+				"that never reach it, declare it in motifGateCallSites with the reason.", rel, hits)
 	}
+	for rel, why := range motifGateCallSites {
+		require.Containsf(t, offenders, rel,
+			"%s is declared a direct gate call site (%s) but no longer calls one — "+
+				"remove the entry, or restore the gate it was granted for", rel, why)
+	}
+
+	// The merge helper is permitted, but only where a fact merge actually
+	// happens, and every declared site must still be one.
+	for rel := range mergeCallers {
+		require.Containsf(t, motifMergeSites, rel,
+			"%s calls fact.MergeMotifs but is not a declared fact-merge site — "+
+				"add it to motifMergeSites with a reason, or stop merging motifs there", rel)
+	}
+	for rel, why := range motifMergeSites {
+		require.Truef(t, mergeCallers[rel],
+			"%s is declared a motif-merge site (%s) but no longer calls fact.MergeMotifs — "+
+				"a merge that drops the loser's motifs silently loses authored data", rel, why)
+	}
+}
+
+// mechanicsPaths are the engine's mechanical decision paths, mapped to the
+// functions within each that may legitimately touch motifs.
+//
+// Empty slice = no function in that file may mention them at all.
+var mechanicsPaths = map[string][]string{
+	// dedupCluster is a WRITER: it merges two facts and commits the survivor,
+	// so it must carry the loser's motifs across or that authored data is
+	// deleted with the loser and no derived state can rebuild it. Every OTHER
+	// function here — the similarity scoring, the threshold comparison, the
+	// greedy pair selection — must stay blind to motifs, which is the actual
+	// MN6 constraint.
+	"internal/synthesize/dedup.go":           {"dedupCluster"},
+	"internal/synthesize/bridge.go":          nil,
+	"internal/synthesize/bridge_score.go":    nil,
+	"internal/synthesize/bridge_filtered.go": nil,
+	"internal/synthesize/bridge_reshape.go":  nil,
+	"internal/synthesize/restatement.go":     nil,
+	"internal/synthesize/cluster.go":         nil,
+	"internal/synthesize/louvain.go":         nil,
+	"internal/store/search_query.go":         nil,
 }
 
 // TestMN6_MotifsDoNotDriveMechanics — MN6 as clarified by the designer on
 // 2026-08-21: the restriction is about MECHANICS, not visibility.
 //
 // Motifs may be READ by anyone — UI, query/explain output, the ontology rule
-// sandbox, serialization. None of those is a "consumer" in this rule's sense,
-// and this test deliberately does not police them. What motifs must never do
-// is influence the engine's mechanical decisions: dedup thresholds, clustering,
-// search ranking, or anything that spawns work outside the §4/§5/§7 synthesis
-// paths designed for them. The files below are those decision paths.
+// sandbox, serialization — and they may be MERGED by anything that writes
+// facts. None of that is a "consumer" in this rule's sense. What motifs must
+// never do is influence the engine's mechanical decisions: dedup thresholds,
+// clustering, search ranking, or anything that spawns work outside the
+// §4/§5/§7 synthesis paths designed for them.
+//
+// The check is per-FUNCTION rather than per-file, and that distinction is the
+// whole point. A file-level ban read MN6 as "dedup.go must not say motif",
+// which is how the review-session merge came to drop the loser's motifs: the
+// conformance test was enforcing a rule stricter than the one written down,
+// and the code obediently lost data to satisfy it.
 func TestMN6_MotifsDoNotDriveMechanics(t *testing.T) {
 	sources := goSources(t)
-	for _, rel := range []string{
-		"internal/synthesize/dedup.go",
-		"internal/synthesize/bridge.go",
-		"internal/synthesize/bridge_score.go",
-		"internal/synthesize/bridge_filtered.go",
-		"internal/synthesize/bridge_reshape.go",
-		"internal/synthesize/restatement.go",
-		"internal/store/search_query.go",
-	} {
-		src, ok := sources[rel]
+	for rel, allowed := range mechanicsPaths {
 		// ERROR, not skip: if one of these was renamed, this test has stopped
 		// checking the thing it names and must say so rather than shrink.
-		require.Truef(t, ok,
+		require.Containsf(t, sources, rel,
 			"MN6 target %s is missing — update this list, do not let the check lapse", rel)
-		require.NotContainsf(t, strings.ToLower(src), "motif",
-			"MN6: %s is a mechanical decision path and must not read motifs", rel)
+
+		offenders := funcsMentioningMotifs(t, rel)
+		for _, name := range allowed {
+			require.Containsf(t, offenders, name,
+				"%s is allow-listed to touch motifs in %s but no longer does — "+
+					"remove the entry rather than leaving a permission nothing uses", name, rel)
+		}
+		for _, fn := range offenders {
+			require.Containsf(t, allowed, fn,
+				"MN6: %s.%s is a mechanical decision path and must not read motifs. "+
+					"If it WRITES facts rather than deciding something, allow-list it in "+
+					"mechanicsPaths with a reason.", rel, fn)
+		}
 	}
+}
+
+// funcsMentioningMotifs returns the names of top-level functions in rel whose
+// body mentions a motif identifier. Parsed, not grepped, so a comment
+// explaining why a function has nothing to do with motifs does not trip it —
+// and so the check can be scoped to a function rather than a whole file.
+func funcsMentioningMotifs(t *testing.T, rel string) []string {
+	t.Helper()
+	var out []string
+	for _, decl := range parseGo(t, rel).Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		mentions := false
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			switch id := n.(type) {
+			case *ast.Ident:
+				if strings.Contains(strings.ToLower(id.Name), "motif") {
+					mentions = true
+				}
+			case *ast.SelectorExpr:
+				if strings.Contains(strings.ToLower(id.Sel.Name), "motif") {
+					mentions = true
+				}
+			}
+			return !mentions
+		})
+		if mentions {
+			out = append(out, fn.Name.Name)
+		}
+	}
+	return out
 }
 
 // TestMN2_NoLLMInMotifCode — vacuous this phase, and stated anyway so the
@@ -144,19 +249,107 @@ func TestMN2_NoLLMInMotifCode(t *testing.T) {
 }
 
 // TestMN13_MotifConstantsAreClassified — every numeric constant in the motif
-// path is a documented budget, never a corpus-property constant. Phase 1
-// introduces three (MaxMotifs and the two word bounds) and no float literal at
-// all; a float appearing here would be a threshold in disguise.
+// path is a documented budget, never a corpus-property constant.
+//
+// Two things it deliberately does NOT do, both fixed after review:
+//
+//   - It does not assert the ORDER of comment prose. The first version required
+//     "CONSTANT CLASSIFICATION" to appear before "const MaxMotifs" in the file
+//     text, which is a rule about paragraph layout, not about the code — moving
+//     a doc comment would have failed it while changing nothing that matters.
+//     It now checks that the constant's own doc comment says what class it is.
+//   - It does not regex the file for float literals. A float in a COMMENT
+//     ("measured 0.75 on the research corpus") is calibration evidence being
+//     cited, which MN13 explicitly permits; a float in the CODE is a threshold.
+//     Only the parser can tell those apart.
 func TestMN13_MotifConstantsAreClassified(t *testing.T) {
-	src := goSources(t)["internal/fact/motif.go"]
-	require.NotEmpty(t, src)
+	const rel = "internal/fact/motif.go"
+	file := parseGo(t, rel)
 
-	require.Regexp(t, `(?s)CONSTANT CLASSIFICATION.*const MaxMotifs`, src,
-		"MaxMotifs must state its class where it is defined")
-	require.Regexp(t, `(?s)contract, not\s*//?\s*calibration.*minMotifWords`, src,
-		"the word bounds must state that they are contract, not calibration")
+	// Each named constant must carry a doc comment declaring its class.
+	wantClassified := map[string]string{
+		"MaxMotifs":     "CONSTANT CLASSIFICATION",
+		"minMotifWords": "contract, not",
+		"maxMotifWords": "contract, not",
+	}
+	seen := map[string]bool{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		// A const block's doc comment covers every spec inside it.
+		blockDoc := gen.Doc.Text()
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			doc := blockDoc + vs.Doc.Text()
+			for _, name := range vs.Names {
+				want, tracked := wantClassified[name.Name]
+				if !tracked {
+					continue
+				}
+				seen[name.Name] = true
+				require.Containsf(t, doc, want,
+					"MN13: const %s must state its class where it is defined "+
+						"(expected its doc comment to contain %q)", name.Name, want)
+			}
+		}
+	}
+	for name := range wantClassified {
+		require.Truef(t, seen[name], "const %s no longer exists in %s — "+
+			"update this test rather than letting the classification rule lapse", name, rel)
+	}
 
-	floats := regexp.MustCompile(`\b\d+\.\d+\b`).FindAllString(src, -1)
+	// No float literal anywhere in the CODE. Comments are exempt by
+	// construction: ast.Inspect walks expressions, not trivia.
+	var floats []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.FLOAT {
+			floats = append(floats, lit.Value)
+		}
+		return true
+	})
 	require.Emptyf(t, floats,
-		"MN13: a float literal in the motif path is a corpus-property constant in disguise: %v", floats)
+		"MN13: a float literal in the motif path is a corpus-property constant "+
+			"in disguise: %v", floats)
+}
+
+// callsFunc reports whether the file at repo-relative rel contains an actual
+// CALL to name (bare or selector-qualified), parsed rather than grepped, so
+// comments and strings mentioning the name do not count.
+func callsFunc(t *testing.T, rel, name string) bool {
+	t.Helper()
+	file := parseGo(t, rel)
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			if fn.Name == name {
+				found = true
+			}
+		case *ast.SelectorExpr:
+			if fn.Sel.Name == name {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// parseGo parses one repo-relative Go file, failing (never skipping) if it
+// cannot be read or parsed.
+func parseGo(t *testing.T, rel string) *ast.File {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath.Join(repoRoot(t), rel), nil, parser.ParseComments)
+	require.NoErrorf(t, err, "parsing %s", rel)
+	return file
 }

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -1,0 +1,156 @@
+package fact
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// repoRoot walks up from the test's working directory to the module root.
+// It FAILS rather than skips when it cannot find one: every check in this file
+// is a constraint the roadmap enforces by inspection, and a conformance test
+// that cannot locate its subject must say so, not report success.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqualf(t, parent, dir,
+			"no go.mod above %s — the conformance scans below cannot run and are NOT being enforced", dir)
+		dir = parent
+	}
+}
+
+// goSources returns every non-test .go file under internal/, keyed by its
+// repo-relative path.
+func goSources(t *testing.T) map[string]string {
+	t.Helper()
+	root := repoRoot(t)
+	out := map[string]string{}
+	require.NoError(t, filepath.Walk(filepath.Join(root, "internal"),
+		func(p string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return err
+			}
+			if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+				return nil
+			}
+			b, rerr := os.ReadFile(p)
+			if rerr != nil {
+				return rerr
+			}
+			rel, _ := filepath.Rel(root, p)
+			out[filepath.ToSlash(rel)] = string(b)
+			return nil
+		}))
+	// A scan that examined nothing is not a check.
+	require.Greater(t, len(out), 100, "the source scan must actually be reading the tree")
+	return out
+}
+
+// motifRuleNames are the helpers that define the motif contract. Any use of
+// one outside internal/fact is a second place the rules are applied.
+var motifRuleNames = regexp.MustCompile(`\b(ValidateMotifs|StripSubjectMotifs|DropInvalidMotifs|MaxMotifs)\b`)
+
+// TestMN4_MotifValidationHasOneCallSite is the roadmap's MN4 grep, as a test.
+//
+// It fails on any non-test file outside internal/fact that touches the motif
+// rule helpers. That is the property MN4 actually protects: the rules can be
+// DEFINED once and still be re-applied by a handler that "just checks the
+// count first", which is exactly how per-path validation grows back.
+func TestMN4_MotifValidationHasOneCallSite(t *testing.T) {
+	callers := map[string][]string{}
+	for rel, src := range goSources(t) {
+		if strings.HasPrefix(rel, "internal/fact/") {
+			continue // the definition site
+		}
+		if hits := motifRuleNames.FindAllString(src, -1); len(hits) > 0 {
+			callers[rel] = hits
+		}
+	}
+
+	// internal/mcp/learn.go references MaxMotifs to TRIM the dedup-merge union.
+	// That is blueprint §2.1's mechanical rule, not a second validation site,
+	// and it is the sole permitted reference.
+	permitted := callers["internal/mcp/learn.go"]
+	delete(callers, "internal/mcp/learn.go")
+	require.Empty(t, callers,
+		"MN4: the motif rules are defined AND applied in internal/fact only")
+
+	// Pin WHAT the exception may name, not how many times it says it: the trim
+	// is one rule spelled over two lines (a bound check and a slice), and
+	// re-spelling it must not fail this. What must never appear there is a
+	// rule HELPER — that would be learn.go deciding for itself what a valid
+	// motif is, which is the failure MN4 exists to prevent.
+	require.NotEmpty(t, permitted, "the trim in learn.go must still reference MaxMotifs")
+	for _, hit := range permitted {
+		require.Equalf(t, "MaxMotifs", hit,
+			"internal/mcp/learn.go may reference MaxMotifs to trim the merge union, never %s", hit)
+	}
+}
+
+// TestMN6_NoMotifConsumers — motifs are stored and counted this phase and
+// consumed by nothing. Not by dedup thresholds, not by clustering, not by
+// search ranking, and not by the bridge engine, which is phase 3.
+func TestMN6_NoMotifConsumers(t *testing.T) {
+	sources := goSources(t)
+	for _, rel := range []string{
+		"internal/synthesize/dedup.go",
+		"internal/synthesize/bridge.go",
+		"internal/synthesize/bridge_score.go",
+		"internal/synthesize/bridge_filtered.go",
+		"internal/synthesize/bridge_reshape.go",
+		"internal/synthesize/restatement.go",
+		"internal/store/search_query.go",
+	} {
+		src, ok := sources[rel]
+		// ERROR, not skip: if one of these was renamed, this test has stopped
+		// checking the thing it names and must say so rather than shrink.
+		require.Truef(t, ok,
+			"MN6 target %s is missing — update this list, do not let the check lapse", rel)
+		require.NotContainsf(t, strings.ToLower(src), "motif",
+			"MN6: %s must not consume motifs in phase 1", rel)
+	}
+}
+
+// TestMN2_NoLLMInMotifCode — vacuous this phase, and stated anyway so the
+// phase-3 enumeration loop inherits a check that already exists rather than
+// needing one written under deadline.
+func TestMN2_NoLLMInMotifCode(t *testing.T) {
+	sources := goSources(t)
+	for _, rel := range []string{"internal/fact/motif.go", "internal/textnorm/textnorm.go"} {
+		src, ok := sources[rel]
+		require.Truef(t, ok, "MN2 target %s is missing", rel)
+		lower := strings.ToLower(src)
+		for _, banned := range []string{"internal/llm", "anthropic", "openai", "completion"} {
+			require.NotContainsf(t, lower, banned,
+				"MN2: %s must reach no LLM — all motif gating is mechanical", rel)
+		}
+	}
+}
+
+// TestMN13_MotifConstantsAreClassified — every numeric constant in the motif
+// path is a documented budget, never a corpus-property constant. Phase 1
+// introduces three (MaxMotifs and the two word bounds) and no float literal at
+// all; a float appearing here would be a threshold in disguise.
+func TestMN13_MotifConstantsAreClassified(t *testing.T) {
+	src := goSources(t)["internal/fact/motif.go"]
+	require.NotEmpty(t, src)
+
+	require.Regexp(t, `(?s)CONSTANT CLASSIFICATION.*const MaxMotifs`, src,
+		"MaxMotifs must state its class where it is defined")
+	require.Regexp(t, `(?s)contract, not\s*//?\s*calibration.*minMotifWords`, src,
+		"the word bounds must state that they are contract, not calibration")
+
+	floats := regexp.MustCompile(`\b\d+\.\d+\b`).FindAllString(src, -1)
+	require.Emptyf(t, floats,
+		"MN13: a float literal in the motif path is a corpus-property constant in disguise: %v", floats)
+}

--- a/internal/fact/motif_test.go
+++ b/internal/fact/motif_test.go
@@ -240,3 +240,50 @@ func TestFactToJS_MotifsAreResolved(t *testing.T) {
 	require.Equal(t, []string{"silent-fallback"}, js["motifs"],
 		"the rule sandbox must see what lands on disk, not the raw field")
 }
+
+// TestStripSubjectMotifs_SubjectDriftDropsAnAuthoredMotif pins as INTENDED the
+// behaviour that looks most like a bug: a motif that was legal when authored is
+// dropped on a later write, because the fact's subject grew to cover it.
+//
+// The invariant is "no STORED motif restates its fact's CURRENT subject", and
+// it is maintained forward rather than retroactively — facts are immutable, so
+// nothing rewrites the earlier revision, and the drift is resolved the next
+// time the fact is written. Silently, like every other subject strip: the
+// author of THIS write did not necessarily write the motif, and failing their
+// edit over a predecessor's word choice would be the wrong bill to hand them.
+//
+// Designer ruling 2026-08-21, in response to the Phase-1 review raising it as a
+// possible defect. Do not "fix" this into a grandfather clause; the exemption
+// would let a motif that names its own fact's subject sit in the corpus
+// permanently, which is exactly what the field contract forbids.
+func TestStripSubjectMotifs_SubjectDriftDropsAnAuthoredMotif(t *testing.T) {
+	f := NewFact("kb/gotchas/build/x.md")
+	f.Title = "A title"
+	f.Body = "Body."
+	f.Type = Observation
+	f.Domain = []string{"build"}
+	f.Entities = []string{"Bazel"}
+	f.Refs = []string{}
+	f.Confidence = 0.9
+	f.Sources = 1
+	f.Motifs = []string{"remote-caching"}
+
+	// At authoring time "remote-caching" transfers: neither word is a subject
+	// word, so it stores.
+	first, err := SerializeFact(f)
+	require.NoError(t, err)
+	require.Contains(t, first, "motifs: [remote-caching]")
+
+	// The subject later grows to cover it — someone adds the entities the fact
+	// was always about.
+	f.Entities = []string{"Bazel", "remote", "caching"}
+
+	second, err := SerializeFact(f)
+	require.NoError(t, err, "drift resolves silently; it must never fail the write")
+	require.NotContains(t, second, "motifs",
+		"once the subject covers it, the motif restates the subject and must go")
+
+	// And the earlier revision is untouched — it is a committed blob, and the
+	// invariant is about what is stored NOW, not a claim about history.
+	require.Contains(t, first, "motifs: [remote-caching]")
+}

--- a/internal/fact/motif_test.go
+++ b/internal/fact/motif_test.go
@@ -1,0 +1,132 @@
+package fact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMotifs_Shape(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		motif string
+		ok    bool
+	}{
+		{"two words", "capital-influx", true},
+		{"three words", "derived-state-liability", true},
+		{"four words", "atomic-write-via-rename", true},
+		// The Block B example, as amended by designer ruling 2026-08-21 to fit
+		// the measured 2-4 contract.
+		{"block b example", "zero-value-as-valid", true},
+		{"one word", "collision", false},
+		{"five words", "zero-value-treated-as-valid", false},
+		{"uppercase", "Capital-Influx", false},
+		{"space separated", "capital influx", false},
+		{"snake case", "capital_influx", false},
+		{"empty", "", false},
+		{"leading hyphen", "-capital-influx", false},
+		{"trailing hyphen", "capital-influx-", false},
+		{"double hyphen", "capital--influx", false},
+		{"leading space", " capital-influx", false},
+		{"digits allowed", "http2-head-of-line", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMotifs([]string{tc.motif})
+			if tc.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateMotifs_Count(t *testing.T) {
+	require.NoError(t, ValidateMotifs(nil))
+	require.NoError(t, ValidateMotifs([]string{"a-b", "c-d", "e-f"}))
+	err := ValidateMotifs([]string{"a-b", "c-d", "e-f", "g-h"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "maximum of 3")
+}
+
+func TestValidateMotifs_Duplicates(t *testing.T) {
+	err := ValidateMotifs([]string{"capital-influx", "capital-influx"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate")
+}
+
+// TestSerializeFact_RejectsBadMotifs — the write gate. This is the MN4
+// property: no per-path check anywhere, because every write path renders
+// through here.
+func TestSerializeFact_RejectsBadMotifs(t *testing.T) {
+	f := NewFact("kb/gotchas/build/x.md")
+	f.Title = "A title"
+	f.Type = Observation
+	f.Confidence = 0.9
+	f.Sources = 1
+	f.Motifs = []string{"onlyoneword"}
+
+	_, err := SerializeFact(f)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SerializeFact")
+}
+
+// TestParseFact_DropsBadMotifsSilently — the read side is LENIENT, matching
+// how HEAD already treats refs and origin: a version that was legal when it
+// was committed must stay readable forever. A malformed motif renders inert
+// rather than making the fact unloadable.
+func TestParseFact_DropsBadMotifsSilently(t *testing.T) {
+	raw := "---\n" +
+		"type: observation\n" +
+		"domain: [build]\n" +
+		"confidence: 0.9\n" +
+		"sources: 1\n" +
+		"entities: []\n" +
+		"motifs: [capital-influx, onlyoneword, derived-state-liability]\n" +
+		"refs: []\n" +
+		"---\n# A title\n\nBody.\n"
+
+	f, err := ParseFact("kb/gotchas/build/x.md", raw)
+	require.NoError(t, err)
+	require.Equal(t, []string{"capital-influx", "derived-state-liability"}, f.Motifs)
+}
+
+// TestParseFact_TrimsOverCapSilently — same reasoning as above for count.
+func TestParseFact_TrimsOverCapSilently(t *testing.T) {
+	raw := "---\n" +
+		"type: observation\n" +
+		"domain: []\n" +
+		"confidence: 0.9\n" +
+		"sources: 1\n" +
+		"entities: []\n" +
+		"motifs: [a-b, c-d, e-f, g-h]\n" +
+		"refs: []\n" +
+		"---\n# A title\n\nBody.\n"
+
+	f, err := ParseFact("kb/gotchas/build/x.md", raw)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a-b", "c-d", "e-f"}, f.Motifs)
+}
+
+// TestParseFact_AllInvalidMotifsParseAsNil — nil and empty must stay
+// indistinguishable (see Fact.Motifs), or a fact whose every motif was
+// dropped serializes differently from one that never had any.
+func TestParseFact_AllInvalidMotifsParseAsNil(t *testing.T) {
+	raw := "---\n" +
+		"type: observation\n" +
+		"domain: []\n" +
+		"confidence: 0.9\n" +
+		"sources: 1\n" +
+		"entities: []\n" +
+		"motifs: [onlyoneword]\n" +
+		"refs: []\n" +
+		"---\n# A title\n\nBody.\n"
+
+	f, err := ParseFact("kb/gotchas/build/x.md", raw)
+	require.NoError(t, err)
+	require.Nil(t, f.Motifs)
+
+	out, err := SerializeFact(f)
+	require.NoError(t, err, "a fact whose motifs were all dropped must still be writable")
+	require.NotContains(t, out, "motifs")
+}

--- a/internal/fact/motif_test.go
+++ b/internal/fact/motif_test.go
@@ -130,3 +130,113 @@ func TestParseFact_AllInvalidMotifsParseAsNil(t *testing.T) {
 	require.NoError(t, err, "a fact whose motifs were all dropped must still be writable")
 	require.NotContains(t, out, "motifs")
 }
+
+func stripFixture() Fact {
+	f := NewFact("kb/gotchas/integrations/antigravity/plugin-dir-resolution/e5d04257.md")
+	f.Title = "A title"
+	f.Body = "Body."
+	f.Type = Observation
+	f.Domain = []string{"integrations", "build tooling"}
+	f.Entities = []string{"Antigravity", "mcp_config.json"}
+	f.Refs = []string{}
+	f.Confidence = 0.9
+	f.Sources = 1
+	return f
+}
+
+func TestStripSubjectMotifs_DropsEntitySubsets(t *testing.T) {
+	f := stripFixture()
+	// "antigravity-shadowing" -> {antigravity, shadowing}: NOT a subset
+	// (shadowing is not a subject token), so it survives.
+	// "antigravity-plugin-resolution" -> {antigravity, plugin, resolution}:
+	// every token is an entity or path token, so it is the fact's own subject
+	// wearing a motif's clothes.
+	f.Motifs = []string{"antigravity-shadowing", "antigravity-plugin-resolution"}
+	require.Equal(t, []string{"antigravity-shadowing"}, StripSubjectMotifs(f))
+}
+
+func TestStripSubjectMotifs_DropsDomainSubsets(t *testing.T) {
+	f := stripFixture()
+	f.Motifs = []string{"build-tooling"}
+	require.Nil(t, StripSubjectMotifs(f))
+}
+
+func TestStripSubjectMotifs_DropsPathSubsets(t *testing.T) {
+	f := stripFixture()
+	f.Motifs = []string{"plugin-dir-resolution"}
+	require.Nil(t, StripSubjectMotifs(f))
+}
+
+func TestStripSubjectMotifs_IsStemmed(t *testing.T) {
+	f := stripFixture()
+	f.Entities = []string{"vulnerabilities"}
+	f.Domain = []string{"scanning"}
+	f.Motifs = []string{"vulnerability-scanning"}
+	require.Nil(t, StripSubjectMotifs(f), "stemming must collapse vulnerabilities/vulnerability")
+}
+
+func TestStripSubjectMotifs_KeepsGeneralRegularities(t *testing.T) {
+	f := stripFixture()
+	f.Motifs = []string{"zero-value-as-valid", "silent-fallback", "name-collision"}
+	require.Equal(t, f.Motifs, StripSubjectMotifs(f))
+}
+
+// TestStripSubjectMotifs_ExtensionIsNotASubjectToken — "md" must not enter
+// the subject set, or a two-word motif ending in it would be judged against a
+// token that describes the file format, not the fact.
+func TestStripSubjectMotifs_ExtensionIsNotASubjectToken(t *testing.T) {
+	f := stripFixture()
+	f.Motifs = []string{"md-rendering"}
+	require.Equal(t, []string{"md-rendering"}, StripSubjectMotifs(f))
+}
+
+// TestSerializeFact_StripIsSilent — the strip NEVER errors. A caller that
+// writes a subject-restating motif gets a stored fact, minus the motif.
+func TestSerializeFact_StripIsSilent(t *testing.T) {
+	f := stripFixture()
+	f.Motifs = []string{"antigravity-plugin-resolution"}
+
+	out, err := SerializeFact(f)
+	require.NoError(t, err, "the subject strip drops, it never errors")
+	require.NotContains(t, out, "motifs")
+
+	back, err := ParseFact(f.Path(), out)
+	require.NoError(t, err)
+	require.Nil(t, back.Motifs)
+}
+
+// TestSerializeFact_StripDoesNotMutateInput — SerializeFact is a pure
+// renderer. The strip must not reach back into the caller's Fact.
+func TestSerializeFact_StripDoesNotMutateInput(t *testing.T) {
+	f := stripFixture()
+	f.Motifs = []string{"antigravity-plugin-resolution", "silent-fallback"}
+
+	_, err := SerializeFact(f)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"antigravity-plugin-resolution", "silent-fallback"}, f.Motifs)
+}
+
+// TestSerializeFact_ValidateBeforeStrip — a malformed motif must be REPORTED
+// even when the strip would have removed it anyway. Ordering the strip first
+// would silently swallow the caller's misunderstanding of the field.
+func TestSerializeFact_ValidateBeforeStrip(t *testing.T) {
+	f := stripFixture()
+	f.Motifs = []string{"antigravity"} // one word AND a subject word
+	_, err := SerializeFact(f)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "kebab-case words")
+}
+
+// TestFactToJS_MotifsAreResolved — ValidateFact runs BEFORE SerializeFact, so
+// a rule reading the raw field would judge motifs that are about to vanish.
+// `fact.motifs.length >= 1` must not pass on a fact that will be written with
+// none.
+func TestFactToJS_MotifsAreResolved(t *testing.T) {
+	f := stripFixture()
+	f.Motifs = []string{"antigravity-plugin-resolution", "silent-fallback"}
+
+	js := factToJS(f)
+	require.Equal(t, []string{"silent-fallback"}, js["motifs"],
+		"the rule sandbox must see what lands on disk, not the raw field")
+}

--- a/internal/fact/validation.go
+++ b/internal/fact/validation.go
@@ -39,6 +39,10 @@ func compileRules(topic string, rules []Validation) ([]compiledRule, error) {
 
 // factToJS converts a Fact into a plain map suitable for read-only JS access.
 //
+// Two fields are exposed as their RESOLVED value rather than the raw one —
+// origin and motifs — because ValidateFact runs before SerializeFact and both
+// are rewritten there. See resolvedOrigin and resolvedMotifs.
+//
 // Every field of Fact is exposed, keyed by its json tag, with one deliberate
 // exception: RefWarnings. That field is derived on read and never stored, and
 // a rule over it could not be trusted in either direction — it is structurally
@@ -57,7 +61,7 @@ func factToJS(f Fact) map[string]any {
 		"type":            string(f.Type),
 		"domain":          append([]string{}, f.Domain...),
 		"entities":        append([]string{}, f.Entities...),
-		"motifs":          append([]string{}, f.Motifs...),
+		"motifs":          append([]string{}, resolvedMotifs(f)...),
 		"refs":            append([]string{}, f.Refs...),
 		"title":           f.Title,
 		"body":            f.Body,
@@ -68,6 +72,18 @@ func factToJS(f Fact) map[string]any {
 		"evidence_weight": f.EvidenceWeight,
 	}
 }
+
+// resolvedMotifs is the motif list a rule sees: the value that will actually
+// land on disk, never the raw field — the same discipline resolvedOrigin
+// applies below, for the same reason.
+//
+// ValidateFact runs BEFORE SerializeFact, and SerializeFact silently drops
+// any motif that merely restates its fact's own subject. A rule reading the
+// raw field would therefore judge motifs that are about to vanish:
+// `fact.motifs.length >= 1` would pass on a fact whose single motif is a
+// subject motif, and that fact would then be written carrying none. Resolving
+// here keeps the rule sandbox and the on-disk fact telling one story.
+func resolvedMotifs(f Fact) []string { return StripSubjectMotifs(f) }
 
 // resolvedOrigin is the origin a rule sees: the value that will actually land
 // on disk, never the raw field.

--- a/internal/fact/validation.go
+++ b/internal/fact/validation.go
@@ -57,6 +57,7 @@ func factToJS(f Fact) map[string]any {
 		"type":            string(f.Type),
 		"domain":          append([]string{}, f.Domain...),
 		"entities":        append([]string{}, f.Entities...),
+		"motifs":          append([]string{}, f.Motifs...),
 		"refs":            append([]string{}, f.Refs...),
 		"title":           f.Title,
 		"body":            f.Body,

--- a/internal/fact/validation_test.go
+++ b/internal/fact/validation_test.go
@@ -227,6 +227,12 @@ var factToJSOmitted = map[string]string{
 		"SerializeFact refuses to write a malformed ref anyway), and stale on the knomit_update " +
 		"path (ParseFact computes it from the on-disk refs, which the handler replaces wholesale " +
 		"before ValidateFact runs) — so a rule would judge refs that are not being written",
+	"MotifWarnings": "derived on read, never stored, and unusable from a rule for the same reason " +
+		"RefWarnings is: structurally always empty on the knomit_learn path (the fact is built in " +
+		"memory and SerializeFact refuses to write a motif that would earn a warning), and stale on " +
+		"the knomit_update path (ParseFact computes it from the on-disk motifs, which the handler may " +
+		"replace wholesale before ValidateFact runs) — so a rule would judge motifs that are not " +
+		"being written. The STRIPPED motif list is exposed instead; see resolvedMotifs.",
 }
 
 // TestFactToJS_ExposesEveryFactField is the regression guard for the omission

--- a/internal/mcp/factschema.go
+++ b/internal/mcp/factschema.go
@@ -85,6 +85,43 @@ var factOriginDocs = map[fact.Origin]string{
 	fact.Discovered: "discovery-engine output from a cross-cluster bridge (type synthesis or hypothesis only)",
 }
 
+// motifFieldDescription is blueprint §2 Block A, VERBATIM. It is SHIP text:
+// the wording is the validated prompt (four models, §12-E2), not a paraphrase,
+// and every rule in it is load-bearing — including the closing "an empty list
+// is a correct answer", whose blunter v1 phrasing suppressed valid motifs in
+// two of three models.
+//
+// It is STATIC. No corpus vocabulary, no examples drawn from this repo, no
+// reuse-before-minting rule (roadmap MN1): a served list was measured to bias
+// authors toward force-fitting a new fact onto an existing name (§12-E3), and
+// cold minting converges without one (§12-E2). Phrasing convergence is
+// manufactured downstream, in derived state, where being wrong costs a rebuild
+// instead of a fact.
+//
+// Guarded byte-for-byte by TestShipBlockA_Verbatim against
+// testdata/motif_block_a.txt. Do not reflow, re-punctuate, or "fix" the
+// en-dashes: the goldens are a straight copy of §2 and any difference from it
+// is a defect.
+const motifFieldDescription = `motifs (optional, 0–3): the general regularities this fact is an instance of.
+Each motif is a 2–4 word kebab-case noun phrase naming a mechanism, failure
+shape, or pattern that a fact about a completely different subject could also
+carry — that is the test. Examples: identifier-collision,
+derived-state-liability, harness-over-model, capital-influx. NOT the fact's
+subject (that is entities), NOT its area (that is domain), NOT its claim
+compressed (that is the title). Omit entirely when the fact is a bare
+datapoint with no general shape — an empty list is a correct answer.`
+
+// motifsProperty returns the JSON-schema fragment for the `motifs` property,
+// shared by knomit_learn and knomit_update so the two cannot drift on what the
+// field means.
+func motifsProperty() map[string]any {
+	return map[string]any{
+		"type":        "array",
+		"items":       map[string]any{"type": "string"},
+		"description": motifFieldDescription,
+	}
+}
+
 // enumValues renders a slice of string-kinded domain values as the []string
 // a JSON-schema "enum" key expects.
 func enumValues[T ~string](vals []T) []string {

--- a/internal/mcp/instructions.go
+++ b/internal/mcp/instructions.go
@@ -91,6 +91,56 @@ func lensInstructions(b *repos.Binding) string {
 	return sb.String()
 }
 
+// motifInstructionsSection is blueprint §2 Block B, VERBATIM and STATIC.
+//
+// "Static" is the whole constraint (roadmap MN1): not one byte of it varies
+// with what the corpus holds. There is no vocabulary listing and no
+// reuse-before-minting rule, and their absence is deliberate and measured — a
+// served list biases authors toward force-fitting a new fact onto an existing
+// name (§12-E3), and cold minting was shown to converge without one (§12-E2).
+// Phrasing convergence is manufactured downstream, in derived state, where
+// being wrong costs a rebuild instead of a fact.
+//
+// The calibrated zero rule at the end is likewise load-bearing: the blunter v1
+// wording suppressed valid motifs in two of three models.
+//
+// Written as an interpreted literal rather than a raw one because the text
+// contains backticks. Guarded byte-for-byte by TestShipBlockB_Verbatim against
+// testdata/motif_block_b.txt, and its corpus-independence by
+// TestMN1_InstructionsAreCorpusIndependent.
+const motifInstructionsSection = "### Motifs\n" +
+	"\n" +
+	"Facts may carry `motifs:` — names for the underlying regularity, independent\n" +
+	"of subject. Motifs exist so that two facts about unrelated subjects can be\n" +
+	"connected when they exemplify the same mechanism: a build tool silently\n" +
+	"mis-configuring on an unset variable and a hook guard that must fail closed\n" +
+	"on a missing field are different subjects with the same motif,\n" +
+	"zero-value-as-valid.\n" +
+	"\n" +
+	"Writing a motif:\n" +
+	"- Apply the transfer test: could a fact in a completely different area of\n" +
+	"  this corpus carry this exact phrase? If not, it is a title fragment, not a\n" +
+	"  motif.\n" +
+	"- Name the regularity, not the instance: atomic-write-via-rename, not\n" +
+	"  keypair-written-atomically.\n" +
+	"- Name the regularity, not its remedy. If a fact describes a problem and its\n" +
+	"  fix, the motif names the problem's shape, never the fix:\n" +
+	"  unmonitored-expiry, not renew-certs-automatically.\n" +
+	"- No subject words: a motif containing an entity name, a domain term, or a\n" +
+	"  path segment of its own fact will be stripped at write time.\n" +
+	"- Prefer the most specific phrasing that still transfers.\n" +
+	"- 2–4 words, kebab-case, noun phrase. One motif is normal; three is the\n" +
+	"  maximum. Never attach two phrasings of the same regularity to one fact —\n" +
+	"  pick the better one; a second motif requires a genuinely second regularity.\n" +
+	"- Zero is correct when the fact records only a quantity or an event (a\n" +
+	"  funding round, an acquisition, a release). But a specific dynamic — a time\n" +
+	"  window between cause and effect, a direction of failure, a feedback loop —\n" +
+	"  IS a general shape and deserves a motif.\n" +
+	"\n" +
+	"What motifs are not: not predictions of where the fact applies, not tags for\n" +
+	"retrieval, not summaries. They are consumed only by synthesis (bridging and\n" +
+	"discovery); a wrong motif costs a wasted discovery candidate, nothing more.\n"
+
 // baseInstructionsText returns the base MCP server instructions with the given ontology root.
 func baseInstructionsText(ontologyRoot string, ontology *fact.Ontology) string {
 	// Build dynamic topic list from ontology.
@@ -167,6 +217,9 @@ Each fact has YAML frontmatter with:
 - **sources**: number of independent sources
 - **refs**: citations. For a fact in THIS repo use the bare path as knomit_query returned it (kb/topic/.../id.md); the server rewrites it to the canonical kb://<repo-id>/<path> form on write, so you never supply this repo's id. For a fact in ANOTHER repo, copy the kb://<repo-id>/<path> form verbatim from the result that gave it to you; knomit_query and knomit_explain already return other repos' paths that way, and knomit_repos lists every mounted repo's id. For source use src://<source-repo-id>/<path>@<commit>:<blob>, where the id is the SOURCE repo's root commit, not a knomit id. A ref to a fact in THIS repo must resolve when the call lands — write the cited fact in the same call, or in an earlier one. A ref that will not resolve rejects the whole call and names every offending ref.
 - **origin**: which pipeline minted the fact — NOT where the information came from. %s Immutable after write — knomit_update cannot change it.
+- **motifs**: 0–3 general regularities this fact instantiates — see the Motifs section below.
+
+%s
 
 ## Tools
 
@@ -226,6 +279,21 @@ Important: hypotheses must only cite observations and synthesis facts as evidenc
 		instructionTypeLines(fact.AllEpistemicTypes(), "    "),
 		instructionTypeLines(fact.AllPragmaticTypes(), "    "),
 		originGlossSentence(),
+		// Block B goes here, "alongside the ontology topics" per §2: inside the
+		// frontmatter section, because that is what it documents, and before
+		// ## Tools so an agent has read the field contract before it reads the
+		// tool that writes it. Static — see the constant.
+		//
+		// The one-line motifs bullet above it is a POINTER, not a second
+		// description. It exists because the frontmatter list is an
+		// ENUMERATION, and readers treat enumerations as complete: without a
+		// motifs line, an agent whose model of a fact's fields comes from that
+		// list is one inference from reading an unlisted `motifs:` on a fact it
+		// is updating as cruft — and knomit_update replaces list fields
+		// wholesale, so that inference deletes them. The rules stay
+		// single-sourced in Block B, and the line is corpus-independent, so MN1
+		// still holds.
+		motifInstructionsSection,
 		ontologyRoot, ontologyRoot, ontologyRoot)
 }
 

--- a/internal/mcp/instructions.go
+++ b/internal/mcp/instructions.go
@@ -126,8 +126,9 @@ const motifInstructionsSection = "### Motifs\n" +
 	"- Name the regularity, not its remedy. If a fact describes a problem and its\n" +
 	"  fix, the motif names the problem's shape, never the fix:\n" +
 	"  unmonitored-expiry, not renew-certs-automatically.\n" +
-	"- No subject words: a motif containing an entity name, a domain term, or a\n" +
-	"  path segment of its own fact will be stripped at write time.\n" +
+	"- No subject words: a motif built entirely from its own fact's subject\n" +
+	"  words (entity names, domain terms, path segments) will be stripped at\n" +
+	"  write time.\n" +
 	"- Prefer the most specific phrasing that still transfers.\n" +
 	"- 2–4 words, kebab-case, noun phrase. One motif is normal; three is the\n" +
 	"  maximum. Never attach two phrasings of the same regularity to one fact —\n" +
@@ -235,7 +236,7 @@ Each fact has YAML frontmatter with:
   - min_confidence: minimum confidence threshold (0–1)
   - sort: set to "recent" to browse facts ordered by most recently committed (paginated, 25 per page). Use path to scope to a subtree. Pass the returned cursor to get the next page.
 - **knomit_explain**: explain a fact by walking its versioned provenance graph. Anchored at a commit — pass commit to explain the fact AS OF that version (the graph is rewound to how it stood then), or omit it for HEAD. Every referenced fact is read at the exact version the referrer pointed to, recursively. The root fact comes back in full with its evolution history (recent revisions + confidence/content diffs); every other fact is a lean summary (no body) flagged summary:true — re-call knomit_explain with that fact's path AND commit to read it in full and walk its subtree. A summary may be flagged deleted:true (source retracted since the edge formed) or superseded:true (source still live but changed since the referrer reasoned over it). Use file to start, pass cursor for next page. External URL refs are returned for you to inspect.
-- **knomit_update**: modify an existing fact's fields. List fields (domain, entities, refs) are replaced wholesale — send the complete new list, because any existing entry you leave out is dropped; omit a field entirely to leave it unchanged. Prior revisions keep their refs in history, so replacing refs never erases past provenance. It cannot change origin or the topic/category path — fixing those requires knomit_retract plus a fresh knomit_learn.
+- **knomit_update**: modify an existing fact's fields. List fields (domain, entities, motifs, refs) are replaced wholesale — send the complete new list, because any existing entry you leave out is dropped; omit a field entirely to leave it unchanged. Prior revisions keep their refs in history, so replacing refs never erases past provenance. It cannot change origin or the topic/category path — fixing those requires knomit_retract plus a fresh knomit_learn.
 - **knomit_retract**: remove outdated knowledge
 
 ## knomit_review — Knowledge Base Maintenance

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -334,7 +334,9 @@ func newFactWins(newFact, existing fact.Fact) bool {
 // the identity — title, body, kind, type, origin — while the metadata is
 // always pooled, because both facts are evidence of the same thing. Confidence
 // takes the max rather than the winner's, and sources add: two independent
-// observations of one fact are worth more than either alone. Pure.
+// observations of one fact are worth more than either alone. Motifs are the
+// one field that unions WINNER-first, because they are capped and so their
+// order decides what survives — see the call site. Pure.
 //
 // existingPath is the existing fact's RAW on-disk path and is deliberately
 // distinct from existing.Path(). The two differ in case: existing came from
@@ -347,23 +349,39 @@ func newFactWins(newFact, existing fact.Fact) bool {
 // names nothing on disk, so every provenance walk through that edge dangles.
 func mergeFacts(newFact, existing fact.Fact, existingPath string) fact.Fact {
 	merged := fact.NewFact(existing.Path())
+	winner, loser := existing, newFact
 	if newFactWins(newFact, existing) {
-		merged.Title = newFact.Title
-		merged.Body = newFact.Body
-		merged.Kind = newFact.Kind
-		merged.Type = newFact.Type
-		// New fact's identity wins, so its origin wins too.
-		merged.Origin = newFact.Origin
-	} else {
-		merged.Title = existing.Title
-		merged.Body = existing.Body
-		merged.Kind = existing.Kind
-		merged.Type = existing.Type
-		// Existing fact's identity wins, so its origin wins too.
-		merged.Origin = existing.Origin
+		winner, loser = newFact, existing
 	}
+	merged.Title = winner.Title
+	merged.Body = winner.Body
+	merged.Kind = winner.Kind
+	merged.Type = winner.Type
+	// The winner's identity wins, so its origin wins too.
+	merged.Origin = winner.Origin
+
 	merged.Domain = fact.UnionStrings(newFact.Domain, existing.Domain)
 	merged.Entities = fact.UnionStrings(newFact.Entities, existing.Entities)
+	// Motifs union WINNER-first — not incoming-first like domain and entities
+	// on the two lines above — and are then trimmed to the cap (§2.1).
+	//
+	// The inconsistency with its immediate neighbours is deliberate, and it is
+	// the spec's. Domain and entities are uncapped, so their order is cosmetic:
+	// every value survives whichever way round they go. Motifs are capped at
+	// three, so order decides what SURVIVES. Dropping the winner's own naming
+	// of its regularity in favour of the loser's, because the loser happened to
+	// arrive in the newFact slot, would contradict the tiebreak philosophy
+	// every other field here follows — the winner contributes the identity.
+	//
+	// Trimming here rather than letting SerializeFact reject the over-cap list
+	// is what keeps a routine merge from failing a caller's whole learn call.
+	// Cross-parent phrasing duplicates that are not string-equal ride along and
+	// cost a slot until alias resolution collapses them in derived state; that
+	// is the accepted price of doing this mechanically at learn time.
+	merged.Motifs = fact.UnionStrings(winner.Motifs, loser.Motifs)
+	if len(merged.Motifs) > fact.MaxMotifs {
+		merged.Motifs = merged.Motifs[:fact.MaxMotifs]
+	}
 	merged.Confidence = max(newFact.Confidence, existing.Confidence)
 	merged.Sources = newFact.Sources + existing.Sources
 	// Raw path, not existing.Path(): see the doc comment above.

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -378,26 +378,11 @@ func mergeFacts(newFact, existing fact.Fact, existingPath string) fact.Fact {
 
 	merged.Domain = fact.UnionStrings(newFact.Domain, existing.Domain)
 	merged.Entities = fact.UnionStrings(newFact.Entities, existing.Entities)
-	// Motifs union WINNER-first — not incoming-first like domain and entities
-	// on the two lines above — and are then trimmed to the cap (§2.1).
-	//
-	// The inconsistency with its immediate neighbours is deliberate, and it is
-	// the spec's. Domain and entities are uncapped, so their order is cosmetic:
-	// every value survives whichever way round they go. Motifs are capped at
-	// three, so order decides what SURVIVES. Dropping the winner's own naming
-	// of its regularity in favour of the loser's, because the loser happened to
-	// arrive in the newFact slot, would contradict the tiebreak philosophy
-	// every other field here follows — the winner contributes the identity.
-	//
-	// Trimming here rather than letting SerializeFact reject the over-cap list
-	// is what keeps a routine merge from failing a caller's whole learn call.
-	// Cross-parent phrasing duplicates that are not string-equal ride along and
-	// cost a slot until alias resolution collapses them in derived state; that
-	// is the accepted price of doing this mechanically at learn time.
-	merged.Motifs = fact.UnionStrings(winner.Motifs, loser.Motifs)
-	if len(merged.Motifs) > fact.MaxMotifs {
-		merged.Motifs = merged.Motifs[:fact.MaxMotifs]
-	}
+	// Motifs union WINNER-first and trim at the cap — deliberately unlike the
+	// incoming-first domain and entity unions two lines above. The rule and the
+	// reasoning live in fact.MergeMotifs, shared with the review-session merge
+	// so the two cannot drift.
+	merged.Motifs = fact.MergeMotifs(winner.Motifs, loser.Motifs)
 	merged.Confidence = max(newFact.Confidence, existing.Confidence)
 	merged.Sources = newFact.Sources + existing.Sources
 	// Raw path, not existing.Path(): see the doc comment above.

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -67,39 +67,50 @@ func learnTool() mcpgo.Tool {
 			mcpgo.Required(),
 			mcpgo.Description("Array of fact objects to write."),
 			mcpgo.Items(map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					// topic and category are REQUIRED for knowledge, but cannot
-					// say so in the schema's `required` list: `path` replaces
-					// them for private state, and JSON Schema cannot express
-					// "one or the other" in a list. The descriptions carry the
-					// rule instead.
-					"topic":    map[string]any{"type": "string", "description": "Top-level ontology topic (e.g. technology, people, science). REQUIRED unless you supply path."},
-					"category": map[string]any{"type": "string", "description": "Category path within the topic (e.g. languages/go/concurrency). REQUIRED unless you supply path."},
-					"path":     map[string]any{"type": "string", "description": "PRIVATE STATE ONLY. An explicit repo path under " + fact.PrivateRoot + "/<area>/, e.g. " + fact.PrivateRoot + "/<area>/<name>.md, where <area> is a directory name containing no dot, for machinery that is not knowledge — a periodic job's bookkeeping. Mutually exclusive with topic/category: supply one or the other, never both. A fact written here is INVISIBLE to knomit_query, the UI and export, by design; address it later by this exact path. Fails if the path already exists — use knomit_update to write a new revision."},
-					"title":    map[string]any{"type": "string", "description": "Fact title (short, descriptive)."},
-					"body":     map[string]any{"type": "string", "description": "Fact body in natural language. State compound conditions in full — name every component; never abbreviate a multi-part condition into a catchier summary. Include the consequence a consumer should act on. For rules and policies, name the foreseeable misreading (what the fact does NOT mean) if you can see one."},
-					// kind/type/origin come from the shared fragments in
-					// factschema.go so this schema, knomit_update's, and the
-					// server instructions cannot disagree. knomit_learn mints
-					// facts, so it declares the defaults it will assume.
-					"kind":       kindProperty(fact.DefaultKind),
-					"type":       typeProperty(fact.DefaultEpistemicType),
-					"origin":     originProperty(),
-					"domain":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Cross-cutting domain tags."},
-					"confidence": map[string]any{"type": "number", "description": "Certainty level 0.0–1.0.", "default": defaultConfidence},
-					"sources":    map[string]any{"type": "integer", "description": "Count of independent corroborations — how many independent agents or observations produced this fact.", "default": defaultSources},
-					"entities":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Entities this fact mentions."},
-					"refs": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "References, in four forms. " +
-						"(1) A fact in THIS repo: use the bare path, `kb/<topic>/…/<id>.md` — exactly as it appears in a knomit_query result. You never need this repo's id: the server rewrites the ref to the canonical `kb://<repo-id>/<path>` form on write. The target MUST already exist, or be written in this same call — all facts in one call are committed together, so they may cite each other in any order, including circularly. Citing a fact that will not exist REJECTS the whole call and names every offending ref. " +
-						"(2) A fact in ANOTHER repo: `kb://<repo-id>/<path>`. Do not build this yourself — COPY it verbatim from the knomit_query or knomit_explain result that gave you the fact, which already returns other repos' paths in this form. (knomit_repos lists every mounted repo's id if you need to look one up.) Never checked. " +
-						"(3) Source code: `src://<source-repo-id>/<path>@<commit>:<blob>`, with FULL 40-hex commit and blob, optionally `#L<start>-L<end>`. This id is the SOURCE repo's, not a knomit repo id — get all three components by running git in the checkout you are citing: `git rev-list --max-parents=0 HEAD | cut -c1-12` (repo id), `git rev-parse HEAD` (commit), `git rev-parse <commit>:<path>` (blob). That last command failing IS the check — the server holds no source objects and cannot verify src refs for you, so never cite source that does not exist in the repo's history. The older `src://<name>/<path>@<commit>` form is still accepted and is never rewritten. " +
-						"(4) An external URL: `https://…` or `file:///…`."},
-				},
-				"required": []string{"title", "body"},
+				"type":       "object",
+				"properties": learnToolSchemaProperties(),
+				"required":   []string{"title", "body"},
 			}),
 		),
 	)
+}
+
+// learnToolSchemaProperties is the knomit_learn input schema's properties map.
+//
+// Extracted from the registration literal above so conformance tests can read
+// the bytes actually served — in particular that the motifs description is
+// blueprint §2 Block A verbatim. The registration is its only production
+// caller.
+func learnToolSchemaProperties() map[string]any {
+	return map[string]any{
+		// topic and category are REQUIRED for knowledge, but cannot
+		// say so in the schema's `required` list: `path` replaces
+		// them for private state, and JSON Schema cannot express
+		// "one or the other" in a list. The descriptions carry the
+		// rule instead.
+		"topic":    map[string]any{"type": "string", "description": "Top-level ontology topic (e.g. technology, people, science). REQUIRED unless you supply path."},
+		"category": map[string]any{"type": "string", "description": "Category path within the topic (e.g. languages/go/concurrency). REQUIRED unless you supply path."},
+		"path":     map[string]any{"type": "string", "description": "PRIVATE STATE ONLY. An explicit repo path under " + fact.PrivateRoot + "/<area>/, e.g. " + fact.PrivateRoot + "/<area>/<name>.md, where <area> is a directory name containing no dot, for machinery that is not knowledge — a periodic job's bookkeeping. Mutually exclusive with topic/category: supply one or the other, never both. A fact written here is INVISIBLE to knomit_query, the UI and export, by design; address it later by this exact path. Fails if the path already exists — use knomit_update to write a new revision."},
+		"title":    map[string]any{"type": "string", "description": "Fact title (short, descriptive)."},
+		"body":     map[string]any{"type": "string", "description": "Fact body in natural language. State compound conditions in full — name every component; never abbreviate a multi-part condition into a catchier summary. Include the consequence a consumer should act on. For rules and policies, name the foreseeable misreading (what the fact does NOT mean) if you can see one."},
+		// kind/type/origin come from the shared fragments in
+		// factschema.go so this schema, knomit_update's, and the
+		// server instructions cannot disagree. knomit_learn mints
+		// facts, so it declares the defaults it will assume.
+		"kind":       kindProperty(fact.DefaultKind),
+		"type":       typeProperty(fact.DefaultEpistemicType),
+		"origin":     originProperty(),
+		"domain":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Cross-cutting domain tags."},
+		"confidence": map[string]any{"type": "number", "description": "Certainty level 0.0–1.0.", "default": defaultConfidence},
+		"sources":    map[string]any{"type": "integer", "description": "Count of independent corroborations — how many independent agents or observations produced this fact.", "default": defaultSources},
+		"entities":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Entities this fact mentions."},
+		"motifs":     motifsProperty(),
+		"refs": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "References, in four forms. " +
+			"(1) A fact in THIS repo: use the bare path, `kb/<topic>/…/<id>.md` — exactly as it appears in a knomit_query result. You never need this repo's id: the server rewrites the ref to the canonical `kb://<repo-id>/<path>` form on write. The target MUST already exist, or be written in this same call — all facts in one call are committed together, so they may cite each other in any order, including circularly. Citing a fact that will not exist REJECTS the whole call and names every offending ref. " +
+			"(2) A fact in ANOTHER repo: `kb://<repo-id>/<path>`. Do not build this yourself — COPY it verbatim from the knomit_query or knomit_explain result that gave you the fact, which already returns other repos' paths in this form. (knomit_repos lists every mounted repo's id if you need to look one up.) Never checked. " +
+			"(3) Source code: `src://<source-repo-id>/<path>@<commit>:<blob>`, with FULL 40-hex commit and blob, optionally `#L<start>-L<end>`. This id is the SOURCE repo's, not a knomit repo id — get all three components by running git in the checkout you are citing: `git rev-list --max-parents=0 HEAD | cut -c1-12` (repo id), `git rev-parse HEAD` (commit), `git rev-parse <commit>:<path>` (blob). That last command failing IS the check — the server holds no source objects and cannot verify src refs for you, so never cite source that does not exist in the repo's history. The older `src://<name>/<path>@<commit>` form is still accepted and is never rewritten. " +
+			"(4) An external URL: `https://…` or `file:///…`."},
+	}
 }
 
 // learnFactInput is the JSON shape of a single fact in the input array.
@@ -125,6 +136,7 @@ type learnFactInput struct {
 	Confidence *float64 `json:"confidence"`
 	Sources    *int     `json:"sources"`
 	Entities   []string `json:"entities"`
+	Motifs     []string `json:"motifs"`
 	Refs       []string `json:"refs"`
 	Origin     string   `json:"origin"`
 }
@@ -287,6 +299,10 @@ func validateAndBuildFacts(ontology *fact.Ontology, ontologyRoot string, inputs 
 			f.Sources = *fi.Sources
 		}
 		f.Entities = entities
+		// Passed through untouched: SerializeFact is the single gate (MN4). A
+		// subject motif is dropped there, silently, and a malformed one fails
+		// the call there — neither decision belongs in a handler.
+		f.Motifs = fi.Motifs
 		f.Refs = refs
 		// Explicit origin: set it and let SerializeFact validate, the
 		// same way (kind, type) is handled above — one chokepoint, so

--- a/internal/mcp/learn_motif_test.go
+++ b/internal/mcp/learn_motif_test.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// motifMergeFixture builds a new/existing pair whose winner is the one the
+// caller asked for, asserts that intent against newFactWins so the fixture
+// cannot silently invert, and returns the merge result.
+func motifMergeFixture(t *testing.T, newMotifs, existingMotifs []string, newWins bool) fact.Fact {
+	t.Helper()
+	nf := fact.NewFact("kb/alpha/new.md")
+	nf.Title = "New"
+	nf.Body = "New body"
+	nf.Type = fact.Observation
+	nf.Confidence = 0.9
+	nf.Sources = 1
+	nf.Motifs = newMotifs
+
+	ex := fact.NewFact("kb/alpha/existing.md")
+	ex.Title = "Existing"
+	ex.Body = "Existing body"
+	ex.Type = fact.Observation
+	ex.Confidence = 0.5
+	ex.Sources = 1
+	ex.Motifs = existingMotifs
+
+	if !newWins {
+		nf.Confidence, ex.Confidence = 0.5, 0.9
+	}
+	require.Equal(t, newWins, newFactWins(nf, ex), "fixture must produce the intended winner")
+	return mergeFacts(nf, ex, "kb/alpha/existing.md")
+}
+
+// TestMergeFacts_MotifsWinnerFirstTrimAtCap is the roadmap's conformance case,
+// verbatim: winner has 2, loser has 3, and exactly the winner's 2 plus the
+// loser's FIRST 1 survive, in that order.
+func TestMergeFacts_MotifsWinnerFirstTrimAtCap(t *testing.T) {
+	merged := motifMergeFixture(t,
+		[]string{"win-one", "win-two"},
+		[]string{"lose-one", "lose-two", "lose-three"},
+		true)
+	require.Equal(t, []string{"win-one", "win-two", "lose-one"}, merged.Motifs)
+}
+
+// TestMergeFacts_MotifsFollowTheWinnerNotTheCaller — same inputs, opposite
+// winner, so the order flips. This is what distinguishes winner-first from the
+// incoming-first union that domain and entities happen to use; without it a
+// test could pass on either implementation.
+func TestMergeFacts_MotifsFollowTheWinnerNotTheCaller(t *testing.T) {
+	merged := motifMergeFixture(t,
+		[]string{"new-one", "new-two"},
+		[]string{"old-one", "old-two", "old-three"},
+		false)
+	require.Equal(t, []string{"old-one", "old-two", "old-three"}, merged.Motifs)
+}
+
+// TestMergeFacts_DomainAndEntitiesStayIncomingFirst pins the deliberate local
+// inconsistency, so a later tidying pass cannot "make them consistent" without
+// a failing test to argue with. Domain and entities are uncapped, so their
+// order is cosmetic; motifs are capped, so order decides what survives.
+func TestMergeFacts_DomainAndEntitiesStayIncomingFirst(t *testing.T) {
+	nf := fact.NewFact("kb/alpha/new.md")
+	nf.Title, nf.Body, nf.Type = "New", "New body", fact.Observation
+	nf.Confidence, nf.Sources = 0.5, 1 // loses
+	nf.Domain = []string{"new-domain"}
+	nf.Entities = []string{"NewEntity"}
+
+	ex := fact.NewFact("kb/alpha/existing.md")
+	ex.Title, ex.Body, ex.Type = "Existing", "Existing body", fact.Observation
+	ex.Confidence, ex.Sources = 0.9, 1 // wins
+	ex.Domain = []string{"old-domain"}
+	ex.Entities = []string{"OldEntity"}
+
+	require.False(t, newFactWins(nf, ex))
+	merged := mergeFacts(nf, ex, "kb/alpha/existing.md")
+
+	require.Equal(t, []string{"new-domain", "old-domain"}, merged.Domain,
+		"domain stays incoming-first even when the incoming fact loses")
+	require.Equal(t, []string{"NewEntity", "OldEntity"}, merged.Entities,
+		"entities stay incoming-first even when the incoming fact loses")
+}
+
+func TestMergeFacts_MotifsDeduplicateAcrossParents(t *testing.T) {
+	merged := motifMergeFixture(t,
+		[]string{"shared-shape"},
+		[]string{"shared-shape", "other-shape"},
+		true)
+	require.Equal(t, []string{"shared-shape", "other-shape"}, merged.Motifs)
+}
+
+func TestMergeFacts_MotifsEmptyStaysEmpty(t *testing.T) {
+	merged := motifMergeFixture(t, nil, nil, true)
+	require.Nil(t, merged.Motifs)
+}
+
+// TestMergeFacts_MergedFactSerializes — an over-cap union that was not trimmed
+// would fail SerializeFact and abort the whole knomit_learn call, turning a
+// routine merge into a user-visible error. Trimming in the merge is what keeps
+// that from happening.
+func TestMergeFacts_MergedFactSerializes(t *testing.T) {
+	merged := motifMergeFixture(t,
+		[]string{"win-one", "win-two", "win-three"},
+		[]string{"lose-one", "lose-two", "lose-three"},
+		true)
+	merged.Domain = []string{}
+	merged.Entities = []string{}
+	merged.Refs = []string{}
+	_, err := fact.SerializeFact(merged)
+	require.NoError(t, err)
+	require.Len(t, merged.Motifs, fact.MaxMotifs)
+}

--- a/internal/mcp/learn_motif_test.go
+++ b/internal/mcp/learn_motif_test.go
@@ -1,12 +1,25 @@
 package mcp
 
 import (
+	"context"
 	"testing"
 
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/fact"
+	"knomit/internal/repos"
 )
+
+// riFrom pulls the write RepoInstance back out of a handler context, so these
+// tests can reuse readFactAt (write_path_test.go) instead of shipping a
+// near-duplicate keyed on *store.Service.
+func riFrom(t *testing.T, ctx context.Context) *repos.RepoInstance {
+	t.Helper()
+	b := repos.BindingFromContext(ctx)
+	require.NotNil(t, b)
+	return b.Write()
+}
 
 // motifMergeFixture builds a new/existing pair whose winner is the one the
 // caller asked for, asserts that intent against newFactWins so the fixture
@@ -113,4 +126,133 @@ func TestMergeFacts_MergedFactSerializes(t *testing.T) {
 	_, err := fact.SerializeFact(merged)
 	require.NoError(t, err)
 	require.Len(t, merged.Motifs, fact.MaxMotifs)
+}
+
+// motifLearnReq is one observation carrying motifs, with a body whose LENGTH
+// is controlled — newLenEmbedder keys similarity on length, so two requests
+// with equal-length bodies dedup-match.
+func motifLearnReq(moment, body string, confidence float64, motifs []any) mcpgo.CallToolRequest {
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"moment_name": moment,
+		"facts": []any{
+			map[string]any{
+				"topic":      "gotchas",
+				"category":   "build/tooling",
+				"title":      "A build gotcha",
+				"body":       body,
+				"type":       "observation",
+				"domain":     []any{"build"},
+				"confidence": confidence,
+				"sources":    1,
+				"entities":   []any{"Bazel"},
+				"motifs":     motifs,
+				"refs":       []any{},
+			},
+		},
+	}
+	return req
+}
+
+// TestLearnHandler_MotifsSurviveDedupMergeAcrossSessions is Phase 1's named
+// dynamics question, asked end-to-end: a motif written in session N must
+// survive the dedup merge in session N+1, and the survivors must be the
+// winner's first.
+//
+// It drives the real knomit_learn handler rather than mergeFacts directly. The
+// unit tests next door already pin the merge function; what they cannot see is
+// whether the handler carries motifs into it at all, whether the merged fact
+// serializes, and whether what lands on disk matches — three places a correct
+// merge function still ends up storing nothing.
+func TestLearnHandler_MotifsSurviveDedupMergeAcrossSessions(t *testing.T) {
+	_, ctx, emb := newPrinciplesTestRepo(t)
+
+	// Session N: two motifs, lower confidence, so it LOSES the merge below.
+	body := "the toolchain silently falls back when the variable is unset...."
+	r1, err := LearnHandler(emb)(ctx, motifLearnReq("session-n", body, 0.6,
+		[]any{"silent-fallback", "config-drift"}))
+	require.NoError(t, err)
+	require.False(t, r1.IsError, "seed write must succeed: %s", resultText(t, r1))
+
+	seedPath := mergedFactPath(t, r1)
+	seed := readFactAt(t, riFrom(t, ctx), seedPath)
+	require.Equal(t, []string{"silent-fallback", "config-drift"}, seed.Motifs,
+		"session N must actually store its motifs, or the merge below proves nothing")
+
+	// Session N+1: same body length so dedup matches, higher confidence so the
+	// INCOMING fact wins, and three motifs of its own.
+	r2, err := LearnHandler(emb)(ctx, motifLearnReq("session-n-plus-1", body, 0.9,
+		[]any{"unmonitored-expiry", "harness-over-model", "capital-influx"}))
+	require.NoError(t, err)
+	require.False(t, r2.IsError, "the merge must not fail the call: %s", resultText(t, r2))
+
+	mergedPath := mergedFactPath(t, r2)
+	merged := readFactAt(t, riFrom(t, ctx), mergedPath)
+
+	// A MERGE must have happened, not two separate facts. Without these two
+	// lines every assertion below also holds when dedup missed entirely and
+	// session N+1 simply minted its own fact carrying its own three motifs —
+	// the test would pass while proving nothing about the merge at all.
+	require.Equal(t, seedPath, mergedPath,
+		"session N+1 must have merged INTO the seed, not landed at its own path")
+	require.Equal(t, 2, merged.Sources, "a merge sums sources")
+	require.Equal(t, 0.9, merged.Confidence, "the new fact must have won the merge")
+
+	require.Equal(t,
+		[]string{"unmonitored-expiry", "harness-over-model", "capital-influx"},
+		merged.Motifs,
+		"the winner's three motifs fill the cap; the loser's are dropped, not interleaved")
+}
+
+// TestLearnHandler_MotifsMergeWinnerFirstOnDisk — the same path with room left
+// over, so the loser's motifs actually appear and their ORDER is observable on
+// disk rather than only in the merge function's return value.
+func TestLearnHandler_MotifsMergeWinnerFirstOnDisk(t *testing.T) {
+	_, ctx, emb := newPrinciplesTestRepo(t)
+
+	body := "the toolchain silently falls back when the variable is unset...."
+	r1, err := LearnHandler(emb)(ctx, motifLearnReq("session-n", body, 0.6,
+		[]any{"config-drift"}))
+	require.NoError(t, err)
+	require.False(t, r1.IsError, resultText(t, r1))
+
+	r2, err := LearnHandler(emb)(ctx, motifLearnReq("session-n-plus-1", body, 0.9,
+		[]any{"silent-fallback"}))
+	require.NoError(t, err)
+	require.False(t, r2.IsError, resultText(t, r2))
+
+	mergedPath := mergedFactPath(t, r2)
+	require.Equal(t, mergedFactPath(t, r1), mergedPath, "the two writes must have merged")
+	merged := readFactAt(t, riFrom(t, ctx), mergedPath)
+	require.Equal(t, 2, merged.Sources, "a merge sums sources")
+	require.Equal(t, []string{"silent-fallback", "config-drift"}, merged.Motifs,
+		"winner first, then the loser's — on disk, not just in memory")
+}
+
+// TestLearnHandler_MalformedMotifFailsTheCall — the gate is real at the tool
+// boundary, not only in a unit test of SerializeFact.
+func TestLearnHandler_MalformedMotifFailsTheCall(t *testing.T) {
+	_, ctx, emb := newPrinciplesTestRepo(t)
+
+	r, err := LearnHandler(emb)(ctx, motifLearnReq("bad", "a body of some length here.", 0.8,
+		[]any{"onlyoneword"}))
+	require.NoError(t, err)
+	require.True(t, r.IsError, "a malformed motif must fail the call, not be silently dropped")
+	require.Contains(t, resultText(t, r), "kebab-case words")
+}
+
+// TestLearnHandler_SubjectMotifIsDroppedSilently — the other half of the
+// contract at the same boundary: the call SUCCEEDS and the fact stores without
+// the motif.
+func TestLearnHandler_SubjectMotifIsDroppedSilently(t *testing.T) {
+	_, ctx, emb := newPrinciplesTestRepo(t)
+
+	// "bazel-build" is entity ∪ domain for motifLearnReq's fixtures.
+	r, err := LearnHandler(emb)(ctx, motifLearnReq("subject", "a body of some length here.", 0.8,
+		[]any{"bazel-build", "silent-fallback"}))
+	require.NoError(t, err)
+	require.False(t, r.IsError, "the strip must not fail the call: %s", resultText(t, r))
+
+	stored := readFactAt(t, riFrom(t, ctx), mergedFactPath(t, r))
+	require.Equal(t, []string{"silent-fallback"}, stored.Motifs)
 }

--- a/internal/mcp/motif_acceptance_test.go
+++ b/internal/mcp/motif_acceptance_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -37,6 +38,7 @@ func TestAcceptance_MotifInstructions(t *testing.T) {
 	if dbPath == "" {
 		t.Skip("set KNOMIT_PHASE1_DB to a COPY of a repo database to run the acceptance measurement")
 	}
+	requireCopyNotLiveCorpus(t, dbPath)
 	ctx := context.Background()
 
 	svc, err := store.Open(dbPath)
@@ -82,7 +84,7 @@ func TestAcceptance_MotifInstructions(t *testing.T) {
 	// The LEAK check is what this harness adds over the unit test.
 	//
 	// Byte-identity across corpora is proven structurally: the corpus is not an
-	// input to ProfileInstructions at all, and TestMN1_InstructionsAreCorpusIndependent
+	// input to ProfileInstructions at all, and TestMN1_InstructionsCarryNoCorpusVocabulary
 	// builds both sides from real stores and compares bytes. Re-staging that
 	// here would be a comparison of a value with itself. What only a real
 	// corpus can test is whether any of the strings it ACTUALLY holds appear in
@@ -151,4 +153,30 @@ func corpusMotifs(ctx context.Context, svc *store.Service, branch string) ([]str
 	}
 	sort.Strings(out)
 	return out, nil
+}
+
+// requireCopyNotLiveCorpus refuses to run against a database inside the user's
+// knomit home.
+//
+// "Work on a COPY" was a comment, and a comment is not enforcement. Both
+// acceptance harnesses migrate the schema, and the instructions one WRITES a
+// sentinel fact through the ordinary path — pointed at a live repo that is a
+// stray commit on someone's real knowledge base, produced by a test run they
+// thought was read-only. The check is a refusal, never a skip: a harness that
+// quietly did nothing here would look like it had passed.
+func requireCopyNotLiveCorpus(t *testing.T, dbPath string) {
+	t.Helper()
+	abs, err := filepath.Abs(dbPath)
+	require.NoError(t, err)
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	live := filepath.Join(home, ".knomit")
+	rel, err := filepath.Rel(live, abs)
+	require.NoError(t, err)
+	require.Truef(t, strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == "..",
+		"refusing to run against %s: it is inside %s, which is a LIVE corpus. "+
+			"This harness migrates the schema and writes a fact. Copy the database "+
+			"out first:\n    cp %s /tmp/accept.db\n    KNOMIT_PHASE1_DB=/tmp/accept.db go test ...",
+		abs, live, abs)
 }

--- a/internal/mcp/motif_acceptance_test.go
+++ b/internal/mcp/motif_acceptance_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// TestAcceptance_MotifInstructions is Phase 1's SECOND acceptance item against
+// a real corpus: the served instructions must be the same bytes whether the
+// corpus is empty or full of motifs.
+//
+// The unit test next door proves this on a fixture. This proves it on real
+// data, where a templating mistake would have real vocabulary available to
+// leak — and it names every motif the corpus actually holds, so the log says
+// whether the check had anything to leak in the first place. A pass on a corpus
+// carrying zero motifs is a pass that proved nothing, and the output makes that
+// visible rather than hiding it behind a green tick.
+//
+// The first item — a subject-restating motif stores without it — is measured by
+// TestAcceptance_MotifField in internal/synthesize.
+//
+//	cp ~/.knomit/repos/<uid>.db /tmp/accept.db
+//	KNOMIT_PHASE1_DB=/tmp/accept.db go test ./internal/mcp/ \
+//	    -run TestAcceptance_MotifInstructions -v
+//
+// Work on a COPY. The run migrates the schema.
+func TestAcceptance_MotifInstructions(t *testing.T) {
+	dbPath := os.Getenv("KNOMIT_PHASE1_DB")
+	if dbPath == "" {
+		t.Skip("set KNOMIT_PHASE1_DB to a COPY of a repo database to run the acceptance measurement")
+	}
+	ctx := context.Background()
+
+	svc, err := store.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.OpenRepo())
+
+	branch := os.Getenv("KNOMIT_PHASE1_BRANCH")
+	if branch == "" {
+		branch, err = svc.Branches().DefaultBranch(ctx)
+		require.NoError(t, err)
+	}
+
+	motifs, err := corpusMotifs(ctx, svc, branch)
+	require.NoError(t, err)
+	t.Logf("corpus %q carries %d distinct motif strings", branch, len(motifs))
+	if len(motifs) > 0 {
+		show := motifs
+		if len(show) > 25 {
+			show = show[:25]
+		}
+		t.Logf("sample: %s", strings.Join(show, ", "))
+	} else {
+		t.Log("NOTE: this corpus carries no motifs of its own yet — expected " +
+			"before anything has written one. The planted sentinel below is " +
+			"what keeps the leak check from passing vacuously.")
+	}
+
+	// Plant a sentinel so the leak check is REAL regardless of corpus state.
+	// Without it, a corpus that carries no motifs yet — which every corpus does
+	// until an agent writes one — makes this test a green tick over an empty
+	// loop. The sentinel is written through the ordinary write path into the
+	// COPY, so it is a genuine corpus motif by the time it is checked.
+	const sentinel = "sentinel-leak-canary"
+	plantMotif(t, svc, branch, sentinel)
+	motifs = append(motifs, sentinel)
+
+	replanted, err := corpusMotifs(ctx, svc, branch)
+	require.NoError(t, err)
+	require.Contains(t, replanted, sentinel,
+		"the sentinel must actually be in the corpus, or it proves nothing")
+
+	// The LEAK check is what this harness adds over the unit test.
+	//
+	// Byte-identity across corpora is proven structurally: the corpus is not an
+	// input to ProfileInstructions at all, and TestMN1_InstructionsAreCorpusIndependent
+	// builds both sides from real stores and compares bytes. Re-staging that
+	// here would be a comparison of a value with itself. What only a real
+	// corpus can test is whether any of the strings it ACTUALLY holds appear in
+	// what a session is served — a templating mistake needs real vocabulary
+	// available before it can leak any.
+	for _, profile := range []string{"code", "chat", "generic"} {
+		t.Run(profile, func(t *testing.T) {
+			served := ProfileInstructions(profile, "kb", fact.CodeOntology())
+			require.Contains(t, served, "### Motifs")
+			for _, m := range motifs {
+				require.NotContainsf(t, served, m,
+					"MN1: the corpus motif %q leaked into the %s instructions", m, profile)
+			}
+			t.Logf("%s: %d bytes, leaks none of the %d corpus motifs",
+				profile, len(served), len(motifs))
+		})
+	}
+}
+
+// plantMotif writes one fact carrying motif into the copied corpus, so the leak
+// check has something to leak on a corpus that has none of its own yet.
+func plantMotif(t *testing.T, svc *store.Service, branch, motif string) {
+	t.Helper()
+	f := fact.NewFact("kb/meta/acceptance/motif-sentinel.md")
+	f.Title = "Acceptance sentinel"
+	f.Body = "Planted by TestAcceptance_MotifInstructions. Safe to delete."
+	f.Type = fact.Observation
+	f.Domain = []string{"meta"}
+	f.Entities = []string{}
+	f.Refs = []string{}
+	f.Confidence = 0.5
+	f.Sources = 1
+	f.Motifs = []string{motif}
+	body, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(context.Background(), branch, f.Path(), body,
+		"acceptance: plant motif sentinel", "test")
+	require.NoError(t, err)
+}
+
+// corpusMotifs returns every distinct motif string live on branch, read from
+// the committed files rather than the junction so it reports what is actually
+// on disk.
+func corpusMotifs(ctx context.Context, svc *store.Service, branch string) ([]string, error) {
+	paths, err := svc.Facts().ListAll(ctx, branch)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, p := range paths {
+		res, rerr := svc.Facts().ReadFact(ctx, branch, p, nil)
+		if rerr != nil {
+			continue
+		}
+		f, perr := fact.ParseFact(p, res.Content)
+		if perr != nil {
+			continue // not a fact file
+		}
+		for _, m := range f.Motifs {
+			if !seen[m] {
+				seen[m] = true
+				out = append(out, m)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/mcp/motif_conformance_test.go
+++ b/internal/mcp/motif_conformance_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// readShipText loads a SHIP block golden file.
+//
+// It ERRORS on a missing file rather than skipping. The blueprint these blocks
+// come from lives under .claude/, which .gitignore excludes, so these goldens
+// are the only in-repo copy of the verbatim product text — and a test that
+// quietly disabled itself when its subject went missing would be no test at
+// all.
+func readShipText(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile("testdata/" + name)
+	require.NoErrorf(t, err,
+		"SHIP golden %s must exist — it is the only in-repo copy of blueprint §2 text", name)
+	got := strings.TrimRight(string(b), "\n")
+	require.NotEmpty(t, got, "SHIP golden %s is empty; this check would pass vacuously", name)
+	return got
+}
+
+// TestShipBlockA_Verbatim — the field description in both write-tool schemas
+// is blueprint §2 Block A, byte for byte, and it is the SAME string in both,
+// because knomit_learn and knomit_update describe one field.
+func TestShipBlockA_Verbatim(t *testing.T) {
+	want := readShipText(t, "motif_block_a.txt")
+	require.Equal(t, want, motifFieldDescription)
+
+	for _, tc := range []struct {
+		tool   string
+		schema map[string]any
+	}{
+		{"knomit_learn", learnToolSchemaProperties()},
+		{"knomit_update", updateToolSchemaProperties()},
+	} {
+		t.Run(tc.tool, func(t *testing.T) {
+			prop, ok := tc.schema["motifs"].(map[string]any)
+			require.True(t, ok, "%s schema must declare a motifs property", tc.tool)
+			require.Equal(t, want, prop["description"])
+			require.Equal(t, "array", prop["type"])
+			require.Equal(t, map[string]any{"type": "string"}, prop["items"])
+		})
+	}
+}
+
+// TestShipBlockA_TeachesTheShapeItEnforces — the blueprint's own examples must
+// survive the validator that ships alongside them. This is the check that
+// would have caught the five-word zero-value-treated-as-valid before the
+// designer amended it: SHIP text that teaches an example the gate rejects is a
+// defect in one of the two, and the suite should say which.
+func TestShipBlockA_TeachesTheShapeItEnforces(t *testing.T) {
+	requireExamplesValid(t, readShipText(t, "motif_block_a.txt"))
+}
+
+// kebabToken matches any lowercase hyphenated token in SHIP prose. Every such
+// token in blocks A and B today is either a motif example or an ordinary
+// hyphenated word ("kebab-case", "mis-configuring"), and all of them are legal
+// motif shapes — so scanning generically costs nothing and needs no list of
+// examples to keep in sync with the text.
+var kebabToken = regexp.MustCompile(`[a-z0-9]+(?:-[a-z0-9]+)+`)
+
+// requireExamplesValid asserts every hyphenated token in SHIP text would
+// survive the validator that ships with it. A 5+ word hyphenation trips this,
+// which is exactly the case worth a human look.
+func requireExamplesValid(t *testing.T, ship string) {
+	t.Helper()
+	found := kebabToken.FindAllString(ship, -1)
+	require.NotEmpty(t, found, "no hyphenated tokens found; this check would pass vacuously")
+	for _, tok := range found {
+		require.NoErrorf(t, fact.ValidateMotifs([]string{tok}),
+			"SHIP text teaches %q, which the shipped validator rejects — amend one or the other", tok)
+	}
+}

--- a/internal/mcp/motif_conformance_test.go
+++ b/internal/mcp/motif_conformance_test.go
@@ -99,29 +99,42 @@ func TestShipBlockB_TeachesTheShapeItEnforces(t *testing.T) {
 	requireExamplesValid(t, readShipText(t, "motif_block_b.txt"))
 }
 
-// TestMN1_InstructionsAreCorpusIndependent — the write path stays light.
-// Instructions must be byte-identical whatever the corpus holds: no served
-// vocabulary, no examples mined from the repo, no counts.
+// TestMN1_InstructionsCarryNoCorpusVocabulary — the write path stays light: no
+// served vocabulary, no examples mined from the repo, no counts.
 //
-// The comparison is on BYTES rather than a grep for a motif string, because a
-// grep only catches the spelling it was written to expect; a templating change
-// that interpolated corpus data in some other shape would slip past it.
-func TestMN1_InstructionsAreCorpusIndependent(t *testing.T) {
+// This replaces an earlier version that compared ProfileInstructions against
+// itself. Both sides passed a nil ontology and the same root, so it was a
+// tautology dressed as a corpus comparison — and it tested ProfileInstructions
+// while a real session is served BindingInstructions, which appends
+// repo-derived lens text that the tautology could never have caught.
+//
+// So this drives the ACTUALLY-SERVED function, over a corpus carrying a planted
+// sentinel motif, and asserts the sentinel does not appear. A sentinel rather
+// than "whatever the corpus happens to hold": every corpus holds zero motifs
+// until an agent writes one, so without planting, the check is a green tick
+// over an empty loop.
+func TestMN1_InstructionsCarryNoCorpusVocabulary(t *testing.T) {
+	const sentinel = "zzz-sentinel-motif"
+
 	empty := newInstructionsTestRepo(t, nil)
 	rich := newInstructionsTestRepo(t, []motifSeed{
-		{path: "kb/alpha/one.md", motifs: []string{"silent-fallback", "config-drift"}},
-		{path: "kb/alpha/two.md", motifs: []string{"silent-fallback"}},
+		{path: "kb/alpha/one.md", motifs: []string{sentinel, "config-drift"}},
+		{path: "kb/alpha/two.md", motifs: []string{sentinel}},
 		{path: "kb/beta/three.md", motifs: []string{"unmonitored-expiry"}},
 	})
 
 	for _, profile := range []string{"code", "chat", "generic"} {
 		t.Run(profile, func(t *testing.T) {
-			a := ProfileInstructions(profile, empty.OntologyRoot(), empty.Ontology())
-			b := ProfileInstructions(profile, rich.OntologyRoot(), rich.Ontology())
-			require.Equal(t, a, b,
-				"MN1: server instructions must not vary with corpus content")
-			require.Contains(t, a, "### Motifs",
-				"the comparison is worthless if neither side carries the section")
+			// The served surface, not the inner helper.
+			fromEmpty := BindingInstructions(repos.NewBindingOfRepo(empty, "agent/test"), profile)
+			fromRich := BindingInstructions(repos.NewBindingOfRepo(rich, "agent/test"), profile)
+
+			require.Contains(t, fromRich, "### Motifs",
+				"a comparison is worthless if neither side carries the section")
+			require.NotContains(t, fromRich, sentinel,
+				"MN1: a motif the corpus holds must never reach the served instructions")
+			require.Equal(t, fromEmpty, fromRich,
+				"MN1: served instructions must not vary with corpus content")
 		})
 	}
 }

--- a/internal/mcp/motif_conformance_test.go
+++ b/internal/mcp/motif_conformance_test.go
@@ -1,7 +1,9 @@
 package mcp
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -9,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/fact"
+	"knomit/internal/repos"
+	"knomit/internal/store"
 )
 
 // readShipText loads a SHIP block golden file.
@@ -79,4 +83,135 @@ func requireExamplesValid(t *testing.T, ship string) {
 		require.NoErrorf(t, fact.ValidateMotifs([]string{tok}),
 			"SHIP text teaches %q, which the shipped validator rejects — amend one or the other", tok)
 	}
+}
+
+// TestShipBlockB_Verbatim — the instructions section is blueprint §2 Block B,
+// byte for byte, and it actually reaches what a session is served.
+func TestShipBlockB_Verbatim(t *testing.T) {
+	want := readShipText(t, "motif_block_b.txt")
+	require.Equal(t, want, strings.TrimRight(motifInstructionsSection, "\n"))
+
+	require.Contains(t, ProfileInstructions("code", "kb", nil), want,
+		"Block B must appear in the served instructions, not merely exist as a constant")
+}
+
+func TestShipBlockB_TeachesTheShapeItEnforces(t *testing.T) {
+	requireExamplesValid(t, readShipText(t, "motif_block_b.txt"))
+}
+
+// TestMN1_InstructionsAreCorpusIndependent — the write path stays light.
+// Instructions must be byte-identical whatever the corpus holds: no served
+// vocabulary, no examples mined from the repo, no counts.
+//
+// The comparison is on BYTES rather than a grep for a motif string, because a
+// grep only catches the spelling it was written to expect; a templating change
+// that interpolated corpus data in some other shape would slip past it.
+func TestMN1_InstructionsAreCorpusIndependent(t *testing.T) {
+	empty := newInstructionsTestRepo(t, nil)
+	rich := newInstructionsTestRepo(t, []motifSeed{
+		{path: "kb/alpha/one.md", motifs: []string{"silent-fallback", "config-drift"}},
+		{path: "kb/alpha/two.md", motifs: []string{"silent-fallback"}},
+		{path: "kb/beta/three.md", motifs: []string{"unmonitored-expiry"}},
+	})
+
+	for _, profile := range []string{"code", "chat", "generic"} {
+		t.Run(profile, func(t *testing.T) {
+			a := ProfileInstructions(profile, empty.OntologyRoot(), empty.Ontology())
+			b := ProfileInstructions(profile, rich.OntologyRoot(), rich.Ontology())
+			require.Equal(t, a, b,
+				"MN1: server instructions must not vary with corpus content")
+			require.Contains(t, a, "### Motifs",
+				"the comparison is worthless if neither side carries the section")
+		})
+	}
+}
+
+// TestMN1_NoVocabularyInAnyPrompt — nothing in the served surface may
+// enumerate this corpus's motifs. Phase 2 introduces exactly one exception
+// (the backfill work item); until then the count is zero.
+func TestMN1_NoVocabularyInAnyPrompt(t *testing.T) {
+	const marker = "zzz-unique-marker"
+	rich := newInstructionsTestRepo(t, []motifSeed{
+		{path: "kb/alpha/one.md", motifs: []string{marker}},
+	})
+	require.NotContains(t,
+		ProfileInstructions("code", rich.OntologyRoot(), rich.Ontology()), marker)
+
+	for name, schema := range map[string]map[string]any{
+		"knomit_learn":  learnToolSchemaProperties(),
+		"knomit_update": updateToolSchemaProperties(),
+	} {
+		for prop, spec := range schema {
+			m, ok := spec.(map[string]any)
+			if !ok {
+				continue
+			}
+			desc, _ := m["description"].(string)
+			require.NotContainsf(t, desc, marker, "%s.%s leaks corpus vocabulary", name, prop)
+		}
+	}
+}
+
+// TestMN1_FrontmatterListNamesMotifs — the pointer bullet must be present.
+// Its absence is not cosmetic: the frontmatter list is an enumeration, and an
+// agent that reads it as complete will treat an unlisted motifs: as cruft on
+// a fact it is updating — which, since knomit_update replaces list fields
+// wholesale, deletes them.
+func TestMN1_FrontmatterListNamesMotifs(t *testing.T) {
+	instr := ProfileInstructions("code", "kb", nil)
+	require.Contains(t, instr, "- **motifs**:")
+	require.Less(t, strings.Index(instr, "- **motifs**:"), strings.Index(instr, "### Motifs"),
+		"the pointer bullet must come before the section it points at")
+}
+
+// motifSeed is one fact to plant in a corpus fixture.
+type motifSeed struct {
+	path   string
+	motifs []string
+}
+
+// newInstructionsTestRepo opens a fresh store, writes the seeded facts, and
+// returns the instance. The seeds are REAL committed facts, not a stub: MN1 is
+// a claim about what happens when a corpus actually holds motifs, and a
+// fixture that never wrote any would make the comparison trivially true.
+func newInstructionsTestRepo(t *testing.T, seeds []motifSeed) *repos.RepoInstance {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+
+	for _, seed := range seeds {
+		f := fact.NewFact(seed.path)
+		f.Title = "T " + seed.path
+		f.Body = "Body of " + seed.path
+		f.Type = fact.Observation
+		f.Domain = []string{"alpha"}
+		f.Entities = []string{"Widget"}
+		f.Refs = []string{}
+		f.Confidence = 0.8
+		f.Sources = 1
+		f.Motifs = seed.motifs
+		body, err := fact.SerializeFact(f)
+		require.NoError(t, err)
+		_, err = svc.Facts().WriteFact(context.Background(), "agent/test", f.Path(), body, "seed", "")
+		require.NoError(t, err)
+	}
+
+	// The seeds must have LANDED, or every assertion below is about an empty
+	// corpus wearing a rich corpus's name.
+	if len(seeds) > 0 {
+		n, err := svc.Search().TokenDF(context.Background(), "agent/test", seeds[0].motifs[0], "motif")
+		require.NoError(t, err)
+		require.Positive(t, n, "seeded motifs must be indexed, or this fixture proves nothing")
+	}
+
+	return repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:         "test",
+		UID:          nextTestRepoUID(),
+		AgentBranch:  "agent/test",
+		Svc:          svc,
+		OntologyRoot: "kb",
+	})
 }

--- a/internal/mcp/testdata/motif_block_a.txt
+++ b/internal/mcp/testdata/motif_block_a.txt
@@ -1,0 +1,8 @@
+motifs (optional, 0–3): the general regularities this fact is an instance of.
+Each motif is a 2–4 word kebab-case noun phrase naming a mechanism, failure
+shape, or pattern that a fact about a completely different subject could also
+carry — that is the test. Examples: identifier-collision,
+derived-state-liability, harness-over-model, capital-influx. NOT the fact's
+subject (that is entities), NOT its area (that is domain), NOT its claim
+compressed (that is the title). Omit entirely when the fact is a bare
+datapoint with no general shape — an empty list is a correct answer.

--- a/internal/mcp/testdata/motif_block_b.txt
+++ b/internal/mcp/testdata/motif_block_b.txt
@@ -1,0 +1,32 @@
+### Motifs
+
+Facts may carry `motifs:` — names for the underlying regularity, independent
+of subject. Motifs exist so that two facts about unrelated subjects can be
+connected when they exemplify the same mechanism: a build tool silently
+mis-configuring on an unset variable and a hook guard that must fail closed
+on a missing field are different subjects with the same motif,
+zero-value-as-valid.
+
+Writing a motif:
+- Apply the transfer test: could a fact in a completely different area of
+  this corpus carry this exact phrase? If not, it is a title fragment, not a
+  motif.
+- Name the regularity, not the instance: atomic-write-via-rename, not
+  keypair-written-atomically.
+- Name the regularity, not its remedy. If a fact describes a problem and its
+  fix, the motif names the problem's shape, never the fix:
+  unmonitored-expiry, not renew-certs-automatically.
+- No subject words: a motif containing an entity name, a domain term, or a
+  path segment of its own fact will be stripped at write time.
+- Prefer the most specific phrasing that still transfers.
+- 2–4 words, kebab-case, noun phrase. One motif is normal; three is the
+  maximum. Never attach two phrasings of the same regularity to one fact —
+  pick the better one; a second motif requires a genuinely second regularity.
+- Zero is correct when the fact records only a quantity or an event (a
+  funding round, an acquisition, a release). But a specific dynamic — a time
+  window between cause and effect, a direction of failure, a feedback loop —
+  IS a general shape and deserves a motif.
+
+What motifs are not: not predictions of where the fact applies, not tags for
+retrieval, not summaries. They are consumed only by synthesis (bridging and
+discovery); a wrong motif costs a wasted discovery candidate, nothing more.

--- a/internal/mcp/testdata/motif_block_b.txt
+++ b/internal/mcp/testdata/motif_block_b.txt
@@ -16,8 +16,9 @@ Writing a motif:
 - Name the regularity, not its remedy. If a fact describes a problem and its
   fix, the motif names the problem's shape, never the fix:
   unmonitored-expiry, not renew-certs-automatically.
-- No subject words: a motif containing an entity name, a domain term, or a
-  path segment of its own fact will be stripped at write time.
+- No subject words: a motif built entirely from its own fact's subject
+  words (entity names, domain terms, path segments) will be stripped at
+  write time.
 - Prefer the most specific phrasing that still transfers.
 - 2–4 words, kebab-case, noun phrase. One motif is normal; three is the
   maximum. Never attach two phrasings of the same regularity to one fact —

--- a/internal/mcp/update.go
+++ b/internal/mcp/update.go
@@ -32,22 +32,35 @@ func updateTool() mcpgo.Tool {
 		mcpgo.WithObject("updates",
 			mcpgo.Required(),
 			mcpgo.Description("Fields to update. Include only the fields you want to change. origin and the topic/category path are immutable and not accepted here — fixing either requires knomit_retract plus a fresh knomit_learn."),
-			mcpgo.Properties(map[string]any{
-				"title": map[string]any{"type": "string", "description": "New title."},
-				"body":  map[string]any{"type": "string", "description": "New body text."},
-				// Shared with knomit_learn via factschema.go, minus the
-				// defaults: an update patches an existing fact, so declaring
-				// a schema "default" would read as "omit this and it resets".
-				"kind":       kindProperty(""),
-				"type":       typeProperty(""),
-				"confidence": map[string]any{"type": "number", "description": "Certainty level 0.0–1.0."},
-				"sources":    map[string]any{"type": "integer", "description": "Number of independent sources."},
-				"domain":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces domain tags."},
-				"entities":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces entity list."},
-				"refs":       map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces the ENTIRE refs list. Send every ref the fact should keep — any existing ref you leave out is dropped. To add or refresh a ref, read the current refs first and resend the full merged list. Omit the field to leave refs unchanged."},
-			}),
+			mcpgo.Properties(updateToolSchemaProperties()),
 		),
 	)
+}
+
+// updateToolSchemaProperties is the knomit_update `updates` object's
+// properties map. Extracted from the registration literal above for the same
+// reason learnToolSchemaProperties is: conformance tests read the bytes
+// actually served.
+func updateToolSchemaProperties() map[string]any {
+	return map[string]any{
+		"title": map[string]any{"type": "string", "description": "New title."},
+		"body":  map[string]any{"type": "string", "description": "New body text."},
+		// Shared with knomit_learn via factschema.go, minus the
+		// defaults: an update patches an existing fact, so declaring
+		// a schema "default" would read as "omit this and it resets".
+		"kind":       kindProperty(""),
+		"type":       typeProperty(""),
+		"confidence": map[string]any{"type": "number", "description": "Certainty level 0.0–1.0."},
+		"sources":    map[string]any{"type": "integer", "description": "Number of independent sources."},
+		"domain":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces domain tags."},
+		"entities":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces entity list."},
+		// Block A verbatim, shared with knomit_learn. The wholesale-
+		// replacement rule this tool applies to every list field is
+		// stated once in the `updates` description above, so the field
+		// text stays identical across the two tools.
+		"motifs": motifsProperty(),
+		"refs":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces the ENTIRE refs list. Send every ref the fact should keep — any existing ref you leave out is dropped. To add or refresh a ref, read the current refs first and resend the full merged list. Omit the field to leave refs unchanged."},
+	}
 }
 
 // updateInput represents the updates object in the request.
@@ -61,6 +74,7 @@ type updateInput struct {
 	Refs       []string `json:"refs"`
 	Domain     []string `json:"domain"`
 	Entities   []string `json:"entities"`
+	Motifs     []string `json:"motifs"`
 }
 
 // UpdateHandler returns the handler function for knomit_update.
@@ -172,6 +186,13 @@ func UpdateHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 		}
 		if updates.Entities != nil {
 			fact.Entities = updates.Entities
+		}
+		// Wholesale replacement, like Domain and Entities. nil means
+		// "unchanged"; an explicit [] clears. No validation here — a malformed
+		// motif is rejected and a subject motif silently dropped by
+		// SerializeFact, the single gate (MN4).
+		if updates.Motifs != nil {
+			fact.Motifs = updates.Motifs
 		}
 		// Refs replace wholesale, like Domain and Entities — the caller
 		// sends the complete new list. Dropping a ref only affects this

--- a/internal/mcp/update.go
+++ b/internal/mcp/update.go
@@ -54,10 +54,11 @@ func updateToolSchemaProperties() map[string]any {
 		"sources":    map[string]any{"type": "integer", "description": "Number of independent sources."},
 		"domain":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces domain tags."},
 		"entities":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces entity list."},
-		// Block A verbatim, shared with knomit_learn. The wholesale-
-		// replacement rule this tool applies to every list field is
-		// stated once in the `updates` description above, so the field
-		// text stays identical across the two tools.
+		// Block A verbatim, shared with knomit_learn, so the two tools cannot
+		// drift on what the field means. The wholesale-replacement rule is
+		// stated once in the `updates` description above, where it covers every
+		// list field at once — keeping it out of here is what lets this string
+		// stay byte-identical to knomit_learn's.
 		"motifs": motifsProperty(),
 		"refs":   map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Replaces the ENTIRE refs list. Send every ref the fact should keep — any existing ref you leave out is dropped. To add or refresh a ref, read the current refs first and resend the full merged list. Omit the field to leave refs unchanged."},
 	}

--- a/internal/store/domain_match.go
+++ b/internal/store/domain_match.go
@@ -4,11 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"unicode"
 
-	"github.com/gertd/go-pluralize"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/unicode/norm"
+	"knomit/internal/textnorm"
 )
 
 // Domain-tag matching: a domain tag is canonicalised deterministically at the
@@ -18,88 +15,20 @@ import (
 // variants and makes matching word-order-independent, with no FTS5/embeddings.
 // Authored tags stay in git; this canonical/token form is derived index state.
 
-// domainCaser performs Unicode case folding (language-neutral). Allocated once.
-var domainCaser = cases.Fold()
-
-// domainPluralizer singularizes plural tokens to a match key. go-pluralize is a
-// port of the widely-used JS `pluralize`, with a real irregular/exception table
-// (not naive suffix rules), so it is symmetric and idempotent on the irregulars
-// a hand-rolled or Porter/Snowball stemmer breaks: analyses≡analysis,
-// indices≡index, matrices≡matrix, theses≡thesis. Allocated once; configured for
-// the technical vocabulary in stemDomainToken's guards. Pure-Go, zero deps.
-var domainPluralizer = pluralize.NewClient()
-
-// canonicalizeDomain normalises a domain tag for matching and junction storage:
-// NFC → case-fold → replace hyphens and Unicode whitespace with a single space →
-// trim. Underscores are PRESERVED so identifier-like tags (commit_log) stay one
-// token. Pure and idempotent.
-func canonicalizeDomain(s string) string {
-	s = norm.NFC.String(s)
-	s = domainCaser.String(s)
-	var b strings.Builder
-	b.Grow(len(s))
-	prevSpace := true // leading-trim: suppress leading spaces
-	for _, r := range s {
-		if r == '-' || unicode.IsSpace(r) {
-			if !prevSpace {
-				b.WriteByte(' ')
-				prevSpace = true
-			}
-			continue
-		}
-		b.WriteRune(r)
-		prevSpace = false
-	}
-	return strings.TrimRight(b.String(), " ")
-}
-
-// stemDomainToken normalises a token to its singular form as a MATCH-ONLY key —
-// the result is never displayed or stored as the canonical tag, only used so a
-// query token and a stored token collapse to the same key ("vulnerabilities" ≡
-// "vulnerability"). It delegates to go-pluralize, which is symmetric and
-// idempotent on the irregulars a hand-rolled or Porter/Snowball stemmer breaks
-// (analyses≡analysis, indices≡index, matrices≡matrix, theses≡thesis), verified
-// against the real domain corpus.
+// The three normalizers below moved to internal/textnorm so internal/fact can
+// use the SAME definition of "the same token" for the motif subject-word strip
+// without inverting the store -> fact dependency (internal/fact imports no
+// internal package, by design). Two stemmers are two things that drift, and a
+// drifted stemmer lets a motif that renames its own fact's subject past the
+// strip.
 //
-// Two guards prevent over-singularizing non-plurals that merely end in 's'
-// (any pluralizer treats a trailing 's' as plural, which is what we DON'T want
-// for these — confirmed against real knomit domains):
-//   - len <= 3: acronyms/identifiers (ai, aws, llm, tls) are never plurals.
-//   - "...ics": -ics field/mass nouns (economics, robotics, metrics, ethics)
-//     are singular; stripping to -ic would be wrong and asymmetric.
-//
-// Both guards are symmetric (applied identically at index and query time), so
-// they never break matching; they only avoid mangling internal keys.
-func stemDomainToken(t string) string {
-	if len(t) <= 3 || strings.HasSuffix(t, "ics") {
-		return t
-	}
-	return domainPluralizer.Singular(t)
-}
-
-// domainTokens returns the stemmed, de-duplicated token set of a canonical
-// domain, split on whitespace AND slash. Splitting on '/' too means a
-// hierarchical tag's individual segments are each searchable as a word
-// ("multi-tenant/auth" → ["multi","tenant","auth"]) — without it, a segment
-// glued to a slash ("tenant/auth") is unreachable by its own middle word and
-// the slash-hierarchy branch only matches whole prefixes. Order follows first
-// appearance; callers treat it as a set. Pass the output of canonicalizeDomain.
-func domainTokens(canonical string) []string {
-	fields := strings.FieldsFunc(canonical, func(r rune) bool {
-		return r == '/' || unicode.IsSpace(r)
-	})
-	seen := make(map[string]struct{}, len(fields))
-	out := make([]string, 0, len(fields))
-	for _, f := range fields {
-		st := stemDomainToken(f)
-		if _, ok := seen[st]; ok {
-			continue
-		}
-		seen[st] = struct{}{}
-		out = append(out, st)
-	}
-	return out
-}
+// They stay as unexported names here because every call site in this package
+// reads better with the domain-specific name, and because renaming ~30 call
+// sites would bury a mechanical extraction inside an unrelated diff. The
+// existing domain-match suite is the zero-diff gate: no test was edited.
+func canonicalizeDomain(s string) string     { return textnorm.Canonicalize(s) }
+func stemDomainToken(t string) string        { return textnorm.Stem(t) }
+func domainTokens(canonical string) []string { return textnorm.Tokens(canonical) }
 
 // DomainTagMatches reports whether queryTag matches factTag under the SAME default
 // semantics SearchOptions.Domain uses (search_query.go:339-373): canonical
@@ -135,7 +64,7 @@ func DomainTagMatches(factTag, queryTag string) bool {
 // EntityTagMatches reports case-folded equality, mirroring the COLLATE NOCASE
 // fact_entities junction. Entities are not tokenized (no entity token table).
 func EntityTagMatches(factEntity, queryEntity string) bool {
-	return domainCaser.String(factEntity) == domainCaser.String(queryEntity)
+	return textnorm.Fold(factEntity) == textnorm.Fold(queryEntity)
 }
 
 // CanonicalizeTag exposes canonicalizeDomain for consumers that must group tags

--- a/internal/store/fact_motifs_test.go
+++ b/internal/store/fact_motifs_test.go
@@ -1,0 +1,153 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// motifEnv opens a store on a temp dir with one branch, ready for writes.
+func motifEnv(t *testing.T) (*Service, string) {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "main"))
+	return svc, "main"
+}
+
+// writeMotifFact writes a fact carrying motifs. Domain and entities are fixed
+// and deliberately unrelated to the motifs used below, so the subject strip
+// never fires by accident and hides a storage bug.
+func writeMotifFact(t *testing.T, svc *Service, branch, path string, motifs []string) {
+	t.Helper()
+	f := fact.NewFact(path)
+	f.Title = "T " + path
+	f.Body = "Body of " + path
+	f.Type = fact.Observation
+	f.Domain = []string{"alpha"}
+	f.Entities = []string{"Widget"}
+	f.Refs = []string{}
+	f.Confidence = 0.8
+	f.Sources = 1
+	f.Motifs = motifs
+	body, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(context.Background(), branch, f.Path(), body, "seed", "")
+	require.NoError(t, err)
+}
+
+// motifRows reads the junction rows for the LIVE revision of path on branch.
+func motifRows(t *testing.T, svc *Service, branch, path string) []string {
+	t.Helper()
+	rows, err := svc.si.rh.db.QueryContext(context.Background(), `
+		SELECT m.motif
+		  FROM fact_motifs m
+		  JOIN branch_facts bf ON bf.fact_id = m.fact_id
+		  JOIN branches b ON b.id = bf.branch_id
+		 WHERE bf.path = ? AND b.name = ?
+		 ORDER BY m.motif`, path, branch)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var s string
+		require.NoError(t, rows.Scan(&s))
+		out = append(out, s)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+func TestFactMotifs_PopulatedOnUpsert(t *testing.T) {
+	svc, branch := motifEnv(t)
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md",
+		[]string{"silent-fallback", "config-drift"})
+
+	require.Equal(t, []string{"config-drift", "silent-fallback"},
+		motifRows(t, svc, branch, "kb/alpha/one.md"))
+}
+
+func TestFactMotifs_MotiflessFactHasNoRows(t *testing.T) {
+	svc, branch := motifEnv(t)
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md", nil)
+	require.Empty(t, motifRows(t, svc, branch, "kb/alpha/one.md"))
+}
+
+// TestFactMotifs_RebuildRepopulatesJunction is the regression this table's
+// migration comment warns about: the bulk rebuild repopulates junctions from
+// the facts table's JSON columns, NOT by re-parsing, so a junction without a
+// matching column is never filled on a machine that only ever rebuilds — a
+// fresh clone, or any repo whose index was dropped.
+//
+// The junction rows are CLEARED before the rebuild, deliberately. Without
+// that this test passes vacuously: rebuildFacts upserts facts with
+// ON CONFLICT DO UPDATE, which preserves rowids and therefore fires no
+// cascade, so rows the incremental upsert already wrote simply survive
+// untouched and the rebuild path is never exercised at all. Clearing first is
+// what makes the assertion mean "the rebuild populated these", rather than
+// "something populated these once".
+func TestFactMotifs_RebuildRepopulatesJunction(t *testing.T) {
+	svc, branch := motifEnv(t)
+	ctx := context.Background()
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md",
+		[]string{"silent-fallback", "config-drift"})
+	writeMotifFact(t, svc, branch, "kb/alpha/two.md", []string{"silent-fallback"})
+	writeMotifFact(t, svc, branch, "kb/alpha/three.md", nil)
+
+	fromIncremental := motifRows(t, svc, branch, "kb/alpha/one.md")
+	require.Len(t, fromIncremental, 2, "fixture must have rows to lose")
+
+	_, err := svc.si.rh.db.ExecContext(ctx, `DELETE FROM fact_motifs`)
+	require.NoError(t, err)
+	require.Empty(t, motifRows(t, svc, branch, "kb/alpha/one.md"),
+		"clearing must actually empty the junction, or the rebuild below proves nothing")
+
+	require.NoError(t, svc.IndexManager().Rebuild(ctx, branch, nil))
+
+	require.Equal(t, fromIncremental, motifRows(t, svc, branch, "kb/alpha/one.md"),
+		"the rebuild path must reproduce exactly what the incremental path built")
+	require.Equal(t, []string{"silent-fallback"},
+		motifRows(t, svc, branch, "kb/alpha/two.md"))
+	require.Empty(t, motifRows(t, svc, branch, "kb/alpha/three.md"))
+}
+
+// TestFactMotifs_StrippedMotifNeverReachesJunction — the strip happens at
+// serialize time, so the committed bytes never carry a subject motif and no
+// index path can resurrect one. This asserts that end-to-end rather than
+// trusting the layering.
+func TestFactMotifs_StrippedMotifNeverReachesJunction(t *testing.T) {
+	svc, branch := motifEnv(t)
+	// "widget-alpha" is entity ∪ domain for these fixtures.
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md",
+		[]string{"widget-alpha", "silent-fallback"})
+
+	require.Equal(t, []string{"silent-fallback"},
+		motifRows(t, svc, branch, "kb/alpha/one.md"))
+}
+
+func TestTokenDF_MotifKind(t *testing.T) {
+	svc, branch := motifEnv(t)
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md", []string{"silent-fallback"})
+	writeMotifFact(t, svc, branch, "kb/alpha/two.md", []string{"silent-fallback", "config-drift"})
+	writeMotifFact(t, svc, branch, "kb/alpha/three.md", nil)
+
+	ctx := context.Background()
+	for _, tc := range []struct {
+		token string
+		want  int
+	}{
+		{"silent-fallback", 2},
+		{"config-drift", 1},
+		{"never-written", 0},
+	} {
+		n, err := svc.Search().TokenDF(ctx, branch, tc.token, "motif")
+		require.NoError(t, err)
+		require.Equalf(t, tc.want, n, "df for %q", tc.token)
+	}
+}

--- a/internal/store/fact_motifs_test.go
+++ b/internal/store/fact_motifs_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -150,4 +151,126 @@ func TestTokenDF_MotifKind(t *testing.T) {
 		require.NoError(t, err)
 		require.Equalf(t, tc.want, n, "df for %q", tc.token)
 	}
+}
+
+// TestMigration019_DownUpCycle pins that the rollback actually rolls back.
+//
+// The first version of this down migration DROPped the table but kept
+// facts.motifs, citing 000012 as precedent — which drops its column. Two things
+// were wrong with that: the precedent said the opposite, and re-applying the up
+// migration afterwards fails on "duplicate column name: motifs", leaving the
+// schema dirty. A down migration nothing ever exercises is a rollback nobody
+// can perform.
+func TestMigration019_DownUpCycle(t *testing.T) {
+	svc, branch := motifEnv(t)
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md", []string{"silent-fallback"})
+	require.NotEmpty(t, motifRows(t, svc, branch, "kb/alpha/one.md"))
+
+	db := svc.si.rh.db
+	hasMotifsColumn := func() bool {
+		var n int
+		require.NoError(t, db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('facts') WHERE name = 'motifs'`).Scan(&n))
+		return n == 1
+	}
+	require.True(t, hasMotifsColumn())
+
+	_, err := db.Exec(migrationSQL(t, "000019_fact_motifs.down.sql"))
+	require.NoError(t, err, "the down migration must apply cleanly")
+	require.False(t, hasMotifsColumn(), "down must take the column, not only the table")
+
+	// The cycle: up must re-apply on a rolled-back schema.
+	_, err = db.Exec(migrationSQL(t, "000019_fact_motifs.up.sql"))
+	require.NoError(t, err, "re-applying up after down must not collide with a leftover column")
+	require.True(t, hasMotifsColumn())
+
+	// And the junction is rebuildable from git, which is what makes the
+	// rollback safe to perform at all.
+	require.NoError(t, svc.IndexManager().Rebuild(context.Background(), branch, nil))
+	require.Equal(t, []string{"silent-fallback"}, motifRows(t, svc, branch, "kb/alpha/one.md"))
+}
+
+// TestVerify_DetectsMotifJunctionDrift — checkDerivedTables' own doc comment
+// names this failure mode: the facts are all present and correct, and a lookup
+// over them returns nothing. For motifs the symptom is worse than silent,
+// because document-frequency is an INPUT to later phases: a half-populated
+// junction makes a motif look rarer than it is, and nothing downstream can tell.
+func TestVerify_DetectsMotifJunctionDrift(t *testing.T) {
+	svc, branch := motifEnv(t)
+	ctx := context.Background()
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md", []string{"silent-fallback", "config-drift"})
+
+	clean, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+	require.Empty(t, derivedTableIssues(clean),
+		"a healthy repo must report no derived-table issues, or the test below proves nothing")
+
+	// Junction row lost while the column still lists it — what a rebuild that
+	// forgot to repopulate would leave behind.
+	_, err = svc.si.rh.db.ExecContext(ctx,
+		`DELETE FROM fact_motifs WHERE motif = 'config-drift'`)
+	require.NoError(t, err)
+
+	drifted, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+	issues := derivedTableIssues(drifted)
+	require.NotEmpty(t, issues, "a lost junction row must be reported")
+	require.Contains(t, issues[0].Detail, "absent from fact_motifs")
+
+	// And the reverse: a junction row for a motif the column no longer lists.
+	_, err = svc.si.rh.db.ExecContext(ctx,
+		`INSERT INTO fact_motifs(fact_id, motif) SELECT id, 'never-authored' FROM facts LIMIT 1`)
+	require.NoError(t, err)
+
+	both, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+	var details []string
+	for _, i := range derivedTableIssues(both) {
+		details = append(details, i.Detail)
+	}
+	require.Len(t, details, 2, "both directions must be reported, not just the first")
+}
+
+// TestVerify_DetectsMotifOrphans — a junction row pointing at a facts row that
+// no longer exists.
+func TestVerify_DetectsMotifOrphans(t *testing.T) {
+	svc, branch := motifEnv(t)
+	ctx := context.Background()
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md", []string{"silent-fallback"})
+
+	// The FK plus ON DELETE CASCADE makes an orphan impossible while foreign
+	// keys are ON, which is exactly why the check exists: SQLite's
+	// foreign_keys pragma is PER-CONNECTION and defaults OFF, so any tool that
+	// writes this DB without setting it can leave rows the schema would have
+	// refused. Reproducing that is the only honest way to test the check.
+	conn, err := svc.si.rh.db.Conn(ctx)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, `PRAGMA foreign_keys = OFF`)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx,
+		`INSERT INTO fact_motifs(fact_id, motif) VALUES (999999, 'orphaned-row')`)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, `PRAGMA foreign_keys = ON`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	report, err := svc.Verify(ctx, VerifyOpts{})
+	require.NoError(t, err)
+	var found bool
+	for _, i := range derivedTableIssues(report) {
+		if strings.Contains(i.Detail, "fact_motifs has 1 row(s) referencing a missing facts row") {
+			found = true
+		}
+	}
+	require.True(t, found, "an orphaned fact_motifs row must be reported")
+}
+
+func derivedTableIssues(r IntegrityReport) []IntegrityIssue {
+	var out []IntegrityIssue
+	for _, i := range r.Issues {
+		if i.Category == CategoryDerivedTables {
+			out = append(out, i)
+		}
+	}
+	return out
 }

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -27,6 +27,7 @@ type FactRecord struct {
 	Type           string   `json:"type"`
 	Domain         []string `json:"domain"`
 	Entities       []string `json:"entities"`
+	Motifs         []string `json:"motifs,omitempty"`
 	Confidence     float64  `json:"confidence"`
 	Sources        int      `json:"sources"`
 	Refs           []string `json:"refs"`
@@ -59,6 +60,7 @@ func NewFactRecord(f fact.Fact, blobHash string) FactRecord {
 		Type:           string(f.Type),
 		Domain:         f.Domain,
 		Entities:       f.Entities,
+		Motifs:         f.Motifs,
 		Confidence:     f.Confidence,
 		Sources:        f.Sources,
 		Refs:           f.Refs,

--- a/internal/store/migrate/repo/000019_fact_motifs.down.sql
+++ b/internal/store/migrate/repo/000019_fact_motifs.down.sql
@@ -1,6 +1,7 @@
+DROP INDEX IF EXISTS fact_motifs_motif;
 DROP TABLE IF EXISTS fact_motifs;
--- facts.motifs is deliberately left in place. SQLite's DROP COLUMN is refused
--- while the column is named by an index or a live statement, and a stale
--- unread column costs one JSON literal per row. The 000012 origin migration
--- set the same precedent: junction and index come out, the parsed-cache column
--- stays.
+-- The column goes too, matching 000006 (kind) and 000012 (origin), which both
+-- drop theirs. Keeping it would also break the down→up cycle: re-running the up
+-- migration would hit "duplicate column name: motifs" and leave the schema
+-- dirty.
+ALTER TABLE facts DROP COLUMN motifs;

--- a/internal/store/migrate/repo/000019_fact_motifs.down.sql
+++ b/internal/store/migrate/repo/000019_fact_motifs.down.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS fact_motifs;
+-- facts.motifs is deliberately left in place. SQLite's DROP COLUMN is refused
+-- while the column is named by an index or a live statement, and a stale
+-- unread column costs one JSON literal per row. The 000012 origin migration
+-- set the same precedent: junction and index come out, the parsed-cache column
+-- stays.

--- a/internal/store/migrate/repo/000019_fact_motifs.up.sql
+++ b/internal/store/migrate/repo/000019_fact_motifs.up.sql
@@ -1,0 +1,31 @@
+-- The motif field's storage (blueprint §1), mirroring fact_domains: a JSON
+-- column on facts for the bulk rebuild to read, and a junction table for
+-- indexed counting (TokenDF kind "motif").
+--
+-- BOTH are required, and the pairing is easy to get wrong. upsert() populates
+-- the junction directly from the parsed record, but rebuildFacts repopulates
+-- it with SQL over facts.<column> via json_each — so a junction WITHOUT a
+-- column silently empties on the first full rebuild, while every unit test
+-- that only drives the incremental path stays green while it happens. That is
+-- what TestFactMotifs_SurvivesFullRebuild exists to catch.
+--
+-- Derived index state, rebuilt from git: no data backfill, because no fact in
+-- any existing corpus carries a motif and EMPTY is therefore the correct state
+-- for every row. For the same reason, deliberately NO GraphSchemaVersion bump
+-- (the 000018 precedent, and architecture/store/f6db3a49 — "USUALLY a bump ...
+-- but NOT ALWAYS"): the bump exists to force regeneration of state a rebuild
+-- would otherwise leave stale, and there is no such state here.
+--
+-- Motifs are stored AS WRITTEN (roadmap MN3). Unlike fact_domains, which
+-- stores knomit_canon_domain's output, NO canonicalization happens here: alias
+-- resolution and canonical ids are Phase-2 derived state built FROM these rows
+-- and never written back into them. COLLATE NOCASE is a matching convenience
+-- shared with the sibling junctions; it changes no stored bytes.
+ALTER TABLE facts ADD COLUMN motifs TEXT NOT NULL DEFAULT '[]';
+
+CREATE TABLE IF NOT EXISTS fact_motifs (
+    fact_id INTEGER NOT NULL REFERENCES facts(id) ON DELETE CASCADE,
+    motif   TEXT NOT NULL COLLATE NOCASE,
+    PRIMARY KEY (fact_id, motif)
+);
+CREATE INDEX IF NOT EXISTS fact_motifs_motif ON fact_motifs(motif);

--- a/internal/store/remote_migration_test.go
+++ b/internal/store/remote_migration_test.go
@@ -70,7 +70,7 @@ func TestMigration017_UpgradesPreMigrationDatabase(t *testing.T) {
 	var dirty bool
 	require.NoError(t, svc2.rh.db.QueryRow(
 		`SELECT version, dirty FROM schema_migrations`).Scan(&v, &dirty))
-	require.Equal(t, 18, v, "the store must have migrated forward")
+	require.Equal(t, 19, v, "the store must have migrated forward")
 	require.False(t, dirty)
 
 	// The connection columns are gone...

--- a/internal/store/search_crud.go
+++ b/internal/store/search_crud.go
@@ -133,6 +133,17 @@ func (si *searchIndex) upsert(ctx context.Context, branch, commitHash string, re
 	if err != nil {
 		return fmt.Errorf("marshal refs: %w", err)
 	}
+	// nil marshals to "null", which json_each cannot walk — the rebuild would
+	// then read no motifs for a motif-less fact instead of an empty list, and
+	// the column's DEFAULT '[]' only covers rows this statement never names.
+	motifsList := rec.Motifs
+	if motifsList == nil {
+		motifsList = []string{}
+	}
+	motifsJSON, err := json.Marshal(motifsList)
+	if err != nil {
+		return fmt.Errorf("marshal motifs: %w", err)
+	}
 
 	factType := rec.Type
 	if factType == "" {
@@ -189,10 +200,10 @@ func (si *searchIndex) upsert(ctx context.Context, branch, commitHash string, re
 
 	// Atomic: insert fact if it doesn't exist yet (no TOCTOU race).
 	_, err = db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO facts(path, blob_hash, title, kind, type, domain, entities, confidence, sources, refs, evidence_weight, origin)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT OR IGNORE INTO facts(path, blob_hash, title, kind, type, domain, entities, motifs, confidence, sources, refs, evidence_weight, origin)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		rec.Path, rec.BlobHash, rec.Title, factKind, factType,
-		string(domainJSON), string(entitiesJSON),
+		string(domainJSON), string(entitiesJSON), string(motifsJSON),
 		rec.Confidence, rec.Sources,
 		string(refsJSON), rec.EvidenceWeight, factOrigin,
 	)
@@ -307,6 +318,21 @@ func (si *searchIndex) upsert(ctx context.Context, branch, commitHash string, re
 			); err != nil {
 				return fmt.Errorf("upsert fact_domain_tokens: %w", err)
 			}
+		}
+	}
+	// Stored AS WRITTEN (MN3) — no canonicalization, unlike fact_domains
+	// above. The motif strings on disk ARE the fact's claim; every
+	// normalization the design calls for (alias ids, definitions, df) is
+	// derived state built FROM these rows and never written back into them.
+	for _, motif := range rec.Motifs {
+		if motif == "" {
+			continue
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT OR IGNORE INTO fact_motifs(fact_id, motif) VALUES (?, ?)`,
+			factID, motif,
+		); err != nil {
+			return fmt.Errorf("upsert fact_motifs: %w", err)
 		}
 	}
 

--- a/internal/store/search_index.go
+++ b/internal/store/search_index.go
@@ -792,7 +792,7 @@ func (si *searchIndex) rebuildFacts(ctx context.Context, branch, head string, pr
 			FROM _rebuild_entries e
 			JOIN objects o ON o.hash = e.blob_hash AND o.type = ?
 		)
-		INSERT INTO facts (path, blob_hash, title, kind, type, domain, entities, confidence, sources, refs, evidence_weight, origin)
+		INSERT INTO facts (path, blob_hash, title, kind, type, domain, entities, motifs, confidence, sources, refs, evidence_weight, origin)
 		SELECT
 			pe.path,
 			pe.blob_hash,
@@ -801,6 +801,7 @@ func (si *searchIndex) rebuildFacts(ctx context.Context, branch, head string, pr
 			json_extract(pe.parsed, '$.type'),
 			json_extract(pe.parsed, '$.domain'),
 			json_extract(pe.parsed, '$.entities'),
+			COALESCE(json_extract(pe.parsed, '$.motifs'), '[]'),
 			json_extract(pe.parsed, '$.confidence'),
 			json_extract(pe.parsed, '$.sources'),
 			json_extract(pe.parsed, '$.refs'),
@@ -814,6 +815,7 @@ func (si *searchIndex) rebuildFacts(ctx context.Context, branch, head string, pr
 			type            = excluded.type,
 			domain          = excluded.domain,
 			entities        = excluded.entities,
+			motifs          = excluded.motifs,
 			confidence      = excluded.confidence,
 			sources         = excluded.sources,
 			refs            = excluded.refs,
@@ -878,6 +880,28 @@ func (si *searchIndex) rebuildFacts(ctx context.Context, branch, head string, pr
 		WHERE j.value IS NOT NULL AND j.value != ''
 	`); err != nil {
 		return 0, fmt.Errorf("rebuildFacts: repopulate fact_entities: %w", err)
+	}
+	if _, err := conn(ctx, si.rh.db).ExecContext(ctx, `
+		DELETE FROM fact_motifs WHERE fact_id IN (
+			SELECT f.id FROM facts f
+			JOIN _rebuild_entries e ON e.path = f.path AND e.blob_hash = f.blob_hash
+		)
+	`); err != nil {
+		return 0, fmt.Errorf("rebuildFacts: clear fact_motifs: %w", err)
+	}
+	// No knomit_canon_* wrapper, unlike fact_domains above: motifs are stored
+	// AS WRITTEN (MN3). DISTINCT + OR IGNORE anyway, because the primary key
+	// is (fact_id, motif) and the column is COLLATE NOCASE — two spellings
+	// that differ only in case collide there even though neither is rewritten.
+	if _, err := conn(ctx, si.rh.db).ExecContext(ctx, `
+		INSERT OR IGNORE INTO fact_motifs(fact_id, motif)
+		SELECT DISTINCT f.id, j.value
+		FROM facts f
+		JOIN _rebuild_entries e ON e.path = f.path AND e.blob_hash = f.blob_hash
+		JOIN json_each(f.motifs) j
+		WHERE j.value IS NOT NULL AND j.value != ''
+	`); err != nil {
+		return 0, fmt.Errorf("rebuildFacts: repopulate fact_motifs: %w", err)
 	}
 
 	// Populate branch_facts: link each fact to this branch with its commit_hash.

--- a/internal/store/sqlfuncs.go
+++ b/internal/store/sqlfuncs.go
@@ -31,6 +31,7 @@ type parsedFact struct {
 	Type           string   `json:"type"`
 	Domain         []string `json:"domain"`
 	Entities       []string `json:"entities"`
+	Motifs         []string `json:"motifs,omitempty"`
 	Confidence     float64  `json:"confidence"`
 	Sources        int      `json:"sources"`
 	Refs           []string `json:"refs"`
@@ -59,6 +60,7 @@ func sqlParseFact(data []byte) interface{} {
 		Type:           string(f.Type),
 		Domain:         f.Domain,
 		Entities:       f.Entities,
+		Motifs:         f.Motifs,
 		Confidence:     f.Confidence,
 		Sources:        f.Sources,
 		Refs:           f.Refs,

--- a/internal/store/token_df.go
+++ b/internal/store/token_df.go
@@ -7,15 +7,22 @@ import (
 )
 
 // TokenDF returns the number of facts LIVE on `branch` at HEAD that carry the
-// given domain or entity tag — the document-frequency input to discovery's
-// `spec` (rarity) signal. It is a plain indexed COUNT over the junction tables
-// joined to branch_facts for liveness; it never reads or tokenizes fact body
-// text. kind must be "domain" or "entity".
+// given domain, entity or motif tag — the document-frequency input to
+// discovery's `spec` (rarity) signal. It is a plain indexed COUNT over the
+// junction tables joined to branch_facts for liveness; it never reads or
+// tokenizes fact body text. kind must be "domain", "entity" or "motif".
 //
 //   - "domain": token is the CANONICAL tag (canonicalizeDomain form). fact_domains
 //     stores the canonical form, so this is an exact indexed match.
 //   - "entity": token is matched case-insensitively (fact_entities is COLLATE
 //     NOCASE); pass the authored entity form. Entities are not de-hyphenized.
+//   - "motif": token is the motif string AS WRITTEN. There is no canonical
+//     form to pass and none is computed here (MN3): a motif is stored exactly
+//     as its author typed it, and the alias resolution that maps spellings to
+//     a canonical id is derived state that resolves the token BEFORE calling
+//     this. Matching is case-insensitive (fact_motifs is COLLATE NOCASE), but
+//     motifs are validated lowercase, so that only ever forgives a
+//     hand-edited file.
 //
 // Liveness + branch scoping come from branch_facts (UNIQUE(branch_id, path) =>
 // one row per live path per branch), exactly as BlastRadius does.
@@ -26,8 +33,10 @@ func (gs *graphStore) TokenDF(ctx context.Context, branch, token, kind string) (
 		table, col = "fact_domains", "domain"
 	case "entity":
 		table, col = "fact_entities", "entity"
+	case "motif":
+		table, col = "fact_motifs", "motif"
 	default:
-		return 0, fmt.Errorf("TokenDF: invalid kind %q: must be \"domain\" or \"entity\"", kind)
+		return 0, fmt.Errorf("TokenDF: invalid kind %q: must be \"domain\", \"entity\" or \"motif\"", kind)
 	}
 	branchID, err := gs.rh.branchID(ctx, branch)
 	if err != nil {

--- a/internal/store/verify.go
+++ b/internal/store/verify.go
@@ -1207,9 +1207,9 @@ func (s *Service) loadCommitParents(ctx context.Context) (map[string][]string, e
 	return out, rows.Err()
 }
 
-// checkDerivedTables verifies the three fact_* projections that domain and
-// entity search read. Nothing else checks them, and their failure mode is the
-// quiet one: the facts are all present and correct, and searching by domain
+// checkDerivedTables verifies the four fact_* projections that domain, entity
+// and motif lookups read. Nothing else checks them, and their failure mode is
+// the quiet one: the facts are all present and correct, and searching by domain
 // returns nothing.
 //
 // The two directions differ in severity ON PURPOSE.
@@ -1229,6 +1229,7 @@ func (s *Service) checkDerivedTables(ctx context.Context) []IntegrityIssue {
 		{"fact_domains", "fact_id"},
 		{"fact_domain_tokens", "fact_id"},
 		{"fact_entities", "fact_id"},
+		{"fact_motifs", "fact_id"},
 	}
 	for _, o := range orphans {
 		var n int
@@ -1271,6 +1272,47 @@ func (s *Service) checkDerivedTables(ctx context.Context) []IntegrityIssue {
 			issues = append(issues, IntegrityIssue{
 				Severity: SeverityError, Category: CategoryDerivedTables,
 				Detail: fmt.Sprintf("%d fact(s) present in %s but absent from %s", n, d.have, d.missing),
+			})
+		}
+	}
+
+	// fact_motifs against the facts.motifs JSON column, in BOTH directions and
+	// at (fact_id, motif) granularity — stricter than the domain comparison
+	// below, and legitimately so. Motifs are stored AS WRITTEN, with no
+	// canonicalization on either side, so there is no drift a healthy repo
+	// could exhibit: any difference means one of the two writers ran and the
+	// other did not. The incremental upsert fills the junction from the parsed
+	// record while the bulk rebuild fills it with SQL over the column, so a
+	// disagreement is exactly the "half-populated" state that leaves motif
+	// document-frequency wrong while every fact still reads correctly.
+	for _, d := range []struct{ desc, query string }{
+		{"absent from fact_motifs", `
+			SELECT f.id, j.value FROM facts f JOIN json_each(f.motifs) j
+			 WHERE j.value IS NOT NULL AND j.value != ''
+			EXCEPT
+			SELECT fact_id, motif FROM fact_motifs`},
+		{"absent from the facts.motifs column", `
+			SELECT fact_id, motif FROM fact_motifs
+			EXCEPT
+			SELECT f.id, j.value FROM facts f JOIN json_each(f.motifs) j
+			 WHERE j.value IS NOT NULL AND j.value != ''`},
+	} {
+		var n int
+		if err := s.rh.gits.DB().QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM (`+d.query+`)`).Scan(&n); err != nil {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDerivedTables,
+				Detail: fmt.Sprintf("compare motifs (%s): %v", d.desc, err),
+			})
+			continue
+		}
+		if n > 0 {
+			issues = append(issues, IntegrityIssue{
+				Severity: SeverityError, Category: CategoryDerivedTables,
+				Detail: fmt.Sprintf(
+					"%d (fact_id, motif) pair(s) %s — motif document-frequency is wrong "+
+						"for these facts while the facts themselves read correctly; a rebuild "+
+						"repopulates the junction from the column", n, d.desc),
 			})
 		}
 	}

--- a/internal/synthesize/dedup.go
+++ b/internal/synthesize/dedup.go
@@ -229,6 +229,12 @@ func dedupCluster(
 		fullWinner.Entities = winnerFact.Entities
 		fullWinner.Confidence = winnerFact.Confidence
 		fullWinner.Sources = winnerFact.Sources
+		// Motifs are merged HERE rather than in mergeFacts above, because
+		// factForLLM does not carry them — only the full parsed facts do. Same
+		// helper as the learn-time merge: this is the same operation in a second
+		// location, and without it the loser's motifs are simply deleted along
+		// with the loser, losing authored data that no derived state can rebuild.
+		fullWinner.Motifs = fact.MergeMotifs(fullWinner.Motifs, fullLoser.Motifs)
 		// Refs = union of both refs + loser's path.
 		mergedRefs := fact.UnionStrings(fullWinner.Refs, fullLoser.Refs)
 		mergedRefs = fact.AppendUnique(mergedRefs, loserFact.File)

--- a/internal/synthesize/motif_acceptance_test.go
+++ b/internal/synthesize/motif_acceptance_test.go
@@ -1,0 +1,196 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// TestAcceptance_MotifField runs Phase 1's FIRST acceptance item against a
+// REAL knomit repo database, and prints what the field does to a real corpus:
+// a fact written with a subject-restating motif stores WITHOUT it.
+//
+// The second item — server instructions byte-identical regardless of corpus
+// state — is measured by TestAcceptance_MotifInstructions in internal/mcp.
+// It cannot live here: internal/mcp imports this package, so the dependency
+// cannot run back the other way.
+//
+// Skipped unless KNOMIT_PHASE1_DB names a COPY of a repo DB, matching the
+// Phase-0 harness next door: it needs a real corpus, and it is a MEASUREMENT
+// rather than a contract. The assertions are deliberately weak — the strip must
+// not error, must not take everything, and must not take nothing. What makes it
+// worth keeping is the output: which real facts' own subject words would have
+// eaten a motif, and which survived.
+//
+//	cp ~/.knomit/repos/<uid>.db /tmp/accept.db
+//	KNOMIT_PHASE1_DB=/tmp/accept.db go test ./internal/synthesize/ \
+//	    -run TestAcceptance_MotifField -v -timeout 30m
+//
+// Work on a COPY. The run migrates the schema.
+//
+// No embedder is configured: unlike Phase 0, nothing here embeds anything. That
+// is itself worth stating — a motif is a string and a junction row, and the
+// design has NO per-fact-motif embeddings anywhere.
+func TestAcceptance_MotifField(t *testing.T) {
+	dbPath := os.Getenv("KNOMIT_PHASE1_DB")
+	if dbPath == "" {
+		t.Skip("set KNOMIT_PHASE1_DB to a COPY of a repo database to run the acceptance measurement")
+	}
+	ctx := context.Background()
+
+	svc, err := store.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.OpenRepo())
+
+	branch := os.Getenv("KNOMIT_PHASE1_BRANCH")
+	if branch == "" {
+		branch, err = svc.Branches().DefaultBranch(ctx)
+		require.NoError(t, err)
+	}
+
+	acceptanceSubjectStrip(t, svc, branch)
+}
+
+// acceptanceSubjectStrip walks real facts, synthesizes a subject motif for each
+// out of the fact's OWN entity/domain/path words, and checks the strip removes
+// it — then does the same with a generic regularity name and checks it survives.
+//
+// The generator is the interesting half. It builds the motif a careless author
+// would actually write: two of the fact's own subject words, kebab-joined. If
+// the strip is too narrow that motif survives; if it is too broad the generic
+// control dies. Both directions are measured and logged.
+func acceptanceSubjectStrip(t *testing.T, svc *store.Service, branch string) {
+	ctx := context.Background()
+	paths, err := svc.Facts().ListAll(ctx, branch)
+	require.NoError(t, err)
+	require.NotEmpty(t, paths, "the corpus must have facts, or this measures nothing")
+
+	// A control that is a real regularity name and shares no word with any
+	// plausible subject. It must survive on every fact.
+	const control = "zero-value-as-valid"
+
+	var examined, stripped, notStripped, controlSurvived, skipped int
+	var strippedEg, survivedEg []string
+
+	for _, p := range paths {
+		// No suffix pre-filter: the ParseFact below already rejects every
+		// non-fact file, and a second rule for "what is a fact file" is a
+		// second rule to keep in sync (ref_consumers_test.go polices exactly
+		// this).
+		res, rerr := svc.Facts().ReadFact(ctx, branch, p, nil)
+		if rerr != nil {
+			skipped++
+			continue
+		}
+		f, perr := fact.ParseFact(p, res.Content)
+		if perr != nil {
+			skipped++ // not a fact file (README, ontology, ...)
+			continue
+		}
+
+		subject := subjectMotifFor(f)
+		if subject == "" {
+			skipped++ // too few usable subject words to build a two-word motif
+			continue
+		}
+		examined++
+
+		f.Motifs = []string{subject, control}
+		out, serr := fact.SerializeFact(f)
+		require.NoErrorf(t, serr, "the strip must never error, and did on %s", p)
+
+		back, berr := fact.ParseFact(p, out)
+		require.NoError(t, berr)
+
+		hasSubject := containsStr(back.Motifs, subject)
+		if hasSubject {
+			notStripped++
+			if len(survivedEg) < 8 {
+				survivedEg = append(survivedEg, fmt.Sprintf("%s\n      motif %q survived; entities=%v domain=%v",
+					p, subject, f.Entities, f.Domain))
+			}
+		} else {
+			stripped++
+			if len(strippedEg) < 8 {
+				strippedEg = append(strippedEg, fmt.Sprintf("%s\n      motif %q stripped", p, subject))
+			}
+		}
+		if containsStr(back.Motifs, control) {
+			controlSurvived++
+		}
+	}
+
+	t.Logf("\n=== subject strip on a real corpus ===\n"+
+		"  facts examined:            %d  (skipped %d: unparseable or too few subject words)\n"+
+		"  subject motif stripped:    %d  (%.1f%%)\n"+
+		"  subject motif survived:    %d  (%.1f%%)\n"+
+		"  control %q survived: %d/%d\n",
+		examined, skipped,
+		stripped, pct(stripped, examined),
+		notStripped, pct(notStripped, examined),
+		control, controlSurvived, examined)
+
+	if len(strippedEg) > 0 {
+		t.Logf("stripped examples:\n    - %s", strings.Join(strippedEg, "\n    - "))
+	}
+	if len(survivedEg) > 0 {
+		t.Logf("SURVIVED (inspect these — each is a subject motif the strip let through):\n    - %s",
+			strings.Join(survivedEg, "\n    - "))
+	}
+
+	require.Positive(t, examined, "no fact yielded a testable subject motif; the generator is wrong, not the strip")
+	// Weak by design. A strip that removed nothing is broken; one that removed
+	// the control on any fact is over-broad. Between those, the RATE is a
+	// measurement to read, not a threshold to enforce — it depends entirely on
+	// how this corpus names things.
+	require.Positive(t, stripped, "the strip removed nothing on a real corpus")
+	require.Equal(t, examined, controlSurvived,
+		"a generic regularity name must survive on every fact; the strip is over-broad")
+}
+
+// subjectMotifFor builds the motif a careless author would write for f: two of
+// the fact's own subject words, kebab-joined. Returns "" when the fact has
+// fewer than two usable words.
+func subjectMotifFor(f fact.Fact) string {
+	var words []string
+	seen := map[string]bool{}
+	for _, s := range append(append([]string{}, f.Entities...), f.Domain...) {
+		for _, w := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+			return r < 'a' || r > 'z'
+		}) {
+			if len(w) < 3 || seen[w] {
+				continue
+			}
+			seen[w] = true
+			words = append(words, w)
+		}
+	}
+	if len(words) < 2 {
+		return ""
+	}
+	return words[0] + "-" + words[1]
+}
+
+func containsStr(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func pct(n, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return 100 * float64(n) / float64(total)
+}

--- a/internal/synthesize/motif_acceptance_test.go
+++ b/internal/synthesize/motif_acceptance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -43,6 +44,7 @@ func TestAcceptance_MotifField(t *testing.T) {
 	if dbPath == "" {
 		t.Skip("set KNOMIT_PHASE1_DB to a COPY of a repo database to run the acceptance measurement")
 	}
+	requireCopyNotLiveCorpus(t, dbPath)
 	ctx := context.Background()
 
 	svc, err := store.Open(dbPath)
@@ -193,4 +195,30 @@ func pct(n, total int) float64 {
 		return 0
 	}
 	return 100 * float64(n) / float64(total)
+}
+
+// requireCopyNotLiveCorpus refuses to run against a database inside the user's
+// knomit home.
+//
+// "Work on a COPY" was a comment, and a comment is not enforcement. Both
+// acceptance harnesses migrate the schema, and the instructions one WRITES a
+// sentinel fact through the ordinary path — pointed at a live repo that is a
+// stray commit on someone's real knowledge base, produced by a test run they
+// thought was read-only. The check is a refusal, never a skip: a harness that
+// quietly did nothing here would look like it had passed.
+func requireCopyNotLiveCorpus(t *testing.T, dbPath string) {
+	t.Helper()
+	abs, err := filepath.Abs(dbPath)
+	require.NoError(t, err)
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	live := filepath.Join(home, ".knomit")
+	rel, err := filepath.Rel(live, abs)
+	require.NoError(t, err)
+	require.Truef(t, strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == "..",
+		"refusing to run against %s: it is inside %s, which is a LIVE corpus. "+
+			"This harness migrates the schema and writes a fact. Copy the database "+
+			"out first:\n    cp %s /tmp/accept.db\n    KNOMIT_PHASE1_DB=/tmp/accept.db go test ...",
+		abs, live, abs)
 }

--- a/internal/synthesize/motif_dynamics_test.go
+++ b/internal/synthesize/motif_dynamics_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
 )
 
 // Multi-session motif dynamics.
@@ -141,4 +143,51 @@ func TestMotifDynamics_AccumulatesAcrossSessions(t *testing.T) {
 	require.Equal(t, 5, motifDF(t, env, "silent-fallback"))
 	require.Equal(t, 1, motifDF(t, env, "unmonitored-expiry"),
 		"a hapax motif stays a hapax — the band floor depends on this being honest")
+}
+
+// TestMotifDynamics_ReviewMergePreservesLoserMotifs — the review-session
+// consolidation merge is the SECOND fact-merge site, and it deletes the loser.
+// If it does not carry the loser's motifs across, that authored data is gone
+// for good: motifs are not derived state and nothing can rebuild them.
+//
+// This is the defect the Phase-1 review found. It survived the first round
+// because the conformance test banned dedup.go from mentioning motifs at all —
+// an over-reading of MN6 that made the correct code look like a violation.
+func TestMotifDynamics_ReviewMergePreservesLoserMotifs(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+	ctx := context.Background()
+
+	// Two near-identical facts. The higher-confidence one wins.
+	env.writeFactWithMotifsConf("kb/alpha/winner.md", "Cache invalidation on write",
+		"one account of it", []string{"stale-read-window"}, 0.9)
+	env.writeFactWithMotifsConf("kb/alpha/loser.md", "Cache invalidation on write",
+		"one account of it", []string{"silent-fallback"}, 0.5)
+
+	cluster := []factForLLM{
+		{File: "kb/alpha/winner.md", Title: "Cache invalidation on write", Body: "one account of it",
+			Type: string(fact.Observation), Confidence: 0.9, Sources: 1},
+		{File: "kb/alpha/loser.md", Title: "Cache invalidation on write", Body: "one account of it",
+			Type: string(fact.Observation), Confidence: 0.5, Sources: 1},
+	}
+
+	// threshold 0 so the pair merges on the deterministic embedder's similarity.
+	out, err := dedupCluster(ctx, cluster, env.svc.Facts(), env.svc.Search(), 0,
+		"test", func(ProgressEvent) {}, env.branch, bareRefFixture)
+	require.NoError(t, err)
+	require.Len(t, out, 1, "the fixture must actually have merged, or this proves nothing")
+
+	survivor := readFactFromStore(t, env, out[0].File)
+	require.Equal(t, []string{"stale-read-window", "silent-fallback"}, survivor.Motifs,
+		"winner's motif first, then the loser's — the loser is deleted, so its "+
+			"motifs must travel or they are lost")
+}
+
+// readFactFromStore reads and parses the committed fact at path.
+func readFactFromStore(t *testing.T, e *restatementEnv, path string) fact.Fact {
+	t.Helper()
+	res, err := e.svc.Facts().ReadFact(context.Background(), e.branch, path, nil)
+	require.NoError(t, err)
+	f, err := fact.ParseFact(path, res.Content)
+	require.NoError(t, err)
+	return f
 }

--- a/internal/synthesize/motif_dynamics_test.go
+++ b/internal/synthesize/motif_dynamics_test.go
@@ -1,0 +1,144 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Multi-session motif dynamics.
+//
+// The Phase-0 review's lesson, applied forward: every component here is
+// trivially correct in isolation, and the failures live in what happens on the
+// SECOND session, after an edit, or after a retraction. A test that calls a
+// function once cannot see any of it.
+//
+// These assert through TokenDF rather than by reading the junction directly:
+// df is the public surface Phase 1 actually ships, it is what later phases
+// consume, and it is the number a wrong answer here would corrupt. Per-path
+// junction correctness is asserted where the SQL lives, in
+// internal/store/fact_motifs_test.go.
+//
+// Phase 1's named question — does a motif written in session N survive
+// dedup-merge in session N+1 — is driven through the real knomit_learn handler
+// in internal/mcp/learn_motif_test.go, because internal/mcp imports this
+// package and the dependency cannot run the other way.
+
+func motifDF(t *testing.T, e *restatementEnv, motif string) int {
+	t.Helper()
+	n, err := e.svc.Search().TokenDF(context.Background(), e.branch, motif, "motif")
+	require.NoError(t, err)
+	return n
+}
+
+// TestMotifDynamics_SurvivesEditAcrossSessions — facts rows are
+// content-addressed, so an edit is a NEW row with a NEW id, and the junction is
+// keyed by fact_id. If the new row's motifs were not re-derived, an edited fact
+// would silently lose them: its df would drop by one with nothing to point at,
+// and the loss would stay invisible until a much later phase went looking for a
+// bridge whose seed had quietly evaporated.
+func TestMotifDynamics_SurvivesEditAcrossSessions(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+
+	// Session 1.
+	env.writeFactWithMotifs("kb/alpha/one.md", "Title one", "body one",
+		[]string{"silent-fallback"})
+	require.Equal(t, 1, motifDF(t, env, "silent-fallback"))
+
+	// Session 2: edit the body, keep the motif. The fact is a new row; the
+	// motif must come with it.
+	env.writeFactWithMotifs("kb/alpha/one.md", "Title one", "body one, revised",
+		[]string{"silent-fallback"})
+	require.Equal(t, 1, motifDF(t, env, "silent-fallback"),
+		"an edit must neither drop the motif nor double-count it")
+
+	// Session 3: change the motif itself.
+	env.writeFactWithMotifs("kb/alpha/one.md", "Title one", "body one, revised again",
+		[]string{"config-drift"})
+	require.Equal(t, 1, motifDF(t, env, "config-drift"))
+	require.Zero(t, motifDF(t, env, "silent-fallback"),
+		"a motif removed by an edit must stop counting immediately — the superseded "+
+			"revision is still in git, but df is about what is LIVE")
+}
+
+// TestMotifDynamics_DFTracksLivePathsNotRevisions — TokenDF counts DISTINCT
+// live paths. Rewriting one fact three times must not inflate its motif's df to
+// three: a later phase reads df as corroboration ("how many facts share this
+// regularity"), and edit churn is not corroboration. Getting this wrong would
+// promote a single much-edited fact into a df band it never earned.
+func TestMotifDynamics_DFTracksLivePathsNotRevisions(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+	for i := range 3 {
+		env.writeFactWithMotifs("kb/alpha/one.md", "Title one",
+			fmt.Sprintf("body revision %d", i), []string{"silent-fallback"})
+	}
+	env.writeFactWithMotifs("kb/alpha/two.md", "Title two", "body two",
+		[]string{"silent-fallback"})
+
+	require.Equal(t, 2, motifDF(t, env, "silent-fallback"),
+		"df counts live paths, not the revisions behind them")
+}
+
+// TestMotifDynamics_RetractionRemovesTheMotif — deleting a fact must take its
+// junction rows with it, or df keeps counting a carrier that no longer exists
+// and every consumer inherits a phantom.
+func TestMotifDynamics_RetractionRemovesTheMotif(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+	ctx := context.Background()
+
+	env.writeFactWithMotifs("kb/alpha/one.md", "Title one", "body one",
+		[]string{"silent-fallback"})
+	env.writeFactWithMotifs("kb/alpha/two.md", "Title two", "body two",
+		[]string{"silent-fallback"})
+	require.Equal(t, 2, motifDF(t, env, "silent-fallback"))
+
+	_, err := env.svc.Facts().DeleteFact(ctx, env.branch, "kb/alpha/two.md", "retract two")
+	require.NoError(t, err)
+
+	require.Equal(t, 1, motifDF(t, env, "silent-fallback"),
+		"a retracted fact must stop contributing to its motif's df")
+}
+
+// TestMotifDynamics_SubjectStripHoldsAcrossSessions — the strip is a write-time
+// transform, so it must hold on EVERY write, not only the first. A strip that
+// somehow ran once (a cached decision, a first-write-only code path) would let
+// the same subject motif in on the second session, and nothing downstream would
+// question it.
+func TestMotifDynamics_SubjectStripHoldsAcrossSessions(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+
+	// "widget-alpha" is entity ∪ domain for this helper's fixtures, so it is a
+	// subject motif and never lands.
+	env.writeFactWithMotifs("kb/alpha/one.md", "Title one", "body one",
+		[]string{"widget-alpha", "silent-fallback"})
+	require.Equal(t, 1, motifDF(t, env, "silent-fallback"))
+	require.Zero(t, motifDF(t, env, "widget-alpha"))
+
+	// Session 2: offered again, dropped again.
+	env.writeFactWithMotifs("kb/alpha/one.md", "Title one", "body one, revised",
+		[]string{"widget-alpha", "silent-fallback"})
+	require.Equal(t, 1, motifDF(t, env, "silent-fallback"))
+	require.Zero(t, motifDF(t, env, "widget-alpha"),
+		"the strip must run on every write, not only the first")
+}
+
+// TestMotifDynamics_AccumulatesAcrossSessions — the ordinary case, and the one
+// a later phase's df band depends on: motifs written by unrelated sessions over
+// unrelated facts add up, and a motif nobody repeated stays at one.
+func TestMotifDynamics_AccumulatesAcrossSessions(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+	for i := range 5 {
+		motifs := []string{"silent-fallback"}
+		if i == 0 {
+			motifs = append(motifs, "unmonitored-expiry")
+		}
+		env.writeFactWithMotifs(fmt.Sprintf("kb/alpha/f%d.md", i),
+			fmt.Sprintf("Title %d", i), fmt.Sprintf("body %d", i), motifs)
+	}
+
+	require.Equal(t, 5, motifDF(t, env, "silent-fallback"))
+	require.Equal(t, 1, motifDF(t, env, "unmonitored-expiry"),
+		"a hapax motif stays a hapax — the band floor depends on this being honest")
+}

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"knomit/internal/embeddings/params"
+	"knomit/internal/fact"
 	"knomit/internal/repos"
 	"knomit/internal/store"
 )
@@ -265,6 +266,32 @@ func (e *restatementEnv) writeFactWithDomain(path, title, body, domain string) {
 	_, err := e.svc.Facts().WriteFact(context.Background(), e.branch, path,
 		"---\ntype: observation\ndomain: ["+domain+"]\n---\n# "+title+"\n\n"+body,
 		"write "+path, "test")
+	require.NoError(e.t, err)
+}
+
+// writeFactWithMotifs mirrors writeFact but carries motifs, so the motif
+// dynamics tests can drive whole sessions over a corpus that has them.
+//
+// It renders through SerializeFact rather than hand-building frontmatter like
+// its siblings above: motifs are the one field with a WRITE-TIME transform
+// (the silent subject strip), so a hand-built fixture would be a string no
+// real writer could produce.
+func (e *restatementEnv) writeFactWithMotifs(path, title, body string, motifs []string) {
+	e.t.Helper()
+	f := fact.NewFact(path)
+	f.Title = title
+	f.Body = body
+	f.Type = fact.Observation
+	f.Domain = []string{"alpha"}
+	f.Entities = []string{"Widget"}
+	f.Refs = []string{}
+	f.Confidence = 0.7
+	f.Sources = 1
+	f.Motifs = motifs
+	rendered, err := fact.SerializeFact(f)
+	require.NoError(e.t, err)
+	_, err = e.svc.Facts().WriteFact(context.Background(), e.branch, f.Path(),
+		rendered, "write "+path, "test")
 	require.NoError(e.t, err)
 }
 

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -278,6 +278,13 @@ func (e *restatementEnv) writeFactWithDomain(path, title, body, domain string) {
 // real writer could produce.
 func (e *restatementEnv) writeFactWithMotifs(path, title, body string, motifs []string) {
 	e.t.Helper()
+	e.writeFactWithMotifsConf(path, title, body, motifs, 0.7)
+}
+
+// writeFactWithMotifsConf is writeFactWithMotifs with an explicit confidence,
+// for tests that need to decide which of two facts wins a merge.
+func (e *restatementEnv) writeFactWithMotifsConf(path, title, body string, motifs []string, confidence float64) {
+	e.t.Helper()
 	f := fact.NewFact(path)
 	f.Title = title
 	f.Body = body
@@ -285,7 +292,7 @@ func (e *restatementEnv) writeFactWithMotifs(path, title, body string, motifs []
 	f.Domain = []string{"alpha"}
 	f.Entities = []string{"Widget"}
 	f.Refs = []string{}
-	f.Confidence = 0.7
+	f.Confidence = confidence
 	f.Sources = 1
 	f.Motifs = motifs
 	rendered, err := fact.SerializeFact(f)

--- a/internal/textnorm/textnorm.go
+++ b/internal/textnorm/textnorm.go
@@ -1,0 +1,114 @@
+// Package textnorm is the single definition of "the same token" for knomit.
+//
+// It exists because two subsystems must agree on that definition and cannot
+// import each other. Domain matching lives in internal/store; the motif
+// subject-word strip lives in internal/fact, which imports no internal
+// package at all, by design. Two copies of a stemmer are two things that
+// drift, and when they drift a motif that merely renames its own fact's
+// subject slips past the strip — because "vulnerabilities" and
+// "vulnerability" stopped being the same word on one side of the repo.
+// One definition, two importers.
+//
+// Everything here is pure, deterministic and idempotent, and every rule in it
+// was verified against the real knomit domain corpus. The canonical/token
+// forms are derived state: authored tags stay in git, and nothing here is
+// ever written back into a fact.
+package textnorm
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/gertd/go-pluralize"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/unicode/norm"
+)
+
+// caser performs Unicode case folding (language-neutral). Allocated once.
+var caser = cases.Fold()
+
+// pluralizer singularizes plural tokens to a match key. go-pluralize is a
+// port of the widely-used JS `pluralize`, with a real irregular/exception table
+// (not naive suffix rules), so it is symmetric and idempotent on the irregulars
+// a hand-rolled or Porter/Snowball stemmer breaks: analyses≡analysis,
+// indices≡index, matrices≡matrix, theses≡thesis. Allocated once; configured for
+// the technical vocabulary in Stem's guards. Pure-Go, zero deps.
+var pluralizer = pluralize.NewClient()
+
+// Fold applies Unicode case folding and nothing else. It is the same folding
+// Canonicalize uses, exposed on its own for callers that need case-insensitive
+// equality without tokenization — mirroring a COLLATE NOCASE column, where
+// de-hyphenizing would change what the column holds.
+func Fold(s string) string { return caser.String(s) }
+
+// Canonicalize normalises a string for matching and junction storage:
+// NFC → case-fold → replace hyphens and Unicode whitespace with a single space →
+// trim. Underscores are PRESERVED so identifier-like tags (commit_log) stay one
+// token. Pure and idempotent.
+func Canonicalize(s string) string {
+	s = norm.NFC.String(s)
+	s = caser.String(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := true // leading-trim: suppress leading spaces
+	for _, r := range s {
+		if r == '-' || unicode.IsSpace(r) {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	return strings.TrimRight(b.String(), " ")
+}
+
+// Stem normalises a token to its singular form as a MATCH-ONLY key — the
+// result is never displayed or stored as a canonical tag, only used so two
+// tokens collapse to the same key ("vulnerabilities" ≡ "vulnerability"). It
+// delegates to go-pluralize, which is symmetric and idempotent on the
+// irregulars a hand-rolled or Porter/Snowball stemmer breaks (analyses≡analysis,
+// indices≡index, matrices≡matrix, theses≡thesis), verified against the real
+// domain corpus.
+//
+// Two guards prevent over-singularizing non-plurals that merely end in 's'
+// (any pluralizer treats a trailing 's' as plural, which is what we DON'T want
+// for these — confirmed against real knomit domains):
+//   - len <= 3: acronyms/identifiers (ai, aws, llm, tls) are never plurals.
+//   - "...ics": -ics field/mass nouns (economics, robotics, metrics, ethics)
+//     are singular; stripping to -ic would be wrong and asymmetric.
+//
+// Both guards are symmetric (applied identically at index and query time), so
+// they never break matching; they only avoid mangling internal keys.
+func Stem(t string) string {
+	if len(t) <= 3 || strings.HasSuffix(t, "ics") {
+		return t
+	}
+	return pluralizer.Singular(t)
+}
+
+// Tokens returns the stemmed, de-duplicated token set of a canonical string,
+// split on whitespace AND slash. Splitting on '/' too means a hierarchical
+// tag's individual segments are each searchable as a word
+// ("multi-tenant/auth" → ["multi","tenant","auth"]) — without it, a segment
+// glued to a slash ("tenant/auth") is unreachable by its own middle word and
+// the slash-hierarchy branch only matches whole prefixes. Order follows first
+// appearance; callers treat it as a set. Pass the output of Canonicalize.
+func Tokens(canonical string) []string {
+	fields := strings.FieldsFunc(canonical, func(r rune) bool {
+		return r == '/' || unicode.IsSpace(r)
+	})
+	seen := make(map[string]struct{}, len(fields))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		st := Stem(f)
+		if _, ok := seen[st]; ok {
+			continue
+		}
+		seen[st] = struct{}{}
+		out = append(out, st)
+	}
+	return out
+}

--- a/internal/textnorm/textnorm_test.go
+++ b/internal/textnorm/textnorm_test.go
@@ -1,0 +1,64 @@
+package textnorm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalize(t *testing.T) {
+	require.Equal(t, "ai governance", Canonicalize("AI-Governance"))
+	require.Equal(t, "ai governance", Canonicalize("  AI  Governance  "))
+	require.Equal(t, "multi tenant/auth", Canonicalize("Multi-Tenant/Auth"))
+	// Underscores survive: identifier-like tags stay one token.
+	require.Equal(t, "commit_log", Canonicalize("commit_log"))
+	// Idempotent — it is applied at both index and query time.
+	require.Equal(t, Canonicalize("AI-Governance"), Canonicalize(Canonicalize("AI-Governance")))
+}
+
+func TestFold(t *testing.T) {
+	require.Equal(t, Fold("Antigravity"), Fold("ANTIGRAVITY"))
+	// Fold does NOT de-hyphenize — that is the whole reason it is separate
+	// from Canonicalize. It mirrors a COLLATE NOCASE column.
+	require.Equal(t, "multi-tenant", Fold("Multi-Tenant"))
+}
+
+func TestStem_IrregularsAndGuards(t *testing.T) {
+	for _, pair := range [][2]string{
+		{"vulnerability", "vulnerabilities"},
+		{"analysis", "analyses"},
+		{"index", "indices"},
+		{"matrix", "matrices"},
+		{"thesis", "theses"},
+	} {
+		require.Equalf(t, Stem(pair[0]), Stem(pair[1]),
+			"%q and %q must collapse to one key", pair[0], pair[1])
+	}
+
+	// Guards: short tokens and -ics words merely END in 's' and are never
+	// plurals. Over-singularizing them would mangle the key asymmetrically.
+	for _, tok := range []string{"ai", "aws", "llm", "tls", "ops"} {
+		require.Equal(t, tok, Stem(tok))
+	}
+	for _, tok := range []string{"metrics", "economics", "robotics", "ethics"} {
+		require.Equal(t, tok, Stem(tok))
+	}
+
+	// Idempotent.
+	require.Equal(t, Stem("vulnerabilities"), Stem(Stem("vulnerabilities")))
+}
+
+func TestTokens_SplitsOnSlashAndSpace(t *testing.T) {
+	require.Equal(t, []string{"multi", "tenant", "auth"},
+		Tokens(Canonicalize("multi-tenant/auth")))
+}
+
+func TestTokens_DeduplicatesPreservingFirstAppearance(t *testing.T) {
+	require.Equal(t, []string{"auth", "token"},
+		Tokens(Canonicalize("auth/token/auth")))
+}
+
+func TestTokens_Empty(t *testing.T) {
+	require.Empty(t, Tokens(Canonicalize("")))
+	require.Empty(t, Tokens(Canonicalize("   ")))
+}

--- a/internal/web/handlers_fact_write.go
+++ b/internal/web/handlers_fact_write.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
 
 	"github.com/go-chi/chi/v5"
 
@@ -234,12 +235,29 @@ func handleFactUpdate(b hal.URLBuilder, writer FactWriter) http.HandlerFunc {
 			return
 		}
 
-		// The client's bytes are stored verbatim unless canonicalization
-		// actually moved a ref — a PUT that needs no rewriting must not be
-		// silently reformatted by a round trip through SerializeFact.
+		// The motif gate. This path is the ONE write path that does not reach
+		// SerializeFact on its own — it commits the client's bytes — so without
+		// this, a subject-restating motif typed into the raw editor lands on
+		// disk, in fact_motifs and in TokenDF, having passed no gate at all.
+		//
+		// Two things can make the gate non-trivial, and both must be caught:
+		// the subject strip removing a motif, and ParseFact having already
+		// dropped a malformed or over-cap one — the parsed fact is clean in
+		// that second case while body.Content still carries the offender,
+		// which is exactly what MotifWarnings exists to report.
+		gatedMotifs := knomitfact.StripSubjectMotifs(f)
+		motifsChanged := len(f.MotifWarnings) > 0 || !slices.Equal(gatedMotifs, f.Motifs)
+
+		// The client's bytes are stored verbatim unless a gate actually changed
+		// something — a PUT that needs no rewriting must not be silently
+		// reformatted by a round trip through SerializeFact.
 		content := body.Content
-		if changed {
+		if changed || motifsChanged {
 			f.Refs = canonRefs
+			// SerializeFact strips again on its way out; assigning here keeps
+			// the fact handed to BuildFactView below telling the same story as
+			// the bytes committed.
+			f.Motifs = gatedMotifs
 			serialized, serr := knomitfact.SerializeFact(f)
 			if serr != nil {
 				hal.WriteProblem(w, http.StatusUnprocessableEntity,

--- a/internal/web/handlers_fact_write_motif_test.go
+++ b/internal/web/handlers_fact_write_motif_test.go
@@ -1,0 +1,92 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	knomitfact "knomit/internal/fact"
+)
+
+// putFactContent renders a PUT body carrying the given raw motifs line, so a
+// test can send bytes no writer would produce — which is exactly what the raw
+// editor lets a client do.
+func putFactContent(motifsLine string) string {
+	return "---\\ntype: observation\\ndomain: [ai]\\nconfidence: 0.9\\nsources: 1\\nentities: [Anthropic]\\n" +
+		motifsLine + "refs: []\\n---\\n\\n# Test Fact\\n\\nBody text.\\n"
+}
+
+// putFact drives a PUT through the real router and returns the bytes the
+// handler handed to git.
+func putFact(t *testing.T, content string) (int, string) {
+	t.Helper()
+	writer := &stubFactWriter{writeHash: "abc123"}
+	s := &Server{
+		Manager:   newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{factWriter: writer},
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut,
+		"/repos/alpha/branches/agent:test/facts/know/ai/test.md",
+		strings.NewReader(`{"content":"`+content+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	s.NewAPIRouter().ServeHTTP(rec, req)
+	return rec.Code, writer.lastWriteContent
+}
+
+// TestFactPut_SubjectMotifIsStripped is the Phase-1 acceptance property on the
+// REST write path.
+//
+// The handler stores the client's bytes VERBATIM unless a gate changed
+// something, and ParseFact is lenient by design — so without a motif gate here,
+// a subject-restating motif typed into the raw editor reaches disk,
+// fact_motifs, and TokenDF, having flowed through no write gate at all. That is
+// a genuine hole in MN4's "every write path": this path calls neither
+// SerializeFact nor any motif helper, so a grep for helper NAMES cannot see it.
+func TestFactPut_SubjectMotifIsStripped(t *testing.T) {
+	// "anthropic-ai" is entities ∪ domain for this fixture.
+	code, written := putFact(t, putFactContent("motifs: [anthropic-ai, silent-fallback]\\n"))
+	require.Equal(t, http.StatusOK, code, "the strip is silent — it must not fail the request")
+
+	f, err := knomitfact.ParseFact("know/ai/test.md", unescape(written))
+	require.NoError(t, err)
+	require.Equal(t, []string{"silent-fallback"}, f.Motifs,
+		"a subject motif must not reach disk through the raw editor")
+}
+
+// TestFactPut_MalformedMotifIsNotStored — ParseFact drops a malformed motif
+// from the parsed fact, but the handler was storing the CLIENT's bytes, which
+// still carried it. The corpus must never gain one this way.
+func TestFactPut_MalformedMotifIsNotStored(t *testing.T) {
+	code, written := putFact(t, putFactContent("motifs: [onlyoneword, silent-fallback]\\n"))
+	require.Equal(t, http.StatusOK, code)
+	require.NotContains(t, written, "onlyoneword",
+		"a motif the gate rejects must not be committed verbatim")
+}
+
+// TestFactPut_CleanContentIsStoredVerbatim — the gate must stay a no-op when it
+// has nothing to do. The handler's whole reason for storing client bytes
+// unchanged is that a PUT needing no rewrite must not be silently reformatted,
+// and a motif gate that reserialized unconditionally would break that.
+func TestFactPut_CleanContentIsStoredVerbatim(t *testing.T) {
+	content := putFactContent("motifs: [silent-fallback]\\n")
+	code, written := putFact(t, content)
+	require.Equal(t, http.StatusOK, code)
+	require.Equal(t, unescape(content), written,
+		"content the gate does not change must reach git byte-for-byte")
+}
+
+// TestFactPut_MotiflessContentIsStoredVerbatim — the overwhelmingly common
+// case, and the one a regression here would hit hardest.
+func TestFactPut_MotiflessContentIsStoredVerbatim(t *testing.T) {
+	content := putFactContent("")
+	code, written := putFact(t, content)
+	require.Equal(t, http.StatusOK, code)
+	require.Equal(t, unescape(content), written)
+}
+
+// unescape turns the \n sequences used in JSON test bodies into real newlines.
+func unescape(s string) string { return strings.ReplaceAll(s, `\n`, "\n") }

--- a/internal/web/handlers_fact_write_test.go
+++ b/internal/web/handlers_fact_write_test.go
@@ -31,10 +31,17 @@ type stubFactWriter struct {
 	// rejected request never reached git.
 	writeCalls  int
 	deleteCalls int
+
+	// lastWriteContent is the exact byte string handed to git. Tests that care
+	// what the write GATE produced — as opposed to whether it returned 200 —
+	// read this, because a handler that waves bad content through still
+	// answers 200.
+	lastWriteContent string
 }
 
-func (s *stubFactWriter) Write(_ context.Context, _ *repos.RepoInstance, _, _, _, _ string) (string, error) {
+func (s *stubFactWriter) Write(_ context.Context, _ *repos.RepoInstance, _, _, content, _ string) (string, error) {
 	s.writeCalls++
+	s.lastWriteContent = content
 	return s.writeHash, s.writeErr
 }
 

--- a/spec/mbekg.md
+++ b/spec/mbekg.md
@@ -100,6 +100,7 @@ sources: <integer>
 evidence_weight: <float>   # derived; OMITTED when 0 (see §5.2)
 origin: <origin>           # conditionally omitted (see §2.5)
 entities: [<string>, ...]
+motifs: [<kebab-phrase>, ...]  # OMITTED when empty (see §2.10)
 refs: [<string>, ...]
 ---
 # <Fact Title>
@@ -128,7 +129,7 @@ non-empty body follows after one blank line and ends with a trailing newline.
 
 ### 2.2 Emission Order
 
-Writers MUST emit frontmatter keys in exactly this order, with three
+Writers MUST emit frontmatter keys in exactly this order, with four
 conditional omissions. Note that `origin` sits between `evidence_weight` and
 `entities`, not adjacent to `kind`/`type`.
 
@@ -142,7 +143,8 @@ conditional omissions. Note that `origin` sits between `evidence_weight` and
 | 6 | `evidence_weight` | only when `> 0` | shortest numeric form |
 | 7 | `origin` | per the elision rule, §2.5.3 | plain string |
 | 8 | `entities` | always (empty → `[]`) | inline flow sequence |
-| 9 | `refs` | always (empty → `[]`) | inline flow sequence |
+| 9 | `motifs` | only when non-empty | inline flow sequence |
+| 10 | `refs` | always (empty → `[]`) | inline flow sequence |
 
 "Shortest numeric form" means `1.0` renders as `1`, and very small floats may
 render in exponent notation (valid YAML — readers must accept it).
@@ -177,6 +179,7 @@ an explicit 0 from the caller is a legal value and survives.
 | `evidence_weight` | float | `0` | **no bounds check on read or write**; the value only gates emission (`> 0`) | Derived corroboration score (§5.2). Never authored by hand. |
 | `origin` | string | type-aware default (§2.5.1) | **asymmetric**: normalized on read, rejected on write (§2.5.4) | How the fact came to exist: `authored`, `distilled`, `discovered`. |
 | `entities` | string[] | `[]` | not validated | Flat entity tags for discovery; a lightweight search index. |
+| `motifs` | string[] | absent (NOT `[]` — see §2.10) | **asymmetric**: invalid entries dropped on read, rejected on write; subject motifs silently stripped on write (§2.10) | Names for the general regularity the fact instantiates, independent of its subject (§2.10). |
 | `refs` | string[] | `[]` | not validated; stored verbatim | Evidence pointers (§2.9). |
 
 ### 2.4 Kinds and Types
@@ -283,6 +286,15 @@ direction:
 | `sources` >= 0 | strict | strict |
 | `evidence_weight` | no bounds check | no bounds check; only gates emission on `> 0` |
 | `origin` | normalized silently (§2.5.4) | strict, reject |
+| `refs` shape | warning, kept (§2.9) | strict, reject |
+| `motifs` shape and count | invalid entries dropped silently (§2.10) | strict, reject |
+| `motifs` subject-word overlap | not checked | dropped SILENTLY, never an error (§2.10) |
+
+The last row is the only place in the format where a writer changes a value
+without either rejecting it or being asked to. It is deliberate: a motif that
+restates its fact's own subject is an ordinary authoring miss, and the write
+surfaces tell authors the rule up front, so failing the write would cost more
+than it teaches.
 
 Because `confidence` and `sources` are strict in both directions, an
 out-of-range value cannot survive a round-trip, so a conformant writer can
@@ -345,7 +357,58 @@ Refs are one of **two evidence mechanisms**:
   recorded in the file itself — Git supplies *version* lineage (the history
   of one path), not *derivation* lineage (which facts fed another).
 
-### 2.10 What Is NOT in the File
+### 2.10 Motifs (`motifs`)
+
+A motif names the **general regularity the fact is an instance of** — a
+mechanism, failure shape, or pattern — independently of the fact's subject.
+Motifs exist so two facts about unrelated subjects can be connected when they
+exemplify the same mechanism. They are the *aspect* axis, orthogonal to
+`entities` (subject) and `domain` (area).
+
+**Shape.** 0–3 entries. Each entry is a 2–4 word kebab-case noun phrase whose
+segments are lowercase alphanumeric (`silent-fallback`,
+`atomic-write-via-rename`). Duplicate entries within one fact are not allowed.
+
+**Emission.** The key is emitted only when the list is non-empty. An absent
+key and an empty list are the SAME state and MUST both render as no key at
+all: every fact predating this field parses to a fact carrying no motifs and
+re-serializes byte-identically, and two writers of the same fact must not
+disagree on its blob hash over the spelling of "none".
+
+**Read/write asymmetry.** This field is asymmetric on purpose, for the same
+reason `refs` shape and `origin` are (§2.9, §2.5.4) — a version that was legal
+when it was committed must stay readable forever, and nothing a reader does
+depends on a motif being well-formed:
+
+- Readers MUST ignore invalid entries: an entry that is not a well-formed 2–4
+  word kebab phrase, a duplicate, or an entry past the third is DROPPED, and
+  the fact still parses. A file whose every motif is invalid parses as a fact
+  with no motifs — not as a parse error, and not as an empty list distinct
+  from absence.
+- Writers MUST NOT emit an invalid entry. A malformed or over-cap list is a
+  write error, not a silent correction; the caller is an agent that can retry.
+
+**Subject-word strip (writers only, SILENT).** A motif whose canonical stemmed
+tokens are a SUBSET of the fact's own `entities` ∪ `domain` ∪ path tokens is
+DROPPED at write time, without error and without report. Such a motif merely
+renames its fact's subject and so says nothing the fact has not already said
+about itself; it is structurally impossible to store. The test is subset, not
+equality: a phrase contributing at least one word that is not a subject word
+survives.
+
+Because the strip runs on every write, it is evaluated against the subject as
+it stands AT THAT WRITE. A fact whose `entities` or `domain` later grow to
+cover a motif it already carries keeps that motif until its next write, and
+loses it then. The invariant is "no stored motif restates its fact's CURRENT
+subject", and it is maintained forward, not retroactively — facts are
+immutable and nothing rewrites them in place.
+
+**Storage.** Motifs are stored exactly as written. Every normalization built
+on top of them — canonical ids, definitions, document frequency — is derived
+state rebuildable from the files, and nothing derived is ever written back
+into a fact's frontmatter.
+
+### 2.11 What Is NOT in the File
 
 The following are intentionally omitted because Git supplies them (details
 in §4.9):
@@ -361,7 +424,7 @@ in §4.9):
 | Modification history | First-parent commit ancestry of the path |
 | Retraction | The file's deletion commit — absence at HEAD plus history |
 
-### 2.11 Format Traps
+### 2.12 Format Traps
 
 1. The read/write asymmetry is per-axis (§2.6), not global.
 2. Origin elision is not "omit the default" (§2.5.3).


### PR DESCRIPTION
Stacked on #99 (`feat/motif-phase0-consolidation`). Targets that branch, not `dev`.

Implements Phase 1 of `.claude/plans/motif/ROADMAP.md`: `motifs:` exists, validated, stored, counted — and drives nothing.

## What ships

- **The field.** `motifs:` on `fact.Fact`, frontmatter and JSON. Emitted only when non-empty and left nil when absent, so the pre-motif corpus round-trips byte-identically and an omitted list cannot produce a different blob hash from an empty one.
- **Validation in `SerializeFact` only** (MN4). Count ≤ 3 and 2–4-word kebab shape are hard errors; the subject-word strip is silent. `ParseFact` drops what the gate would reject rather than failing, matching how refs and origin already behave — a version legal when committed stays readable forever.
- **`internal/textnorm`.** The stemmer moved out of `internal/store` so the strip and domain matching share one definition of "the same token". `internal/fact` imports no internal package by design, so it could not reach the old one.
- **Storage.** `fact_motifs` junction + `facts.motifs` column (migration 19), populated by both the incremental upsert and the bulk rebuild. `TokenDF` gains kind `motif`.
- **Dedup merge** unions motifs winner-first and trims at the cap (§2.1).
- **SHIP text.** Blocks A and B verbatim from blueprint §2, static, with byte-for-byte goldens under `internal/mcp/testdata/`.

## Verification

| Check | Result |
|---|---|
| MN1 instructions byte-identical across corpora | tested, all 3 profiles |
| MN2 no LLM in motif code | grep clean |
| MN4 rules applied only in `internal/fact` | grep clean (one permitted `MaxMotifs` for the merge trim) |
| MN5 `review_effort_normal_test.go` | blob `439a2f85`, unchanged; the diff-based gate passes, not skips |
| MN6 no motifs in mechanical decision paths | tested |
| MN13 constants classified, no float literals | tested |
| `bridge*.go` | untouched |

**Acceptance, measured on a real 1674-fact corpus:** the subject strip removed 96.1% of motifs built from a fact's own subject words, and the generic control `zero-value-as-valid` survived on 1674 of 1674 — neither inert nor over-broad. Instructions leak none of the corpus's motifs, verified against a planted sentinel so the check cannot pass vacuously.

**Multi-session dynamics** (standing requirement): a motif written in session N survives dedup-merge in N+1, driven end-to-end through the real `knomit_learn` handler; plus motifs surviving content-addressed edits, df counting live paths rather than edit churn, retraction removing a carrier, and the strip holding on every write rather than the first.

## Notes for review

Three tests were tightened after they were found to pass while proving nothing — the rebuild test (rowid-preserving upserts meant nothing was ever deleting the rows it checked), and both merge tests (their assertions also held if dedup had missed entirely and minted a second fact). Each now asserts the mechanism ran, not just the end state.

Deviations are listed in `.claude/plans/motif/2026-08-21-phase1-implementation-plan.md`, all raised and ruled on before implementation.