### PR TITLE
fix(synthesize): dedup merge must not re-judge refs both facts already carried

### DIFF
--- a/internal/store/derived_from.go
+++ b/internal/store/derived_from.go
@@ -248,16 +248,21 @@ func (si *searchIndex) graphAddDerivedFromAtCommitTx(
 			return fmt.Errorf("graphAddDerivedFromAtCommitTx: resolve %s: %w", refPath, err)
 		}
 		if !ok {
-			// With the knomit_learn/knomit_update ref gate in place this is
-			// unreachable for anything written through MCP: a local ref that
-			// will not resolve is rejected before the write. Reaching here
-			// means the fact arrived another way — a direct git push to the
-			// KB branch, a remote reconcile, or a history rewrite — which is
-			// worth seeing. Skipping the edge is still correct; failing the
-			// index is not.
-			log.Warn().Str("branch", branch).Str("source", sourcePath).
+			// The ref gate stops a NEWLY ADDED local ref from being written
+			// unresolvable, but it deliberately exempts refs a fact already
+			// carried — internal/refs does not re-judge the past. So this is
+			// reachable through ordinary MCP writes too: a dedup merge grafts
+			// the loser's carried refs onto the winner, and on a corpus that
+			// predates the gate, or whose targets fell past the walk-back
+			// horizon, those refs land here on every index sync. That is
+			// expected, not a bypass — hence Debug, not Warn. A fact that
+			// arrived another way (a direct git push to the KB branch, a
+			// remote reconcile, a history rewrite) also lands here and is
+			// indistinguishable at this point. Skipping the edge is still
+			// correct; failing the index is not.
+			log.Debug().Str("branch", branch).Str("source", sourcePath).
 				Str("ref", refPath).Str("source_commit", sourceCommit).
-				Msg("derived_from: local ref did not resolve; edge skipped (bypassed the ref gate?)")
+				Msg("derived_from: local ref did not resolve; edge skipped")
 			continue
 		}
 

--- a/internal/synthesize/dedup.go
+++ b/internal/synthesize/dedup.go
@@ -233,10 +233,30 @@ func dedupCluster(
 		mergedRefs := fact.UnionStrings(fullWinner.Refs, fullLoser.Refs)
 		mergedRefs = fact.AppendUnique(mergedRefs, loserFact.File)
 
-		// Same gate as every other write path. The loser is passed as retracted
-		// because it is deleted immediately below and the winner cites it as
-		// lineage — that citation is the record of the merge, not a dead ref.
-		canonRefs, _, gerr := gate.Apply(ctx, winnerFact.File, mergedRefs, []string{loserFact.File})
+		// Same gate as every other write path — but this merge ADDS no
+		// citation, so the whole union goes in as prior.
+		//
+		// Both operands are facts already in the corpus: each carried its refs
+		// from its own commit, where they were checked once, and grafting the
+		// loser's lineage onto the winner is a transfer, not the author making
+		// a fresh claim about today's index. internal/refs is explicit that
+		// such refs are never re-judged, "a retraction anywhere in history
+		// makes every fact that ever cited it uneditable" being exactly the
+		// failure re-judging produces. Here it was worse than uneditable: one
+		// cluster member citing a fact that no longer resolves aborted the
+		// whole review session — every pass in the run lost, and lost again on
+		// every retry (#103). Dropping the offending refs instead would trade
+		// the abort for silent provenance loss, and these targets are usually
+		// still reachable through the commit their referrer pinned.
+		//
+		// The loser's own path is prior for the reason it always was: it is
+		// deleted immediately below and the winner cites it as lineage — that
+		// citation is the record of the merge, not a dead ref.
+		//
+		// The check is therefore structurally satisfied today. The call stays
+		// for Canonicalize, and so this write path still meets the gate if a
+		// genuinely new ref is ever introduced here.
+		canonRefs, _, gerr := gate.Apply(ctx, winnerFact.File, mergedRefs, mergedRefs)
 		if gerr != nil {
 			return nil, fmt.Errorf("dedupCluster: refs for winner %q: %w", winnerFact.File, gerr)
 		}

--- a/internal/synthesize/dedup.go
+++ b/internal/synthesize/dedup.go
@@ -204,24 +204,37 @@ func dedupCluster(
 
 		onProgress(ProgressEvent{Phase: "dedup-merge", Message: fmt.Sprintf("%s <- %s (%.2f)", winnerFact.File, loserFact.File, p.similarity)})
 
+		// Every failure from here to the end of the iteration is scoped to
+		// THIS pair: warn, skip it, keep going — the same shape the merge and
+		// discovery loops use. A single member that cannot be read or parsed
+		// (frontmatter from an older serializer, a hand-edit on the KB branch)
+		// otherwise aborts the whole review session before it plans anything,
+		// which is the #103 failure again from a different cause and just as
+		// permanent across retries. Skipping leaves both facts live, so the
+		// next pass is free to try the pair again.
+
 		// Read the winner's full fact from git to get its Refs.
 		winnerResult, err := gs.ReadFact(ctx, agentBranch, winnerFact.File, nil)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: read winner %q: %w", winnerFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup read winner %s: %v", winnerFact.File, err)})
+			continue
 		}
 		fullWinner, err := fact.ParseFact(winnerFact.File, winnerResult.Content)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: parse winner %q: %w", winnerFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup parse winner %s: %v", winnerFact.File, err)})
+			continue
 		}
 
 		// Read the loser's full fact to get its Refs.
 		loserResult, err := gs.ReadFact(ctx, agentBranch, loserFact.File, nil)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: read loser %q: %w", loserFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup read loser %s: %v", loserFact.File, err)})
+			continue
 		}
 		fullLoser, err := fact.ParseFact(loserFact.File, loserResult.Content)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: parse loser %q: %w", loserFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup parse loser %s: %v", loserFact.File, err)})
+			continue
 		}
 
 		// Apply merged fields to the full winner fact.
@@ -232,6 +245,15 @@ func dedupCluster(
 		// Refs = union of both refs + loser's path.
 		mergedRefs := fact.UnionStrings(fullWinner.Refs, fullLoser.Refs)
 		mergedRefs = fact.AppendUnique(mergedRefs, loserFact.File)
+
+		// The carried set is snapshotted into its OWN list here, while it is
+		// still true that every element came from one of the two operands.
+		// Handing mergedRefs to Apply as both arguments would read the same,
+		// but it would exempt whatever a later change appends to the write
+		// list — a lineage pointer to a synthesized parent, an annex ref —
+		// and the gate could then never reject anything. prior must be able
+		// to diverge from refs for the check below to mean what it says.
+		carriedRefs := append([]string(nil), mergedRefs...)
 
 		// Same gate as every other write path — but this merge ADDS no
 		// citation, so the whole union goes in as prior.
@@ -256,33 +278,43 @@ func dedupCluster(
 		// The check is therefore structurally satisfied today. The call stays
 		// for Canonicalize, and so this write path still meets the gate if a
 		// genuinely new ref is ever introduced here.
-		canonRefs, _, gerr := gate.Apply(ctx, winnerFact.File, mergedRefs, mergedRefs)
+		canonRefs, _, gerr := gate.Apply(ctx, winnerFact.File, mergedRefs, carriedRefs)
 		if gerr != nil {
-			return nil, fmt.Errorf("dedupCluster: refs for winner %q: %w", winnerFact.File, gerr)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup merge %s rejected: %v", winnerFact.File, gerr)})
+			continue
 		}
 		fullWinner.Refs = canonRefs
 
 		// Serialize and write the winner back to git.
 		newContent, err := fact.SerializeFact(fullWinner)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: serialize winner %q: %w", winnerFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup serialize winner %s: %v", winnerFact.File, err)})
+			continue
 		}
 		if _, err := gs.WriteFact(ctx, agentBranch, winnerFact.File, newContent, fmt.Sprintf("dedup: merge %s into %s [%s]", loserFact.File, winnerFact.File, recipeName), "subsume"); err != nil {
-			return nil, fmt.Errorf("dedupCluster: write winner %q: %w", winnerFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup write winner %s: %v", winnerFact.File, err)})
+			continue
 		}
 
-		// Delete the loser from git.
-		if _, err := gs.DeleteFact(ctx, agentBranch, loserFact.File, fmt.Sprintf("dedup: remove duplicate %s (merged into %s) [%s]", loserFact.File, winnerFact.File, recipeName)); err != nil {
-			return nil, fmt.Errorf("dedupCluster: delete loser %q: %w", loserFact.File, err)
-		}
-
-		removedPaths[loserFact.File] = true
-
-		// Update the in-memory fact for the winner in case subsequent searches see it.
+		// Update the in-memory fact for the winner in case subsequent searches
+		// see it. This happens BEFORE the delete below, so the in-memory copy
+		// matches what is on the branch even if the delete is what fails.
 		updatedWinner := winnerFact
 		updatedWinner.Confidence = fullWinner.Confidence
 		updatedWinner.Sources = fullWinner.Sources
 		clusterByPath[winnerFact.File] = updatedWinner
+
+		// Delete the loser from git. A failure here leaves the winner merged
+		// and the loser still live: the pair stays a near-duplicate for this
+		// pass, and the winner's citation of it resolves either way. The loser
+		// stays in the surviving cluster, so nothing downstream is handed a
+		// path that is still there.
+		if _, err := gs.DeleteFact(ctx, agentBranch, loserFact.File, fmt.Sprintf("dedup: remove duplicate %s (merged into %s) [%s]", loserFact.File, winnerFact.File, recipeName)); err != nil {
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup delete loser %s: %v", loserFact.File, err)})
+			continue
+		}
+
+		removedPaths[loserFact.File] = true
 	}
 
 	// Build surviving cluster (exclude losers).

--- a/internal/synthesize/dedup_prior_refs_test.go
+++ b/internal/synthesize/dedup_prior_refs_test.go
@@ -1,0 +1,123 @@
+package synthesize
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fixedPairSearch is a SearchQuery whose Search returns a canned result set,
+// so a dedup pair can be forced without standing up an embedder. Every other
+// method — crucially FactExistsAt, which the ref gate resolves through — is
+// the real one.
+type fixedPairSearch struct {
+	SearchQuery
+	results []store.SearchResult
+}
+
+func (f *fixedPairSearch) Search(context.Context, string, store.SearchOptions) ([]store.SearchResult, error) {
+	return f.results, nil
+}
+
+// searchHit is a result above any dedup threshold — dedupCluster divides Score
+// by 100 to get the cosine it compares against the threshold.
+func searchHit(path string) store.SearchResult {
+	return store.SearchResult{
+		FactWithBody: store.FactWithBody{FactRecord: store.FactRecord{Path: path}},
+		Score:        96,
+	}
+}
+
+// seedFactWithRefs writes a fact straight to the store, bypassing every write
+// path's ref gate. That is not a test shortcut — it is how a corpus acquires
+// facts whose refs no longer resolve: they were written before the gate
+// existed, or their target was retracted past the walk-back horizon, or the
+// citing repo's history was rewritten. The gate's `prior` parameter exists
+// precisely because this state is real and must stay editable.
+func seedFactWithRefs(t *testing.T, svc *store.Service, branch, path string, confidence float64, refs []string) {
+	t.Helper()
+	f := fact.NewFact(path)
+	f.Title = path
+	f.Body = "body of " + path
+	f.Type = fact.Observation
+	f.Domain = []string{"test"}
+	f.Confidence = confidence
+	f.Sources = 1
+	f.Refs = refs
+	body, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(context.Background(), branch, f.Path(), body, "seed", "")
+	require.NoError(t, err)
+}
+
+// TestDedupCluster_KeepsUnresolvableCarriedRefs regresses knomit#103: a dedup
+// merge grafts the loser's refs onto the winner and used to hand the whole
+// union to the ref gate with prior=nil, re-litigating citations both facts
+// had carried for months against today's live index. One stale citation
+// anywhere in one cluster then aborted the entire review session — every pass
+// in the run lost, not just the affected merge — and it aborted again on every
+// retry, so the corpus could never be reviewed until the facts were hand-edited.
+//
+// internal/refs' contract: "A ref is checked ONCE, against the commit the write
+// lands on. Refs a fact ALREADY carried are never re-checked." A mechanical
+// merge introduces no new citation, so nothing in the union is new.
+func TestDedupCluster_KeepsUnresolvableCarriedRefs(t *testing.T) {
+	ctx := context.Background()
+	branch := "agent/test"
+
+	svc, err := store.Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+
+	const (
+		winnerPath  = "kb/technology/winner.md"
+		loserPath   = "kb/technology/loser.md"
+		winnerStale = "kb/technology/winner-cited-gone.md"
+		loserStale  = "kb/technology/loser-cited-gone.md"
+		liveRefPath = "kb/technology/still-here.md"
+	)
+
+	// A real, resolvable citation alongside the stale ones, so the assertion
+	// below distinguishes "refs survived" from "ref list was emptied".
+	seedFactWithRefs(t, svc, branch, liveRefPath, 0.7, nil)
+	seedFactWithRefs(t, svc, branch, winnerPath, 0.9, []string{winnerStale, liveRefPath})
+	seedFactWithRefs(t, svc, branch, loserPath, 0.5, []string{loserStale})
+
+	cluster := []factForLLM{
+		{File: winnerPath, Title: "winner", Body: "b", Type: string(fact.Observation), Confidence: 0.9, Sources: 1},
+		{File: loserPath, Title: "loser", Body: "b", Type: string(fact.Observation), Confidence: 0.5, Sources: 1},
+	}
+	idx := &fixedPairSearch{
+		SearchQuery: svc.Search(),
+		results: []store.SearchResult{
+			searchHit(winnerPath),
+			searchHit(loserPath),
+		},
+	}
+
+	surviving, err := dedupCluster(ctx, cluster, svc.Facts(), idx, 0.92, "test",
+		func(ProgressEvent) {}, branch, bareRefFixture)
+	require.NoError(t, err, "a carried ref that no longer resolves must not abort the dedup pass")
+
+	require.Len(t, surviving, 1)
+	require.Equal(t, winnerPath, surviving[0].File)
+
+	rf, err := svc.Facts().ReadFact(ctx, branch, winnerPath, nil)
+	require.NoError(t, err)
+	merged, err := fact.ParseFact(winnerPath, rf.Content)
+	require.NoError(t, err)
+
+	// Provenance survives: dropping the unresolvable refs to satisfy a check
+	// that should never have run on them destroys the lineage the merge exists
+	// to preserve.
+	require.Contains(t, merged.Refs, winnerStale, "winner's own carried ref was dropped")
+	require.Contains(t, merged.Refs, loserStale, "loser's carried ref was not grafted onto the winner")
+	require.Contains(t, merged.Refs, liveRefPath)
+	require.Contains(t, merged.Refs, loserPath, "the merge must cite the fact it subsumed")
+}

--- a/internal/synthesize/dedup_test.go
+++ b/internal/synthesize/dedup_test.go
@@ -2,9 +2,13 @@ package synthesize
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
+	"knomit/internal/fact"
 	"knomit/internal/store"
+
+	"github.com/stretchr/testify/require"
 )
 
 // ctxCapturingSearchIndex is a minimal SearchIndex stub that records
@@ -120,4 +124,63 @@ func errorsIs(err, target error) bool {
 		err = u.Unwrap()
 	}
 	return false
+}
+
+// TestDedupCluster_SkipsUnparsableMember regresses the other half of knomit#103:
+// the run must survive a bad member, not just a bad ref. dedupCluster used to
+// return an error from every per-merge step, so one cluster member whose stored
+// content no longer parses — frontmatter from an older serializer, a hand-edit
+// on the KB branch — aborted StartSession before it planned anything, and did
+// so again on every retry. Every sibling write path in decision.go and
+// discovery.go warns and continues; this one now does too.
+func TestDedupCluster_SkipsUnparsableMember(t *testing.T) {
+	ctx := context.Background()
+	branch := "agent/test"
+
+	svc, err := store.Open(filepath.Join(t.TempDir(), "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+
+	const (
+		winnerPath = "kb/technology/winner.md"
+		loserPath  = "kb/technology/loser.md"
+	)
+
+	seedFactWithRefs(t, svc, branch, winnerPath, 0.9, nil)
+	seedFactWithRefs(t, svc, branch, loserPath, 0.5, nil)
+
+	// Corrupt the loser in place: still a blob at that path, no longer a
+	// parsable fact. The cluster and the index still know about it, which is
+	// exactly the state that used to be unrecoverable.
+	_, err = svc.Facts().WriteFact(ctx, branch, loserPath, "not a fact any more\n", "corrupt", "")
+	require.NoError(t, err)
+
+	cluster := []factForLLM{
+		{File: winnerPath, Title: "winner", Body: "b", Type: string(fact.Observation), Confidence: 0.9, Sources: 1},
+		{File: loserPath, Title: "loser", Body: "b", Type: string(fact.Observation), Confidence: 0.5, Sources: 1},
+	}
+	idx := &fixedPairSearch{
+		SearchQuery: svc.Search(),
+		results: []store.SearchResult{
+			searchHit(winnerPath),
+			searchHit(loserPath),
+		},
+	}
+
+	var warnings []string
+	surviving, err := dedupCluster(ctx, cluster, svc.Facts(), idx, 0.92, "test",
+		func(e ProgressEvent) {
+			if e.Phase == "warn" {
+				warnings = append(warnings, e.Message)
+			}
+		}, branch, bareRefFixture)
+	require.NoError(t, err, "an unparsable cluster member must cost its own merge, not the whole pass")
+
+	require.Len(t, warnings, 1, "the skipped merge must be reported, not swallowed")
+	require.Contains(t, warnings[0], loserPath)
+
+	// The merge was skipped whole: both facts are still live and still in the
+	// surviving cluster, so a later pass can try the pair again.
+	require.Len(t, surviving, 2)
 }


### PR DESCRIPTION
Fixes #103.

## The bug

`dedupCluster` grafts the loser's refs onto the winner and then calls the ref gate with `prior` set to the loser's path alone:

```go
mergedRefs := fact.UnionStrings(fullWinner.Refs, fullLoser.Refs)
mergedRefs = fact.AppendUnique(mergedRefs, loserFact.File)
gate.Apply(ctx, winnerFact.File, mergedRefs, []string{loserFact.File})
```

Every citation the two facts had carried from their own commits is therefore treated as newly added and re-litigated against today's live index — precisely what `internal/refs`' temporal contract forbids: *"a retraction anywhere in history makes every fact that ever cited it uneditable."*

`dedupCluster` returns the error rather than warning and skipping, so one stale citation anywhere in one cluster aborted the whole review session before it planned anything — and aborted again on every retry. A mature corpus could never be reviewed until the offending facts were hand-edited.

## The fix

The merge introduces no new citation — everything in the union was carried by the winner, carried by the loser, or is the loser's own path — so the whole union goes in as `prior`. The gate call stays for `Canonicalize`, and so this write path still meets the gate if a genuinely new ref is ever introduced here.

Not fixed by dropping the unresolvable refs: those targets are usually still reachable through the commit their referrer pinned, and dropping them destroys provenance to satisfy a check that should never have run.

## Scope note

The issue's fix direction names `decision.go:214` and `:324` as the dedup call sites. Those are the prune-merge and distill paths, and their `prior = nil` is correct: both write **new** facts whose refs are wholly LLM-authored. `factForLLM` carries no `Refs` field, so the model never sees the cluster members' citations and cannot copy them forward. They also warn-and-skip rather than abort, so neither produces the reported symptom. The single site that grafts pre-existing refs — and the one that aborts — is `dedup.go`, and it is the only one changed. `internal/mcp/learn.go`'s dedup-on-learn merge already passes the existing fact's refs as `prior`.

## Test

`TestDedupCluster_KeepsUnresolvableCarriedRefs` seeds two near-duplicates, each carrying a ref to a fact that does not resolve, forces them into a dedup pair, and asserts the merge succeeds with both stale refs and the subsumed fact's path intact on the winner. Against the pre-fix code it reproduces the reported error verbatim.

Full suite green.