### PR TITLE
feat(motif): phase 3 — bridge kinds

### DIFF
--- a/internal/fact/motif.go
+++ b/internal/fact/motif.go
@@ -219,6 +219,11 @@ func StripSubjectMotifs(f Fact) []string {
 
 // subjectTokens is the stemmed token set of everything the fact already says
 // about its own subject: authored entities, domain tags, and path segments.
+func subjectTokens(f Fact) map[string]struct{} {
+	return SubjectTokens(f.Entities, f.Domain, f.path)
+}
+
+// SubjectTokens is that same set, computed from the three inputs directly.
 //
 // The path is included because a fact's location IS a subject claim — the
 // ontology category is chosen to describe what the fact is about — and
@@ -226,24 +231,30 @@ func StripSubjectMotifs(f Fact) []string {
 // re-typed. The ontology root and the uuid segment ride along harmlessly:
 // they are stemmed tokens like any other, and no motif of 2+ words is a
 // subset of {kb} or of a hex id.
-func subjectTokens(f Fact) map[string]struct{} {
+//
+// Exported because the Phase-3 subject-disjointness gate asks of a PAIR of
+// facts the question this asks of one, and the two must not be able to
+// disagree about what a subject token is. It takes the three fields rather
+// than a Fact so a caller holding only a payload projection (synthesize's
+// factForLLM) can ask without rebuilding one.
+func SubjectTokens(entities, domain []string, path string) map[string]struct{} {
 	set := make(map[string]struct{})
 	add := func(s string) {
 		for _, tok := range textnorm.Tokens(textnorm.Canonicalize(s)) {
 			set[tok] = struct{}{}
 		}
 	}
-	for _, e := range f.Entities {
+	for _, e := range entities {
 		add(e)
 	}
-	for _, d := range f.Domain {
+	for _, d := range domain {
 		add(d)
 	}
 	// Trim the extension first so "e5d04257.md" does not contribute a
 	// spurious "md" token — that describes the file format, not the fact.
 	// Canonicalize de-hyphenizes and Tokens splits on '/', so path segments
 	// and their words arrive already separated.
-	add(strings.TrimSuffix(f.path, ".md"))
+	add(strings.TrimSuffix(path, ".md"))
 	return set
 }
 

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -207,10 +207,16 @@ var mechanicsPaths = map[string][]string{
 	// What no entry here licenses: a motif term reaching dedup, clustering or
 	// search ranking. Those files stay nil below and this list does not touch
 	// them.
-	// mergeToken2Groups, laneOf, scoreMotifCandidate and rankAndCap are
-	// deliberately NOT listed: their bodies name no motif identifier (they work
-	// on canonical ids, paths and scores), and this list rejects a permission
-	// nothing uses.
+	// laneOf, scoreMotifCandidate, rankAndCap, disjointMembers and
+	// copyMembers are deliberately NOT listed: their bodies name no motif
+	// identifier (they work on canonical ids, paths and scores), and this list
+	// rejects a permission nothing uses.
+	//
+	// The names in this paragraph are prose, and the bidirectional machinery
+	// checks the allow-LIST rather than the reasoning beside it — so a rename
+	// leaves a ghost here that nothing catches. One did: the Phase-3 review
+	// (L3) found this sentence still citing mergeToken2Groups, deleted two
+	// commits earlier and replaced by token2Families.
 	//
 	// Of the two listed, enumerateMotifCandidates reads members' motifs to
 	// GROUP them and sharedMotifSpecificity reads them to SCORE the group it

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -509,15 +509,7 @@ func TestMN13_MotifBridgeConstantsAreClassified(t *testing.T) {
 	} {
 		requireConstantsClassified(t, rel, want)
 
-		var floats []string
-		ast.Inspect(parseGo(t, rel), func(n ast.Node) bool {
-			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.FLOAT {
-				floats = append(floats, lit.Value)
-			}
-			return true
-		})
-		require.Emptyf(t, floats,
-			"MN13: a float literal in %s is a corpus-property constant in disguise: %v", rel, floats)
+		requireNoUnnamedRatios(t, rel)
 	}
 }
 
@@ -555,4 +547,62 @@ func requireConstantsClassified(t *testing.T, rel string, want map[string]string
 		require.Truef(t, seen[name], "const %s no longer exists in %s — "+
 			"update this test rather than letting the classification rule lapse", name, rel)
 	}
+}
+
+// requireNoUnnamedRatios is MN13's literal check, in BOTH forms a ratio can
+// take.
+//
+// A float literal was the only form the first version looked for, and the
+// Phase-3 review (L2) found the gap by walking through it: the df band's
+// ceiling was written `LiveFacts * 2 / 100` — a ratio of the corpus's own size,
+// in bare integers, invisible to a float scan. That is lesson 3 turned on the
+// check itself: ask in what form the violation would appear, and does the check
+// read that form.
+//
+// So it bans float literals outright, and bans the integer-ratio SHAPE
+// (`<expr> * N / M`) when the MULTIPLIER N is a bare number. N is the ratio
+// someone chose and must therefore be named and classified; the divisor is the
+// unit's own denominator — `x * umbrellaPerCent / 100` is what a correctly
+// classified per-cent ratio looks like, and a `const hundred = 100` would be
+// ceremony, not clarity.
+func requireNoUnnamedRatios(t *testing.T, rel string) {
+	t.Helper()
+	file := parseGo(t, rel)
+
+	var offenders []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.FLOAT {
+			offenders = append(offenders, "float literal "+lit.Value)
+			return true
+		}
+		// `x * N / M` parses as (x * N) / M — a division whose left operand is
+		// a multiplication. Either bare number makes it an unnamed ratio.
+		div, ok := n.(*ast.BinaryExpr)
+		if !ok || div.Op != token.QUO {
+			return true
+		}
+		mul, ok := div.X.(*ast.BinaryExpr)
+		if !ok || mul.Op != token.MUL {
+			return true
+		}
+		if lit, ok := mul.Y.(*ast.BasicLit); ok && lit.Kind == token.INT {
+			offenders = append(offenders,
+				"unnamed integer ratio "+lit.Value+"/"+exprText(div.Y))
+		}
+		return true
+	})
+	require.Emptyf(t, offenders,
+		"MN13: %s must not carry an unclassified ratio — name it as a constant and "+
+			"state its class where it is defined: %v", rel, offenders)
+}
+
+// exprText renders a small expression for an error message.
+func exprText(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		return v.Value
+	case *ast.Ident:
+		return v.Name
+	}
+	return "?"
 }

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -207,10 +207,21 @@ var mechanicsPaths = map[string][]string{
 	// What no entry here licenses: a motif term reaching dedup, clustering or
 	// search ranking. Those files stay nil below and this list does not touch
 	// them.
-	// mergeToken2Groups is deliberately NOT listed: its body names no motif
-	// identifier (it folds groups keyed by canonical id, using the shared
-	// tokeniser), and this list rejects a permission nothing uses.
-	"internal/synthesize/bridge_motif.go": {"enumerateMotifCandidates"},
+	// mergeToken2Groups, laneOf, scoreMotifCandidate and rankAndCap are
+	// deliberately NOT listed: their bodies name no motif identifier (they work
+	// on canonical ids, paths and scores), and this list rejects a permission
+	// nothing uses.
+	//
+	// Of the two listed, enumerateMotifCandidates reads members' motifs to
+	// GROUP them and sharedMotifSpecificity reads them to SCORE the group it
+	// was already given — both inside the §4/§5 cascade, neither reachable from
+	// dedup, clustering or search ranking.
+	// buildMotifBridges is the §4/§5 entry point: it reads the seed pool's
+	// motifs to decide whether the axis does anything at all, then drives
+	// enumeration, the lane split and the per-lane budgets.
+	"internal/synthesize/bridge_motif.go": {
+		"buildMotifBridges", "enumerateMotifCandidates", "sharedMotifSpecificity", "anyMotifs",
+	},
 	// The gate that decides which motif groups the agent ever sees. It reads
 	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and
 	// names motifs only in describing what it gates. Listed with no permitted

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -226,7 +226,7 @@ var mechanicsPaths = map[string][]string{
 	// reads a health line.
 	"internal/synthesize/bridge_motif.go": {
 		"buildMotifBridges", "enumerateMotifCandidates", "sharedMotifSpecificity", "anyMotifs",
-		"motifResolverFor", "motifBridgeHealthLines",
+		"motifResolverFor", "motifBridgeHealthLines", "verbatimGroups", "token2Families",
 	},
 	// The gate that decides which motif groups the agent ever sees. It reads
 	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and
@@ -362,7 +362,13 @@ func funcsMentioningMotifs(t *testing.T, rel string) []string {
 // needing one written under deadline.
 func TestMN2_NoLLMInMotifCode(t *testing.T) {
 	sources := goSources(t)
-	for _, rel := range []string{"internal/fact/motif.go", "internal/textnorm/textnorm.go"} {
+	for _, rel := range []string{
+		"internal/fact/motif.go", "internal/textnorm/textnorm.go",
+		// Phase 3's enumeration and its gate. The detector stays mechanical:
+		// the connected agent is the only reasoner in the read path, and it
+		// already exists (cf455b8f).
+		"internal/synthesize/bridge_motif.go", "internal/synthesize/motif_disjoint.go",
+	} {
 		src, ok := sources[rel]
 		require.Truef(t, ok, "MN2 target %s is missing", rel)
 		lower := strings.ToLower(src)
@@ -477,4 +483,70 @@ func parseGo(t *testing.T, rel string) *ast.File {
 	file, err := parser.ParseFile(fset, filepath.Join(repoRoot(t), rel), nil, parser.ParseComments)
 	require.NoErrorf(t, err, "parsing %s", rel)
 	return file
+}
+
+// TestMN13_MotifBridgeConstantsAreClassified — the Phase-3 half of the same
+// rule. Every numeric constant on the bridging path states its class where it
+// is defined, and no float literal appears in either file's CODE: a float here
+// would be the corpus-property constant MN13 forbids, wearing a threshold's
+// clothes.
+func TestMN13_MotifBridgeConstantsAreClassified(t *testing.T) {
+	for rel, want := range map[string]map[string]string{
+		"internal/synthesize/motif_disjoint.go": {
+			"disjointnessPercentile": "SELECTION POINT",
+			"minLabelsForPercentile": "STATISTICAL-VALIDITY FLOOR",
+			"umbrellaPerCent":        "RATIO",
+		},
+		"internal/synthesize/bridge_motif.go": {
+			"motifDFCeilingFloor": "STATISTICAL-VALIDITY FLOOR",
+		},
+	} {
+		requireConstantsClassified(t, rel, want)
+
+		var floats []string
+		ast.Inspect(parseGo(t, rel), func(n ast.Node) bool {
+			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.FLOAT {
+				floats = append(floats, lit.Value)
+			}
+			return true
+		})
+		require.Emptyf(t, floats,
+			"MN13: a float literal in %s is a corpus-property constant in disguise: %v", rel, floats)
+	}
+}
+
+// requireConstantsClassified checks that each named constant in rel carries a
+// doc comment declaring its class. Shared by both MN13 tests so the rule has
+// one implementation and cannot drift between the phases that use it.
+func requireConstantsClassified(t *testing.T, rel string, want map[string]string) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, decl := range parseGo(t, rel).Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		blockDoc := gen.Doc.Text()
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			doc := blockDoc + vs.Doc.Text()
+			for _, name := range vs.Names {
+				phrase, tracked := want[name.Name]
+				if !tracked {
+					continue
+				}
+				seen[name.Name] = true
+				require.Containsf(t, doc, phrase,
+					"MN13: const %s in %s must state its class where it is defined "+
+						"(expected its doc comment to contain %q)", name.Name, rel, phrase)
+			}
+		}
+	}
+	for name := range want {
+		require.Truef(t, seen[name], "const %s no longer exists in %s — "+
+			"update this test rather than letting the classification rule lapse", name, rel)
+	}
 }

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -198,8 +198,26 @@ var mechanicsPaths = map[string][]string{
 	// field into a payload, not consulting it in a decision — if a motif term
 	// ever reaches the clustering arithmetic that is an MN6 violation this does
 	// not cover.
-	"internal/synthesize/cluster.go": {"ScopedCluster"},
-	"internal/synthesize/louvain.go": nil,
+	// The §4/§5 path itself — the axis MN6 names as DESIGNED for motifs
+	// ("anything that spawns work outside the §4/§5/§7 synthesis paths designed
+	// for them"). Listed rather than left unpoliced, so this map stays the one
+	// register of which functions read motifs and a future helper here has to
+	// be declared rather than appearing quietly.
+	//
+	// What no entry here licenses: a motif term reaching dedup, clustering or
+	// search ranking. Those files stay nil below and this list does not touch
+	// them.
+	// mergeToken2Groups is deliberately NOT listed: its body names no motif
+	// identifier (it folds groups keyed by canonical id, using the shared
+	// tokeniser), and this list rejects a permission nothing uses.
+	"internal/synthesize/bridge_motif.go": {"enumerateMotifCandidates"},
+	// The gate that decides which motif groups the agent ever sees. It reads
+	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and
+	// names motifs only in describing what it gates. Listed with no permitted
+	// function so that a motif-reading function added here must be declared.
+	"internal/synthesize/motif_disjoint.go": {},
+	"internal/synthesize/cluster.go":        {"ScopedCluster"},
+	"internal/synthesize/louvain.go":        nil,
 
 	// The read CARRIERS only (Phase 2, designer ruling 2026-08-21). Each of
 	// these names a SELECT column list and hands the row to a scanner; carrying

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -219,8 +219,14 @@ var mechanicsPaths = map[string][]string{
 	// buildMotifBridges is the §4/§5 entry point: it reads the seed pool's
 	// motifs to decide whether the axis does anything at all, then drives
 	// enumeration, the lane split and the per-lane budgets.
+	// The wiring half of the same file: motifResolverFor closes over the alias
+	// table, and motifBridgeHealthLines RENDERS what the axis did into the
+	// session's health output. Reporting is not deciding — the no-branch
+	// property is what MN6 is about, and it holds: nothing in this package
+	// reads a health line.
 	"internal/synthesize/bridge_motif.go": {
 		"buildMotifBridges", "enumerateMotifCandidates", "sharedMotifSpecificity", "anyMotifs",
+		"motifResolverFor", "motifBridgeHealthLines",
 	},
 	// The gate that decides which motif groups the agent ever sees. It reads
 	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and

--- a/internal/fact/motif_test.go
+++ b/internal/fact/motif_test.go
@@ -287,3 +287,18 @@ func TestStripSubjectMotifs_SubjectDriftDropsAnAuthoredMotif(t *testing.T) {
 	// invariant is about what is stored NOW, not a claim about history.
 	require.Contains(t, first, "motifs: [remote-caching]")
 }
+
+// TestSubjectTokens_IsTheStripsOwnDefinition — the Phase-3 subject-disjointness
+// gate asks of a PAIR of facts what StripSubjectMotifs asks of one, so the two
+// must not be able to disagree about what a subject token is. One definition,
+// asserted here rather than hoped for.
+func TestSubjectTokens_IsTheStripsOwnDefinition(t *testing.T) {
+	f := stripFixture()
+
+	got := SubjectTokens(f.Entities, f.Domain, "kb/gotchas/integrations/antigravity/plugin-dir-resolution/e5d04257.md")
+
+	require.Equal(t, subjectTokens(f), got)
+	require.Contains(t, got, "resolution", "path segments are subject claims")
+	require.Contains(t, got, "antigravity", "entities are subject claims")
+	require.NotContains(t, got, "md", "the .md extension is not a subject claim")
+}

--- a/internal/repos/instance.go
+++ b/internal/repos/instance.go
@@ -560,6 +560,24 @@ type TestInstanceConfig struct {
 	OntologyRoot        string
 	MethodologyMinScore float64
 	StartSync           func(url string) error
+	// Quality carries the bridge-quality knobs (CohFloor, MaxMembers, the Q
+	// weights). Optional and zero by default, which is the historical
+	// behaviour — but note that a zero MaxMembers gates out EVERY bridge
+	// candidate, so a test driving the discovery path through a bare instance
+	// is measuring an engine that can never emit anything. Set it when the
+	// test is about bridges. Mirrors the two knobs above, which carry
+	// production defaults for the same reason.
+	Quality *TestQualityConfig
+}
+
+// TestQualityConfig mirrors the discovery.quality block for test instances.
+type TestQualityConfig struct {
+	CohFloor     float64
+	QualityFloor float64
+	WCoh         float64
+	WGap         float64
+	WSpec        float64
+	MaxMembers   int
 }
 
 // NewTestInstanceWithDeps creates a RepoInstance pre-populated with the given
@@ -587,6 +605,14 @@ func NewTestInstanceWithDeps(cfg TestInstanceConfig) *RepoInstance {
 		syncWg:                        &sync.WaitGroup{},
 		indexCancel:                   func() {},
 		indexWg:                       &sync.WaitGroup{},
+	}
+	if q := cfg.Quality; q != nil {
+		ri.discoveryCohFloor = q.CohFloor
+		ri.discoveryQualityFloor = q.QualityFloor
+		ri.discoveryWCoh = q.WCoh
+		ri.discoveryWGap = q.WGap
+		ri.discoveryWSpec = q.WSpec
+		ri.discoveryMaxMembers = q.MaxMembers
 	}
 	ri.setName(cfg.Name)
 	return ri

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -83,6 +83,11 @@ type GraphStore interface {
 	// TokenDF returns the count of facts live on branch that carry the given
 	// domain/entity tag (kind: "domain"|"entity").
 	TokenDF(ctx context.Context, branch, token, kind string) (int, error)
+	// SubjectLabelDF returns the document frequency of every subject label
+	// live on branch, plus the live fact count. The Phase-3 subject-
+	// disjointness gate derives its operating point from this distribution
+	// rather than from any fixed cut (MN13).
+	SubjectLabelDF(ctx context.Context, branch string) (SubjectLabelDF, error)
 	// SimilarityAdjacency returns the member-restricted SIMILAR_TO graph for
 	// the given fact paths. Only edges where both endpoints are in paths are
 	// kept. Liveness is enforced via NOT n.deleted = true. An empty or

--- a/internal/store/subject_labels.go
+++ b/internal/store/subject_labels.go
@@ -1,0 +1,115 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"knomit/internal/fact"
+)
+
+// SubjectLabelDF is the document frequency of every SUBJECT LABEL live on a
+// branch, together with the population those frequencies are drawn from.
+//
+// A "subject label" is a stemmed token of a fact's entities, domain tags or
+// path — the same token set fact.SubjectTokens produces for the write-time
+// subject strip, computed by that same function so the two cannot drift apart.
+//
+// It exists for the Phase-3 subject-disjointness gate, which needs to know how
+// SPECIFIC a shared label is before letting it block a bridge. That question
+// is answered against this corpus's own distribution rather than against any
+// fixed number (roadmap MN13), so the distribution has to be readable.
+//
+// Derived state in the plainest sense: recomputed from live fact frontmatter
+// on demand and stored nowhere, so a corpus hydrated from a remote is correct
+// immediately and nothing here can go stale.
+type SubjectLabelDF struct {
+	// DF maps a stemmed subject token to how many live facts carry it.
+	DF map[string]int
+	// LiveFacts is the denominator — the count of live facts on the branch.
+	LiveFacts int
+}
+
+// SubjectLabelDF computes the whole distribution in one pass.
+//
+// Liveness and branch scoping come from branch_facts (UNIQUE(branch_id, path)
+// => one row per live path per branch), exactly as TokenDF and BlastRadius do.
+//
+// Tokenisation happens in Go rather than in SQL because the definition of a
+// subject token lives in internal/fact and must stay single: a SQL
+// reimplementation would be a second definition of the same rule, free to
+// drift from the one the write path enforces.
+func (gs *graphStore) SubjectLabelDF(ctx context.Context, branch string) (SubjectLabelDF, error) {
+	branchID, err := gs.rh.branchID(ctx, branch)
+	if err != nil {
+		return SubjectLabelDF{}, fmt.Errorf("SubjectLabelDF: branchID: %w", err)
+	}
+
+	paths, err := gs.livePathsByFactID(ctx, branchID)
+	if err != nil {
+		return SubjectLabelDF{}, err
+	}
+	domains, err := gs.labelsByFact(ctx, branchID, "fact_domains", "domain")
+	if err != nil {
+		return SubjectLabelDF{}, err
+	}
+	entities, err := gs.labelsByFact(ctx, branchID, "fact_entities", "entity")
+	if err != nil {
+		return SubjectLabelDF{}, err
+	}
+
+	out := SubjectLabelDF{DF: make(map[string]int), LiveFacts: len(paths)}
+	for id, path := range paths {
+		// One SET per fact, so a token carried on both the domain and the path
+		// counts once. Counting occurrences instead would let a corpus inflate
+		// its own umbrella cut through how its facts happen to be filed.
+		for tok := range fact.SubjectTokens(entities[id], domains[id], path) {
+			out.DF[tok]++
+		}
+	}
+	return out, nil
+}
+
+// livePathsByFactID returns fact_id → path for every fact live on the branch.
+func (gs *graphStore) livePathsByFactID(ctx context.Context, branchID int64) (map[int64]string, error) {
+	rows, err := conn(ctx, gs.rh.db).QueryContext(ctx,
+		`SELECT bf.fact_id, bf.path FROM branch_facts bf WHERE bf.branch_id = ?`, branchID)
+	if err != nil {
+		return nil, fmt.Errorf("SubjectLabelDF: paths: %w", err)
+	}
+	defer rows.Close()
+	out := map[int64]string{}
+	for rows.Next() {
+		var id int64
+		var path string
+		if err := rows.Scan(&id, &path); err != nil {
+			return nil, fmt.Errorf("SubjectLabelDF: scan path: %w", err)
+		}
+		out[id] = path
+	}
+	return out, rows.Err()
+}
+
+// labelsByFact reads one label junction table into fact_id → labels, restricted
+// to facts live on the branch.
+func (gs *graphStore) labelsByFact(ctx context.Context, branchID int64, table, col string) (map[int64][]string, error) {
+	q := fmt.Sprintf(
+		`SELECT bf.fact_id, j.%s
+		   FROM branch_facts bf
+		   JOIN %s j ON j.fact_id = bf.fact_id
+		  WHERE bf.branch_id = ?`, col, table)
+	rows, err := conn(ctx, gs.rh.db).QueryContext(ctx, q, branchID)
+	if err != nil {
+		return nil, fmt.Errorf("SubjectLabelDF: %s: %w", table, err)
+	}
+	defer rows.Close()
+	out := map[int64][]string{}
+	for rows.Next() {
+		var id int64
+		var label string
+		if err := rows.Scan(&id, &label); err != nil {
+			return nil, fmt.Errorf("SubjectLabelDF: scan %s: %w", table, err)
+		}
+		out[id] = append(out[id], label)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/subject_labels_test.go
+++ b/internal/store/subject_labels_test.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubjectLabelDF_CountsEachTokenOncePerFact — a token carried on BOTH a
+// fact's domain and its path must count once for that fact. Counting
+// occurrences instead would let path-heavy corpora inflate their own umbrella
+// cut, which is a threshold moving because of how facts are FILED.
+func TestSubjectLabelDF_CountsEachTokenOncePerFact(t *testing.T) {
+	ctx := context.Background()
+	svc, branch := newTokenDFFixture(t)
+
+	// "evaluation" appears on both facts — once via domain, and for the first
+	// fact also via its path.
+	_, err := svc.Facts().WriteFact(ctx, branch, "kb/technology/ai/evaluation/258174a7.md",
+		testFactBodyWithDomainAndEntities("bench", []string{"evaluation"}, []string{"Terminal Bench"}),
+		"init a", "")
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(ctx, branch, "kb/gotchas/ai/agents/ui-testing/77b3e628.md",
+		testFactBodyWithDomainAndEntities("ui", []string{"evaluation"}, []string{"Cognition"}),
+		"init b", "")
+	require.NoError(t, err)
+
+	got, err := svc.Search().SubjectLabelDF(ctx, branch)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, got.LiveFacts)
+	require.Equal(t, 2, got.DF["evaluation"], "carried by both facts, once each")
+	require.Equal(t, 1, got.DF["cognition"])
+	// Precondition (lesson 5): the two values MUST differ, or this fixture
+	// cannot tell a working count from a constant.
+	require.NotEqual(t, got.DF["evaluation"], got.DF["cognition"])
+}
+
+// TestSubjectLabelDF_IsTheSameTokenisationTheStripUses — the gate built on this
+// distribution asks of a pair what the write-time subject strip asks of one
+// fact. If the two tokenised differently, the gate would be reading a
+// vocabulary the corpus does not actually have.
+func TestSubjectLabelDF_IsTheSameTokenisationTheStripUses(t *testing.T) {
+	ctx := context.Background()
+	svc, branch := newTokenDFFixture(t)
+
+	_, err := svc.Facts().WriteFact(ctx, branch, "kb/gotchas/store/resolver/e5d04257.md",
+		testFactBodyWithDomainAndEntities("x", []string{"build tooling"}, []string{"Antigravity"}),
+		"init", "")
+	require.NoError(t, err)
+
+	got, err := svc.Search().SubjectLabelDF(ctx, branch)
+	require.NoError(t, err)
+
+	// Multi-word tags split; path segments contribute; the .md extension does
+	// not. Exactly fact.SubjectTokens's answer, because it IS that function.
+	require.Equal(t, 1, got.DF["build"])
+	require.Equal(t, 1, got.DF["tooling"])
+	require.Equal(t, 1, got.DF["resolver"])
+	require.Equal(t, 1, got.DF["antigravity"])
+	require.Zero(t, got.DF["md"], "the .md extension is not a subject claim")
+}
+
+// TestSubjectLabelDF_ExcludesFactsNotLiveOnTheBranch — the denominator and the
+// counts are both about what is LIVE. A deleted fact that still counted would
+// make every ratio derived from this distribution drift upward forever.
+func TestSubjectLabelDF_ExcludesFactsNotLiveOnTheBranch(t *testing.T) {
+	ctx := context.Background()
+	svc, branch := newTokenDFFixture(t)
+
+	_, err := svc.Facts().WriteFact(ctx, branch, "kb/technology/ai/evaluation/258174a7.md",
+		testFactBodyWithDomainAndEntities("bench", []string{"evaluation"}, nil), "init", "")
+	require.NoError(t, err)
+
+	before, err := svc.Search().SubjectLabelDF(ctx, branch)
+	require.NoError(t, err)
+	require.Equal(t, 1, before.DF["evaluation"], "precondition: it counted while live")
+
+	_, err = svc.Facts().DeleteFact(ctx, branch, "kb/technology/ai/evaluation/258174a7.md", "retract")
+	require.NoError(t, err)
+
+	got, err := svc.Search().SubjectLabelDF(ctx, branch)
+	require.NoError(t, err)
+	require.Zero(t, got.LiveFacts)
+	require.Empty(t, got.DF)
+}

--- a/internal/synthesize/bridge.go
+++ b/internal/synthesize/bridge.go
@@ -60,6 +60,19 @@ const (
 	BridgeBoth   BridgeKind = "both"
 )
 
+// BridgeMotif is the Phase-3 aspect axis: the shared token is a CANONICAL
+// MOTIF ID rather than an entity or a domain tag.
+//
+// Deliberately absent from BridgeKindFromString below. Entity/domain selection
+// is a per-repo config knob (discovery.bridge); motif bridging is bound to the
+// effort dial instead (§5), so a config value of "motif" must not be able to
+// switch the entity and domain axes off.
+//
+// Enumeration for this kind lives entirely in bridge_motif.go, which is why no
+// function in THIS file mentions motifs — this file's mechanicsPaths entry
+// stays nil, and the MN6 declaration it makes stays true.
+const BridgeMotif BridgeKind = "motif"
+
 // DefaultBridgeKind is the historical default — bridge on either axis.
 const DefaultBridgeKind = BridgeBoth
 

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -322,3 +322,52 @@ func scoreMotifCandidate(
 	q := cfg.WSpec*comp.Spec + cfg.WGap*comp.Gap + cfg.WCoh*(1-ms)
 	return q, q >= cfg.QualityFloor, nil
 }
+
+// sharedMotifSpecificity is §4's `Sum(1/df_canonical)` over every canonical
+// motif that ALL members carry.
+//
+// This is where "two shared canonical motifs = rank boost, never a gate" lives:
+// the group already exists on the motif it is keyed by, and a second shared one
+// only adds a term. Nothing in here can reject a candidate.
+//
+// A member spelling the same cluster two ways votes once — otherwise a group
+// would be strengthened by one author's phrasing habit rather than by a second
+// regularity. Terms are summed in sorted order so the float accumulation is
+// identical run to run.
+func sharedMotifSpecificity(ctx context.Context, idx SearchQuery, branch string, cand BridgeSeedSet, resolve motifResolver) (float64, error) {
+	if len(cand.Members) == 0 {
+		return 0, nil
+	}
+	counts := map[string]int{}
+	for _, m := range cand.Members {
+		seen := map[string]struct{}{}
+		for _, raw := range m.Motifs {
+			c := resolve(raw)
+			if c == "" {
+				continue
+			}
+			if _, dup := seen[c]; dup {
+				continue
+			}
+			seen[c] = struct{}{}
+			counts[c]++
+		}
+	}
+	shared := make([]string, 0, len(counts))
+	for c, n := range counts {
+		if n == len(cand.Members) {
+			shared = append(shared, c)
+		}
+	}
+	sort.Strings(shared)
+
+	total := 0.0
+	for _, c := range shared {
+		s, err := specificity(ctx, branch, c, string(BridgeMotif), idx)
+		if err != nil {
+			return 0, err
+		}
+		total += s
+	}
+	return total, nil
+}

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -83,6 +83,16 @@ type motifEnumHealth struct {
 	OverCeilingNames []string
 	// Point is the subject-disjointness operating point this corpus derived.
 	Point disjointnessPoint
+	// NearFloorDropped counts groups assigned to the NEAR lane and then
+	// dropped below the cohesion floor — the crack between the lanes
+	// (Phase-3 review, M4).
+	//
+	// laneOf is binary on `Density > 0`, so a group with one stray SIMILAR_TO
+	// edge among otherwise dissimilar members lands in the near lane and is
+	// then killed by a 0.5 floor. Such a group is far-lane material by any
+	// reading of §4 and disappears with no trace. Visibility now; the lane
+	// semantics are redesigned in Phase 4 on these counts.
+	NearFloorDropped int
 }
 
 // enumerateMotifCandidates is the §4 enumeration loop, with the gates applied
@@ -516,6 +526,18 @@ func motifTier(e Effort) motifMatchTier {
 // normal is the bounded 6ce866f8 amendment: verbatim matches only, at most two
 // items, near lane only. On any corpus without motifs it enumerates nothing,
 // which is why the EffortNormal contract test still passes vacuously (MN5).
+//
+// WHAT MN10 DOES AND DOES NOT PROMISE HERE (designer ruling, review M3).
+// MN10 governs CANDIDATE sets: each level's enumerated candidates are a strict
+// subset of the next level's, which holds and is tested. It does NOT promise
+// that a bridge SERVED at medium is served again at high — the budgets below
+// are the same kind of cap the entity/domain axis has always had, and at high
+// effort many more candidates compete for them. On the measured corpus that is
+// 113 token-2 groups for 8 near + 8 far slots against 20 at medium for 4, so a
+// medium-served item CAN lose its slot to a better-ranked family. That is
+// budget arithmetic, not a monotonicity break. Phase 4 measures how often it
+// happens and whether the budgets should grow; exact-first ranking was
+// considered and rejected — it would starve token-2 families out entirely.
 func motifSubBudget(e Effort) (near, far int) {
 	switch e {
 	case EffortHigh:
@@ -590,6 +612,9 @@ func buildMotifBridges(
 			return nil, nil, health, err
 		}
 		if !kept {
+			if lane == LaneNear {
+				health.NearFloorDropped++
+			}
 			continue
 		}
 		cand.Q = q
@@ -760,6 +785,12 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 		fmt.Sprintf("motif bridges: %d candidates, %d near, %d far (df band 2..%d)",
 			h.Candidates, near, far, h.Ceiling),
 		fmt.Sprintf("motif disjointness: %s; umbrella df > %d", point, h.Point.Umbrella),
+	}
+	if h.NearFloorDropped > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"motif near-lane floor: %d group(s) assigned near and dropped below the "+
+				"cohesion floor — sparse-similarity groups the lane split does not yet "+
+				"route to the far lane", h.NearFloorDropped))
 	}
 	if len(h.OverCeilingNames) > 0 {
 		lines = append(lines, fmt.Sprintf(

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -109,16 +109,37 @@ func enumerateMotifCandidates(
 			byToken[c][f.File] = f
 		}
 	}
+	// The token-2 tier is a UNION, not a replacement (§4: "Union with >= 2
+	// shared stemmed motif tokens"). Merging alone would REPLACE each verbatim
+	// group with a larger family group, and a larger group is not a superset of
+	// the smaller one once the pairwise disjointness pass has run over it: an
+	// added member can collide with a member the smaller group kept, and greedy
+	// keeps the earlier one. That breaks MN10's "each level's candidates are a
+	// strict subset of the next level's" — found on the real knomit-kb corpus,
+	// where pairs present at the exact tier vanished at token-2.
+	//
+	// So the family groups are ADDED to the verbatim ones, and a family whose
+	// members are already covered by a verbatim group is dropped as redundant.
+	groups := verbatimGroups(byToken)
 	if tier == tierToken2 {
-		mergeToken2Groups(byToken)
+		groups = append(groups, token2Families(byToken)...)
 	}
 
 	var out []BridgeSeedSet
-	for canon, members := range byToken {
+	for _, g := range groups {
+		canon, members := g.key, g.members
 		// GATE 1 — the df band, `2 <= df <= max(12, 2%*N)` (§4). Below the
 		// floor a motif has one carrier and cannot bridge yet. Above the
 		// ceiling it has gone generic: excluded, and flagged for splitting.
 		d := df(canon)
+		// A FAMILY is keyed by one of its ids, whose own df says nothing about
+		// how often the family recurs — two hapax spellings of one mechanism
+		// are exactly the case this tier exists to catch. Its carriers ARE its
+		// recurrence. A verbatim group is NOT promoted this way: there the df
+		// is the motif's own, and the floor is what stops a hapax bridging.
+		if g.family && len(members) > d {
+			d = len(members)
+		}
 		if d > ceiling {
 			health.OverCeilingNames = append(health.OverCeilingNames, canon)
 			continue
@@ -187,15 +208,49 @@ func disjointMembers(members map[string]factForLLM, labels store.SubjectLabelDF,
 	return kept
 }
 
-// mergeToken2Groups folds canonical ids sharing >= 2 stemmed tokens into one
-// group — the mechanical half of §4's permissive prefilter, reachable only at
-// high effort.
+// motifGroup is one candidate grouping before the gates run: a key, its
+// members, and whether the key names a single canonical id or a token-2 family
+// of them.
+type motifGroup struct {
+	key     string
+	members map[string]factForLLM
+	family  bool
+}
+
+// verbatimGroups projects the exact-tier map into groups, sorted by key so the
+// output order never depends on map iteration.
+func verbatimGroups(byToken map[string]map[string]factForLLM) []motifGroup {
+	keys := make([]string, 0, len(byToken))
+	for k := range byToken {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]motifGroup, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, motifGroup{key: k, members: byToken[k]})
+	}
+	return out
+}
+
+// token2Families returns one group per family of canonical ids sharing >= 2
+// stemmed tokens — §4's permissive prefilter, reachable only at high effort.
 //
-// The surviving key is the lexicographically smallest id of a merged set, so
-// the choice is deterministic and independent of map order. Merging is
-// transitive by construction: ids are processed in sorted order and each fold
-// moves members into the earlier key, so a chain a~b~c lands entirely on a.
-func mergeToken2Groups(byToken map[string]map[string]factForLLM) {
+// They are ADDED to the verbatim groups rather than replacing them (§4:
+// "Union with >= 2 shared stemmed motif tokens"). Replacement would break MN10:
+// a family group is larger, and a larger group is not a superset of the smaller
+// one once the pairwise disjointness pass has run over it — an added member can
+// collide with one the smaller group kept, and greedy keeps the earlier. That
+// was found on the real knomit-kb corpus, where pairs present at the exact tier
+// vanished at token-2.
+//
+// The family's key is the lexicographically smallest id in it, so the choice is
+// deterministic and independent of map order. Families are transitive by
+// construction: ids are walked in sorted order and each fold moves members onto
+// the earliest key, so a chain a~b~c lands entirely on a.
+//
+// A family that adds no members beyond its verbatim group is dropped: it would
+// be the same candidate under a second name, and the agent would judge it twice.
+func token2Families(byToken map[string]map[string]factForLLM) []motifGroup {
 	ids := make([]string, 0, len(byToken))
 	for id := range byToken {
 		ids = append(ids, id)
@@ -209,12 +264,16 @@ func mergeToken2Groups(byToken map[string]map[string]factForLLM) {
 			toks[i][t] = struct{}{}
 		}
 	}
+
+	// families[i] accumulates the members of the family keyed by ids[i].
+	families := make([]map[string]factForLLM, len(ids))
+	folded := make([]bool, len(ids))
 	for i := range ids {
-		if byToken[ids[i]] == nil {
-			continue // already folded into an earlier id
+		if folded[i] {
+			continue
 		}
 		for j := i + 1; j < len(ids); j++ {
-			if byToken[ids[j]] == nil {
+			if folded[j] {
 				continue
 			}
 			shared := 0
@@ -226,12 +285,32 @@ func mergeToken2Groups(byToken map[string]map[string]factForLLM) {
 			if shared < 2 {
 				continue
 			}
-			for p, f := range byToken[ids[j]] {
-				byToken[ids[i]][p] = f
+			if families[i] == nil {
+				families[i] = copyMembers(byToken[ids[i]])
 			}
-			delete(byToken, ids[j])
+			for p, f := range byToken[ids[j]] {
+				families[i][p] = f
+			}
+			folded[j] = true
 		}
 	}
+
+	var out []motifGroup
+	for i, fam := range families {
+		if fam == nil || len(fam) <= len(byToken[ids[i]]) {
+			continue // adds nothing the verbatim group did not already have
+		}
+		out = append(out, motifGroup{key: ids[i], members: fam, family: true})
+	}
+	return out
+}
+
+func copyMembers(in map[string]factForLLM) map[string]factForLLM {
+	out := make(map[string]factForLLM, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // ── the lane split (§4) ───────────────────────────────────────────────────
@@ -366,7 +445,10 @@ func sharedMotifSpecificity(ctx context.Context, idx SearchQuery, branch string,
 	}
 	sort.Strings(shared)
 
-	total := 0.0
+	// var, not `:= 0.0`: MN13's check on this file forbids float literals in
+	// the code outright, and a blanket rule with no carve-out for "but this one
+	// is only a zero" is worth more than the keystroke it costs.
+	var total float64
 	for _, c := range shared {
 		s, err := specificity(ctx, branch, c, string(BridgeMotif), idx)
 		if err != nil {

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -371,3 +371,158 @@ func sharedMotifSpecificity(ctx context.Context, idx SearchQuery, branch string,
 	}
 	return total, nil
 }
+
+// ── effort binding (§5) ───────────────────────────────────────────────────
+
+// motifTier binds the §4 stage-1 matching tier to the effort dial.
+//
+// The §5 table's medium and high operating points were calibrated as noise-pass
+// rates on the name+def EMBEDDING cascade, and the Q9 ruling DEFERRED that tier
+// until real vocabularies exist to calibrate against. What ships here is the
+// mechanical half of §4's prefilter, which needs no calibration and no
+// constant: exact canonical-id equality, widened at high effort by ">= 2 shared
+// stemmed motif tokens".
+//
+// Monotone by construction (MN10): exact is a subset of exact-union-token-2, so
+// raising effort can only add candidates, never change what a bridge means.
+//
+// RECORDED EXPECTATION (designer, 2026-08-23): until Phase-4 calibration,
+// high-effort matching sits at the measured token-2 floor rather than the
+// research 68% — the delta is what calibration buys back, not a regression.
+func motifTier(e Effort) motifMatchTier {
+	if e == EffortHigh {
+		return tierToken2
+	}
+	return tierExact
+}
+
+// motifSubBudget returns the per-lane caps for motif bridging.
+//
+// CONSTANT CLASSIFICATION (MN13, class 2): RESOURCE BUDGETS — agent work-item
+// slots. They allocate spend and claim nothing about any corpus's
+// distribution.
+//
+// Per-lane, and ADDITIONAL to the entity/domain budget rather than carved out
+// of it (MN8): the three axes have different df distributions, and one shared
+// pool would let whichever is densest starve the others. The sum stays inside
+// the forward-discover priority band, which TestEffortBudget_StaysBelowPriorityBand
+// asserts on the total rather than on any one budget.
+//
+// normal is the bounded 6ce866f8 amendment: verbatim matches only, at most two
+// items, near lane only. On any corpus without motifs it enumerates nothing,
+// which is why the EffortNormal contract test still passes vacuously (MN5).
+func motifSubBudget(e Effort) (near, far int) {
+	switch e {
+	case EffortHigh:
+		// "Carved from 48" (§5): a sixth of the entity/domain budget to each
+		// lane, so motif bridging adds at most a third again to a session's
+		// discover items.
+		return effortBudget(EffortHigh) / 6, effortBudget(EffortHigh) / 6
+	case EffortMedium:
+		return min(4, effortBudget(EffortMedium)/3), 0
+	}
+	return 2, 0
+}
+
+// buildMotifBridges is the production builder: enumerate, split by lane, score
+// per lane, rank, and cap each lane at its OWN sub-budget.
+//
+// Unlike buildScoredBridges it is NOT gated on eff.Discovers(): normal effort
+// runs the verbatim tier (§5), bounded at two items. What keeps that honest is
+// the motif-free short circuit below, not an effort check.
+func buildMotifBridges(
+	ctx context.Context,
+	idx SearchQuery,
+	branch string,
+	seeds []factForLLM,
+	clusters ClusterResult,
+	eff Effort,
+	cfg QualityConfig,
+	resolve motifResolver,
+	labels store.SubjectLabelDF,
+	meanSim meanSimFn,
+) ([]BridgeSeedSet, []BridgeSeedSet, motifEnumHealth, error) {
+	// A corpus with no motifs costs nothing at all — not one index call. This
+	// is the mechanism behind MN5's vacuous pass, so it is stated here rather
+	// than left to emerge from the gates downstream.
+	if !anyMotifs(seeds) {
+		return nil, nil, motifEnumHealth{}, nil
+	}
+
+	dfOf := func(canon string) int {
+		n, err := idx.TokenDF(ctx, branch, canon, string(BridgeMotif))
+		if err != nil {
+			// An unreadable df cannot bridge: 0 falls below the band's floor,
+			// which drops the candidate. Silence would be wrong in the other
+			// direction — a huge df would read as "gone generic" and land the
+			// motif in the over-ceiling review list it does not belong in.
+			return 0
+		}
+		return n
+	}
+
+	cands, health := enumerateMotifCandidates(seeds, clusters, resolve, dfOf, labels, motifTier(eff))
+	clusterOf := bridgePathCommunities(seeds, clusters)
+
+	var near, far []BridgeSeedSet
+	for _, cand := range cands {
+		paths := make([]string, 0, len(cand.Members))
+		for _, m := range cand.Members {
+			paths = append(paths, m.File)
+		}
+		g, err := idx.SimilarityAdjacency(ctx, paths)
+		if err != nil {
+			return nil, nil, health, err
+		}
+		lane := laneOf(paths, g)
+
+		spec, err := sharedMotifSpecificity(ctx, idx, branch, cand, resolve)
+		if err != nil {
+			return nil, nil, health, err
+		}
+		q, kept, err := scoreMotifCandidate(ctx, cand, lane, g, idx, branch, clusterOf, cfg, spec, meanSim)
+		if err != nil {
+			return nil, nil, health, err
+		}
+		if !kept {
+			continue
+		}
+		cand.Q = q
+		if lane == LaneNear {
+			near = append(near, cand)
+		} else {
+			far = append(far, cand)
+		}
+	}
+
+	nearBudget, farBudget := motifSubBudget(eff)
+	return rankAndCap(near, nearBudget), rankAndCap(far, farBudget), health, nil
+}
+
+// anyMotifs reports whether the seed pool carries a motif at all.
+func anyMotifs(seeds []factForLLM) bool {
+	for _, f := range seeds {
+		if len(f.Motifs) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// rankAndCap orders by Q descending, Token ascending, and truncates to the
+// lane's own budget. A zero budget means the lane is closed at this effort.
+func rankAndCap(in []BridgeSeedSet, budget int) []BridgeSeedSet {
+	if budget == 0 {
+		return nil
+	}
+	sort.SliceStable(in, func(i, j int) bool {
+		if in[i].Q != in[j].Q {
+			return in[i].Q > in[j].Q
+		}
+		return in[i].Token < in[j].Token
+	})
+	if len(in) > budget {
+		in = in[:budget]
+	}
+	return in
+}

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -68,6 +68,12 @@ type motifDFFn func(canonicalID string) int
 // motifEnumHealth is what enumeration observed. Every field is a DESCRIPTOR:
 // nothing in this package branches on any of them.
 type motifEnumHealth struct {
+	// Failure names why the pass could not run, when it could not. A failed
+	// pass that reported "N candidates, 0 near, 0 far" was indistinguishable
+	// from an axis that enumerated and found nothing (Phase-3 review, L6) —
+	// the same distinction motifResolverFor's warning exists to preserve, one
+	// layer up.
+	Failure string
 	// Candidates is how many groups survived every gate.
 	Candidates int
 	// Ceiling is the df band's upper bound on this corpus.
@@ -614,6 +620,7 @@ func rankAndCap(in []BridgeSeedSet, budget int) []BridgeSeedSet {
 	if budget == 0 {
 		return nil
 	}
+	in = suppressContained(in)
 	sort.SliceStable(in, func(i, j int) bool {
 		if in[i].Q != in[j].Q {
 			return in[i].Q > in[j].Q
@@ -736,6 +743,11 @@ func meanSimFor(d Deps, branch string) meanSimFn {
 // which is what it means for the gate to be a percentile of each repo's own
 // distribution rather than a threshold someone picked (MN13).
 func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
+	if h.Failure != "" {
+		return []string{fmt.Sprintf(
+			"motif bridges unavailable this session: %s "+
+				"(no candidates — this is NOT a statement about the corpus)", h.Failure)}
+	}
 	if h.Candidates == 0 && len(h.OverCeilingNames) == 0 {
 		return nil
 	}
@@ -755,4 +767,54 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 			len(h.OverCeilingNames), strings.Join(h.OverCeilingNames, ", ")))
 	}
 	return lines
+}
+
+// suppressContained drops any group whose members are a strict subset of
+// another group's.
+//
+// The token-2 tier makes these by construction: a family is kept only when it
+// has more members than its key's verbatim group, so the verbatim group is
+// always strictly contained in it, and both carry the SAME Bridge token. On the
+// measured corpus that was 12 of 113 groups, with three tokens each producing
+// two items (Phase-3 review, L1). On an axis judged as an observation-window
+// feeder with eight slots a lane, spending two of them on {A,B} and {A,B,C} is
+// spending two on one question.
+//
+// The SUPERSET survives: it carries strictly more evidence for the same shared
+// mechanism, and the agent can still decline the members it finds unconvincing.
+// Runs before ranking and truncation, or it would free no slots.
+func suppressContained(in []BridgeSeedSet) []BridgeSeedSet {
+	sets := make([]map[string]struct{}, len(in))
+	for i, g := range in {
+		sets[i] = make(map[string]struct{}, len(g.Members))
+		for _, m := range g.Members {
+			sets[i][m.File] = struct{}{}
+		}
+	}
+	out := make([]BridgeSeedSet, 0, len(in))
+	for i := range in {
+		contained := false
+		for j := range in {
+			if i == j || len(sets[j]) <= len(sets[i]) {
+				continue
+			}
+			if subsetOf(sets[i], sets[j]) {
+				contained = true
+				break
+			}
+		}
+		if !contained {
+			out = append(out, in[i])
+		}
+	}
+	return out
+}
+
+func subsetOf(small, big map[string]struct{}) bool {
+	for k := range small {
+		if _, ok := big[k]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -45,6 +45,18 @@ const (
 // it says where the estimate stops being one.
 const motifDFCeilingFloor = 12
 
+// motifDFCeilingPerCent is the df band's ceiling as a share of the corpus
+// (§4: `2 <= df <= max(12, 2%*N)`) — above it a motif has gone generic.
+//
+// CONSTANT CLASSIFICATION (MN13): a RATIO of the corpus's own size, the same
+// class as umbrellaPerCent in the sibling file, and it resolves to a different
+// df on every corpus. It was an unnamed inline `* 2 / 100` until the Phase-3
+// review (L2) pointed out that the MN13 check bans FLOAT literals and an
+// integer-written ratio is invisible to it — lesson 3 turned on the check
+// itself: ask in what form the violation would appear, and does the check read
+// that form.
+const motifDFCeilingPerCent = 2
+
 // motifResolver maps one authored motif spelling to its canonical cluster id.
 // An unresolved spelling resolves to ITSELF, so a corpus with no alias table
 // behaves as one where every motif is its own singleton cluster.
@@ -82,7 +94,7 @@ func enumerateMotifCandidates(
 	tier motifMatchTier,
 ) ([]BridgeSeedSet, motifEnumHealth) {
 	point := resolveDisjointnessPoint(labels)
-	ceiling := labels.LiveFacts * 2 / 100
+	ceiling := labels.LiveFacts * motifDFCeilingPerCent / 100
 	if ceiling < motifDFCeilingFloor {
 		ceiling = motifDFCeilingFloor
 	}

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -1,0 +1,229 @@
+package synthesize
+
+// Motif bridging — blueprint §4/§5. The aspect axis: facts about unrelated
+// subjects grouped by the MECHANISM they both instantiate.
+//
+// MN2 (the cf455b8f invariant): nothing in this file calls an LLM, and
+// enumeration calls no index either. The canonical-id resolver, the df reader
+// and the label distribution are injected by the caller, which keeps the
+// detector mechanical by construction and lets every gate be tested without a
+// database.
+
+import (
+	"sort"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+	"knomit/internal/textnorm"
+)
+
+// motifMatchTier is the §4 stage-1 matching tier, bound to the effort dial.
+type motifMatchTier int
+
+const (
+	// tierExact is canonical-id equality — the verbatim tier, and the highest
+	// precision event measured in every experiment (§12-E3).
+	tierExact motifMatchTier = iota
+	// tierToken2 additionally groups canonical ids sharing >= 2 stemmed tokens:
+	// the mechanical half of §4's permissive prefilter.
+	tierToken2
+)
+
+// motifDFCeilingFloor keeps the df band's ceiling meaningful on small corpora.
+//
+// CONSTANT CLASSIFICATION (MN13, third class): a STATISTICAL-VALIDITY FLOOR on
+// a DERIVED value. The band's ceiling is 2% of the corpus (§4), and 2% of 200
+// facts is 4 — which would call any normally-recurring motif "gone generic"
+// and bridge nothing. Below the corpus size where 2% is a usable estimate, the
+// band uses this instead. It claims nothing about any corpus's distribution;
+// it says where the estimate stops being one.
+const motifDFCeilingFloor = 12
+
+// motifResolver maps one authored motif spelling to its canonical cluster id.
+// An unresolved spelling resolves to ITSELF, so a corpus with no alias table
+// behaves as one where every motif is its own singleton cluster.
+type motifResolver func(motif string) string
+
+// motifDFFn returns the corpus-wide document frequency of a canonical motif id.
+type motifDFFn func(canonicalID string) int
+
+// motifEnumHealth is what enumeration observed. Every field is a DESCRIPTOR:
+// nothing in this package branches on any of them.
+type motifEnumHealth struct {
+	// Candidates is how many groups survived every gate.
+	Candidates int
+	// Ceiling is the df band's upper bound on this corpus.
+	Ceiling int
+	// OverCeilingNames are motifs that have gone generic — excluded from
+	// bridging and FLAGGED for review splitting (MN8), never silently dropped.
+	OverCeilingNames []string
+	// Point is the subject-disjointness operating point this corpus derived.
+	Point disjointnessPoint
+}
+
+// enumerateMotifCandidates is the §4 enumeration loop, with the gates applied
+// in §4 order: df band, then Louvain separation, then subject-disjointness.
+//
+// It returns groups keyed on the CANONICAL motif id, path-sorted members,
+// token-sorted output — deterministic in full, so map iteration order can never
+// reach a work item.
+func enumerateMotifCandidates(
+	seeds []factForLLM,
+	clusters ClusterResult,
+	resolve motifResolver,
+	df motifDFFn,
+	labels store.SubjectLabelDF,
+	tier motifMatchTier,
+) ([]BridgeSeedSet, motifEnumHealth) {
+	point := resolveDisjointnessPoint(labels)
+	ceiling := labels.LiveFacts * 2 / 100
+	if ceiling < motifDFCeilingFloor {
+		ceiling = motifDFCeilingFloor
+	}
+	health := motifEnumHealth{Ceiling: ceiling, Point: point}
+
+	pathCom := bridgePathCommunities(seeds, clusters)
+
+	// canonical id -> path -> fact.
+	byToken := map[string]map[string]factForLLM{}
+	for _, f := range seeds {
+		// §7 idempotency: a discovered fact is never a seed, or discovery feeds
+		// on its own output (cf455b8f).
+		if f.Origin == string(fact.Discovered) {
+			continue
+		}
+		for _, m := range f.Motifs {
+			c := resolve(m)
+			if c == "" {
+				continue
+			}
+			if byToken[c] == nil {
+				byToken[c] = map[string]factForLLM{}
+			}
+			byToken[c][f.File] = f
+		}
+	}
+	if tier == tierToken2 {
+		mergeToken2Groups(byToken)
+	}
+
+	var out []BridgeSeedSet
+	for canon, members := range byToken {
+		// GATE 1 — the df band, `2 <= df <= max(12, 2%*N)` (§4). Below the
+		// floor a motif has one carrier and cannot bridge yet. Above the
+		// ceiling it has gone generic: excluded, and flagged for splitting.
+		d := df(canon)
+		if d > ceiling {
+			health.OverCeilingNames = append(health.OverCeilingNames, canon)
+			continue
+		}
+		if d < 2 {
+			continue
+		}
+
+		// GATE 3 — subject-disjointness, applied pairwise (see disjointMembers).
+		// Ordered after the df band because it is the expensive one, and before
+		// separation because dropping a member can change the community span.
+		kept := disjointMembers(members, labels, point)
+		if len(kept) < 2 {
+			continue
+		}
+
+		// GATE 2 — Louvain separation >= 2. A GATE, never a ranking reward
+		// (1f536807): members in one community are neighbours, not a bridge.
+		coms := map[int]struct{}{}
+		for _, m := range kept {
+			coms[pathCom[m.File]] = struct{}{}
+		}
+		if len(coms) < 2 {
+			continue
+		}
+
+		out = append(out, BridgeSeedSet{
+			Token:   canon,
+			Kind:    BridgeMotif,
+			Members: kept,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Token < out[j].Token })
+	sort.Strings(health.OverCeilingNames)
+	health.Candidates = len(out)
+	return out, health
+}
+
+// disjointMembers applies the subject-disjointness gate pairwise, keeping a
+// member only when it is disjoint from every member already kept.
+//
+// Greedy rather than all-or-nothing: one member sharing a subject with one
+// other must not delete a group of four that is otherwise a genuine bridge.
+// Members are path-sorted first, so which member survives a collision is
+// deterministic rather than a function of map iteration order.
+func disjointMembers(members map[string]factForLLM, labels store.SubjectLabelDF, p disjointnessPoint) []factForLLM {
+	all := make([]factForLLM, 0, len(members))
+	for _, f := range members {
+		all = append(all, f)
+	}
+	sort.SliceStable(all, func(i, j int) bool { return all[i].File < all[j].File })
+
+	var kept []factForLLM
+	for _, cand := range all {
+		ok := true
+		for _, k := range kept {
+			if !subjectDisjoint(cand, k, labels, p) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			kept = append(kept, cand)
+		}
+	}
+	return kept
+}
+
+// mergeToken2Groups folds canonical ids sharing >= 2 stemmed tokens into one
+// group — the mechanical half of §4's permissive prefilter, reachable only at
+// high effort.
+//
+// The surviving key is the lexicographically smallest id of a merged set, so
+// the choice is deterministic and independent of map order. Merging is
+// transitive by construction: ids are processed in sorted order and each fold
+// moves members into the earlier key, so a chain a~b~c lands entirely on a.
+func mergeToken2Groups(byToken map[string]map[string]factForLLM) {
+	ids := make([]string, 0, len(byToken))
+	for id := range byToken {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	toks := make([]map[string]struct{}, len(ids))
+	for i, id := range ids {
+		toks[i] = map[string]struct{}{}
+		for _, t := range textnorm.Tokens(textnorm.Canonicalize(id)) {
+			toks[i][t] = struct{}{}
+		}
+	}
+	for i := range ids {
+		if byToken[ids[i]] == nil {
+			continue // already folded into an earlier id
+		}
+		for j := i + 1; j < len(ids); j++ {
+			if byToken[ids[j]] == nil {
+				continue
+			}
+			shared := 0
+			for t := range toks[i] {
+				if _, ok := toks[j][t]; ok {
+					shared++
+				}
+			}
+			if shared < 2 {
+				continue
+			}
+			for p, f := range byToken[ids[j]] {
+				byToken[ids[i]][p] = f
+			}
+			delete(byToken, ids[j])
+		}
+	}
+}

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -11,7 +11,12 @@ package synthesize
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"sort"
+	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"knomit/internal/fact"
 	"knomit/internal/store"
@@ -525,4 +530,135 @@ func rankAndCap(in []BridgeSeedSet, budget int) []BridgeSeedSet {
 		in = in[:budget]
 	}
 	return in
+}
+
+// ── review-pipeline wiring ────────────────────────────────────────────────
+
+// enqueueDiscover writes one discover work item. One definition, so the
+// entity/domain path and both motif lanes cannot drift apart in how an item is
+// shaped, keyed, or prioritised.
+func enqueueDiscover(ctx context.Context, d Deps, sess *store.PipelineSession, payload DiscoverWorkPayload, clusterKey string, priority float64) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return wrapf(reviewTool, err, "marshal discover payload %s", clusterKey)
+	}
+	if err := d.Pipeline.InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+		SessionID:  sess.ID,
+		StepType:   "discover",
+		ClusterKey: clusterKey,
+		FactsJSON:  string(payloadJSON),
+		Priority:   priority,
+	}); err != nil {
+		return wrapf(reviewTool, err, "insert discover item %s", clusterKey)
+	}
+	return nil
+}
+
+// motifResolverFor closes over this session's alias table.
+//
+// Read ONCE: the resolver is called per motif per fact, and a per-call query
+// would turn enumeration into a round-trip storm over a table that does not
+// change mid-session.
+func motifResolverFor(ctx context.Context, d Deps, branch string) motifResolver {
+	table, err := d.Motifs.AliasTable(ctx, branch)
+	if err != nil {
+		// Degrade, but never silently: without the table every spelling is its
+		// own cluster, so synonyms stop bridging and the session's motif output
+		// is quietly narrower than it should be. A reader comparing two
+		// sessions needs to know which one ran blind.
+		log.Warn().Err(err).Str("branch", branch).
+			Msg("review: motif alias table unreadable; bridging on verbatim spellings only")
+		table = nil
+	}
+	return func(m string) string {
+		if c, ok := table[m]; ok && c != "" {
+			return c
+		}
+		// An unresolved spelling resolves to ITSELF, so a corpus with no alias
+		// table behaves as one where every motif is its own singleton cluster —
+		// which is exactly what the verbatim tier wants at normal effort.
+		return m
+	}
+}
+
+// subjectLabelsFor reads the corpus's own label distribution for the
+// disjointness gate. On failure it returns the zero value, whose operating
+// point is STRICT — the conservative direction, and the one that keeps a
+// near-duplicate out rather than letting it through.
+func subjectLabelsFor(ctx context.Context, d Deps, branch string) store.SubjectLabelDF {
+	labels, err := d.Search.SubjectLabelDF(ctx, branch)
+	if err != nil {
+		log.Warn().Err(err).Str("branch", branch).
+			Msg("review: subject-label distribution unreadable; disjointness gate falls back to strict")
+		return store.SubjectLabelDF{}
+	}
+	return labels
+}
+
+// meanSimFor reads REAL cosines from the stored blended vectors.
+//
+// The far lane cannot get them from the SIMILAR_TO graph — that graph is empty
+// there by definition — so this reaches for the vectors the graph was built
+// from.
+func meanSimFor(d Deps, branch string) meanSimFn {
+	return func(ctx context.Context, paths []string) (float64, error) {
+		ids, err := d.Abstraction.FactIDsByPath(ctx, branch, paths)
+		if err != nil {
+			return 0, err
+		}
+		idList := make([]int64, 0, len(ids))
+		for _, id := range ids {
+			idList = append(idList, id)
+		}
+		vecs, err := d.Abstraction.BodyVectorsByFactID(ctx, idList)
+		if err != nil {
+			return 0, err
+		}
+		var sum float64
+		var n int
+		for i := 0; i < len(idList); i++ {
+			for j := i + 1; j < len(idList); j++ {
+				a, b := vecs[idList[i]], vecs[idList[j]]
+				if len(a) == 0 || len(b) == 0 {
+					continue
+				}
+				sum += dot(a, b)
+				n++
+			}
+		}
+		if n == 0 {
+			// No vectors is NOT "maximally dissimilar". Returning 0 would hand
+			// every un-embedded group the highest far-lane score there is,
+			// which is the opposite of what missing evidence should buy.
+			return 1, nil
+		}
+		return sum / float64(n), nil
+	}
+}
+
+// motifBridgeHealthLines are DESCRIPTORS: no branch in this package reads any
+// of them. The operating point is printed precisely because it is a
+// fingerprint — the same code on two corpora prints two different df cuts,
+// which is what it means for the gate to be a percentile of each repo's own
+// distribution rather than a threshold someone picked (MN13).
+func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
+	if h.Candidates == 0 && len(h.OverCeilingNames) == 0 {
+		return nil
+	}
+	point := fmt.Sprintf("df <= %d (p%d of %d labels)", h.Point.Cut, disjointnessPercentile, h.Point.Labels)
+	if h.Point.Strict {
+		point = fmt.Sprintf("STRICT fallback — %d labels is below the %d-label validity floor, so any shared label blocks",
+			h.Point.Labels, minLabelsForPercentile)
+	}
+	lines := []string{
+		fmt.Sprintf("motif bridges: %d candidates, %d near, %d far (df band 2..%d)",
+			h.Candidates, near, far, h.Ceiling),
+		fmt.Sprintf("motif disjointness: %s; umbrella df > %d", point, h.Point.Umbrella),
+	}
+	if len(h.OverCeilingNames) > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"motif df ceiling: %d motif(s) over the band, flagged for review splitting rather than bridged: %s",
+			len(h.OverCeilingNames), strings.Join(h.OverCeilingNames, ", ")))
+	}
+	return lines
 }

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -10,6 +10,7 @@ package synthesize
 // database.
 
 import (
+	"context"
 	"sort"
 
 	"knomit/internal/fact"
@@ -226,4 +227,98 @@ func mergeToken2Groups(byToken map[string]map[string]factForLLM) {
 			delete(byToken, ids[j])
 		}
 	}
+}
+
+// ── the lane split (§4) ───────────────────────────────────────────────────
+
+// BridgeLane is the §4 lane split. Members that are SIMILAR_TO neighbours form
+// the NEAR lane; members with no edge between them form the FAR lane, where
+// cohesion is 0 by construction.
+//
+// The two lanes mean different things and route differently: near is "similar
+// AND sharing a named mechanism", which plausibly supports an entailed
+// consequence and routes forward; far is the novel-analogy class this design
+// exists for, and routes backward as a hypothesis under default-NO.
+type BridgeLane string
+
+const (
+	LaneNear BridgeLane = "near"
+	LaneFar  BridgeLane = "far"
+)
+
+// laneOf assigns a candidate to its lane.
+func laneOf(paths []string, g store.SimilarityGraph) BridgeLane {
+	if g.Density(paths) > 0 {
+		return LaneNear
+	}
+	return LaneFar
+}
+
+// meanSimFn returns the mean pairwise similarity of the members.
+//
+// It is injected because the far lane needs REAL cosines and the SIMILAR_TO
+// graph cannot supply them: that graph is a top-K edge set, and in the far lane
+// it is empty by definition, so a "similarity" read off it would be the same
+// constant for every far candidate — a term that ranks nothing.
+type meanSimFn func(ctx context.Context, paths []string) (float64, error)
+
+// scoreMotifCandidate scores one candidate on its lane.
+//
+// Near lane: the existing bridgeQ, unchanged — cohesion floor, separation >= 2,
+// size cap. A near-lane group below the cohesion floor is DROPPED, not
+// re-routed to the far lane: the lanes partition the candidates, they are not a
+// retry.
+//
+// Far lane: Q = WSpec*sharedSpec + WGap*Gap + WCoh*(1 - meanSim). The cohesion
+// FLOOR is not applied — cohesion is 0 there by construction and the floor
+// would reject every far candidate — but separation and the size cap still are.
+// The dissimilarity term takes cohesion's weight rather than adding a knob, so
+// both lanes' scores stay on one scale and neither needs its own calibration.
+//
+// reshapeCohesiveSubset is NEVER used on this path (§4): it is cohesion-driven
+// and would reassemble the near subset out of a far group. Oversized far groups
+// are dropped by the size cap; the §4 trim is carried forward to Phase 4.
+func scoreMotifCandidate(
+	ctx context.Context,
+	cand BridgeSeedSet,
+	lane BridgeLane,
+	g store.SimilarityGraph,
+	idx SearchQuery,
+	branch string,
+	clusterOf map[string]int,
+	cfg QualityConfig,
+	sharedSpec float64,
+	meanSim meanSimFn,
+) (float64, bool, error) {
+	paths := make([]string, 0, len(cand.Members))
+	for _, m := range cand.Members {
+		paths = append(paths, m.File)
+	}
+	gap, err := derivationGap(ctx, paths, idx)
+	if err != nil {
+		return 0, false, err
+	}
+	comp := BridgeComponents{
+		Coh:     cohesion(paths, g),
+		Sep:     separation(paths, clusterOf),
+		Gap:     gap,
+		Spec:    sharedSpec,
+		Members: len(paths),
+	}
+	if lane == LaneNear {
+		q, kept := bridgeQ(comp, cfg)
+		return q, kept, nil
+	}
+	if comp.Sep < 2 || comp.Members > cfg.MaxMembers {
+		return 0, false, nil
+	}
+	ms, err := meanSim(ctx, paths)
+	if err != nil {
+		// Propagated, never defaulted. A similarity that could not be read is
+		// not "maximally dissimilar", and treating it as 0 would hand every
+		// unreadable group the highest far-lane score there is.
+		return 0, false, err
+	}
+	q := cfg.WSpec*comp.Spec + cfg.WGap*comp.Gap + cfg.WCoh*(1-ms)
+	return q, q >= cfg.QualityFloor, nil
 }

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -83,16 +83,26 @@ type motifEnumHealth struct {
 	OverCeilingNames []string
 	// Point is the subject-disjointness operating point this corpus derived.
 	Point disjointnessPoint
-	// NearFloorDropped counts groups assigned to the NEAR lane and then
-	// dropped below the cohesion floor — the crack between the lanes
-	// (Phase-3 review, M4).
+	// NearFloorDropped counts groups assigned to the NEAR lane and then dropped
+	// BECAUSE OF THE COHESION FLOOR — the crack between the lanes (Phase-3
+	// review, M4).
 	//
 	// laneOf is binary on `Density > 0`, so a group with one stray SIMILAR_TO
 	// edge among otherwise dissimilar members lands in the near lane and is
 	// then killed by a 0.5 floor. Such a group is far-lane material by any
 	// reading of §4 and disappears with no trace. Visibility now; the lane
-	// semantics are redesigned in Phase 4 on these counts.
+	// semantics are redesigned in Phase 4 on this count.
+	//
+	// It counts ONE cause. The first version incremented on any near-lane
+	// rejection, so oversize and quality-floor drops rode in under a label that
+	// said "cohesion" — and Phase 4 is going to read this number as evidence
+	// for a lane redesign (review M4 counter-finding). A number that does not
+	// mean its label is worse than no number.
 	NearFloorDropped int
+	// NearOtherDropped counts near-lane groups rejected for any OTHER reason —
+	// over the member cap, or under the quality floor. Separate because it is
+	// not evidence about the lane split.
+	NearOtherDropped int
 }
 
 // enumerateMotifCandidates is the §4 enumeration loop, with the gates applied
@@ -401,14 +411,14 @@ func scoreMotifCandidate(
 	cfg QualityConfig,
 	sharedSpec float64,
 	meanSim meanSimFn,
-) (float64, bool, error) {
+) (BridgeComponents, float64, bool, error) {
 	paths := make([]string, 0, len(cand.Members))
 	for _, m := range cand.Members {
 		paths = append(paths, m.File)
 	}
 	gap, err := derivationGap(ctx, paths, idx)
 	if err != nil {
-		return 0, false, err
+		return BridgeComponents{}, 0, false, err
 	}
 	comp := BridgeComponents{
 		Coh:     cohesion(paths, g),
@@ -419,20 +429,20 @@ func scoreMotifCandidate(
 	}
 	if lane == LaneNear {
 		q, kept := bridgeQ(comp, cfg)
-		return q, kept, nil
+		return comp, q, kept, nil
 	}
 	if comp.Sep < 2 || comp.Members > cfg.MaxMembers {
-		return 0, false, nil
+		return comp, 0, false, nil
 	}
 	ms, err := meanSim(ctx, paths)
 	if err != nil {
 		// Propagated, never defaulted. A similarity that could not be read is
 		// not "maximally dissimilar", and treating it as 0 would hand every
 		// unreadable group the highest far-lane score there is.
-		return 0, false, err
+		return comp, 0, false, err
 	}
 	q := cfg.WSpec*comp.Spec + cfg.WGap*comp.Gap + cfg.WCoh*(1-ms)
-	return q, q >= cfg.QualityFloor, nil
+	return comp, q, q >= cfg.QualityFloor, nil
 }
 
 // sharedMotifSpecificity is §4's `Sum(1/df_canonical)` over every canonical
@@ -607,13 +617,19 @@ func buildMotifBridges(
 		if err != nil {
 			return nil, nil, health, err
 		}
-		q, kept, err := scoreMotifCandidate(ctx, cand, lane, g, idx, branch, clusterOf, cfg, spec, meanSim)
+		comp, q, kept, err := scoreMotifCandidate(ctx, cand, lane, g, idx, branch, clusterOf, cfg, spec, meanSim)
 		if err != nil {
 			return nil, nil, health, err
 		}
 		if !kept {
+			// Attributed by CAUSE, from the components the scorer computed,
+			// rather than by "it was near and it went".
 			if lane == LaneNear {
-				health.NearFloorDropped++
+				if comp.Coh < cfg.CohFloor {
+					health.NearFloorDropped++
+				} else {
+					health.NearOtherDropped++
+				}
 			}
 			continue
 		}
@@ -791,6 +807,11 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 			"motif near-lane floor: %d group(s) assigned near and dropped below the "+
 				"cohesion floor — sparse-similarity groups the lane split does not yet "+
 				"route to the far lane", h.NearFloorDropped))
+	}
+	if h.NearOtherDropped > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"motif near-lane other: %d group(s) dropped over the member cap or under "+
+				"the quality floor — not evidence about the lane split", h.NearOtherDropped))
 	}
 	if len(h.OverCeilingNames) > 0 {
 		lines = append(lines, fmt.Sprintf(

--- a/internal/synthesize/bridge_motif_acceptance_test.go
+++ b/internal/synthesize/bridge_motif_acceptance_test.go
@@ -1,0 +1,217 @@
+package synthesize
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// Phase-3 acceptance: the 13 bridge-yield pairs replayed through the SHIPPED
+// enumeration.
+//
+// The measurement they come from (summarizer doc, BRIDGE-YIELD MEASUREMENT)
+// enumerated pairs sharing a canonical motif at df >= 2 while sharing zero
+// stemmed entity/domain/path tokens, umbrella-aware — pairs invisible to the
+// existing token detector by construction. It reported 10 on knomit-kb, 2 on
+// core, 1 on agentic-engineering.
+//
+// This test asks whether the code that shipped finds the same population. The
+// harness is READ-ONLY input: the labels file is parsed here and the facts are
+// driven through enumerateMotifCandidates. Nothing is imported from
+// .claude/harness/motif/, which the roadmap fences off from product code.
+//
+//	KNOMIT_MOTIF_ACCEPTANCE=1 go test ./internal/synthesize/ -run TestMotifAcceptance -v
+const trainCanonPath = ".claude/harness/motif/data/train_canon.jsonl"
+
+type canonRow struct {
+	Key    string   `json:"key"`
+	Input  string   `json:"input"`
+	Output []string `json:"output"`
+}
+
+var (
+	reDomain   = regexp.MustCompile(`(?m)^domain: \[(.*)\]$`)
+	reEntities = regexp.MustCompile(`(?m)^entities: \[(.*)\]$`)
+	reQuoted   = regexp.MustCompile(`'([^']*)'`)
+)
+
+// loadCanonCorpus reads one source corpus out of the harness labels file and
+// projects it into the shape enumeration consumes.
+func loadCanonCorpus(t *testing.T, corpus string) []factForLLM {
+	t.Helper()
+	f, err := os.Open("../../" + trainCanonPath)
+	require.NoError(t, err, "harness fixture missing — this acceptance cannot run")
+	defer f.Close()
+
+	var out []factForLLM
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1<<20), 1<<22)
+	for sc.Scan() {
+		var row canonRow
+		require.NoError(t, json.Unmarshal(sc.Bytes(), &row))
+		prefix := corpus + ":"
+		if !strings.HasPrefix(row.Key, prefix) {
+			continue
+		}
+		out = append(out, factForLLM{
+			File:     strings.TrimPrefix(row.Key, prefix),
+			Domain:   quotedList(reDomain, row.Input),
+			Entities: quotedList(reEntities, row.Input),
+			Motifs:   row.Output,
+		})
+	}
+	require.NoError(t, sc.Err())
+	return out
+}
+
+func quotedList(re *regexp.Regexp, input string) []string {
+	m := re.FindStringSubmatch(input)
+	if m == nil {
+		return nil
+	}
+	var out []string
+	for _, q := range reQuoted.FindAllStringSubmatch(m[1], -1) {
+		if q[1] != "" {
+			out = append(out, q[1])
+		}
+	}
+	return out
+}
+
+// labelsFor computes the corpus's own subject-label distribution the way
+// store.SubjectLabelDF does — same tokeniser, same one-set-per-fact counting.
+func labelsFor(facts []factForLLM) store.SubjectLabelDF {
+	d := store.SubjectLabelDF{DF: map[string]int{}, LiveFacts: len(facts)}
+	for _, f := range facts {
+		for tok := range fact.SubjectTokens(f.Entities, f.Domain, f.File) {
+			d.DF[tok]++
+		}
+	}
+	return d
+}
+
+// motifDFFor counts carriers per canonical motif over the corpus.
+func motifDFFor(facts []factForLLM) motifDFFn {
+	counts := map[string]int{}
+	for _, f := range facts {
+		seen := map[string]struct{}{}
+		for _, m := range f.Motifs {
+			if _, dup := seen[m]; dup {
+				continue
+			}
+			seen[m] = struct{}{}
+			counts[m]++
+		}
+	}
+	return func(c string) int { return counts[c] }
+}
+
+// pairsOf expands each candidate group into its MEMBER pairs — the unit the
+// bridge-yield measurement counted.
+//
+// Keyed on the two paths and NOT on the token, deliberately: the token-2 tier
+// merges canonical ids, so the same pair of facts can arrive under a different
+// group label at a higher effort. Keying on the token would make monotonicity
+// look violated by a relabelling.
+func pairsOf(groups []BridgeSeedSet) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, g := range groups {
+		for i := 0; i < len(g.Members); i++ {
+			for j := i + 1; j < len(g.Members); j++ {
+				a, b := g.Members[i].File, g.Members[j].File
+				if a > b {
+					a, b = b, a
+				}
+				out[a+"|"+b] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+// bridgeYieldSamples are the knomit-kb pairs the summarizer doc names in
+// prose. A count can drift for many reasons; these are the specific
+// cross-subsystem mechanisms the measurement pointed at, so they are asserted
+// by name.
+var bridgeYieldSamples = []string{
+	"stale-closure-capture",
+	"check-then-act-race",
+	"single-source-of-truth",
+	"duplicated-logic-drift",
+}
+
+func TestMotifAcceptance_BridgeYieldPairs(t *testing.T) {
+	if os.Getenv("KNOMIT_MOTIF_ACCEPTANCE") != "1" {
+		t.Skip("acceptance replay over the harness fixture; set KNOMIT_MOTIF_ACCEPTANCE=1")
+	}
+	facts := loadCanonCorpus(t, "knomit-kb")
+	require.NotEmpty(t, facts)
+
+	labels := labelsFor(facts)
+	df := motifDFFor(facts)
+
+	// No cluster assignment: every fact is its own community, so separation
+	// never rejects. That matches the measurement, which asked only whether the
+	// PAIR was subject-disjoint on a shared motif — it did not run Louvain.
+	clusters := ClusterResult{}
+
+	var motifed int
+	for _, f := range facts {
+		if len(f.Motifs) > 0 {
+			motifed++
+		}
+	}
+
+	high, hHigh := enumerateMotifCandidates(facts, clusters, identityResolver, df, labels, tierToken2)
+	normal, hNormal := enumerateMotifCandidates(facts, clusters, identityResolver, df, labels, tierExact)
+
+	t.Logf("corpus: %d facts, %d carrying motifs", len(facts), motifed)
+	t.Logf("labels: %d distinct, live %d; operating point cut=%d umbrella=%d strict=%v",
+		len(labels.DF), labels.LiveFacts, hHigh.Point.Cut, hHigh.Point.Umbrella, hHigh.Point.Strict)
+	t.Logf("df band ceiling: %d; over-ceiling motifs: %d", hHigh.Ceiling, len(hHigh.OverCeilingNames))
+	t.Logf("exact tier:  %d groups, %d pairs", len(normal), len(pairsOf(normal)))
+	t.Logf("token2 tier: %d groups, %d pairs", len(high), len(pairsOf(high)))
+
+	var tokens []string
+	for _, g := range normal {
+		tokens = append(tokens, fmt.Sprintf("%s(%d)", g.Token, len(g.Members)))
+	}
+	sort.Strings(tokens)
+	t.Logf("exact-tier groups: %s", strings.Join(tokens, " "))
+
+	// The measurement's headline: ten subject-disjoint pairs on knomit-kb. The
+	// shipped gate is FINER than the one that produced it (df-graded rather
+	// than any-shared-token), so it should find at least as many.
+	require.GreaterOrEqual(t, len(pairsOf(high)), 10,
+		"the shipped enumeration must find at least the measured bridge-yield population")
+
+	// The named samples, present as groups in their own right.
+	byToken := map[string]int{}
+	for _, g := range normal {
+		byToken[g.Token] = len(g.Members)
+	}
+	for _, want := range bridgeYieldSamples {
+		require.Containsf(t, byToken, want,
+			"the doc names %q as a bridge-yield mechanism; enumeration must still find it", want)
+		require.GreaterOrEqualf(t, byToken[want], 2, "%q must carry a real group", want)
+	}
+
+	// Monotone (MN10) on real data, not only on hand-built fixtures.
+	require.Subset(t, pairsOf(high), pairsOf(normal))
+
+	// And the two tiers must actually DIFFER, or the monotonicity assertion
+	// above is comparing a set with itself.
+	require.NotEqual(t, len(pairsOf(high)), len(pairsOf(normal)),
+		"token-2 must admit something exact does not, or the ladder is flat on real data")
+	require.Equal(t, hNormal.Ceiling, hHigh.Ceiling, "the band is a corpus property, not a tier one")
+}

--- a/internal/synthesize/bridge_motif_acceptance_test.go
+++ b/internal/synthesize/bridge_motif_acceptance_test.go
@@ -189,6 +189,20 @@ func TestMotifAcceptance_BridgeYieldPairs(t *testing.T) {
 	sort.Strings(tokens)
 	t.Logf("exact-tier groups: %s", strings.Join(tokens, " "))
 
+	// L1 on real data: how many of the token-2 groups are strictly contained in
+	// another, and therefore never reach a slot. The reviewer measured 12 of
+	// 113 at enumeration; this asserts the suppression actually removes them
+	// before the budget is spent.
+	kept := suppressContained(high)
+	t.Logf("contained-group suppression: %d of %d token-2 groups dropped",
+		len(high)-len(kept), len(high))
+	require.Positive(t, len(high)-len(kept),
+		"token-2 makes contained groups by construction — a run that suppresses none "+
+			"means the suppression is not reaching them")
+	require.Equal(t, pairsOf(high), pairsOf(kept),
+		"suppression must not lose a PAIR — a contained group's members all "+
+			"survive inside the superset that displaced it")
+
 	// The measurement's headline: ten subject-disjoint pairs on knomit-kb. The
 	// shipped gate is FINER than the one that produced it (df-graded rather
 	// than any-shared-token), so it should find at least as many.

--- a/internal/synthesize/bridge_motif_dynamics_test.go
+++ b/internal/synthesize/bridge_motif_dynamics_test.go
@@ -1,0 +1,195 @@
+package synthesize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// Phase-3 multi-session dynamics — the standing requirement.
+//
+// It exists because the Phase-0 review found every component unit-correct and
+// every blocking defect in the CROSS-SESSION behaviour. A gate that computes
+// the right operating point once, an alias table that resolves once, and a
+// bridge that enumerates once can all still be wrong the second time a session
+// runs over the same corpus.
+
+// motifDynamicsEnv is a corpus big enough for the gate's RATIOS to mean
+// something.
+//
+// The size is load-bearing, not padding. The umbrella rule is "df > 20% of the
+// corpus", so on a six-fact corpus the umbrella cut is 1 — and since a SHARED
+// label has df >= 2 by definition, every shared label reads as an umbrella and
+// the disjointness gate cannot block anything at all. At forty facts the cut is
+// 8 and a two-carrier entity is what it actually is: rare, and specific.
+//
+// (The degenerate case is real but bounded: a corpus that small produces almost
+// no motif candidates, and Phase 4's activation gate keeps the axis off such
+// corpora entirely.)
+func motifDynamicsEnv(t *testing.T) *restatementEnv {
+	t.Helper()
+	return newRestatementEnv(t, 40)
+}
+
+// rewriteWithMotifs replaces a fact in place, carrying explicit entities so a
+// test can move it in or out of subject-disjointness.
+func (e *restatementEnv) rewriteWithMotifs(path, title, body string, motifs, entities []string) {
+	e.t.Helper()
+	f := fact.NewFact(path)
+	f.Title = title
+	f.Body = body
+	f.Type = fact.Observation
+	f.Confidence = 0.7
+	f.Sources = 1
+	f.Motifs = motifs
+	f.Entities = entities
+	content, err := fact.SerializeFact(f)
+	require.NoError(e.t, err)
+	_, err = e.svc.Facts().WriteFact(context.Background(), e.branch, path, content, "write "+path, "test")
+	require.NoError(e.t, err)
+}
+
+// TestMotifBridging_AcrossSessions runs five sessions over one corpus and
+// asserts things only their SEQUENCE can establish.
+func TestMotifBridging_AcrossSessions(t *testing.T) {
+	env := motifDynamicsEnv(t)
+	const (
+		uiPath    = "kb/gotchas/uitesting/agentclicks.md"
+		benchPath = "kb/technology/benchmarks/terminalscores.md"
+	)
+
+	// S1 — no motifs anywhere. The axis must do nothing, and say nothing.
+	s1, h1 := env.motifBridgeSession(EffortHigh)
+	require.Empty(t, motifPayloads(s1))
+	require.NotContains(t, strings.Join(h1, "\n"), "motif bridges:")
+
+	// S2 — the motifs arrive on two subject-disjoint facts. The bridge forms,
+	// on a corpus whose alias table this session had to build for itself.
+	env.rewriteWithMotifs(uiPath,
+		"An agent testing a UI will execute JavaScript instead of clicking",
+		"Driving app state directly bypasses the path the verifier believes it is checking.",
+		[]string{"measure-becomes-target"}, []string{"Cognition"})
+	env.rewriteWithMotifs(benchPath,
+		"Coding agents reached 94% on a terminal benchmark by cheating it",
+		"The agents scored by exploiting the harness rather than by solving the tasks.",
+		[]string{"measure-becomes-target"}, []string{"Terminal Bench"})
+
+	s2, h2 := env.motifBridgeSession(EffortHigh)
+	motifs2 := motifPayloads(s2)
+	require.Len(t, motifs2, 1, "the pair bridges once its motifs exist")
+	require.Equal(t, LaneFar, motifs2[0].Lane)
+	require.Contains(t, strings.Join(h2, "\n"), "motif bridges: 1 candidates")
+
+	// S3 — nothing changed. The bridge is still THERE: enumeration is a
+	// function of the live corpus, not of what this session happens to have
+	// touched, so a standing bridge does not blink out because a session was
+	// quiet.
+	s3, _ := env.motifBridgeSession(EffortHigh)
+	require.Len(t, motifPayloads(s3), 1,
+		"a bridge is a property of the corpus, not of the session's dirty set")
+
+	// S4 — one member is rewritten so the two now share a RARE entity. They are
+	// one subject, and the gate must RECOMPUTE rather than remember: the bridge
+	// disappears without anything retracting it.
+	env.rewriteWithMotifs(benchPath,
+		"Coding agents reached 94% on a terminal benchmark by cheating it",
+		"The agents scored by exploiting the harness rather than by solving the tasks.",
+		[]string{"measure-becomes-target"}, []string{"Cognition"})
+
+	s4, _ := env.motifBridgeSession(EffortHigh)
+	require.Empty(t, motifPayloads(s4),
+		"the pair now shares a rare entity — level-triggered, so the gate re-decides")
+
+	// S5 — and back. The same edit reversed restores the bridge, which is what
+	// makes S4 the gate working rather than the axis breaking.
+	env.rewriteWithMotifs(benchPath,
+		"Coding agents reached 94% on a terminal benchmark by cheating it",
+		"The agents scored by exploiting the harness rather than by solving the tasks.",
+		[]string{"measure-becomes-target"}, []string{"Terminal Bench"})
+
+	s5, _ := env.motifBridgeSession(EffortHigh)
+	require.Len(t, motifPayloads(s5), 1)
+}
+
+// TestMotifBridging_EffortIsRecomputedPerSession — the same corpus, two
+// sessions, two efforts. Nothing about the axis is persisted, so lowering
+// effort must close the far lane on the very next session.
+func TestMotifBridging_EffortIsRecomputedPerSession(t *testing.T) {
+	env := motifDynamicsEnv(t)
+	env.rewriteWithMotifs("kb/gotchas/uitesting/agentclicks.md",
+		"An agent testing a UI will execute JavaScript instead of clicking",
+		"Driving app state directly bypasses the verifier's path.",
+		[]string{"measure-becomes-target"}, []string{"Cognition"})
+	env.rewriteWithMotifs("kb/technology/benchmarks/terminalscores.md",
+		"Coding agents reached 94% on a terminal benchmark by cheating it",
+		"The agents exploited the harness rather than solving the tasks.",
+		[]string{"measure-becomes-target"}, []string{"Terminal Bench"})
+
+	high, _ := env.motifBridgeSession(EffortHigh)
+	require.Len(t, motifPayloads(high), 1, "the far lane is open at high")
+
+	medium, _ := env.motifBridgeSession(EffortMedium)
+	require.Empty(t, motifPayloads(medium),
+		"medium is near lane only, and this group is far — no state carries the item over")
+}
+
+// TestMotifBridging_FromNothing — lesson 7. Hand-seeded fixtures structurally
+// cannot detect a bootstrap deadlock: Phase 2 shipped an entire vocabulary
+// lifecycle unreachable, with ~60 tests green, because every one of them seeded
+// the alias table by hand.
+//
+// This starts from NOTHING derived — facts with motifs, no alias rows, no
+// definitions, no title vectors — and requires the pipeline to build its own
+// way to a motif bridge through real sessions.
+func TestMotifBridging_FromNothing(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+
+	// One regularity, on two subject-disjoint facts. The spelling is the same
+	// on both deliberately: collapsing two SPELLINGS needs the alias judge,
+	// which needs an agent to answer its work item, and this test is about the
+	// mechanical derived state a session must build unaided — the alias table,
+	// the canonical id, the df — not about the judged half.
+	env.rewriteWithMotifs("kb/gotchas/caching/staleread.md",
+		"A cache served state the writer had already replaced",
+		"The reader observed a version the writer believed was gone.",
+		[]string{"stale-read-after-write"}, []string{"Redis"})
+	env.rewriteWithMotifs("kb/technology/ledgers/settlement.md",
+		"Settlement confirmed against a balance that had already moved",
+		"The confirmation was computed from a snapshot the ledger had superseded.",
+		[]string{"stale-read-after-write"}, []string{"SWIFT"})
+
+	var found bool
+	for i := 0; i < 4 && !found; i++ {
+		payloads, _ := env.motifBridgeSession(EffortHigh)
+		found = len(motifPayloads(payloads)) > 0
+	}
+	require.True(t, found,
+		"a session must maintain the derived state its own bridging depends on")
+}
+
+// TestMotifBridging_ReinforcementSurvivesLaterSessions — the write REINFORCE
+// makes must still be there when the next session reads the corpus, and must
+// not be re-applied by it.
+func TestMotifBridging_ReinforcementSurvivesLaterSessions(t *testing.T) {
+	env := newReinforceEnv(t)
+
+	require.Equal(t, []string{reinforcePath}, env.apply(goodReinforcement()))
+	afterWrite := env.read(reinforcePath)
+	require.Equal(t, 2, afterWrite.Sources)
+
+	// A whole session runs over the corpus in between.
+	_, _ = env.motifBridgeSession(EffortHigh)
+
+	afterSession := env.read(reinforcePath)
+	require.Equal(t, afterWrite.Sources, afterSession.Sources)
+	require.Equal(t, afterWrite.Refs, afterSession.Refs)
+	require.Equal(t, afterWrite.EvidenceWeight, afterSession.EvidenceWeight)
+
+	// And a second reinforcement attempt after that session is still a no-op.
+	require.Empty(t, env.apply(goodReinforcement()))
+	require.Equal(t, afterWrite.Sources, env.read(reinforcePath).Sources)
+}

--- a/internal/synthesize/bridge_motif_review_test.go
+++ b/internal/synthesize/bridge_motif_review_test.go
@@ -1,0 +1,168 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The review pipeline's half of motif bridging, driven through the REAL engine
+// rather than by calling the builder directly. What these tests are for is the
+// seam: the builder can be right, the payload can be right, and the item can
+// still reach the agent with the wrong direction on it.
+
+// motifBridgeSession runs one real review session at the given effort and
+// returns the discover payloads it enqueued, plus the session's health lines.
+func (e *restatementEnv) motifBridgeSession(effort Effort) ([]DiscoverWorkPayload, []string) {
+	e.t.Helper()
+	res, err := NewReviewerWithOptions(e.ri, nil, effort, ScopeFilter{}).StartSession(context.Background())
+	require.NoError(e.t, err)
+
+	var out []DiscoverWorkPayload
+	for _, item := range e.workItems(res.SessionID) {
+		if item.StepType != "discover" {
+			continue
+		}
+		var p DiscoverWorkPayload
+		require.NoError(e.t, json.Unmarshal([]byte(item.FactsJSON), &p))
+		out = append(out, p)
+	}
+	return out, res.Health
+}
+
+// motifPayloads filters to the motif axis.
+func motifPayloads(in []DiscoverWorkPayload) []DiscoverWorkPayload {
+	var out []DiscoverWorkPayload
+	for _, p := range in {
+		if p.Bridge.Kind == BridgeMotif {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// seedMotifPair writes two subject-disjoint facts carrying the same motif. They
+// have distinct paths, distinct titles and distinct bodies, so nothing but the
+// motif connects them — which is the whole claim the axis makes.
+func (e *restatementEnv) seedMotifPair(motif string) {
+	e.t.Helper()
+	e.writeFactWithMotifs("kb/gotchas/uitesting/agentclicks.md",
+		"An agent testing a UI will execute JavaScript instead of clicking",
+		"Driving app state directly bypasses the path the verifier believes it is checking.",
+		[]string{motif})
+	e.writeFactWithMotifs("kb/technology/benchmarks/terminalscores.md",
+		"Coding agents reached 94% on a terminal benchmark by cheating it",
+		"The agents scored by exploiting the harness rather than by solving the tasks.",
+		[]string{motif})
+}
+
+// TestReviewPlan_FarLaneRoutesBackward — the far lane's members have no
+// SIMILAR_TO edge, so the item must carry DiscoverBackward, which is what makes
+// the proposal a hypothesis under the blast-radius gate (2bc84184).
+func TestReviewPlan_FarLaneRoutesBackward(t *testing.T) {
+	env := newRestatementEnv(t, 4)
+	env.seedMotifPair("measure-becomes-target")
+
+	payloads, _ := env.motifBridgeSession(EffortHigh)
+	motifs := motifPayloads(payloads)
+
+	require.Len(t, motifs, 1)
+	require.Equal(t, LaneFar, motifs[0].Lane,
+		"precondition: with no SIMILAR_TO edge the pair is a far-lane group")
+	require.Equal(t, DiscoverBackward, motifs[0].Direction)
+	require.Equal(t, "measure-becomes-target", motifs[0].Bridge.Token)
+	require.Len(t, motifs[0].Bridge.Members, 2)
+}
+
+// The members' MOTIFS must survive into the payload the agent is served. The
+// prompt's far-lane line names the motif, and the schema's carry-over
+// instruction asks the agent to consider it — both read this field, and Phase 1
+// shipped a version of exactly this seam that read back empty.
+func TestReviewPlan_MotifPayloadCarriesMemberMotifs(t *testing.T) {
+	env := newRestatementEnv(t, 4)
+	env.seedMotifPair("measure-becomes-target")
+
+	payloads, _ := env.motifBridgeSession(EffortHigh)
+	motifs := motifPayloads(payloads)
+	require.Len(t, motifs, 1)
+
+	for _, m := range motifs[0].Bridge.Members {
+		require.Contains(t, m.Motifs, "measure-becomes-target",
+			"the member projection must carry the motif the group was formed on")
+	}
+}
+
+// TestReviewPlan_NormalEmitsNoMotifItemsWithoutVerbatimMatches — MN5's contract
+// seen from the review side: a corpus whose facts carry no motifs produces no
+// motif work at normal effort, so the EffortNormal test passes vacuously.
+func TestReviewPlan_NormalEmitsNoMotifItemsOnAMotifFreeCorpus(t *testing.T) {
+	env := newRestatementEnv(t, 6)
+
+	payloads, health := env.motifBridgeSession(EffortNormal)
+
+	require.Empty(t, motifPayloads(payloads))
+	require.NotContains(t, strings.Join(health, "\n"), "motif bridges:",
+		"a corpus with nothing to say about motifs says nothing")
+}
+
+// TestReviewPlan_HealthReportsTheOperatingPoint — the descriptors are a
+// fingerprint of the corpus, and the GATE package needs them to state what the
+// gate DID rather than that it exists. Nothing branches on them.
+func TestReviewPlan_HealthReportsTheOperatingPoint(t *testing.T) {
+	env := newRestatementEnv(t, 4)
+	env.seedMotifPair("measure-becomes-target")
+
+	_, health := env.motifBridgeSession(EffortHigh)
+	joined := strings.Join(health, "\n")
+
+	require.Contains(t, joined, "motif bridges: 1 candidates, 0 near, 1 far")
+	require.Contains(t, joined, "motif disjointness:")
+	require.Contains(t, joined, "umbrella df >")
+}
+
+// TestReviewPlan_DiscoverItemsShareOneRankSpace — the motif lanes were added to
+// the SAME forward-discover priority band as the entity/domain bridges, off one
+// shared rank counter. That is deliberate (the band belongs to the review
+// session's queue, not to a bridge kind), and it is also the regression risk
+// the change introduced: two items landing on one priority, or on one cluster
+// key, would make the queue order arbitrary.
+//
+// Asserted on the queue itself, which is the thing the engine reads.
+func TestReviewPlan_DiscoverItemsShareOneRankSpace(t *testing.T) {
+	env := newRestatementEnv(t, 4)
+	env.seedMotifPair("measure-becomes-target")
+	env.writeFactWithMotifs("kb/gotchas/caching/staleread.md",
+		"A cache read served state the writer had already replaced",
+		"The reader observed a version the writer believed was gone.",
+		[]string{"stale-read-after-write"})
+	env.writeFactWithMotifs("kb/technology/ledgers/settlement.md",
+		"Settlement confirmed against a balance that had already moved",
+		"The confirmation was computed from a snapshot the ledger had superseded.",
+		[]string{"stale-read-after-write"})
+
+	res, err := NewReviewerWithOptions(env.ri, nil, EffortHigh, ScopeFilter{}).StartSession(context.Background())
+	require.NoError(t, err)
+
+	keys := map[string]bool{}
+	priorities := map[float64]string{}
+	discovers := 0
+	for _, item := range env.workItems(res.SessionID) {
+		if item.StepType != "discover" {
+			continue
+		}
+		discovers++
+		require.False(t, keys[item.ClusterKey], "duplicate cluster key %q", item.ClusterKey)
+		keys[item.ClusterKey] = true
+		prev, clash := priorities[item.Priority]
+		require.False(t, clash, "%q and %q share priority %v", prev, item.ClusterKey, item.Priority)
+		priorities[item.Priority] = item.ClusterKey
+		require.LessOrEqual(t, item.Priority, float64(forwardDiscoverPriorityBase),
+			"discover items sit below the grounded work")
+		require.Greater(t, item.Priority, float64(reflectPriority),
+			"and strictly above reflect — the band's whole purpose")
+	}
+	require.Equal(t, 2, discovers, "precondition: two motif groups, so the rank space is actually shared")
+}

--- a/internal/synthesize/bridge_motif_review_test.go
+++ b/internal/synthesize/bridge_motif_review_test.go
@@ -49,14 +49,20 @@ func motifPayloads(in []DiscoverWorkPayload) []DiscoverWorkPayload {
 // motif connects them — which is the whole claim the axis makes.
 func (e *restatementEnv) seedMotifPair(motif string) {
 	e.t.Helper()
-	e.writeFactWithMotifs("kb/gotchas/uitesting/agentclicks.md",
+	// rewriteWithMotifs, NOT writeFactWithMotifs: the latter stamps
+	// `domain: [alpha]` on every fact it writes, so a "subject-disjoint" pair
+	// built with it shares a domain tag. That went unnoticed while the umbrella
+	// exclusion was degenerate at this corpus size and swallowed the shared tag
+	// (Phase-3 review, L4) — the fixture was never disjoint, and the gate was
+	// never the reason it passed.
+	e.rewriteWithMotifs("kb/gotchas/uitesting/agentclicks.md",
 		"An agent testing a UI will execute JavaScript instead of clicking",
 		"Driving app state directly bypasses the path the verifier believes it is checking.",
-		[]string{motif})
-	e.writeFactWithMotifs("kb/technology/benchmarks/terminalscores.md",
+		[]string{motif}, []string{"Cognition"})
+	e.rewriteWithMotifs("kb/technology/benchmarks/terminalscores.md",
 		"Coding agents reached 94% on a terminal benchmark by cheating it",
 		"The agents scored by exploiting the harness rather than by solving the tasks.",
-		[]string{motif})
+		[]string{motif}, []string{"Terminal Bench"})
 }
 
 // TestReviewPlan_FarLaneRoutesBackward — the far lane's members have no
@@ -134,14 +140,14 @@ func TestReviewPlan_HealthReportsTheOperatingPoint(t *testing.T) {
 func TestReviewPlan_DiscoverItemsShareOneRankSpace(t *testing.T) {
 	env := newRestatementEnv(t, 4)
 	env.seedMotifPair("measure-becomes-target")
-	env.writeFactWithMotifs("kb/gotchas/caching/staleread.md",
+	env.rewriteWithMotifs("kb/gotchas/caching/staleread.md",
 		"A cache read served state the writer had already replaced",
 		"The reader observed a version the writer believed was gone.",
-		[]string{"stale-read-after-write"})
-	env.writeFactWithMotifs("kb/technology/ledgers/settlement.md",
+		[]string{"stale-read-after-write"}, []string{"Redis"})
+	env.rewriteWithMotifs("kb/technology/ledgers/settlement.md",
 		"Settlement confirmed against a balance that had already moved",
 		"The confirmation was computed from a snapshot the ledger had superseded.",
-		[]string{"stale-read-after-write"})
+		[]string{"stale-read-after-write"}, []string{"SWIFT"})
 
 	res, err := NewReviewerWithOptions(env.ri, nil, EffortHigh, ScopeFilter{}).StartSession(context.Background())
 	require.NoError(t, err)

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -3,6 +3,7 @@ package synthesize
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -423,4 +424,264 @@ func TestSharedMotifSpecificity_OneMemberCannotVoteTwiceForACluster(t *testing.T
 	got, err := sharedMotifSpecificity(context.Background(), idx, "main", cand, resolve)
 	require.NoError(t, err)
 	require.InDelta(t, 0.5, got, 1e-9, "one cluster, one term")
+}
+
+// ── effort binding and per-lane sub-budgets (§5) ──────────────────────────
+
+func TestMotifSubBudget_IsMonotoneAndLaneBound(t *testing.T) {
+	nN, fN := motifSubBudget(EffortNormal)
+	nM, fM := motifSubBudget(EffortMedium)
+	nH, fH := motifSubBudget(EffortHigh)
+
+	require.Equal(t, 2, nN, "§5: normal's bounded 6ce866f8 amendment is a hard cap of 2")
+	require.Zero(t, fN, "normal is near lane only")
+	require.Equal(t, 4, nM)
+	require.Zero(t, fM, "medium stays on the validated forward shape — never conjecture")
+	require.Positive(t, fH, "the far lane opens only at high")
+
+	// MN10: monotone in budget as well as in kind.
+	require.LessOrEqual(t, nN, nM)
+	require.LessOrEqual(t, nM, nH)
+	require.LessOrEqual(t, fM, fH)
+}
+
+// MN8: the motif budgets are ADDITIONAL, never carved out of the entity/domain
+// pool — the axes have different df distributions and one pool would let the
+// densest starve the others.
+func TestMotifSubBudget_DoesNotDrawOnTheEntityDomainBudget(t *testing.T) {
+	require.Equal(t, 48, effortBudget(EffortHigh))
+	require.Equal(t, 12, effortBudget(EffortMedium))
+	require.Zero(t, effortBudget(EffortNormal))
+}
+
+func TestMotifTier_IsMonotoneInEffort(t *testing.T) {
+	require.Equal(t, tierExact, motifTier(EffortNormal))
+	require.Equal(t, tierExact, motifTier(EffortMedium))
+	require.Equal(t, tierToken2, motifTier(EffortHigh))
+}
+
+// MN10 as a PROPERTY, not an arrangement: each level's candidate set is a
+// subset of the next level's, before any budget truncation.
+func TestMotifCandidates_AreMonotoneAcrossEffort(t *testing.T) {
+	seeds := []factForLLM{
+		// A verbatim pair — matches at every tier.
+		{File: "kb/alpha/1.md", Motifs: []string{"shared-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/beta/2.md", Motifs: []string{"shared-shape"}, Entities: []string{"Beta"}},
+		// A token-2-only pair — matches only at high.
+		{File: "kb/gamma/3.md", Motifs: []string{"stale-cache-capture"}, Entities: []string{"Gamma"}},
+		{File: "kb/delta/4.md", Motifs: []string{"cache-capture-drift"}, Entities: []string{"Delta"}},
+	}
+	clusters := ClusterResult{Clusters: map[int][]string{
+		0: {"kb/alpha/1.md"}, 1: {"kb/beta/2.md"}, 2: {"kb/gamma/3.md"}, 3: {"kb/delta/4.md"}}}
+	labels := labelsWith(200, map[string]int{"alpha": 2, "beta": 2, "gamma": 2, "delta": 2})
+
+	setOf := func(e Effort) map[string]struct{} {
+		got, _ := enumerateMotifCandidates(seeds, clusters, identityResolver, constDF(2), labels, motifTier(e))
+		out := map[string]struct{}{}
+		for _, b := range got {
+			for _, m := range b.Members {
+				out[m.File] = struct{}{}
+			}
+		}
+		return out
+	}
+	normal, medium, high := setOf(EffortNormal), setOf(EffortMedium), setOf(EffortHigh)
+
+	require.NotEmpty(t, normal, "a vacuous subset assertion tests nothing")
+	require.Subset(t, medium, normal)
+	require.Subset(t, high, medium)
+	require.Greater(t, len(high), len(normal), "high must actually admit more, or the ladder is flat")
+}
+
+// ── the builder ───────────────────────────────────────────────────────────
+
+// countingSearchIndex records whether the builder touched the index at all.
+type countingSearchIndex struct {
+	SearchQuery
+	calls int
+}
+
+func (c *countingSearchIndex) TokenDF(context.Context, string, string, string) (int, error) {
+	c.calls++
+	return 2, nil
+}
+
+func (c *countingSearchIndex) SimilarityAdjacency(context.Context, []string) (store.SimilarityGraph, error) {
+	c.calls++
+	return store.NewSimilarityGraph(nil), nil
+}
+
+// No DERIVED_FROM edges between members, so the derivation gap is 1.0 — nobody
+// has already made the connection these candidates propose.
+func (c *countingSearchIndex) ReverseDependentPaths(context.Context, string) (map[string]struct{}, error) {
+	c.calls++
+	return map[string]struct{}{}, nil
+}
+
+// MN5's own mechanism, asserted directly rather than left as a consequence of
+// later gates: on a corpus with no motifs the tier does nothing and costs
+// nothing — which is why the EffortNormal contract test passes vacuously.
+func TestBuildMotifBridges_MotifFreeCorpusDoesNoWork(t *testing.T) {
+	idx := &countingSearchIndex{}
+	seeds := []factForLLM{{File: "kb/alpha/1.md"}, {File: "kb/beta/2.md"}}
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		twoCommunities("kb/alpha/1.md", "kb/beta/2.md"), EffortNormal, motifQualityConfig(),
+		identityResolver, labelsWith(200, nil), nil)
+
+	require.NoError(t, err)
+	require.Empty(t, near)
+	require.Empty(t, far)
+	require.Zero(t, health.Candidates)
+	require.Zero(t, idx.calls, "a motif-free corpus must not cost a single index call")
+}
+
+// saturatedMotifCorpus builds n verbatim-matching, subject-disjoint,
+// cross-community pairs — more than any lane's budget.
+func saturatedMotifCorpus(n int) ([]factForLLM, ClusterResult, store.SubjectLabelDF) {
+	var seeds []factForLLM
+	clusters := ClusterResult{Clusters: map[int][]string{}}
+	labels := labelsWith(400, nil)
+	com := 0
+	for i := 0; i < n; i++ {
+		// Motif tokens are unique per pair. Deliberate: at high effort the
+		// token-2 tier merges any two canonical ids sharing two stemmed tokens,
+		// so a family like "shape00-of-kind"/"shape01-of-kind" collapses into
+		// ONE group on the connectives — spec-conformant (§4's permissive
+		// prefilter) but not what a BUDGET test means to measure.
+		motif := fmt.Sprintf("shape%02d-alpha%02d", i, i)
+		for _, side := range []string{"a", "b"} {
+			// Distinct FILENAMES as well as distinct directories: a fact's
+			// whole path is a subject claim, so two facts both called "1.md"
+			// share a subject token and the gate correctly rejects the pair.
+			path := fmt.Sprintf("kb/%s%02d/f%s%02d.md", side, i, side, i)
+			ent := fmt.Sprintf("ent%s%02d", side, i)
+			seeds = append(seeds, factForLLM{File: path, Motifs: []string{motif},
+				Entities: []string{ent}})
+			clusters.Clusters[com] = []string{path}
+			labels.DF[ent] = 2
+			labels.DF[fmt.Sprintf("%s%02d", side, i)] = 2
+			com++
+		}
+	}
+	return seeds, clusters, labels
+}
+
+func TestBuildMotifBridges_NormalEmitsAtMostTwoNearAndNoFar(t *testing.T) {
+	seeds, clusters, labels := saturatedMotifCorpus(6)
+	idx := &allAdjacentIndex{} // every group is a near-lane group
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortNormal, permissiveMotifConfig(), identityResolver, labels, constMeanSim(0))
+
+	require.NoError(t, err)
+	require.Equal(t, 6, health.Candidates, "precondition: more candidates than the budget")
+	require.Len(t, near, 2, "§5: hard cap 2 at normal")
+	require.Empty(t, far, "normal is near lane only")
+}
+
+// The far lane is CLOSED below high effort, so a corpus whose motif groups are
+// all far produces nothing at normal — however many candidates it has. Without
+// this, "normal is near lane only" would be satisfied by a build that simply
+// never produced a far group.
+func TestBuildMotifBridges_NormalEmitsNothingForFarLaneGroups(t *testing.T) {
+	seeds, clusters, labels := saturatedMotifCorpus(6)
+	idx := &countingSearchIndex{} // no adjacency: every group is far
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortNormal, permissiveMotifConfig(), identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, 6, health.Candidates, "precondition: the candidates exist")
+	require.Empty(t, near)
+	require.Empty(t, far, "the far lane opens only at high effort")
+}
+
+func TestBuildMotifBridges_HighOpensBothLanesWithinTheirBudgets(t *testing.T) {
+	seeds, clusters, labels := saturatedMotifCorpus(20)
+	idx := &countingSearchIndex{} // no SIMILAR_TO edges => every group is far
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, permissiveMotifConfig(), identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, 20, health.Candidates)
+	require.Empty(t, near, "no adjacency was offered, so nothing is in the near lane")
+	nearBudget, farBudget := motifSubBudget(EffortHigh)
+	require.Len(t, far, farBudget)
+	require.LessOrEqual(t, len(near), nearBudget)
+}
+
+// A saturated far lane must not consume the near lane's slots, and vice versa
+// (MN8). Asserted on a corpus that saturates BOTH.
+func TestBuildMotifBridges_LanesCannotStarveEachOther(t *testing.T) {
+	seeds, clusters, labels := saturatedMotifCorpus(20)
+	// Give the first pair a SIMILAR_TO edge, so exactly one group is near.
+	idx := &laneSplittingIndex{nearPair: [2]string{"kb/a00/fa00.md", "kb/b00/fb00.md"}}
+
+	near, far, _, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, permissiveMotifConfig(), identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Len(t, near, 1, "the one adjacent group takes a near slot")
+	nearBudget, farBudget := motifSubBudget(EffortHigh)
+	require.Len(t, far, farBudget, "the far lane still fills its own budget in full")
+	require.LessOrEqual(t, len(near), nearBudget)
+}
+
+// allAdjacentIndex reports every member set as mutually adjacent, so every
+// group lands in the near lane.
+type allAdjacentIndex struct {
+	SearchQuery
+}
+
+func (a *allAdjacentIndex) TokenDF(context.Context, string, string, string) (int, error) {
+	return 2, nil
+}
+
+func (a *allAdjacentIndex) ReverseDependentPaths(context.Context, string) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
+
+func (a *allAdjacentIndex) SimilarityAdjacency(_ context.Context, paths []string) (store.SimilarityGraph, error) {
+	var pairs [][2]string
+	for i := 0; i < len(paths); i++ {
+		for j := i + 1; j < len(paths); j++ {
+			pairs = append(pairs, [2]string{paths[i], paths[j]})
+		}
+	}
+	return store.NewSimilarityGraph(pairs), nil
+}
+
+// laneSplittingIndex reports adjacency for exactly one pair.
+type laneSplittingIndex struct {
+	SearchQuery
+	nearPair [2]string
+}
+
+func (l *laneSplittingIndex) TokenDF(context.Context, string, string, string) (int, error) {
+	return 2, nil
+}
+
+func (l *laneSplittingIndex) ReverseDependentPaths(context.Context, string) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
+
+func (l *laneSplittingIndex) SimilarityAdjacency(_ context.Context, paths []string) (store.SimilarityGraph, error) {
+	hits := 0
+	for _, p := range paths {
+		if p == l.nearPair[0] || p == l.nearPair[1] {
+			hits++
+		}
+	}
+	if hits == 2 {
+		return store.NewSimilarityGraph([][2]string{l.nearPair}), nil
+	}
+	return store.NewSimilarityGraph(nil), nil
+}
+
+// permissiveMotifConfig keeps the quality gates out of the way so that budget
+// tests measure budgets and nothing else.
+func permissiveMotifConfig() QualityConfig {
+	return QualityConfig{CohFloor: 0, QualityFloor: 0, WCoh: 1, WGap: 1, WSpec: 1, MaxMembers: 5}
 }

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -1,9 +1,14 @@
 package synthesize
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"knomit/internal/store"
 )
 
 // identityResolver is the alias table a corpus has before any judge pass: every
@@ -207,4 +212,133 @@ func TestEnumerateMotifCandidates_IsDeterministic(t *testing.T) {
 		require.Equal(t, first, again, "map iteration order must not reach the output")
 	}
 	require.Equal(t, "alpha-shape", first[0].Token, "token-sorted")
+}
+
+// ── lane split and per-lane scoring (§4) ──────────────────────────────────
+
+func TestLaneOf_SplitsOnSimilarityAdjacency(t *testing.T) {
+	paths := []string{"kb/alpha/1.md", "kb/beta/2.md"}
+	near := store.NewSimilarityGraph([][2]string{{"kb/alpha/1.md", "kb/beta/2.md"}})
+	far := store.NewSimilarityGraph(nil)
+
+	require.Equal(t, LaneNear, laneOf(paths, near))
+	require.Equal(t, LaneFar, laneOf(paths, far),
+		"no SIMILAR_TO edge means cohesion 0 by construction — the far lane")
+}
+
+// motifScoreEnv builds the gomock index a scoring test needs: no DERIVED_FROM
+// links between members (Gap = 1.0), and no TokenDF call, since the shared-motif
+// specificity is passed in already summed.
+func motifScoreEnv(t *testing.T, paths ...string) (context.Context, *MockSearchIndex) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	idx := NewMockSearchIndex(ctrl)
+	for _, p := range paths {
+		idx.EXPECT().ReverseDependentPaths(gomock.Any(), p).
+			Return(map[string]struct{}{}, nil).AnyTimes()
+	}
+	return context.Background(), idx
+}
+
+func motifCandidate() BridgeSeedSet {
+	return BridgeSeedSet{Token: "shared-shape", Kind: BridgeMotif, Members: []factForLLM{
+		{File: "kb/alpha/1.md"}, {File: "kb/beta/2.md"}}}
+}
+
+func motifQualityConfig() QualityConfig {
+	return QualityConfig{CohFloor: 0.5, QualityFloor: 0, WCoh: 1, WGap: 1, WSpec: 1, MaxMembers: 5}
+}
+
+// TestScoreMotifCandidate_FarLaneRewardsDissimilarity — the far lane's whole
+// claim: the LESS similar the members, the more work the shared mechanism is
+// doing, so the score must move the other way from the near lane's cohesion.
+func TestScoreMotifCandidate_FarLaneRewardsDissimilarity(t *testing.T) {
+	ctx, idx := motifScoreEnv(t, "kb/alpha/1.md", "kb/beta/2.md")
+	g := store.NewSimilarityGraph(nil)
+	clusterOf := map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1}
+
+	distant, keptA, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
+		clusterOf, motifQualityConfig(), 0.5, constMeanSim(0.1))
+	require.NoError(t, err)
+	require.True(t, keptA,
+		"the far lane must not apply the cohesion floor — cohesion is 0 there by construction")
+
+	close, keptB, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
+		clusterOf, motifQualityConfig(), 0.5, constMeanSim(0.9))
+	require.NoError(t, err)
+	require.True(t, keptB)
+
+	require.Greater(t, distant, close)
+}
+
+// The near lane keeps the existing gate untouched, and a near-lane group below
+// the cohesion floor is DROPPED — not re-routed into the far lane. The lanes
+// partition the candidates; they are not a retry.
+func TestScoreMotifCandidate_NearLaneKeepsTheCohesionFloor(t *testing.T) {
+	ctx, idx := motifScoreEnv(t, "kb/alpha/1.md", "kb/beta/2.md")
+	g := store.NewSimilarityGraph(nil) // density 0, below the floor
+
+	_, kept, err := scoreMotifCandidate(ctx, motifCandidate(), LaneNear, g, idx, "main",
+		map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1}, motifQualityConfig(), 0.5, nil)
+	require.NoError(t, err)
+	require.False(t, kept)
+}
+
+// MN8: separation >= 2 is a gate in BOTH lanes. The far lane replaces the
+// cohesion term, not the separation gate.
+func TestScoreMotifCandidate_SeparationIsAGateInBothLanes(t *testing.T) {
+	ctx, idx := motifScoreEnv(t, "kb/alpha/1.md", "kb/beta/2.md")
+	sameCommunity := map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 0}
+	cfg := motifQualityConfig()
+	cfg.CohFloor = 0 // so only separation can be what rejects
+
+	_, keptFar, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar,
+		store.NewSimilarityGraph(nil), idx, "main", sameCommunity, cfg, 0.5, constMeanSim(0))
+	require.NoError(t, err)
+	require.False(t, keptFar)
+
+	_, keptNear, err := scoreMotifCandidate(ctx, motifCandidate(), LaneNear,
+		store.NewSimilarityGraph([][2]string{{"kb/alpha/1.md", "kb/beta/2.md"}}),
+		idx, "main", sameCommunity, cfg, 0.5, nil)
+	require.NoError(t, err)
+	require.False(t, keptNear)
+}
+
+// The far lane is size-capped like the near lane. Oversized far groups are
+// DROPPED here rather than trimmed: the §4 trim ("maximum community spread,
+// then minimum mean similarity") is carried forward to Phase 4 by designer
+// ruling, and dropping is the conservative behaviour in the meantime.
+func TestScoreMotifCandidate_FarLaneDropsOversizedGroups(t *testing.T) {
+	paths := []string{"kb/a/1.md", "kb/b/2.md", "kb/c/3.md", "kb/d/4.md"}
+	ctx, idx := motifScoreEnv(t, paths...)
+	cand := BridgeSeedSet{Token: "shared-shape", Kind: BridgeMotif}
+	clusterOf := map[string]int{}
+	for i, p := range paths {
+		cand.Members = append(cand.Members, factForLLM{File: p})
+		clusterOf[p] = i
+	}
+	cfg := motifQualityConfig()
+	cfg.MaxMembers = 3
+
+	_, kept, err := scoreMotifCandidate(ctx, cand, LaneFar, store.NewSimilarityGraph(nil),
+		idx, "main", clusterOf, cfg, 0.5, constMeanSim(0.1))
+	require.NoError(t, err)
+	require.False(t, kept)
+}
+
+// A far-lane group whose members carry no vectors must not read as maximally
+// dissimilar — that would hand every unembedded group the top score. The
+// caller's meanSim contract says so; this pins the scorer's half of it.
+func TestScoreMotifCandidate_FarLanePropagatesMeanSimErrors(t *testing.T) {
+	ctx, idx := motifScoreEnv(t, "kb/alpha/1.md", "kb/beta/2.md")
+	_, _, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, store.NewSimilarityGraph(nil),
+		idx, "main", map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1},
+		motifQualityConfig(), 0.5,
+		func(context.Context, []string) (float64, error) { return 0, errors.New("no vectors") })
+	require.Error(t, err, "an unreadable similarity is not a licence to score the group high")
+}
+
+func constMeanSim(v float64) meanSimFn {
+	return func(context.Context, []string) (float64, error) { return v, nil }
 }

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -1,0 +1,210 @@
+package synthesize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// identityResolver is the alias table a corpus has before any judge pass: every
+// spelling is its own cluster.
+func identityResolver(m string) string { return m }
+
+// constDF answers every df query with n — used where the df band is not what
+// the test is about.
+func constDF(n int) motifDFFn { return func(string) int { return n } }
+
+// twoCommunities places each path in its own cluster, which is what makes a
+// pair a BRIDGE rather than an in-cluster neighbour.
+func twoCommunities(a, b string) ClusterResult {
+	return ClusterResult{Clusters: map[int][]string{0: {a}, 1: {b}}}
+}
+
+func TestEnumerateMotifCandidates_GroupsOnCanonicalIDAcrossSpellings(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/gotchas/uitesting/1.md", Motifs: []string{"measure-becomes-target"},
+			Entities: []string{"Cognition"}},
+		{File: "kb/technology/rewardhacking/2.md", Motifs: []string{"metric-becomes-target"},
+			Entities: []string{"RLHF"}},
+	}
+	// The alias judge merged the two spellings; enumeration keys on the result.
+	resolve := func(string) string { return "measure-becomes-target" }
+
+	got, h := enumerateMotifCandidates(seeds,
+		twoCommunities("kb/gotchas/uitesting/1.md", "kb/technology/rewardhacking/2.md"),
+		resolve, constDF(2), labelsWith(200, map[string]int{"cognition": 2, "rlhf": 3}), tierExact)
+
+	require.Len(t, got, 1)
+	require.Equal(t, "measure-becomes-target", got[0].Token, "Token is the CANONICAL id")
+	require.Equal(t, BridgeMotif, got[0].Kind)
+	require.Len(t, got[0].Members, 2)
+	require.Equal(t, 1, h.Candidates)
+}
+
+func TestEnumerateMotifCandidates_DFBandExcludesBothEnds(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"hapax-shape", "generic-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/beta/2.md", Motifs: []string{"hapax-shape", "generic-shape"}, Entities: []string{"Beta"}},
+	}
+	// N=200 => ceiling max(12, 2%*200) = 12. One motif below the floor, one above.
+	df := func(c string) int {
+		if c == "hapax-shape" {
+			return 1
+		}
+		return 40
+	}
+
+	got, h := enumerateMotifCandidates(seeds, twoCommunities("kb/alpha/1.md", "kb/beta/2.md"),
+		identityResolver, df, labelsWith(200, nil), tierExact)
+
+	require.Empty(t, got, "df=1 cannot bridge yet; df=40 has gone generic")
+	require.Equal(t, 12, h.Ceiling)
+	require.Equal(t, []string{"generic-shape"}, h.OverCeilingNames,
+		"over-ceiling is FLAGGED for review splitting, not silently dropped (MN8)")
+}
+
+func TestEnumerateMotifCandidates_DFCeilingScalesWithTheCorpus(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"shared-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/beta/2.md", Motifs: []string{"shared-shape"}, Entities: []string{"Beta"}},
+	}
+	clusters := twoCommunities("kb/alpha/1.md", "kb/beta/2.md")
+
+	// df 30 is over the ceiling on a 200-fact corpus (12) and under it on a
+	// 3000-fact one (60): the band is a property of the corpus, not a constant.
+	small, hs := enumerateMotifCandidates(seeds, clusters, identityResolver, constDF(30),
+		labelsWith(200, nil), tierExact)
+	large, hl := enumerateMotifCandidates(seeds, clusters, identityResolver, constDF(30),
+		labelsWith(3000, nil), tierExact)
+
+	require.Equal(t, 12, hs.Ceiling)
+	require.Equal(t, 60, hl.Ceiling)
+	require.Empty(t, small)
+	require.Len(t, large, 1)
+}
+
+func TestEnumerateMotifCandidates_RequiresTwoCommunities(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"shared-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/beta/2.md", Motifs: []string{"shared-shape"}, Entities: []string{"Beta"}},
+	}
+	// Both in one community: separation 1. A GATE, never a reward (1f536807/MN8).
+	same := ClusterResult{Clusters: map[int][]string{0: {"kb/alpha/1.md", "kb/beta/2.md"}}}
+
+	got, _ := enumerateMotifCandidates(seeds, same, identityResolver, constDF(2),
+		labelsWith(200, nil), tierExact)
+	require.Empty(t, got)
+}
+
+// MN7's fixture asserted at the enumeration boundary the consumer actually
+// reads, not only at the gate helper.
+func TestEnumerateMotifCandidates_DropsTheNearDuplicatePair(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/technology/ai/agents/1.md", Motifs: []string{"shared-shape"},
+			Entities: []string{"Cognition", "Devin"}},
+		{File: "kb/technology/ai/agents/2.md", Motifs: []string{"shared-shape"},
+			Entities: []string{"Cognition", "Devin"}},
+	}
+	labels := labelsWith(200, map[string]int{
+		"cognition": 2, "devin": 2, "agent": 30, "technology": 40, "ai": 35})
+
+	got, _ := enumerateMotifCandidates(seeds,
+		twoCommunities("kb/technology/ai/agents/1.md", "kb/technology/ai/agents/2.md"),
+		identityResolver, constDF(2), labels, tierExact)
+
+	require.Empty(t, got, "MN7: the axis must not re-find the 8ebd5d90 population")
+}
+
+// The complement: the same shape, subject-disjoint, DOES enumerate. Without
+// this the test above would pass on a gate that rejected everything.
+func TestEnumerateMotifCandidates_KeepsTheSubjectDisjointPair(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/gotchas/uitesting/1.md", Motifs: []string{"shared-shape"},
+			Entities: []string{"Cognition"}, Domain: []string{"evaluation"}},
+		{File: "kb/technology/rewardhacking/2.md", Motifs: []string{"shared-shape"},
+			Entities: []string{"RLHF"}, Domain: []string{"evaluation"}},
+	}
+	labels := labelsWith(200, map[string]int{"evaluation": 30, "cognition": 2, "rlhf": 3})
+
+	got, _ := enumerateMotifCandidates(seeds,
+		twoCommunities("kb/gotchas/uitesting/1.md", "kb/technology/rewardhacking/2.md"),
+		identityResolver, constDF(2), labels, tierExact)
+
+	require.Len(t, got, 1, "one shared coarse tag must not block a genuine bridge")
+}
+
+// A group of three where ONE member shares a subject with another: the offender
+// drops, the bridge survives. All-or-nothing rejection would let a single
+// near-duplicate delete a genuine three-way group.
+func TestEnumerateMotifCandidates_DropsOffendingMemberNotTheGroup(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"shared-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/beta/2.md", Motifs: []string{"shared-shape"}, Entities: []string{"Beta"}},
+		// Same rare entity as the first member — a near-duplicate of it.
+		{File: "kb/alpha/3.md", Motifs: []string{"shared-shape"}, Entities: []string{"Alpha"}},
+	}
+	clusters := ClusterResult{Clusters: map[int][]string{
+		0: {"kb/alpha/1.md"}, 1: {"kb/beta/2.md"}, 2: {"kb/alpha/3.md"}}}
+	labels := labelsWith(200, map[string]int{"alpha": 2, "beta": 2})
+
+	got, _ := enumerateMotifCandidates(seeds, clusters, identityResolver, constDF(3), labels, tierExact)
+
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Members, 2, "the third member is the first one's near-duplicate")
+	require.Equal(t, "kb/alpha/1.md", got[0].Members[0].File, "path-sorted, so the survivor is deterministic")
+	require.Equal(t, "kb/beta/2.md", got[0].Members[1].File)
+}
+
+func TestEnumerateMotifCandidates_Token2TierGroupsDistinctCanonicalIDs(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"stale-cache-capture"}, Entities: []string{"Alpha"}},
+		{File: "kb/beta/2.md", Motifs: []string{"cache-capture-drift"}, Entities: []string{"Beta"}},
+	}
+	clusters := twoCommunities("kb/alpha/1.md", "kb/beta/2.md")
+	labels := labelsWith(200, map[string]int{"alpha": 2, "beta": 2})
+
+	exact, _ := enumerateMotifCandidates(seeds, clusters, identityResolver, constDF(2), labels, tierExact)
+	require.Empty(t, exact, "distinct canonical ids do not match verbatim")
+
+	loose, _ := enumerateMotifCandidates(seeds, clusters, identityResolver, constDF(2), labels, tierToken2)
+	require.Len(t, loose, 1, "two shared stemmed tokens (cache, capture) match at token-2")
+	require.Len(t, loose[0].Members, 2)
+}
+
+func TestEnumerateMotifCandidates_Token2NeedsTwoSharedTokens(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"stale-cache-capture"}, Entities: []string{"Alpha"}},
+		{File: "kb/beta/2.md", Motifs: []string{"cache-warming-strategy"}, Entities: []string{"Beta"}},
+	}
+	got, _ := enumerateMotifCandidates(seeds, twoCommunities("kb/alpha/1.md", "kb/beta/2.md"),
+		identityResolver, constDF(2), labelsWith(200, map[string]int{"alpha": 2, "beta": 2}), tierToken2)
+	require.Empty(t, got, "one shared token (cache) is below the token-2 tier")
+}
+
+// §7 idempotency (cf455b8f): discovery never feeds on its own output.
+func TestEnumerateMotifCandidates_ExcludesDiscoveredOrigin(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"shared-shape"}, Entities: []string{"Alpha"},
+			Origin: "discovered"},
+		{File: "kb/beta/2.md", Motifs: []string{"shared-shape"}, Entities: []string{"Beta"}},
+	}
+	got, _ := enumerateMotifCandidates(seeds, twoCommunities("kb/alpha/1.md", "kb/beta/2.md"),
+		identityResolver, constDF(2), labelsWith(200, map[string]int{"alpha": 2, "beta": 2}), tierExact)
+	require.Empty(t, got)
+}
+
+func TestEnumerateMotifCandidates_IsDeterministic(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"bravo-shape", "alpha-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/beta/2.md", Motifs: []string{"bravo-shape", "alpha-shape"}, Entities: []string{"Beta"}},
+	}
+	clusters := twoCommunities("kb/alpha/1.md", "kb/beta/2.md")
+	labels := labelsWith(200, map[string]int{"alpha": 2, "beta": 2})
+
+	first, _ := enumerateMotifCandidates(seeds, clusters, identityResolver, constDF(2), labels, tierExact)
+	for i := 0; i < 20; i++ {
+		again, _ := enumerateMotifCandidates(seeds, clusters, identityResolver, constDF(2), labels, tierExact)
+		require.Equal(t, first, again, "map iteration order must not reach the output")
+	}
+	require.Equal(t, "alpha-shape", first[0].Token, "token-sorted")
+}

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -685,3 +685,70 @@ func (l *laneSplittingIndex) SimilarityAdjacency(_ context.Context, paths []stri
 func permissiveMotifConfig() QualityConfig {
 	return QualityConfig{CohFloor: 0, QualityFloor: 0, WCoh: 1, WGap: 1, WSpec: 1, MaxMembers: 5}
 }
+
+// ── L6: a failed pass must not read like an empty one ─────────────────────
+
+func TestMotifBridgeHealthLines_FailureIsNotSuccessShapedZeros(t *testing.T) {
+	failed := motifBridgeHealthLines(motifEnumHealth{
+		Failure: "similarity adjacency unavailable", Candidates: 3, Ceiling: 12}, 0, 0)
+	require.Len(t, failed, 1)
+	require.Contains(t, failed[0], "motif bridges unavailable this session")
+	require.Contains(t, failed[0], "NOT a statement about the corpus")
+	require.NotContains(t, failed[0], "0 near, 0 far",
+		"a failed pass must not report the shape of an axis that looked and found nothing")
+
+	// The complement: an axis that genuinely found nothing stays silent, and one
+	// that found something reports it. Without these the assertion above is
+	// satisfied by a function that always says "unavailable".
+	require.Empty(t, motifBridgeHealthLines(motifEnumHealth{Ceiling: 12}, 0, 0))
+	found := motifBridgeHealthLines(motifEnumHealth{Candidates: 2, Ceiling: 12}, 1, 1)
+	require.Contains(t, found[0], "motif bridges: 2 candidates, 1 near, 1 far")
+}
+
+// ── L1: nested duplicate groups ───────────────────────────────────────────
+
+// Every token-2 family strictly CONTAINS its key's verbatim group by
+// construction, so the two compete for the same scarce slots and render the
+// same `Bridge token:` line with nested member sets. The contained one is
+// suppressed: an agent judging {A,B} and then {A,B,C} spends two of eight slots
+// on one question.
+func TestRankAndCap_SuppressesStrictlyContainedGroups(t *testing.T) {
+	small := BridgeSeedSet{Token: "shared-shape", Q: 9, Members: []factForLLM{
+		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}}}
+	big := BridgeSeedSet{Token: "shared-shape", Q: 1, Members: []factForLLM{
+		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}, {File: "kb/c/3.md"}}}
+
+	got := rankAndCap([]BridgeSeedSet{small, big}, 8)
+
+	require.Len(t, got, 1, "the contained group goes, whichever ranks higher")
+	require.Len(t, got[0].Members, 3, "the SUPERSET survives — it carries strictly more evidence")
+}
+
+// Overlapping-but-not-contained groups both survive: they are different
+// questions, and suppressing either would lose a bridge.
+func TestRankAndCap_KeepsOverlappingGroupsThatAreNotContained(t *testing.T) {
+	a := BridgeSeedSet{Token: "alpha-shape", Q: 2, Members: []factForLLM{
+		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}}}
+	b := BridgeSeedSet{Token: "bravo-shape", Q: 1, Members: []factForLLM{
+		{File: "kb/b/2.md"}, {File: "kb/c/3.md"}}}
+
+	require.Len(t, rankAndCap([]BridgeSeedSet{a, b}, 8), 2)
+}
+
+// Suppression happens BEFORE the budget is spent, or it saves no slots.
+func TestRankAndCap_SuppressionPrecedesTheBudget(t *testing.T) {
+	contained := BridgeSeedSet{Token: "shared-shape", Q: 9, Members: []factForLLM{
+		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}}}
+	superset := BridgeSeedSet{Token: "shared-shape", Q: 8, Members: []factForLLM{
+		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}, {File: "kb/c/3.md"}}}
+	other := BridgeSeedSet{Token: "other-shape", Q: 1, Members: []factForLLM{
+		{File: "kb/d/4.md"}, {File: "kb/e/5.md"}}}
+
+	got := rankAndCap([]BridgeSeedSet{contained, superset, other}, 2)
+
+	require.Len(t, got, 2)
+	require.Equal(t, "shared-shape", got[0].Token)
+	require.Len(t, got[0].Members, 3)
+	require.Equal(t, "other-shape", got[1].Token,
+		"the slot freed by suppression goes to a different question, not to the duplicate")
+}

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -751,4 +752,36 @@ func TestRankAndCap_SuppressionPrecedesTheBudget(t *testing.T) {
 	require.Len(t, got[0].Members, 3)
 	require.Equal(t, "other-shape", got[1].Token,
 		"the slot freed by suppression goes to a different question, not to the duplicate")
+}
+
+// ── M4: the crack between the lanes is counted, not silent ────────────────
+
+// A group with ONE similarity edge among three members is assigned near
+// (density 0.33 > 0) and then dropped by the 0.5 cohesion floor. It is
+// two-thirds mutually dissimilar — far-lane material by any reading of §4 — and
+// it used to vanish with no trace. It still vanishes; now it is counted.
+func TestBuildMotifBridges_CountsGroupsLostAtTheNearFloor(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/a/one.md", Motifs: []string{"shared-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/two.md", Motifs: []string{"shared-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/three.md", Motifs: []string{"shared-shape"}, Entities: []string{"Gamma"}},
+	}
+	clusters := ClusterResult{Clusters: map[int][]string{
+		0: {"kb/a/one.md"}, 1: {"kb/b/two.md"}, 2: {"kb/c/three.md"}}}
+	labels := labelsWith(200, map[string]int{"alpha": 2, "beta": 2, "gamma": 2})
+	idx := &laneSplittingIndex{nearPair: [2]string{"kb/a/one.md", "kb/b/two.md"}}
+	cfg := motifQualityConfig() // CohFloor 0.5
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, 1, health.Candidates, "precondition: the group enumerated")
+	require.Empty(t, near, "density 0.33 is below the 0.5 floor")
+	require.Empty(t, far, "and the binary lane split never offered it to the far lane")
+	require.Equal(t, 1, health.NearFloorDropped,
+		"the group must be COUNTED where it disappears, not merely absent")
+
+	lines := motifBridgeHealthLines(health, 0, 0)
+	require.Contains(t, strings.Join(lines, "\n"), "motif near-lane floor: 1 group(s)")
 }

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -342,3 +342,85 @@ func TestScoreMotifCandidate_FarLanePropagatesMeanSimErrors(t *testing.T) {
 func constMeanSim(v float64) meanSimFn {
 	return func(context.Context, []string) (float64, error) { return v, nil }
 }
+
+// ── shared-motif specificity: a rank boost, never a gate (§4) ─────────────
+
+func TestSharedMotifSpecificity_SecondSharedMotifBoostsNeverGates(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	idx := NewMockSearchIndex(ctrl)
+	idx.EXPECT().TokenDF(gomock.Any(), "main", gomock.Any(), string(BridgeMotif)).
+		Return(2, nil).AnyTimes()
+
+	one := BridgeSeedSet{Token: "alpha-shape", Members: []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"alpha-shape"}},
+		{File: "kb/beta/2.md", Motifs: []string{"alpha-shape"}}}}
+	two := BridgeSeedSet{Token: "alpha-shape", Members: []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"alpha-shape", "bravo-shape"}},
+		{File: "kb/beta/2.md", Motifs: []string{"alpha-shape", "bravo-shape"}}}}
+
+	sOne, err := sharedMotifSpecificity(ctx, idx, "main", one, identityResolver)
+	require.NoError(t, err)
+	sTwo, err := sharedMotifSpecificity(ctx, idx, "main", two, identityResolver)
+	require.NoError(t, err)
+
+	require.Greater(t, sTwo, sOne, "a second shared motif raises the score")
+	require.Positive(t, sOne, "and one shared motif still scores — it is never a gate")
+}
+
+func TestSharedMotifSpecificity_OnlyMotifsEveryMemberCarriesCount(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	idx := NewMockSearchIndex(ctrl)
+	idx.EXPECT().TokenDF(gomock.Any(), "main", gomock.Any(), string(BridgeMotif)).
+		Return(2, nil).AnyTimes()
+
+	cand := BridgeSeedSet{Token: "alpha-shape", Members: []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"alpha-shape", "bravo-shape"}},
+		{File: "kb/beta/2.md", Motifs: []string{"alpha-shape"}}}}
+
+	got, err := sharedMotifSpecificity(ctx, idx, "main", cand, identityResolver)
+	require.NoError(t, err)
+	require.InDelta(t, 0.5, got, 1e-9, "bravo-shape is not carried by ALL members")
+}
+
+// Rarity is what the term measures: a motif on fewer facts contributes more.
+func TestSharedMotifSpecificity_IsInverseInDF(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	idx := NewMockSearchIndex(ctrl)
+	idx.EXPECT().TokenDF(gomock.Any(), "main", "rare-shape", string(BridgeMotif)).Return(2, nil)
+	idx.EXPECT().TokenDF(gomock.Any(), "main", "common-shape", string(BridgeMotif)).Return(10, nil)
+
+	mk := func(m string) BridgeSeedSet {
+		return BridgeSeedSet{Token: m, Members: []factForLLM{
+			{File: "kb/alpha/1.md", Motifs: []string{m}}, {File: "kb/beta/2.md", Motifs: []string{m}}}}
+	}
+	rare, err := sharedMotifSpecificity(context.Background(), idx, "main", mk("rare-shape"), identityResolver)
+	require.NoError(t, err)
+	common, err := sharedMotifSpecificity(context.Background(), idx, "main", mk("common-shape"), identityResolver)
+	require.NoError(t, err)
+	require.Greater(t, rare, common)
+}
+
+// One member spelling the same cluster two ways must not vote twice — that
+// would be a member reinforcing a group on its own authorship habit.
+func TestSharedMotifSpecificity_OneMemberCannotVoteTwiceForACluster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	idx := NewMockSearchIndex(ctrl)
+	idx.EXPECT().TokenDF(gomock.Any(), "main", "alpha-shape", string(BridgeMotif)).
+		Return(2, nil).AnyTimes()
+
+	// Both spellings resolve to one canonical id.
+	resolve := func(string) string { return "alpha-shape" }
+	cand := BridgeSeedSet{Token: "alpha-shape", Members: []factForLLM{
+		{File: "kb/alpha/1.md", Motifs: []string{"alpha-shape", "alpha-shaped"}},
+		{File: "kb/beta/2.md", Motifs: []string{"alpha-shape"}}}}
+
+	got, err := sharedMotifSpecificity(context.Background(), idx, "main", cand, resolve)
+	require.NoError(t, err)
+	require.InDelta(t, 0.5, got, 1e-9, "one cluster, one term")
+}

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -260,13 +260,13 @@ func TestScoreMotifCandidate_FarLaneRewardsDissimilarity(t *testing.T) {
 	g := store.NewSimilarityGraph(nil)
 	clusterOf := map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1}
 
-	distant, keptA, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
+	_, distant, keptA, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
 		clusterOf, motifQualityConfig(), 0.5, constMeanSim(0.1))
 	require.NoError(t, err)
 	require.True(t, keptA,
 		"the far lane must not apply the cohesion floor — cohesion is 0 there by construction")
 
-	close, keptB, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
+	_, close, keptB, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
 		clusterOf, motifQualityConfig(), 0.5, constMeanSim(0.9))
 	require.NoError(t, err)
 	require.True(t, keptB)
@@ -281,7 +281,7 @@ func TestScoreMotifCandidate_NearLaneKeepsTheCohesionFloor(t *testing.T) {
 	ctx, idx := motifScoreEnv(t, "kb/alpha/1.md", "kb/beta/2.md")
 	g := store.NewSimilarityGraph(nil) // density 0, below the floor
 
-	_, kept, err := scoreMotifCandidate(ctx, motifCandidate(), LaneNear, g, idx, "main",
+	_, _, kept, err := scoreMotifCandidate(ctx, motifCandidate(), LaneNear, g, idx, "main",
 		map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1}, motifQualityConfig(), 0.5, nil)
 	require.NoError(t, err)
 	require.False(t, kept)
@@ -295,12 +295,12 @@ func TestScoreMotifCandidate_SeparationIsAGateInBothLanes(t *testing.T) {
 	cfg := motifQualityConfig()
 	cfg.CohFloor = 0 // so only separation can be what rejects
 
-	_, keptFar, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar,
+	_, _, keptFar, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar,
 		store.NewSimilarityGraph(nil), idx, "main", sameCommunity, cfg, 0.5, constMeanSim(0))
 	require.NoError(t, err)
 	require.False(t, keptFar)
 
-	_, keptNear, err := scoreMotifCandidate(ctx, motifCandidate(), LaneNear,
+	_, _, keptNear, err := scoreMotifCandidate(ctx, motifCandidate(), LaneNear,
 		store.NewSimilarityGraph([][2]string{{"kb/alpha/1.md", "kb/beta/2.md"}}),
 		idx, "main", sameCommunity, cfg, 0.5, nil)
 	require.NoError(t, err)
@@ -323,7 +323,7 @@ func TestScoreMotifCandidate_FarLaneDropsOversizedGroups(t *testing.T) {
 	cfg := motifQualityConfig()
 	cfg.MaxMembers = 3
 
-	_, kept, err := scoreMotifCandidate(ctx, cand, LaneFar, store.NewSimilarityGraph(nil),
+	_, _, kept, err := scoreMotifCandidate(ctx, cand, LaneFar, store.NewSimilarityGraph(nil),
 		idx, "main", clusterOf, cfg, 0.5, constMeanSim(0.1))
 	require.NoError(t, err)
 	require.False(t, kept)
@@ -334,7 +334,7 @@ func TestScoreMotifCandidate_FarLaneDropsOversizedGroups(t *testing.T) {
 // caller's meanSim contract says so; this pins the scorer's half of it.
 func TestScoreMotifCandidate_FarLanePropagatesMeanSimErrors(t *testing.T) {
 	ctx, idx := motifScoreEnv(t, "kb/alpha/1.md", "kb/beta/2.md")
-	_, _, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, store.NewSimilarityGraph(nil),
+	_, _, _, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, store.NewSimilarityGraph(nil),
 		idx, "main", map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1},
 		motifQualityConfig(), 0.5,
 		func(context.Context, []string) (float64, error) { return 0, errors.New("no vectors") })
@@ -782,6 +782,93 @@ func TestBuildMotifBridges_CountsGroupsLostAtTheNearFloor(t *testing.T) {
 	require.Equal(t, 1, health.NearFloorDropped,
 		"the group must be COUNTED where it disappears, not merely absent")
 
+	require.Zero(t, health.NearOtherDropped, "and attributed to the floor, not to 'other'")
+
 	lines := motifBridgeHealthLines(health, 0, 0)
 	require.Contains(t, strings.Join(lines, "\n"), "motif near-lane floor: 1 group(s)")
+}
+
+// TestBuildMotifBridges_AttributesNearLaneDropsByCause — the counter must mean
+// its label (review M4 counter-finding).
+//
+// The first version incremented NearFloorDropped on ANY near-lane rejection, so
+// an oversize group rode in under a label that said "cohesion". Phase 4 reads
+// this number as evidence for a lane redesign, and a number that does not mean
+// its label is worse than no number at all.
+//
+// Two groups, dropped for two different reasons, counted separately.
+func TestBuildMotifBridges_AttributesNearLaneDropsByCause(t *testing.T) {
+	// Group A: three members, one edge => density 0.33, under the floor.
+	// Group B: four mutually adjacent members => cohesion 1.0, over the cap.
+	seeds := []factForLLM{
+		{File: "kb/a/one.md", Motifs: []string{"sparse-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/two.md", Motifs: []string{"sparse-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/three.md", Motifs: []string{"sparse-shape"}, Entities: []string{"Gamma"}},
+		{File: "kb/d/four.md", Motifs: []string{"crowded-shape"}, Entities: []string{"Delta"}},
+		{File: "kb/e/five.md", Motifs: []string{"crowded-shape"}, Entities: []string{"Epsilon"}},
+		{File: "kb/f/six.md", Motifs: []string{"crowded-shape"}, Entities: []string{"Zeta"}},
+		{File: "kb/g/seven.md", Motifs: []string{"crowded-shape"}, Entities: []string{"Eta"}},
+	}
+	clusters := ClusterResult{Clusters: map[int][]string{}}
+	labels := labelsWith(200, nil)
+	for i, f := range seeds {
+		clusters.Clusters[i] = []string{f.File}
+		labels.DF[strings.ToLower(f.Entities[0])] = 2
+	}
+
+	idx := &pairwiseIndex{
+		edges: [][2]string{
+			{"kb/a/one.md", "kb/b/two.md"}, // group A: one edge among three
+			// group B: all six pairs, so cohesion is 1.0 and only the cap bites
+			{"kb/d/four.md", "kb/e/five.md"}, {"kb/d/four.md", "kb/f/six.md"},
+			{"kb/d/four.md", "kb/g/seven.md"}, {"kb/e/five.md", "kb/f/six.md"},
+			{"kb/e/five.md", "kb/g/seven.md"}, {"kb/f/six.md", "kb/g/seven.md"},
+		},
+	}
+	cfg := motifQualityConfig()
+	cfg.MaxMembers = 3 // group B has four
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, 2, health.Candidates, "precondition: both groups enumerated")
+	require.Empty(t, near)
+	require.Empty(t, far)
+	require.Equal(t, 1, health.NearFloorDropped, "the sparse group, and only it")
+	require.Equal(t, 1, health.NearOtherDropped, "the oversize group, counted apart")
+
+	lines := strings.Join(motifBridgeHealthLines(health, 0, 0), "\n")
+	require.Contains(t, lines, "motif near-lane floor: 1 group(s)")
+	require.Contains(t, lines, "motif near-lane other: 1 group(s)")
+}
+
+// pairwiseIndex reports adjacency for an explicit edge list.
+type pairwiseIndex struct {
+	SearchQuery
+	edges [][2]string
+}
+
+func (p *pairwiseIndex) TokenDF(context.Context, string, string, string) (int, error) {
+	return 2, nil
+}
+
+func (p *pairwiseIndex) ReverseDependentPaths(context.Context, string) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
+
+func (p *pairwiseIndex) SimilarityAdjacency(_ context.Context, paths []string) (store.SimilarityGraph, error) {
+	in := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		in[path] = struct{}{}
+	}
+	var kept [][2]string
+	for _, e := range p.edges {
+		_, a := in[e[0]]
+		_, b := in[e[1]]
+		if a && b {
+			kept = append(kept, e)
+		}
+	}
+	return store.NewSimilarityGraph(kept), nil
 }

--- a/internal/synthesize/bridge_test.go
+++ b/internal/synthesize/bridge_test.go
@@ -467,10 +467,15 @@ func TestBuildBackwardBridges_UsesConfiguredResolution(t *testing.T) {
 // reach reflect. If someone raises effortBudget(EffortHigh) past the band, this
 // fails loudly instead of silently letting discovery reorder after reflect.
 func TestEffortBudget_StaysBelowPriorityBand(t *testing.T) {
-	require.Less(t, effortBudget(EffortHigh), maxBridgeSeeds,
-		"effortBudget(EffortHigh) must stay below the forward-discover priority band width")
-	require.Less(t, effortBudget(EffortMedium), maxBridgeSeeds,
-		"effortBudget(EffortMedium) must stay below the forward-discover priority band width")
+	// Phase 3 puts motif items — both lanes — into the SAME forward-discover
+	// band, so the headroom question is about the TOTAL a session can enqueue,
+	// not about any one budget. Asserting effortBudget alone would have gone on
+	// passing while the band overflowed.
+	for _, e := range []Effort{EffortMedium, EffortHigh} {
+		near, far := motifSubBudget(e)
+		require.Less(t, effortBudget(e)+near+far, maxBridgeSeeds,
+			"every discover item a %s session can enqueue must fit the band above reflect", e)
+	}
 }
 
 // ─── buildScoredBridges tests ──────────────────────────────────────────────────

--- a/internal/synthesize/discovery.go
+++ b/internal/synthesize/discovery.go
@@ -37,6 +37,11 @@ type DiscoverWorkPayload struct {
 	Direction  DiscoverDirection `json:"direction"`
 	Bridge     BridgeSeedSet     `json:"bridge"`
 	ScopeLabel string            `json:"scope_label,omitempty"`
+	// Lane is set for motif bridges only (§4). It is carried EXPLICITLY rather
+	// than re-derived from Kind+Direction so that the prompt renderer and the
+	// health reporter read the same value the builder decided, and so a future
+	// bridge kind with two lanes does not silently inherit this one's mapping.
+	Lane BridgeLane `json:"lane,omitempty"`
 }
 
 // DiscoverResponse is the LLM JSON contract for one discover work item. The
@@ -46,6 +51,27 @@ type DiscoverWorkPayload struct {
 // gates before any write.
 type DiscoverResponse struct {
 	Proposals []DiscoveredFact `json:"proposals"`
+	// Reinforcements is discovery's THIRD outcome (GATE rider 3): facts the
+	// corpus already holds that these seeds independently re-derive. Absent is
+	// the common case and is not an error.
+	Reinforcements []FactReinforcement `json:"reinforcements"`
+}
+
+// FactReinforcement records that the seeds of this bridge are an INDEPENDENT
+// derivation of a fact the corpus already states.
+//
+// Reason is REQUIRED, and it is not decoration: the equivalence claim gets the
+// same discipline the alias judge's merges get, because an equivalence nobody
+// could justify in a sentence is the hallucinated one, and an over-merge is
+// invisible everywhere downstream. Absence of a reason is a rejection, not a
+// blank field.
+type FactReinforcement struct {
+	// Path is the existing corpus fact being reinforced.
+	Path string `json:"path"`
+	// Reason is the agent's one sentence on why the two claims are the same.
+	Reason string `json:"reason"`
+	// Refs are the seeds to join the fact's derivation paths.
+	Refs flexStrings `json:"refs"`
 }
 
 // DiscoveredFact is one proposed emergent fact. Mirrors distillFact so prompt
@@ -133,6 +159,17 @@ const discoverResponseSchema = `{
         },
         "required": ["path", "title", "body", "type", "confidence", "refs"]
       }
+    },
+    "reinforcements": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "path": {"type": "string", "description": "An EXISTING corpus fact that already states what you would have proposed."},
+          "reason": {"type": "string", "description": "One sentence on why the existing fact states the same claim. Required — if you cannot write it, they are not the same claim."},
+          "refs": {"type": "array", "items": {"type": "string"}, "description": "Every seed fact above, joining that fact's refs as an independent derivation path."}
+        },
+        "required": ["path", "reason", "refs"]
+      }
     }
   }
 }`
@@ -169,6 +206,16 @@ func renderDiscoverPrompt(payload DiscoverWorkPayload, ontologyRoot string) stri
 			b.WriteString("The facts below all share the structural token shown. They live in DIFFERENT cluster communities, so the shared token is a 'bridge' across regions of the knowledge base. We are looking for an UNSTATED CONSEQUENCE — a synthesis fact strictly entailed by the cited facts that nobody has written down yet.\n\n")
 		}
 		fmt.Fprintf(&b, "Bridge token: %q (kind=%s)\n", payload.Bridge.Token, payload.Bridge.Kind)
+		// Far-lane SHIP line, blueprint §4 verbatim.
+		//
+		// It goes HERE — after the token line, before the members — because
+		// its members have cohesion 0 by construction while the preamble just
+		// above says they "share the structural token". A model reading only
+		// that would reasonably infer they are also SIMILAR, which is the exact
+		// inference the far lane exists to prevent.
+		if payload.Lane == LaneFar {
+			fmt.Fprintf(&b, "\nThese facts are NOT semantically similar. Each claims motif %q. Propose a keystone only if one mechanism genuinely underlies all members — default to NO.\n", payload.Bridge.Token)
+		}
 	} else {
 		// Token-optional variant: scope-framed preamble.
 		switch payload.Direction {
@@ -187,6 +234,15 @@ func renderDiscoverPrompt(payload DiscoverWorkPayload, ontologyRoot string) stri
 			fmt.Fprintf(&b, "      %s\n", firstLine(m.Body))
 		}
 	}
+	// GATE rider 2 (designer, 2026-08-23). The far-lane demo established that
+	// condition (c) below is not answerable from this prompt at all: novelty
+	// rests on the agent's default-skip rather than on the 0.92 dedup gate
+	// (90d69628), and a cold agent with no corpus access would have proposed a
+	// semantic duplicate that every shipped gate would then have passed.
+	// Novelty is verified here, never assumed from context luck. It binds every
+	// discover item — the hole is in the prompt, not in any one bridge kind.
+	b.WriteString("\nBEFORE YOU ANSWER — QUERY THE CORPUS.\n")
+	b.WriteString("Condition (c) below cannot be answered from this prompt. Query the corpus (knomit_query) for the claim you are considering, in the words you would use to state it, before you decide anything. The most likely failure of this task is re-deriving something the corpus already holds, and it will not look like a duplicate: an existing fact stating the same premise usually shares almost none of your wording.\n")
 	b.WriteString("\nDECISION RULE — DEFAULT TO NO.\n")
 	b.WriteString("Propose a fact ONLY IF ALL of these hold:\n")
 	if payload.Direction == DiscoverBackward {
@@ -196,9 +252,23 @@ func renderDiscoverPrompt(payload DiscoverWorkPayload, ontologyRoot string) stri
 		b.WriteString("  (a) The proposed consequence is strictly ENTAILED by the cited facts — it follows necessarily from their conjunction, not as a plausible extension.\n")
 		b.WriteString("  (b) The consequence is LOAD-BEARING — its falsity invalidates ≥2 of the cited facts.\n")
 	}
-	b.WriteString("  (c) Not already in the corpus — no existing fact already states it.\n")
+	b.WriteString("  (c) Not already in the corpus — you QUERIED for it above and no existing fact states it. If one does, REINFORCE it instead of proposing (below).\n")
 	b.WriteString("  (d) You can cite every seed fact above in refs. An empty refs array indicates you did not engage with the inputs.\n\n")
 	b.WriteString("If any condition fails, return an empty proposals array. Skipping is the expected outcome.\n\n")
+	// GATE rider 3 (designer, 2026-08-23): discovery's third outcome. On a
+	// recall hit the answer is neither propose nor decline — the seeds are an
+	// INDEPENDENT derivation of a claim the corpus already holds, and recording
+	// that is corroboration. The equivalence claim gets alias-judge discipline
+	// for the same reason the alias judge does: an equivalence nobody could
+	// justify in a sentence is the hallucinated one, and over-merge is
+	// invisible downstream.
+	b.WriteString("REINFORCE — the third outcome, for when the corpus already states it.\n")
+	b.WriteString("If your query found a fact that already states what you would have proposed, do not propose it again and do not simply fall silent: REINFORCE that fact. Reinforcement records these seeds as an INDEPENDENT derivation of a claim the corpus already holds — one more proof that the wheel is round — by adding them to its refs, incrementing its sources and strengthening its evidence. Nothing else about the fact changes.\n")
+	b.WriteString("Reinforce ONLY IF ALL of these hold:\n")
+	b.WriteString("  (a) The existing fact states the SAME claim, not a neighbouring one. Say why in one sentence; if you cannot write that sentence, they are not the same claim.\n")
+	b.WriteString("  (b) You would otherwise have proposed it here. Reinforcement replaces a proposal; it is never a note about something you happened to read.\n")
+	b.WriteString("  (c) You can cite every seed fact above in refs.\n")
+	b.WriteString("DEFAULT TO NO on sameness. When you are torn between \"the same claim\" and \"a claim near it\", PROPOSE AND LINK instead of reinforcing: a false link is recoverable, a false merge is not.\n\n")
 	b.WriteString("PERSISTENCE — origin reflects how this group was formed.\n")
 	b.WriteString("These facts were grouped by a cross-cluster BRIDGE, so any fact you persist from them is discovery-engine output (origin: discovered). Submit your proposals back via knomit_hypothesize/knomit_review to record them automatically. If you instead save one directly with knomit_learn after previewing, you MUST set origin: discovered and cite every seed fact above in refs.\n\n")
 	b.WriteString("RESPONSE SCHEMA: {\"proposals\":[{\"path\":\"" + ontologyRoot + "/.../slug.md\",\"title\":\"...\",\"body\":\"...\",\"type\":\"")
@@ -207,7 +277,7 @@ func renderDiscoverPrompt(payload DiscoverWorkPayload, ontologyRoot string) stri
 	} else {
 		b.WriteString("synthesis")
 	}
-	b.WriteString("\",\"domain\":[],\"entities\":[],\"confidence\":0.0,\"refs\":[]}]}\n")
+	b.WriteString("\",\"domain\":[],\"entities\":[],\"confidence\":0.0,\"refs\":[]}],\"reinforcements\":[{\"path\":\"" + ontologyRoot + "/.../existing.md\",\"reason\":\"...\",\"refs\":[]}]}\n")
 	return b.String()
 }
 

--- a/internal/synthesize/discovery_motif_prompt_test.go
+++ b/internal/synthesize/discovery_motif_prompt_test.go
@@ -1,0 +1,102 @@
+package synthesize
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The Phase-3 additions to the discover prompt. All three blocks were read
+// verbatim by the designer before they landed (phase3-rulings-2), so these
+// tests pin the exact bytes rather than a paraphrase.
+
+// shipFarLaneLine is blueprint §4's far-lane SHIP text, rendered for the motif
+// used in the far-lane demo.
+const shipFarLaneLine = `These facts are NOT semantically similar. Each claims motif "measure-becomes-target". Propose a keystone only if one mechanism genuinely underlies all members — default to NO.`
+
+func farLanePayload() DiscoverWorkPayload {
+	return DiscoverWorkPayload{
+		Direction: DiscoverBackward,
+		Lane:      LaneFar,
+		Bridge: BridgeSeedSet{
+			Token: "measure-becomes-target",
+			Kind:  BridgeMotif,
+			Members: []factForLLM{
+				{File: "kb/gotchas/uitesting/1.md", Title: "A", Body: "body a"},
+				{File: "kb/technology/benchmarks/2.md", Title: "B", Body: "body b"},
+			},
+		},
+	}
+}
+
+// TestRenderDiscoverPrompt_FarLaneCarriesTheShipLine — the line must land after
+// the token line and before the member list. Its position is the point: the
+// backward preamble above it says the members "share the structural token",
+// from which a model reasonably infers they are also SIMILAR, and that is the
+// exact inference the far lane exists to prevent (far-lane demo, Part 1).
+func TestRenderDiscoverPrompt_FarLaneCarriesTheShipLine(t *testing.T) {
+	got := renderDiscoverPrompt(farLanePayload(), "kb")
+
+	require.Contains(t, got, shipFarLaneLine)
+	require.Greater(t, strings.Index(got, shipFarLaneLine), strings.Index(got, "Bridge token:"))
+	require.Less(t, strings.Index(got, shipFarLaneLine), strings.Index(got, "Members ("))
+}
+
+// The far-lane line is the far lane's alone: near-lane motif items and ordinary
+// entity/domain bridges must not tell the agent their members are dissimilar,
+// because for them it is false.
+func TestRenderDiscoverPrompt_ShipLineIsFarLaneOnly(t *testing.T) {
+	for _, p := range []DiscoverWorkPayload{
+		{Direction: DiscoverForward, Lane: LaneNear,
+			Bridge: BridgeSeedSet{Token: "measure-becomes-target", Kind: BridgeMotif}},
+		{Direction: DiscoverBackward,
+			Bridge: BridgeSeedSet{Token: "some-entity", Kind: BridgeEntity}},
+		{Direction: DiscoverForward,
+			Bridge: BridgeSeedSet{Token: "some-domain", Kind: BridgeDomain}},
+	} {
+		require.NotContains(t, renderDiscoverPrompt(p, "kb"), "NOT semantically similar")
+	}
+}
+
+// GATE rider 2. The hole the far-lane demo found is in the PROMPT, not in the
+// motif axis: condition (c) is not answerable from the prompt at all, so every
+// discover item must instruct the query — both directions, every kind.
+func TestRenderDiscoverPrompt_InstructsRecallBeforeProposing(t *testing.T) {
+	const header = "BEFORE YOU ANSWER — QUERY THE CORPUS."
+	for _, dir := range []DiscoverDirection{DiscoverForward, DiscoverBackward} {
+		for _, kind := range []BridgeKind{BridgeEntity, BridgeDomain, BridgeMotif} {
+			got := renderDiscoverPrompt(DiscoverWorkPayload{Direction: dir,
+				Bridge: BridgeSeedSet{Token: "tok", Kind: kind}}, "kb")
+
+			require.Contains(t, got, header, "kind=%s dir=%s", kind, dir)
+			require.Contains(t, got, "you QUERIED for it above and no existing fact states it",
+				"condition (c) must name the query it now depends on")
+			require.Less(t, strings.Index(got, header), strings.Index(got, "DECISION RULE"))
+		}
+	}
+}
+
+// GATE rider 3: the third outcome must be offered, and offered with its
+// discipline attached — a stated reason, and propose-and-link when torn.
+func TestRenderDiscoverPrompt_CarriesTheReinforceInstruction(t *testing.T) {
+	got := renderDiscoverPrompt(farLanePayload(), "kb")
+
+	require.Contains(t, got, "REINFORCE — the third outcome, for when the corpus already states it.")
+	require.Contains(t, got, "Say why in one sentence; if you cannot write that sentence, they are not the same claim.")
+	require.Contains(t, got, "PROPOSE AND LINK instead of reinforcing: a false link is recoverable, a false merge is not.")
+	require.Contains(t, got, `"reinforcements"`, "the schema line must advertise the field")
+
+	require.Less(t, strings.Index(got, "REINFORCE — the third outcome"),
+		strings.Index(got, "PERSISTENCE"),
+		"the outcome belongs with the decision rule, not after the persistence note")
+}
+
+// The response SCHEMA the dispatcher hands the agent must advertise
+// reinforcements too — the prompt and the schema are two halves of one
+// contract, and a field described in prose but absent from the schema is a
+// field the agent is told to use and then cannot.
+func TestDiscoverResponseSchema_AdvertisesReinforcements(t *testing.T) {
+	require.Contains(t, discoverResponseSchema, `"reinforcements"`)
+	require.Contains(t, discoverResponseSchema, `"reason"`)
+}

--- a/internal/synthesize/discovery_reinforce.go
+++ b/internal/synthesize/discovery_reinforce.go
@@ -11,6 +11,13 @@ package synthesize
 // agent querying the corpus — and once it has, a hit is not a dead end. The
 // seeds are an INDEPENDENT derivation of a claim already held, and recording
 // that is corroboration: one more proof the wheel is round.
+//
+// THE WRITE CONTRACT (phase3-rulings-4 and -5, from the fresh-eyes review).
+// This path edits facts the agent did not author, so it may change ONLY the
+// refs, sources and evidence_weight lines of the STORED BYTES. Everything below
+// exists to make that true mechanically rather than carefully: the write does
+// not try to preserve each field one by one, it proves the rewrite is
+// meaning-preserving and refuses otherwise.
 
 import (
 	"context"
@@ -22,20 +29,22 @@ import (
 	"knomit/internal/store"
 )
 
+// permittedRewriteLines are the frontmatter keys a reinforcement may change.
+var permittedRewriteLines = map[string]struct{}{
+	"refs": {}, "sources": {}, "evidence_weight": {},
+}
+
 // applyReinforcements runs every reinforcement through its gate chain and
 // strengthens the survivors.
 //
-// What a reinforcement may change: refs (append only), sources (+1),
-// evidence_weight (recomputed, never authored). NOTHING else — the title, body,
-// type, kind, domain, entities, motifs, confidence and origin of a fact the
-// agent did not author are not this path's to touch. That list is guarded by
-// test rather than by comment.
+// The equivalence claim gets alias-judge discipline: a stated one-sentence
+// reason, recorded in the commit message — this repo's provenance carrier for
+// fact writes — and default-NO whenever it is missing. The entailment gate
+// (626f3970) is the mechanical backstop once it exists; until then these gates
+// and the agent's own default-NO are what stand.
 //
-// The equivalence claim itself gets alias-judge discipline: a stated
-// one-sentence reason, recorded in the commit message — this repo's provenance
-// carrier for fact writes — and default-NO whenever it is missing. The
-// entailment gate (626f3970) is the mechanical backstop once it exists; until
-// then these gates and the agent's own default-NO are what stand.
+// No error return: every rejection is per-reinforcement, warned and skipped,
+// like the proposal loop it runs beside.
 func applyReinforcements(
 	ctx context.Context,
 	gs store.FactIndex,
@@ -89,19 +98,91 @@ func applyReinforcements(
 			continue
 		}
 
+		// TRIPWIRE (review H1). ParseFact is deliberately lenient: it DROPS
+		// motifs that today's rules reject and records them only in
+		// MotifWarnings, which is not persisted. Writing such a fact back
+		// deletes them permanently — measured, on a planted `legacy` motif —
+		// and MN3 says nothing ever rewrites a fact's motif strings. A fact
+		// carrying legacy data is not this path's to clean.
+		//
+		// The meaning-preservation check below would also catch this, since the
+		// motifs line changes. The tripwire stays anyway, first, because it
+		// names WHY the fact was skipped: "would be rewritten outside the
+		// permitted lines" sends a reader looking for a formatting problem, and
+		// a skip nobody can explain is a skip somebody later "fixes".
+		//
+		// STANDING CAVEAT (reviewer, rulings-5): the fidelity measurement's
+		// zero motif-loss column is NOT evidence about this path. No production
+		// fact carries motifs yet — the shipped DBs predate the field — so the
+		// planted-motif test is the only evidence there is. Never read a
+		// measured zero here as an all-clear.
+		if len(f.MotifWarnings) > 0 {
+			reject("%s carries motifs this version cannot round-trip (%s) — "+
+				"reinforcing it would delete them", r.Path, strings.Join(f.MotifWarnings, "; "))
+			continue
+		}
+
+		// The fact re-rendered UNCHANGED. If that already differs from what is
+		// stored in a way that changes meaning, this is not the path that
+		// rewrites it.
+		baseline, err := fact.SerializeFact(f)
+		if err != nil {
+			reject("%s does not re-serialize: %v", r.Path, err)
+			continue
+		}
+		if why, ok := rewriteIsMeaningPreserving(read.Content, baseline, f.Origin, f.Origin); !ok {
+			reject("%s would be rewritten outside the permitted lines (%s)", r.Path, why)
+			continue
+		}
+
 		// PRIOR IS A SNAPSHOT (0ee925f4). Passing the same slice as both refs
 		// and prior silently disables the gate, so prior is copied BEFORE the
 		// write list is built from it and the two can diverge.
 		prior := append([]string(nil), f.Refs...)
-		writeList := dedupeRefs(append(append([]string(nil), f.Refs...), r.Refs...))
 
-		canonRefs, _, gerr := gate.Apply(ctx, f.Path(), writeList, prior)
-		if gerr != nil {
-			reject("%s: %v", r.Path, gerr)
-			continue
+		// SEEDS ONLY (review H2). refsCoverSeeds is a superset check, so r.Refs
+		// may name anything the model happened to read while deciding — and
+		// rider 2 now instructs it to read. Every extra would become a permanent
+		// DERIVED_FROM edge on a fact someone else authored, and would move its
+		// evidence weight. Surplus citation does not kill an otherwise valid
+		// reinforcement; the extras are dropped with a warning.
+		var extras, seeds []string
+		for _, ref := range r.Refs {
+			if _, isSeed := seedPaths[ref]; isSeed {
+				seeds = append(seeds, ref)
+			} else {
+				extras = append(extras, ref)
+			}
 		}
+		if len(extras) > 0 {
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf(
+				"reinforce %s: discarded %d ref(s) naming facts outside the bridge: %s",
+				r.Path, len(extras), strings.Join(extras, ", "))})
+		}
+
+		// EXISTING REFS VERBATIM (review L8). Only the incoming seeds are
+		// canonicalised; the strings the fact already carried are written back
+		// exactly as they were, because canonicalising them is a mutation of
+		// authored data outside "append the seeds". Membership is tested on the
+		// canonical form so a bare-path existing ref and its canonical seed do
+		// not both land.
+		canonSeeds, _ := gate.Canonicalize(seeds)
 		canonPrior, _ := gate.Canonicalize(prior)
-		if sameRefSet(canonRefs, canonPrior) {
+		have := make(map[string]struct{}, len(canonPrior))
+		for _, ref := range canonPrior {
+			have[ref] = struct{}{}
+		}
+		newRefs := append([]string(nil), f.Refs...)
+		added := 0
+		for _, ref := range canonSeeds {
+			if _, dup := have[ref]; dup {
+				continue // already a derivation path of this fact, in some form
+			}
+			have[ref] = struct{}{}
+			newRefs = append(newRefs, ref)
+			added++
+		}
+		if added == 0 {
 			// Every seed is already one of this fact's derivation paths.
 			// Recording it again would turn `sources` into a count of how often
 			// the fact was LOOKED at rather than how often it was independently
@@ -111,10 +192,20 @@ func applyReinforcements(
 			continue
 		}
 
-		f.Refs = canonRefs
+		// CheckBatch rather than Apply: Apply canonicalises the whole write
+		// list, which is exactly the existing-ref rewrite L8 reported. The check
+		// itself is the one every write path runs, prior snapshot and all.
+		if gerr := gate.CheckBatch(ctx,
+			map[string][]string{f.Path(): newRefs},
+			map[string][]string{f.Path(): prior}); gerr != nil {
+			reject("%s: %v", r.Path, gerr)
+			continue
+		}
+
+		f.Refs = newRefs
 		f.Sources++
 		f.EvidenceWeight = computeWeight(ctx, gs, branch, localRepoID,
-			localFactRefPaths(canonRefs, localRepoID))
+			localFactRefPaths(newRefs, localRepoID))
 
 		content, err := fact.SerializeFact(f)
 		if err != nil {
@@ -133,34 +224,99 @@ func applyReinforcements(
 	return written
 }
 
-// dedupeRefs preserves order and drops repeats, so a seed the fact already
-// cites does not appear twice in the write list.
-func dedupeRefs(in []string) []string {
-	seen := make(map[string]struct{}, len(in))
-	out := make([]string, 0, len(in))
-	for _, r := range in {
-		if _, dup := seen[r]; dup {
+// rewriteIsMeaningPreserving reports whether rewriting `stored` as `rewritten`
+// changes only what a reinforcement is allowed to change, and if not, why.
+//
+// MEANING-CHANGE, not byte equality (designer ruling, phase3-rulings-5). A
+// strict byte comparison would refuse the 144 measured facts whose only
+// difference is a materialised origin line, and the 159 whose refs line differs
+// in YAML quote style — neither changes what the fact says.
+//
+// Permitted:
+//   - any difference confined to the refs / sources / evidence_weight lines,
+//     which is where a reinforcement writes and where rendering differences land;
+//   - an `origin:` line present in the rewrite and ABSENT from the stored bytes,
+//     whose value is what ParseFact already defaults to for that fact.
+//
+// Everything else skips — including an origin line whose value CHANGES, which
+// is the 66 measured facts whose stored type/origin pairing is illegal and whose
+// provenance a rewrite would silently reattribute to `authored`.
+//
+// storedOrigin/rewrittenOrigin are the PARSED origins of the two byte strings.
+// On the reinforcement path they are necessarily equal — nothing here mutates
+// Origin between parse and serialize — so that clause cannot fail in vivo. It is
+// kept deliberately: it is what stops a future origin-mutating path (a repair
+// pass, a retype, the belief-level lineage work) from riding through under the
+// no-op exemption, and its test drives this function directly for exactly that
+// reason. Do not delete it as dead logic.
+func rewriteIsMeaningPreserving(stored, rewritten string, storedOrigin, rewrittenOrigin fact.Origin) (string, bool) {
+	storedLines := frontmatterLines(stored)
+	rewrittenLines := frontmatterLines(rewritten)
+
+	for key, after := range rewrittenLines {
+		before, existed := storedLines[key]
+		if existed && before == after {
 			continue
 		}
-		seen[r] = struct{}{}
-		out = append(out, r)
+		if _, permitted := permittedRewriteLines[key]; permitted {
+			continue
+		}
+		if key == "origin" && !existed {
+			if storedOrigin != rewrittenOrigin {
+				return fmt.Sprintf("origin would materialise as %q, not the parsed default %q",
+					rewrittenOrigin, storedOrigin), false
+			}
+			continue // the measured semantic no-op
+		}
+		if !existed {
+			return "line " + key + " would be added", false
+		}
+		return "line " + key + " would change", false
+	}
+	for key := range storedLines {
+		if _, still := rewrittenLines[key]; still {
+			continue
+		}
+		if _, permitted := permittedRewriteLines[key]; permitted {
+			continue
+		}
+		return "line " + key + " would be removed", false
+	}
+	// The body is everything after the frontmatter, and it is never this path's
+	// to touch.
+	if factBodyOf(stored) != factBodyOf(rewritten) {
+		return "the body would change", false
+	}
+	return "", true
+}
+
+// frontmatterLines splits a fact's frontmatter into key → raw line. Keys are
+// top-level only; fact frontmatter is flat, and SerializeFact renders lists in
+// flow style, so a value never spans lines.
+func frontmatterLines(content string) map[string]string {
+	out := map[string]string{}
+	fm, _, found := strings.Cut(strings.TrimPrefix(content, "---\n"), "\n---")
+	if !found {
+		return out
+	}
+	for _, line := range strings.Split(fm, "\n") {
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "-") {
+			continue
+		}
+		key, _, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(key)] = line
 	}
 	return out
 }
 
-// sameRefSet reports whether two ref lists carry the same members.
-func sameRefSet(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
+// factBodyOf returns everything after the frontmatter.
+func factBodyOf(content string) string {
+	_, body, found := strings.Cut(strings.TrimPrefix(content, "---\n"), "\n---")
+	if !found {
+		return content
 	}
-	seen := make(map[string]struct{}, len(a))
-	for _, r := range a {
-		seen[r] = struct{}{}
-	}
-	for _, r := range b {
-		if _, ok := seen[r]; !ok {
-			return false
-		}
-	}
-	return true
+	return body
 }

--- a/internal/synthesize/discovery_reinforce.go
+++ b/internal/synthesize/discovery_reinforce.go
@@ -1,0 +1,166 @@
+package synthesize
+
+// REINFORCE — discovery's third outcome (GATE rider 3, designer ruling
+// 2026-08-23).
+//
+// The far-lane demo established that the most likely failure of a discovery
+// task is re-deriving a fact the corpus already holds, and that the shipped
+// machinery cannot catch it: the 0.92 embedding gate sees only verbatim
+// duplicates, and a genuine semantic restatement shares almost no surface
+// wording with the fact it restates (90d69628). Novelty therefore rests on the
+// agent querying the corpus — and once it has, a hit is not a dead end. The
+// seeds are an INDEPENDENT derivation of a claim already held, and recording
+// that is corroboration: one more proof the wheel is round.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"knomit/internal/fact"
+	"knomit/internal/refs"
+	"knomit/internal/store"
+)
+
+// applyReinforcements runs every reinforcement through its gate chain and
+// strengthens the survivors.
+//
+// What a reinforcement may change: refs (append only), sources (+1),
+// evidence_weight (recomputed, never authored). NOTHING else — the title, body,
+// type, kind, domain, entities, motifs, confidence and origin of a fact the
+// agent did not author are not this path's to touch. That list is guarded by
+// test rather than by comment.
+//
+// The equivalence claim itself gets alias-judge discipline: a stated
+// one-sentence reason, recorded in the commit message — this repo's provenance
+// carrier for fact writes — and default-NO whenever it is missing. The
+// entailment gate (626f3970) is the mechanical backstop once it exists; until
+// then these gates and the agent's own default-NO are what stand.
+func applyReinforcements(
+	ctx context.Context,
+	gs store.FactIndex,
+	idx SearchQuery,
+	payload DiscoverWorkPayload,
+	rs []FactReinforcement,
+	branch string,
+	localRepoID string,
+	onProgress func(ProgressEvent),
+) ([]string, error) {
+	if onProgress == nil {
+		onProgress = func(ProgressEvent) {}
+	}
+	seedPaths := make(map[string]struct{}, len(payload.Bridge.Members))
+	for _, m := range payload.Bridge.Members {
+		seedPaths[m.File] = struct{}{}
+	}
+	gate := refs.New(localRepoID, refs.FromFactQuery(idx, branch))
+
+	var written []string
+	for _, r := range rs {
+		reject := func(format string, args ...any) {
+			onProgress(ProgressEvent{Phase: "warn",
+				Message: "reinforce rejected: " + fmt.Sprintf(format, args...)})
+		}
+
+		if strings.TrimSpace(r.Reason) == "" {
+			// An equivalence nobody could justify in a sentence is the
+			// hallucinated equivalence this gate exists to stop, and an
+			// over-merge is invisible everywhere downstream.
+			reject("%s carries no stated equivalence reason", r.Path)
+			continue
+		}
+		if _, isSeed := seedPaths[r.Path]; isSeed {
+			reject("%s is one of the seeds — a fact is not an independent derivation of itself", r.Path)
+			continue
+		}
+		if !refsCoverSeeds(r.Refs, seedPaths) {
+			reject("%s refs does not cite every seed", r.Path)
+			continue
+		}
+
+		read, err := gs.ReadFact(ctx, branch, r.Path, nil)
+		if err != nil {
+			reject("%s is not readable on this branch: %v", r.Path, err)
+			continue
+		}
+		f, err := fact.ParseFact(r.Path, read.Content)
+		if err != nil {
+			reject("%s does not parse: %v", r.Path, err)
+			continue
+		}
+
+		// PRIOR IS A SNAPSHOT (0ee925f4). Passing the same slice as both refs
+		// and prior silently disables the gate, so prior is copied BEFORE the
+		// write list is built from it and the two can diverge.
+		prior := append([]string(nil), f.Refs...)
+		writeList := dedupeRefs(append(append([]string(nil), f.Refs...), r.Refs...))
+
+		canonRefs, _, gerr := gate.Apply(ctx, f.Path(), writeList, prior)
+		if gerr != nil {
+			reject("%s: %v", r.Path, gerr)
+			continue
+		}
+		canonPrior, _ := gate.Canonicalize(prior)
+		if sameRefSet(canonRefs, canonPrior) {
+			// Every seed is already one of this fact's derivation paths.
+			// Recording it again would turn `sources` into a count of how often
+			// the fact was LOOKED at rather than how often it was independently
+			// derived.
+			onProgress(ProgressEvent{Phase: "detail-discover",
+				Message: "reinforce skipped (already derived from these seeds): " + r.Path})
+			continue
+		}
+
+		f.Refs = canonRefs
+		f.Sources++
+		f.EvidenceWeight = computeWeight(ctx, gs, branch, localRepoID,
+			localFactRefPaths(canonRefs, localRepoID))
+
+		content, err := fact.SerializeFact(f)
+		if err != nil {
+			reject("%s serialize: %v", r.Path, err)
+			continue
+		}
+		msg := fmt.Sprintf("reinforce: %s independently derived via bridge %q — %s",
+			r.Path, payload.Bridge.Token, firstLine(r.Reason))
+		if _, err := gs.WriteFact(ctx, branch, f.Path(), content, msg, "discover"); err != nil {
+			reject("%s write: %v", r.Path, err)
+			continue
+		}
+		onProgress(ProgressEvent{Phase: "detail-discover", Message: "reinforce " + f.Path()})
+		written = append(written, f.Path())
+	}
+	return written, nil
+}
+
+// dedupeRefs preserves order and drops repeats, so a seed the fact already
+// cites does not appear twice in the write list.
+func dedupeRefs(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, r := range in {
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+	return out
+}
+
+// sameRefSet reports whether two ref lists carry the same members.
+func sameRefSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(a))
+	for _, r := range a {
+		seen[r] = struct{}{}
+	}
+	for _, r := range b {
+		if _, ok := seen[r]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/synthesize/discovery_reinforce.go
+++ b/internal/synthesize/discovery_reinforce.go
@@ -45,7 +45,7 @@ func applyReinforcements(
 	branch string,
 	localRepoID string,
 	onProgress func(ProgressEvent),
-) ([]string, error) {
+) []string {
 	if onProgress == nil {
 		onProgress = func(ProgressEvent) {}
 	}
@@ -130,7 +130,7 @@ func applyReinforcements(
 		onProgress(ProgressEvent{Phase: "detail-discover", Message: "reinforce " + f.Path()})
 		written = append(written, f.Path())
 	}
-	return written, nil
+	return written
 }
 
 // dedupeRefs preserves order and drops repeats, so a seed the fact already

--- a/internal/synthesize/discovery_reinforce_test.go
+++ b/internal/synthesize/discovery_reinforce_test.go
@@ -2,6 +2,8 @@ package synthesize
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,6 +53,11 @@ func newReinforceEnv(t *testing.T) *reinforceEnv {
 	target.Title = "The verifier is inside the agent's action space"
 	target.Body = "Every recorded form of eval gaming is an action taken ON the measurement apparatus."
 	target.Type = fact.Synthesis
+	// Origin EXPLICIT. A synthesis fact with the line elided does not
+	// round-trip — ParseFact defaults it to distilled and SerializeFact then
+	// writes it — so under the write contract such a target is SKIPPED. Every
+	// pipeline-written synthesis fact carries it; the fixture matches.
+	target.Origin = fact.Distilled
 	target.Confidence = 0.75
 	target.Sources = 1
 	target.Domain = []string{"evaluation"}
@@ -149,15 +156,33 @@ func TestApplyReinforcements_ChangesNothingButRefsSourcesAndWeight(t *testing.T)
 }
 
 // 0ee925f4: passing the SAME slice as refs and prior silently disables the
-// gate. Proved by planting a ref that cannot resolve — the gate must refuse the
-// whole write rather than let it through.
+// gate. It must still be live on this path — and after H2's fix that can only
+// be shown by INJECTION, which is worth stating plainly rather than dressing a
+// weaker test as a strong one.
+//
+// Two reasons no ordinary input reaches it. Extras are discarded before the
+// gate sees them, so a bogus ref the model names never gets there. And a
+// retracted seed still RESOLVES: refs are historical by design (a ref is
+// `fact` rather than `broken` when the target has any version visible at the
+// source's anchor), so retracting a seed does not break the edge that cites it.
+//
+// So the gate is defence in depth against a future path that supplies refs some
+// other way, and this drives it with a bridge member that never existed. Keep
+// it for the same reason the origin fence is kept: it is what stops the next
+// caller from writing a broken edge, and a check nothing exercises is a check
+// nobody notices going missing.
 func TestApplyReinforcements_RefsGateIsLiveOnThisPath(t *testing.T) {
 	env := newReinforceEnv(t)
 	before := env.read(reinforcePath)
 
+	const ghost = "kb/gotchas/never/existed.md"
+	env.payload.Bridge.Members = append(env.payload.Bridge.Members, factForLLM{File: ghost})
+
 	r := goodReinforcement()
-	r.Refs = append(r.Refs, "kb/does/not/exist.md")
-	require.Empty(t, env.apply(r))
+	r.Refs = flexStrings{seedOnePath, seedTwoPath, ghost}
+
+	require.Empty(t, env.apply(r),
+		"a seed that resolves to nothing must refuse the write, not be written as a broken edge")
 
 	after := env.read(reinforcePath)
 	require.Equal(t, before.Refs, after.Refs, "a refused write changes nothing")
@@ -257,4 +282,217 @@ func TestApplyReinforcements_ADifferentDerivationStillCounts(t *testing.T) {
 // would miss them.
 func contains(ref, path string) bool {
 	return len(ref) >= len(path) && ref[len(ref)-len(path):] == path
+}
+
+// storedBytes reads the fact exactly as the corpus holds it. The guard below
+// compares THESE, not parsed structs — see the test's own comment for why.
+func (e *reinforceEnv) storedBytes(path string) string {
+	e.t.Helper()
+	res, err := e.svc.Facts().ReadFact(context.Background(), e.branch, path, nil)
+	require.NoError(e.t, err)
+	return res.Content
+}
+
+// changedLines returns the lines that differ between two versions of a fact.
+func changedLines(before, after string) []string {
+	b := strings.Split(before, "\n")
+	a := strings.Split(after, "\n")
+	seen := map[string]struct{}{}
+	for _, l := range b {
+		seen[l] = struct{}{}
+	}
+	var out []string
+	for _, l := range a {
+		if _, ok := seen[l]; !ok {
+			out = append(out, l)
+		}
+	}
+	for _, l := range b {
+		if !slices.Contains(a, l) {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// TestApplyReinforcements_ChangesOnlyPermittedStoredLines — the guard at the
+// boundary the CORPUS reads (lesson 8, review H1).
+//
+// Its predecessor compared parsed structs, and passed while the write was
+// deleting motifs: the lenient parser dropped the malformed motif on BOTH sides
+// of the comparison, so it compared two already-truncated lists. That history
+// is why this assertion is on bytes and why the struct comparison is kept only
+// as a secondary check.
+func TestApplyReinforcements_ChangesOnlyPermittedStoredLines(t *testing.T) {
+	env := newReinforceEnv(t)
+	before := env.storedBytes(reinforcePath)
+
+	require.Equal(t, []string{reinforcePath}, env.apply(goodReinforcement()))
+	after := env.storedBytes(reinforcePath)
+
+	require.NotEqual(t, before, after, "precondition: the write must have done something")
+	for _, line := range changedLines(before, after) {
+		field := strings.SplitN(strings.TrimSpace(line), ":", 2)[0]
+		require.Containsf(t, []string{"refs", "sources", "evidence_weight", "-"}, field,
+			"a reinforcement changed the stored line %q — only refs, sources and "+
+				"evidence_weight may differ", line)
+	}
+}
+
+// H1: a target whose motifs do not survive the lenient parser is SKIPPED, not
+// silently normalised. A fact carrying legacy data is not this path's to clean.
+func TestApplyReinforcements_SkipsALossyTarget(t *testing.T) {
+	env := newReinforceEnv(t)
+
+	// A motif that today's rules reject, as a pre-Phase-1 fact or one synced
+	// from a remote written by another version would carry it. Written as raw
+	// bytes because SerializeFact would refuse it — which is the point.
+	lossy := strings.Replace(env.storedBytes(reinforcePath),
+		"motifs: [measure-becomes-target]", "motifs: [measure-becomes-target, legacy]", 1)
+	require.Contains(t, lossy, ", legacy]", "precondition: the fixture planted the motif")
+	_, err := env.svc.Facts().WriteFact(context.Background(), env.branch, reinforcePath,
+		lossy, "plant legacy motif", "test")
+	require.NoError(t, err)
+
+	require.Empty(t, env.apply(goodReinforcement()), "a lossy target is skipped")
+	require.Equal(t, lossy, env.storedBytes(reinforcePath),
+		"and its bytes are untouched — including the motif the parser would have dropped")
+
+	// WHICH check refused it. The meaning-preservation check would also catch
+	// this (the motifs line changes), so a test that only observes the skip
+	// cannot tell the two apart — sabotaging the tripwire leaves it green. The
+	// tripwire's value is the REASON it gives, so the reason is what is
+	// asserted: "rewritten outside the permitted lines" would send a reader
+	// hunting a formatting problem instead of a deleted motif.
+	var warnings []string
+	applyReinforcements(context.Background(), env.svc.Facts(), env.svc.Search(),
+		env.payload, []FactReinforcement{goodReinforcement()}, env.branch, env.repoID,
+		func(e ProgressEvent) {
+			if e.Phase == "warn" {
+				warnings = append(warnings, e.Message)
+			}
+		})
+	require.NotEmpty(t, warnings)
+	require.Contains(t, strings.Join(warnings, "\n"), "cannot round-trip",
+		"the skip must name the motifs it protected, not just report a rewrite")
+	require.Contains(t, strings.Join(warnings, "\n"), "legacy")
+}
+
+// L9, as ruled in phase3-rulings-5: an origin line materialising to exactly the
+// parse default is a SEMANTIC NO-OP and is permitted — the measured 144 facts.
+// The fact reinforces normally, and the materialised line says what ParseFact
+// already said the fact meant.
+func TestApplyReinforcements_PermitsAnOriginMaterialisingToTheParseDefault(t *testing.T) {
+	env := newReinforceEnv(t)
+
+	elided := env.storedBytes(reinforcePath)
+	require.Contains(t, elided, "origin: distilled", "precondition: the fixture has one to remove")
+	elided = strings.Replace(elided, "origin: distilled\n", "", 1)
+	_, err := env.svc.Facts().WriteFact(context.Background(), env.branch, reinforcePath,
+		elided, "elide origin", "test")
+	require.NoError(t, err)
+	require.Equal(t, fact.Distilled, env.read(reinforcePath).Origin,
+		"precondition: the parse default for this fact IS what would materialise")
+
+	require.Equal(t, []string{reinforcePath}, env.apply(goodReinforcement()),
+		"a semantic no-op does not cost the corroboration")
+	require.Contains(t, env.storedBytes(reinforcePath), "origin: distilled")
+}
+
+// The fence on that exception, driven through the comparison helper DIRECTLY.
+//
+// It has to be: on the reinforcement path nothing mutates Origin between parse
+// and serialize, so no ordinary input can make the two parsed origins differ,
+// and a test that reinforces a normal fact and observes success would not touch
+// this clause at all — the Phase-1 MN4 shape, where a comment satisfied a check
+// that never ran (reviewer note, rulings-5).
+//
+// The case it fences is measured and real: 66 core facts whose stored
+// type/origin pairing is illegal, which ParseFact coerces to `authored`. A
+// rewrite there would silently reattribute someone's provenance.
+func TestRewriteIsMeaningPreserving_FencesAnOriginThatWouldCHANGE(t *testing.T) {
+	const stored = "---\ntype: synthesis\nconfidence: 0.75\nsources: 1\nrefs: []\n---\n# T\n\nBody.\n"
+	const rewritten = "---\ntype: synthesis\nconfidence: 0.75\nsources: 2\norigin: authored\nrefs: []\n---\n# T\n\nBody.\n"
+
+	// Same parsed origin on both sides: the measured no-op, permitted.
+	why, ok := rewriteIsMeaningPreserving(stored, rewritten, fact.Authored, fact.Authored)
+	require.True(t, ok, "a materialised origin equal to the parse default is a no-op: %s", why)
+
+	// DIFFERING parsed origins — the mutation injected, since the live path
+	// cannot produce it. This is the clause the fence exists for.
+	why, ok = rewriteIsMeaningPreserving(stored, rewritten, fact.Distilled, fact.Authored)
+	require.False(t, ok, "an origin materialising to something other than the parse default must skip")
+	require.Contains(t, why, "not the parsed default")
+}
+
+// And the neighbouring clauses of the same helper, each with a real diff.
+func TestRewriteIsMeaningPreserving_RefusesEveryOtherLineChange(t *testing.T) {
+	const stored = "---\ntype: observation\nconfidence: 0.8\nsources: 1\nmotifs: [shape-of-thing]\nrefs: []\n---\n# T\n\nBody.\n"
+
+	for name, rewritten := range map[string]string{
+		"a dropped motif":      "---\ntype: observation\nconfidence: 0.8\nsources: 2\nrefs: []\n---\n# T\n\nBody.\n",
+		"a changed motif":      "---\ntype: observation\nconfidence: 0.8\nsources: 2\nmotifs: [other-shape]\nrefs: []\n---\n# T\n\nBody.\n",
+		"a changed confidence": "---\ntype: observation\nconfidence: 0.9\nsources: 2\nmotifs: [shape-of-thing]\nrefs: []\n---\n# T\n\nBody.\n",
+		"a changed body":       "---\ntype: observation\nconfidence: 0.8\nsources: 2\nmotifs: [shape-of-thing]\nrefs: []\n---\n# T\n\nDifferent body.\n",
+	} {
+		_, ok := rewriteIsMeaningPreserving(stored, rewritten, fact.Authored, fact.Authored)
+		require.Falsef(t, ok, "%s must skip", name)
+	}
+
+	// The permitted lines, and the rendering difference the ruling names
+	// explicitly: quote style on the refs line is not a value change.
+	for name, rewritten := range map[string]string{
+		"only the permitted lines": "---\ntype: observation\nconfidence: 0.8\nsources: 2\nmotifs: [shape-of-thing]\nrefs: [kb/a.md]\nevidence_weight: 0.5\n---\n# T\n\nBody.\n",
+		"refs quote style":         "---\ntype: observation\nconfidence: 0.8\nsources: 1\nmotifs: [shape-of-thing]\nrefs: ['kb/a.md']\n---\n# T\n\nBody.\n",
+	} {
+		why, ok := rewriteIsMeaningPreserving(stored, rewritten, fact.Authored, fact.Authored)
+		require.Truef(t, ok, "%s must be permitted: %s", name, why)
+	}
+}
+
+// H2: refs the model names beyond the bridge's seeds are DISCARDED, and the
+// valid reinforcement still lands. Surplus citation does not kill it.
+func TestApplyReinforcements_DiscardsRefsBeyondTheSeeds(t *testing.T) {
+	env := newReinforceEnv(t)
+
+	// A live fact with no relationship to this bridge — the shape an agent
+	// produces when it lists what it read while deciding.
+	const unrelated = "kb/gotchas/unrelated/somethingelse.md"
+	f := fact.NewFact(unrelated)
+	f.Title = "An unrelated fact"
+	f.Body = "Nothing to do with the bridge."
+	f.Type = fact.Observation
+	f.Confidence = 0.8
+	f.Sources = 1
+	content, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = env.svc.Facts().WriteFact(context.Background(), env.branch, unrelated, content, "write", "test")
+	require.NoError(t, err)
+
+	r := goodReinforcement()
+	r.Refs = flexStrings{seedOnePath, seedTwoPath, unrelated}
+
+	require.Equal(t, []string{reinforcePath}, env.apply(r), "the reinforcement still lands")
+
+	after := env.read(reinforcePath)
+	require.Len(t, after.Refs, 3, "existing + two seeds, and nothing else")
+	for _, ref := range after.Refs {
+		require.NotContains(t, ref, "somethingelse",
+			"a ref the model named beyond the seeds must never become a derivation edge")
+	}
+}
+
+// L8: the strings already on the fact are written back exactly as they were.
+func TestApplyReinforcements_DoesNotRewriteExistingRefs(t *testing.T) {
+	env := newReinforceEnv(t)
+	before := env.read(reinforcePath)
+	require.Equal(t, []string{existingRef}, before.Refs,
+		"precondition: the existing ref is stored in bare-path form")
+
+	require.Equal(t, []string{reinforcePath}, env.apply(goodReinforcement()))
+
+	after := env.read(reinforcePath)
+	require.Contains(t, after.Refs, existingRef,
+		"the existing ref keeps its exact string — canonicalising it would be a "+
+			"mutation of authored data outside 'append the seeds'")
 }

--- a/internal/synthesize/discovery_reinforce_test.go
+++ b/internal/synthesize/discovery_reinforce_test.go
@@ -496,3 +496,69 @@ func TestApplyReinforcements_DoesNotRewriteExistingRefs(t *testing.T) {
 		"the existing ref keeps its exact string — canonicalising it would be a "+
 			"mutation of authored data outside 'append the seeds'")
 }
+
+// warnsOf runs a reinforcement and returns what was written alongside the
+// warnings raised, so a test can assert WHICH gate refused rather than only
+// that something did.
+func warnsOf(env *reinforceEnv, rs ...FactReinforcement) ([]string, []string) {
+	var warns []string
+	written := applyReinforcements(context.Background(), env.svc.Facts(), env.svc.Search(),
+		env.payload, rs, env.branch, env.repoID, func(e ProgressEvent) {
+			if e.Phase == "warn" {
+				warns = append(warns, e.Message)
+			}
+		})
+	return written, warns
+}
+
+// TestApplyReinforcements_SkipsAnIllegalTypeOriginPairing binds the fidelity
+// check to the WRITE PATH (review M5).
+//
+// rewriteIsMeaningPreserving had thorough tests of its own, and none of them
+// reached it through applyReinforcements: deleting the call left the entire
+// repo suite green. The two write-path tests that should have caught it each
+// shadowed the other — the lossy-motif case is refused by the tripwire before
+// the fidelity check runs, and the byte-guard fixture round-trips cleanly, so
+// nothing arrived at the check by the front door. This test is that binding.
+//
+// The population is measured, not hypothetical: 66 live facts on `core` are
+// stored with a type/origin pairing ValidateForType rejects (33 `observation` +
+// `discovered`, 33 `observation` + `distilled`). ParseFact coerces them to
+// `authored` and SerializeFact then ELIDES the now-default line, so a write
+// that does not refuse moves 33 discovery-engine facts to human-authored
+// provenance — the belief-level discipline designer-intent item 3 forbids.
+func TestApplyReinforcements_SkipsAnIllegalTypeOriginPairing(t *testing.T) {
+	env := newReinforceEnv(t)
+
+	// The exact illegal pairing, planted as RAW BYTES: SerializeFact would
+	// refuse to produce it, which is why such facts can only arrive from an
+	// older version or another writer.
+	raw := "---\ntype: observation\ndomain: [evaluation]\nconfidence: 0.75\nsources: 1\n" +
+		"origin: discovered\nentities: [verifier gaming]\nrefs: [" + existingRef + "]\n---\n" +
+		"# The verifier is inside the agent's action space\n\nBody text.\n"
+	_, err := env.svc.Facts().WriteFact(context.Background(), env.branch, reinforcePath, raw, "plant", "test")
+	require.NoError(t, err)
+
+	// PRECONDITIONS, asserted rather than logged. If ParseFact ever stops
+	// coercing this pairing, or SerializeFact stops eliding the default line,
+	// the assertions below would go on passing while testing nothing.
+	parsed := env.read(reinforcePath)
+	require.Equal(t, fact.Authored, parsed.Origin,
+		"precondition: the stored `discovered` is coerced on read — that coercion is the danger")
+	round, err := fact.SerializeFact(parsed)
+	require.NoError(t, err)
+	require.NotContains(t, round, "origin:",
+		"precondition: the round trip DELETES the line, which is what a write would persist")
+
+	written, warns := warnsOf(env, goodReinforcement())
+
+	require.Empty(t, written, "an illegal-pairing target must be SKIPPED, not reattributed")
+	require.Equal(t, raw, env.storedBytes(reinforcePath),
+		"and its bytes untouched, byte for byte — `origin: discovered` survives. "+
+			"Compared against the planted BYTES, not a parsed struct: ParseFact coerces "+
+			"the origin on both sides, so a struct comparison would read authored == "+
+			"authored and pass while the file was rewritten (the H1 mistake)")
+	require.Contains(t, strings.Join(warns, "\n"), "origin",
+		"the refusal must name the origin, or the assertion cannot tell the fidelity "+
+			"check from any other refusal — which is the shadowing that produced M5")
+}

--- a/internal/synthesize/discovery_reinforce_test.go
+++ b/internal/synthesize/discovery_reinforce_test.go
@@ -81,10 +81,8 @@ func newReinforceEnv(t *testing.T) *reinforceEnv {
 
 func (e *reinforceEnv) apply(rs ...FactReinforcement) []string {
 	e.t.Helper()
-	written, err := applyReinforcements(context.Background(), e.svc.Facts(), e.svc.Search(),
+	return applyReinforcements(context.Background(), e.svc.Facts(), e.svc.Search(),
 		e.payload, rs, e.branch, e.repoID, func(ProgressEvent) {})
-	require.NoError(e.t, err)
-	return written
 }
 
 func (e *reinforceEnv) read(path string) fact.Fact {

--- a/internal/synthesize/discovery_reinforce_test.go
+++ b/internal/synthesize/discovery_reinforce_test.go
@@ -1,0 +1,262 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// reinforceEnv is a real store holding two seed facts, one unrelated fact the
+// target already cites, and the target itself.
+type reinforceEnv struct {
+	*restatementEnv
+	payload DiscoverWorkPayload
+	repoID  string
+}
+
+const (
+	seedOnePath   = "kb/gotchas/uitesting/agentclicks.md"
+	seedTwoPath   = "kb/technology/benchmarks/terminalscores.md"
+	existingRef   = "kb/conventions/verifiers/sandboxing.md"
+	reinforcePath = "kb/principles/evaluation/verifierreach.md"
+)
+
+func newReinforceEnv(t *testing.T) *reinforceEnv {
+	t.Helper()
+	env := newRestatementEnv(t, 0)
+	ctx := context.Background()
+
+	write := func(path, title string, refs []string, sources int) {
+		f := fact.NewFact(path)
+		f.Title = title
+		f.Body = "Body of " + title + "."
+		f.Type = fact.Observation
+		f.Confidence = 0.8
+		f.Sources = sources
+		f.Refs = refs
+		content, err := fact.SerializeFact(f)
+		require.NoError(t, err)
+		_, err = env.svc.Facts().WriteFact(ctx, env.branch, path, content, "write "+path, "test")
+		require.NoError(t, err)
+	}
+
+	write(seedOnePath, "An agent testing a UI will execute JavaScript instead of clicking", nil, 1)
+	write(seedTwoPath, "Coding agents cheated a terminal benchmark to 94%", nil, 1)
+	write(existingRef, "Verifiers run in a sandbox the agent cannot write to", nil, 1)
+
+	target := fact.NewFact(reinforcePath)
+	target.Title = "The verifier is inside the agent's action space"
+	target.Body = "Every recorded form of eval gaming is an action taken ON the measurement apparatus."
+	target.Type = fact.Synthesis
+	target.Confidence = 0.75
+	target.Sources = 1
+	target.Domain = []string{"evaluation"}
+	target.Entities = []string{"verifier gaming"}
+	target.Motifs = []string{"measure-becomes-target"}
+	target.Refs = []string{existingRef}
+	content, err := fact.SerializeFact(target)
+	require.NoError(t, err)
+	_, err = env.svc.Facts().WriteFact(ctx, env.branch, reinforcePath, content, "write target", "test")
+	require.NoError(t, err)
+
+	return &reinforceEnv{
+		restatementEnv: env,
+		repoID:         fact.ID12(env.ri.ID()),
+		payload: DiscoverWorkPayload{
+			Direction: DiscoverBackward,
+			Lane:      LaneFar,
+			Bridge: BridgeSeedSet{
+				Token: "measure-becomes-target",
+				Kind:  BridgeMotif,
+				Members: []factForLLM{
+					{File: seedOnePath}, {File: seedTwoPath},
+				},
+			},
+		},
+	}
+}
+
+func (e *reinforceEnv) apply(rs ...FactReinforcement) []string {
+	e.t.Helper()
+	written, err := applyReinforcements(context.Background(), e.svc.Facts(), e.svc.Search(),
+		e.payload, rs, e.branch, e.repoID, func(ProgressEvent) {})
+	require.NoError(e.t, err)
+	return written
+}
+
+func (e *reinforceEnv) read(path string) fact.Fact {
+	e.t.Helper()
+	res, err := e.svc.Facts().ReadFact(context.Background(), e.branch, path, nil)
+	require.NoError(e.t, err)
+	f, err := fact.ParseFact(path, res.Content)
+	require.NoError(e.t, err)
+	return f
+}
+
+func goodReinforcement() FactReinforcement {
+	return FactReinforcement{
+		Path:   reinforcePath,
+		Reason: "Both state that the verifier sits inside the agent's reachable action space.",
+		Refs:   flexStrings{seedOnePath, seedTwoPath},
+	}
+}
+
+// TestApplyReinforcements_ChangesNothingButRefsSourcesAndWeight — lesson 6:
+// treat a write-path mistake AS DATA LOSS until proven otherwise, and guard
+// everything the write must NOT change rather than the fields it does. The
+// damage from the Phase-2 near-miss was invisible from the field being edited.
+func TestApplyReinforcements_ChangesNothingButRefsSourcesAndWeight(t *testing.T) {
+	env := newReinforceEnv(t)
+	before := env.read(reinforcePath)
+
+	written := env.apply(goodReinforcement())
+	require.Equal(t, []string{reinforcePath}, written)
+
+	after := env.read(reinforcePath)
+
+	require.Equal(t, before.Title, after.Title)
+	require.Equal(t, before.Body, after.Body)
+	require.Equal(t, before.Type, after.Type)
+	require.Equal(t, before.Kind, after.Kind)
+	require.Equal(t, before.Domain, after.Domain)
+	require.Equal(t, before.Entities, after.Entities)
+	require.Equal(t, before.Motifs, after.Motifs)
+	require.Equal(t, before.Confidence, after.Confidence)
+	require.Equal(t, before.Origin, after.Origin)
+
+	require.Equal(t, before.Sources+1, after.Sources)
+	require.Greater(t, after.EvidenceWeight, before.EvidenceWeight)
+
+	// APPEND, never replace: the fact's existing derivation path survives.
+	require.Len(t, after.Refs, 3)
+	for _, want := range []string{existingRef, seedOnePath, seedTwoPath} {
+		require.Conditionf(t, func() bool {
+			for _, r := range after.Refs {
+				if r == want || contains(r, want) {
+					return true
+				}
+			}
+			return false
+		}, "refs %v must include %s", after.Refs, want)
+	}
+
+	// Preconditions (lesson 5): the fields compared above must actually carry
+	// values, or "unchanged" is a comparison of two empty strings.
+	require.NotEmpty(t, before.Motifs)
+	require.NotEmpty(t, before.Entities)
+	require.NotEmpty(t, before.Refs)
+}
+
+// 0ee925f4: passing the SAME slice as refs and prior silently disables the
+// gate. Proved by planting a ref that cannot resolve — the gate must refuse the
+// whole write rather than let it through.
+func TestApplyReinforcements_RefsGateIsLiveOnThisPath(t *testing.T) {
+	env := newReinforceEnv(t)
+	before := env.read(reinforcePath)
+
+	r := goodReinforcement()
+	r.Refs = append(r.Refs, "kb/does/not/exist.md")
+	require.Empty(t, env.apply(r))
+
+	after := env.read(reinforcePath)
+	require.Equal(t, before.Refs, after.Refs, "a refused write changes nothing")
+	require.Equal(t, before.Sources, after.Sources)
+}
+
+// Default-NO on equivalence: an unreasoned claim is exactly the hallucinated
+// one, so it is rejected rather than recorded with a blank justification.
+func TestApplyReinforcements_RejectsAnUnreasonedEquivalence(t *testing.T) {
+	env := newReinforceEnv(t)
+	before := env.read(reinforcePath)
+
+	r := goodReinforcement()
+	r.Reason = "   "
+	require.Empty(t, env.apply(r))
+	require.Equal(t, before.Sources, env.read(reinforcePath).Sources)
+}
+
+// The same engagement proof the proposal path demands: cite every seed.
+func TestApplyReinforcements_RejectsWhenRefsDoNotCoverEverySeed(t *testing.T) {
+	env := newReinforceEnv(t)
+	before := env.read(reinforcePath)
+
+	r := goodReinforcement()
+	r.Refs = flexStrings{seedOnePath}
+	require.Empty(t, env.apply(r))
+	require.Equal(t, before.Sources, env.read(reinforcePath).Sources)
+}
+
+// A fact cannot be an independent derivation of itself.
+func TestApplyReinforcements_RejectsReinforcingASeed(t *testing.T) {
+	env := newReinforceEnv(t)
+	before := env.read(seedOnePath)
+
+	r := goodReinforcement()
+	r.Path = seedOnePath
+	require.Empty(t, env.apply(r))
+	require.Equal(t, before.Sources, env.read(seedOnePath).Sources)
+}
+
+func TestApplyReinforcements_RejectsAnAbsentTarget(t *testing.T) {
+	env := newReinforceEnv(t)
+	r := goodReinforcement()
+	r.Path = "kb/principles/evaluation/nothinghere.md"
+	require.Empty(t, env.apply(r))
+}
+
+// Idempotency is the difference between "corroborated by two independent
+// derivations" and "reviewed twice". A repeat must not inflate sources.
+func TestApplyReinforcements_IsIdempotent(t *testing.T) {
+	env := newReinforceEnv(t)
+
+	require.Equal(t, []string{reinforcePath}, env.apply(goodReinforcement()))
+	once := env.read(reinforcePath)
+	require.Equal(t, 2, once.Sources)
+
+	require.Empty(t, env.apply(goodReinforcement()),
+		"every seed is already a derivation path — there is nothing new to record")
+	twice := env.read(reinforcePath)
+	require.Equal(t, once.Sources, twice.Sources)
+	require.Equal(t, once.Refs, twice.Refs)
+	require.Equal(t, once.EvidenceWeight, twice.EvidenceWeight)
+}
+
+// A second, DIFFERENT bridge reinforcing the same fact is not a repeat: it is a
+// third derivation path, and it must count.
+func TestApplyReinforcements_ADifferentDerivationStillCounts(t *testing.T) {
+	env := newReinforceEnv(t)
+	require.Equal(t, []string{reinforcePath}, env.apply(goodReinforcement()))
+	first := env.read(reinforcePath)
+
+	// A new seed, and a bridge that cites it.
+	const seedThree = "kb/incidents/graders/scriptedit.md"
+	f := fact.NewFact(seedThree)
+	f.Title = "An agent edited the grading script instead of passing the test"
+	f.Body = "The run was scored by a script the agent could write to."
+	f.Type = fact.Observation
+	f.Confidence = 0.8
+	f.Sources = 1
+	content, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = env.svc.Facts().WriteFact(context.Background(), env.branch, seedThree, content, "write", "test")
+	require.NoError(t, err)
+
+	env.payload.Bridge.Members = append(env.payload.Bridge.Members, factForLLM{File: seedThree})
+	r := goodReinforcement()
+	r.Refs = flexStrings{seedOnePath, seedTwoPath, seedThree}
+
+	require.Equal(t, []string{reinforcePath}, env.apply(r))
+	after := env.read(reinforcePath)
+	require.Equal(t, first.Sources+1, after.Sources)
+	require.Len(t, after.Refs, 4)
+}
+
+// contains reports whether a canonicalised ref names the given local path.
+// Refs are stored as kb://<repo-id>/<path>, so a bare-path comparison alone
+// would miss them.
+func contains(ref, path string) bool {
+	return len(ref) >= len(path) && ref[len(ref)-len(path):] == path
+}

--- a/internal/synthesize/mock_search_index_test.go
+++ b/internal/synthesize/mock_search_index_test.go
@@ -374,6 +374,21 @@ func (mr *MockSearchIndexMockRecorder) SubgraphEdges(ctx, paths any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubgraphEdges", reflect.TypeOf((*MockSearchIndex)(nil).SubgraphEdges), ctx, paths)
 }
 
+// SubjectLabelDF mocks base method.
+func (m *MockSearchIndex) SubjectLabelDF(ctx context.Context, branch string) (store.SubjectLabelDF, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubjectLabelDF", ctx, branch)
+	ret0, _ := ret[0].(store.SubjectLabelDF)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SubjectLabelDF indicates an expected call of SubjectLabelDF.
+func (mr *MockSearchIndexMockRecorder) SubjectLabelDF(ctx, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubjectLabelDF", reflect.TypeOf((*MockSearchIndex)(nil).SubjectLabelDF), ctx, branch)
+}
+
 // TokenDF mocks base method.
 func (m *MockSearchIndex) TokenDF(ctx context.Context, branch, token, kind string) (int, error) {
 	m.ctrl.T.Helper()

--- a/internal/synthesize/motif_disjoint.go
+++ b/internal/synthesize/motif_disjoint.go
@@ -110,11 +110,37 @@ func subjectDisjoint(a, b factForLLM, d store.SubjectLabelDF, p disjointnessPoin
 		if _, shared := bt[tok]; !shared {
 			continue
 		}
+		if d.DF[tok] >= d.LiveFacts && d.LiveFacts > 0 {
+			// UNIVERSAL LABELS are excluded in EVERY mode, strict included
+			// (designer ruling 2026-08-23, phase3-rulings-5, review L4).
+			//
+			// A label carried by every live fact distinguishes nothing — the
+			// ontology root is one by construction, since every path starts
+			// with it. This is a tautology rather than the ratio judgement the
+			// strict fallback exists to suspend, which is why it survives below
+			// the label floor: without it, "strict" made every pair in the
+			// corpus share `kb` and turned the axis OFF rather than
+			// conservative (measured: four tests red, FromNothing among them).
+			continue
+		}
+		if p.Strict {
+			// STRICT: any shared label blocks, umbrella included.
+			//
+			// The umbrella exclusion is IGNORED here, and that is the whole
+			// point of the fallback. Umbrella is `df > 20% of N`, so on a
+			// corpus of nine facts or fewer the cut is 1 — and a SHARED label
+			// has df >= 2 by definition, which made every shared label an
+			// umbrella and turned the conservative fallback into a no-op in
+			// exactly the regime it exists for (Phase-3 review, L4). A ratio is
+			// no more valid below the population floor than the percentile it
+			// stands beside; MN13's third class applies to both.
+			return false
+		}
 		df := d.DF[tok]
 		if df > p.Umbrella {
 			continue // umbrella: carried by too much of the corpus to mean anything
 		}
-		if p.Strict || df <= p.Cut {
+		if df <= p.Cut {
 			return false // specific enough to be the same subject
 		}
 	}

--- a/internal/synthesize/motif_disjoint.go
+++ b/internal/synthesize/motif_disjoint.go
@@ -1,0 +1,122 @@
+package synthesize
+
+// Subject-disjointness — blueprint §4 gate 3, as amended by GATE RIDER 1
+// (designer ruling 2026-08-23,
+// .claude/plans/motif/2026-08-23-phase3-rulings-1.md Q3).
+//
+// Two facts bridge on a shared mechanism only if they are about DIFFERENT
+// subjects; a "bridge" between two facts about the same thing is a duplicate,
+// not a discovery (8ebd5d90).
+//
+// The blueprint's original test — share no non-umbrella entity, domain tag or
+// path token — was measured TOO STRICT on the merged corpus: it rejected four
+// of the five genuine cross-domain windows on ONE shared coarse tag,
+// `evaluation` (gate annex §7.4). Those four share no entities at all and are
+// plainly different situations: a UI agent faking clicks, a coding agent gaming
+// a terminal benchmark, an RL-tuned agent exploiting a reward.
+//
+// The finer criterion: a shared label blocks only when it is SPECIFIC enough
+// that carrying it is evidence of a shared SUBJECT rather than of a shared
+// AREA. Specificity is read off this corpus's own label-df distribution, never
+// off a fixed number.
+
+import (
+	"sort"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// disjointnessPercentile names WHERE in the corpus's own label-df distribution
+// the specificity line falls.
+//
+// CONSTANT CLASSIFICATION (MN13): a SELECTION POINT, not a df value and not a
+// claim about any corpus. The same code on two corpora derives two different
+// df cuts from it, which is precisely what MN13 requires of anything that
+// would otherwise be a corpus-property constant; the derived cut is printed in
+// the session's health lines as a fingerprint. At p90 only the commonest tenth
+// of a corpus's labels stop blocking — the `evaluation`-class tags the annex
+// indicted, and no more.
+const disjointnessPercentile = 90
+
+// minLabelsForPercentile is the population below which the percentile above is
+// not an estimate of anything.
+//
+// CONSTANT CLASSIFICATION (MN13, third class): a STATISTICAL-VALIDITY FLOOR.
+// It encodes estimator validity, not a property of any corpus. Below it the
+// gate does not invent a cut — it falls back to STRICT (any shared non-umbrella
+// label blocks), which is the conservative direction under default-NO, and the
+// fallback is reported in health rather than being silent.
+const minLabelsForPercentile = 50
+
+// umbrellaPerCent is the umbrella rule (43ae4cac): a label carried by more than
+// this share of the corpus proves nothing about a shared subject, and without
+// excluding it the gate silently rejects entire corpora.
+//
+// CONSTANT CLASSIFICATION (MN13): a RATIO of the corpus's own size, never an
+// absolute count — the df it resolves to is a different number on every corpus.
+const umbrellaPerCent = 20
+
+// disjointnessPoint is the gate's operating point on one corpus, at one moment.
+// It is recomputed per session from live frontmatter: nothing about it is
+// stored, so a corpus whose character drifts changes its own gate.
+type disjointnessPoint struct {
+	// Cut is the df at or below which a shared label is specific enough to
+	// prove a shared subject.
+	Cut int
+	// Umbrella is the df above which a label is excluded from the gate.
+	Umbrella int
+	// Labels is how many distinct labels the point was derived from.
+	Labels int
+	// Strict reports the validity-floor fallback.
+	Strict bool
+}
+
+// resolveDisjointnessPoint derives the operating point from a corpus's own
+// label distribution.
+func resolveDisjointnessPoint(d store.SubjectLabelDF) disjointnessPoint {
+	p := disjointnessPoint{
+		Labels:   len(d.DF),
+		Umbrella: d.LiveFacts * umbrellaPerCent / 100,
+	}
+	if len(d.DF) < minLabelsForPercentile {
+		p.Strict = true
+		return p
+	}
+	vals := make([]int, 0, len(d.DF))
+	for _, v := range d.DF {
+		vals = append(vals, v)
+	}
+	sort.Ints(vals)
+	// Nearest-rank: the smallest value at or above the requested percentile.
+	idx := (disjointnessPercentile*len(vals) + 99) / 100
+	if idx > 0 {
+		idx--
+	}
+	p.Cut = vals[idx]
+	return p
+}
+
+// subjectDisjoint reports whether a and b are about different subjects.
+//
+// It reads fact.SubjectTokens — the same token set the write-time subject strip
+// uses — so the question "does this pair share a subject?" and the question
+// "does this motif restate its own fact's subject?" cannot be answered from two
+// different vocabularies.
+func subjectDisjoint(a, b factForLLM, d store.SubjectLabelDF, p disjointnessPoint) bool {
+	at := fact.SubjectTokens(a.Entities, a.Domain, a.File)
+	bt := fact.SubjectTokens(b.Entities, b.Domain, b.File)
+	for tok := range at {
+		if _, shared := bt[tok]; !shared {
+			continue
+		}
+		df := d.DF[tok]
+		if df > p.Umbrella {
+			continue // umbrella: carried by too much of the corpus to mean anything
+		}
+		if p.Strict || df <= p.Cut {
+			return false // specific enough to be the same subject
+		}
+	}
+	return true
+}

--- a/internal/synthesize/motif_disjoint_test.go
+++ b/internal/synthesize/motif_disjoint_test.go
@@ -1,0 +1,182 @@
+package synthesize
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// labelsWith builds a label distribution SHAPED LIKE A REAL ONE, then overlays
+// the caller's own counts.
+//
+// The shape matters, and the first version of this helper got it wrong in a way
+// the preconditions below caught: it made every filler label df=1, which is a
+// corpus where 95% of labels are hapax, and a p90 over that is 1 — a cut no
+// shared label can ever fall under, since a shared label has df >= 2 by
+// definition. Measured on knomit-kb at 406 live facts (live index, raw
+// domain+entity labels): 2010 distinct labels, 69% hapax, p90 = df 3, umbrella
+// = df 81. The tail below reproduces that shape — roughly seven in ten hapax, a
+// middle band, and a thin common head — so a fixture built on it exercises the
+// same arithmetic production will.
+//
+// Keys are STEMMED tokens, because that is what SubjectLabelDF stores and what
+// fact.SubjectTokens looks up: "agents" is keyed "agent", "gotchas" is keyed
+// "gotcha". A fixture keyed on the unstemmed spelling silently reads df 0 for
+// the token it meant to describe.
+//
+// Every fact's path begins with the ontology root, so "kb" is carried by the
+// whole corpus and is an umbrella by construction. Fixtures must say so: a
+// token ABSENT from this map reads as df 0, which is maximally specific, and a
+// fixture that forgot the root would have every pair blocked by it.
+func labelsWith(liveFacts int, counts map[string]int) store.SubjectLabelDF {
+	d := store.SubjectLabelDF{LiveFacts: liveFacts, DF: map[string]int{"kb": liveFacts}}
+	for i := 0; i < 70; i++ {
+		d.DF[fmt.Sprintf("hapax%d", i)] = 1
+	}
+	for i := 0; i < 20; i++ {
+		d.DF[fmt.Sprintf("middle%d", i)] = 2 + i%3
+	}
+	for i := 0; i < 10; i++ {
+		d.DF[fmt.Sprintf("common%d", i)] = 5 + i
+	}
+	for k, v := range counts {
+		d.DF[k] = v
+	}
+	return d
+}
+
+// TestSubjectDisjoint_RejectsTheNearDuplicatePair — MN7's own fixture. The
+// near-duplicate population (8ebd5d90) is what the axis must never re-find:
+// two facts about the same event, sharing a motif, sharing a RARE entity.
+func TestSubjectDisjoint_RejectsTheNearDuplicatePair(t *testing.T) {
+	labels := labelsWith(200, map[string]int{
+		"cognition": 2, "devin": 2, "agent": 30, "technology": 40, "ai": 35})
+	p := resolveDisjointnessPoint(labels)
+
+	// Preconditions (lesson 5): this fixture only tests the DISTINCTION if it
+	// runs the graded path and its two dfs straddle the operating point.
+	require.False(t, p.Strict, "fixture must exercise the graded path, not the fallback")
+	require.LessOrEqual(t, labels.DF["cognition"], p.Cut, "the rare entity must sit below the cut")
+	require.Greater(t, labels.DF["agent"], p.Cut, "the common tag must sit above it")
+
+	a := factForLLM{File: "kb/technology/ai/agents/1.md",
+		Entities: []string{"Cognition", "Devin"}, Domain: []string{"agents"}}
+	b := factForLLM{File: "kb/technology/ai/agents/2.md",
+		Entities: []string{"Cognition", "Devin"}, Domain: []string{"agents"}}
+
+	require.False(t, subjectDisjoint(a, b, labels, p),
+		"two facts about the same rare entity are one subject, not a bridge")
+}
+
+// TestSubjectDisjoint_AdmitsAPairSharingOnlyACommonTag — the other direction of
+// the MN7 fixture, and the reason the criterion was made finer at all: the gate
+// annex's four near-misses (§7.4) are genuinely different situations, sharing
+// no entities, rejected by the strict test on ONE coarse domain tag.
+func TestSubjectDisjoint_AdmitsAPairSharingOnlyACommonTag(t *testing.T) {
+	labels := labelsWith(200, map[string]int{
+		"evaluation": 30, "cognition": 2, "rlhf": 3, "ai": 35})
+	p := resolveDisjointnessPoint(labels)
+
+	require.False(t, p.Strict)
+	require.Greater(t, labels.DF["evaluation"], p.Cut, "precondition: the shared tag is common")
+	require.LessOrEqual(t, labels.DF["evaluation"], p.Umbrella,
+		"precondition: it is admitted by the GRADED path, not by the umbrella exclusion")
+	require.LessOrEqual(t, labels.DF["cognition"], p.Cut, "precondition: the unshared entities are rare")
+
+	a := factForLLM{File: "kb/gotchas/ai/uitesting/1.md",
+		Entities: []string{"Cognition"}, Domain: []string{"evaluation"}}
+	b := factForLLM{File: "kb/technology/ai/rewardhacking/2.md",
+		Entities: []string{"RLHF"}, Domain: []string{"evaluation"}}
+
+	require.True(t, subjectDisjoint(a, b, labels, p),
+		"one coarse shared tag is not a shared subject (gate annex §7.4)")
+}
+
+// TestSubjectDisjoint_UmbrellaLabelNeverBlocks — 43ae4cac: a label carried by
+// more than a fifth of the corpus proves nothing, and without excluding it the
+// gate silently rejects entire corpora.
+func TestSubjectDisjoint_UmbrellaLabelNeverBlocks(t *testing.T) {
+	labels := labelsWith(100, map[string]int{"agent": 60, "alpha": 1, "beta": 1})
+	p := resolveDisjointnessPoint(labels)
+	require.Greater(t, labels.DF["agent"], p.Umbrella, "precondition: the shared tag is an umbrella")
+
+	a := factForLLM{File: "kb/alpha/1.md", Domain: []string{"agents"}, Entities: []string{"Alpha"}}
+	b := factForLLM{File: "kb/beta/2.md", Domain: []string{"agents"}, Entities: []string{"Beta"}}
+	require.True(t, subjectDisjoint(a, b, labels, p))
+}
+
+// TestSubjectDisjoint_FallsBackToStrictBelowTheFloor — below the validity floor
+// the gate does not guess a cut, it blocks on ANY shared non-umbrella label.
+// Conservative is the ruled direction under default-NO.
+func TestSubjectDisjoint_FallsBackToStrictBelowTheFloor(t *testing.T) {
+	// 40 facts, four distinct labels: enough corpus that a shared label can be
+	// below the umbrella (8), too few LABELS for a percentile to mean anything.
+	// On a corpus small enough that every shared label is also an umbrella,
+	// the gate correctly admits everything and the question is moot — such a
+	// corpus produces no bridge candidates anyway.
+	labels := store.SubjectLabelDF{LiveFacts: 40,
+		DF: map[string]int{"kb": 40, "evaluation": 4, "alpha": 1, "beta": 1}}
+	p := resolveDisjointnessPoint(labels)
+	require.True(t, p.Strict, "a p90 over four labels is not an estimate of anything")
+	require.LessOrEqual(t, labels.DF["evaluation"], p.Umbrella,
+		"precondition: the shared label is NOT an umbrella, so strict is what blocks it")
+
+	a := factForLLM{File: "kb/alpha/1.md", Domain: []string{"evaluation"}, Entities: []string{"Alpha"}}
+	b := factForLLM{File: "kb/beta/2.md", Domain: []string{"evaluation"}}
+	require.False(t, subjectDisjoint(a, b, labels, p),
+		"strict blocks on a shared label the graded path would have admitted")
+
+	// The SAME pair on a corpus with enough labels to estimate with IS
+	// admitted, so the fallback is the floor doing its job rather than the gate
+	// being broken.
+	graded := labelsWith(200, map[string]int{"evaluation": 30})
+	gp := resolveDisjointnessPoint(graded)
+	require.False(t, gp.Strict)
+	require.True(t, subjectDisjoint(a, b, graded, gp))
+}
+
+// TestSubjectDisjoint_StrictStillExcludesUmbrellas — the umbrella rule sits
+// ABOVE the operating point, so it holds in the fallback too. Without this,
+// strict mode would block every pair in the corpus on the ontology root that
+// every path carries, and "conservative" would mean "off".
+func TestSubjectDisjoint_StrictStillExcludesUmbrellas(t *testing.T) {
+	labels := store.SubjectLabelDF{LiveFacts: 6, DF: map[string]int{"kb": 6, "alpha": 1, "beta": 1}}
+	p := resolveDisjointnessPoint(labels)
+	require.True(t, p.Strict)
+
+	a := factForLLM{File: "kb/alpha/1.md", Entities: []string{"Alpha"}}
+	b := factForLLM{File: "kb/beta/2.md", Entities: []string{"Beta"}}
+	require.True(t, subjectDisjoint(a, b, labels, p),
+		"the shared ontology root is an umbrella even when the gate is strict")
+}
+
+// TestSubjectDisjoint_PathTokensAreSubjectClaims — a fact's location is a
+// subject claim, and the gate reads the same token set the write-time strip
+// does. Two facts filed under the same rare category are one subject even when
+// their tags say nothing.
+func TestSubjectDisjoint_PathTokensAreSubjectClaims(t *testing.T) {
+	labels := labelsWith(200, map[string]int{"resolver": 2, "store": 30})
+	p := resolveDisjointnessPoint(labels)
+	require.LessOrEqual(t, labels.DF["resolver"], p.Cut)
+
+	a := factForLLM{File: "kb/gotchas/store/resolver/1.md"}
+	b := factForLLM{File: "kb/incidents/store/resolver/2.md"}
+	require.False(t, subjectDisjoint(a, b, labels, p))
+}
+
+// TestSubjectDisjoint_UnknownLabelIsTreatedAsSpecific — a token the
+// distribution does not know reads as df 0 and BLOCKS. It is the conservative
+// reading, and it is the one the caller gets when a label distribution is
+// stale, partial, or unavailable.
+func TestSubjectDisjoint_UnknownLabelIsTreatedAsSpecific(t *testing.T) {
+	labels := labelsWith(200, nil)
+	p := resolveDisjointnessPoint(labels)
+
+	a := factForLLM{File: "kb/alpha/1.md", Entities: []string{"Unmapped Thing"}}
+	b := factForLLM{File: "kb/beta/2.md", Entities: []string{"Unmapped Thing"}}
+	require.Zero(t, labels.DF["unmapped"], "precondition: the shared token is unknown here")
+	require.False(t, subjectDisjoint(a, b, labels, p))
+}

--- a/internal/synthesize/motif_disjoint_test.go
+++ b/internal/synthesize/motif_disjoint_test.go
@@ -16,11 +16,18 @@ import (
 // the preconditions below caught: it made every filler label df=1, which is a
 // corpus where 95% of labels are hapax, and a p90 over that is 1 — a cut no
 // shared label can ever fall under, since a shared label has df >= 2 by
-// definition. Measured on knomit-kb at 406 live facts (live index, raw
-// domain+entity labels): 2010 distinct labels, 69% hapax, p90 = df 3, umbrella
-// = df 81. The tail below reproduces that shape — roughly seven in ten hapax, a
-// middle band, and a thin common head — so a fixture built on it exercises the
-// same arithmetic production will.
+// definition.
+//
+// Calibrated on knomit-kb at 406 live facts. The first measurement counted RAW
+// DOMAIN+ENTITY labels (2010 distinct, 69% hapax, p90 = df 3, umbrella = df
+// 81), which is NOT the population the shipped SubjectLabelDF counts — it also
+// tokenises paths, uuid segments included. The review re-measured both, across
+// three real corpora: with paths, knomit-kb has 2936 labels / 69.9% hapax /
+// p90 = 3; agentic-engineering 1370 / 61.2% / p90 = 5; core 4806 / 68.6% /
+// p90 = 5. The uuid inflation moves the cut by at most 1 df, always toward the
+// weaker gate, and the ~69% hapax shape this tail reproduces does match
+// production — so the fixture stands, and the population it was calibrated on
+// is now named correctly.
 //
 // Keys are STEMMED tokens, because that is what SubjectLabelDF stores and what
 // fact.SubjectTokens looks up: "agents" is keyed "agent", "gotchas" is keyed
@@ -138,19 +145,50 @@ func TestSubjectDisjoint_FallsBackToStrictBelowTheFloor(t *testing.T) {
 	require.True(t, subjectDisjoint(a, b, graded, gp))
 }
 
-// TestSubjectDisjoint_StrictStillExcludesUmbrellas — the umbrella rule sits
-// ABOVE the operating point, so it holds in the fallback too. Without this,
-// strict mode would block every pair in the corpus on the ontology root that
-// every path carries, and "conservative" would mean "off".
-func TestSubjectDisjoint_StrictStillExcludesUmbrellas(t *testing.T) {
-	labels := store.SubjectLabelDF{LiveFacts: 6, DF: map[string]int{"kb": 6, "alpha": 1, "beta": 1}}
+// TestSubjectDisjoint_StrictExcludesOnlyUniversalLabels — below the label floor
+// strict blocks on any shared label EXCEPT one carried by every live fact.
+//
+// This test previously asserted that strict still honoured the umbrella RATIO,
+// on a six-fact fixture where every shared label is an umbrella by arithmetic —
+// so it could not tell "the ontology root is correctly excluded" from "the gate
+// is entirely off", and it passed while the fallback was a no-op (review L4:
+// lesson 5's coinciding values). The ruling that followed replaced both: the
+// ratio is suspended below the floor, the universal-label tautology is not.
+func TestSubjectDisjoint_StrictExcludesOnlyUniversalLabels(t *testing.T) {
+	labels := store.SubjectLabelDF{LiveFacts: 40,
+		DF: map[string]int{"kb": 40, "evaluation": 4, "alpha": 1, "beta": 1}}
+	p := resolveDisjointnessPoint(labels)
+	require.True(t, p.Strict, "precondition: too few labels for a percentile")
+	require.Equal(t, labels.LiveFacts, labels.DF["kb"],
+		"precondition: the root is carried by every fact — the universal case")
+	require.Less(t, labels.DF["evaluation"], labels.LiveFacts,
+		"precondition: the other shared label is NOT universal")
+
+	// Sharing only the root: admitted, because the root says nothing.
+	rootOnly := factForLLM{File: "kb/alpha/1.md", Entities: []string{"Alpha"}}
+	rootOnly2 := factForLLM{File: "kb/beta/2.md", Entities: []string{"Beta"}}
+	require.True(t, subjectDisjoint(rootOnly, rootOnly2, labels, p))
+
+	// Sharing a non-universal label: blocked, because strict blocks on
+	// everything else — including labels the 20% ratio would have excused.
+	a := factForLLM{File: "kb/alpha/1.md", Domain: []string{"evaluation"}, Entities: []string{"Alpha"}}
+	b := factForLLM{File: "kb/beta/2.md", Domain: []string{"evaluation"}}
+	require.False(t, subjectDisjoint(a, b, labels, p))
+}
+
+// The reviewer's original leak case, pinned: a rare shared entity blocks even at
+// six facts, where the umbrella ratio alone excused everything.
+func TestSubjectDisjoint_StrictIsNotANoOpOnTinyCorpora(t *testing.T) {
+	labels := store.SubjectLabelDF{LiveFacts: 6, DF: map[string]int{"kb": 6, "cognition": 2}}
 	p := resolveDisjointnessPoint(labels)
 	require.True(t, p.Strict)
+	require.Greater(t, labels.DF["cognition"], p.Umbrella,
+		"precondition: at six facts even a two-carrier entity clears the 20%% cut")
 
-	a := factForLLM{File: "kb/alpha/1.md", Entities: []string{"Alpha"}}
-	b := factForLLM{File: "kb/beta/2.md", Entities: []string{"Beta"}}
-	require.True(t, subjectDisjoint(a, b, labels, p),
-		"the shared ontology root is an umbrella even when the gate is strict")
+	a := factForLLM{File: "kb/alpha/1.md", Entities: []string{"Cognition"}}
+	b := factForLLM{File: "kb/beta/2.md", Entities: []string{"Cognition"}}
+	require.False(t, subjectDisjoint(a, b, labels, p),
+		"two facts about the same rare entity must not bridge, however small the corpus")
 }
 
 // TestSubjectDisjoint_PathTokensAreSubjectClaims — a fact's location is a

--- a/internal/synthesize/motif_farlane_demo_test.go
+++ b/internal/synthesize/motif_farlane_demo_test.go
@@ -15,17 +15,18 @@ import (
 // rather than hand-copied into a document, because a hand-copied prompt is a
 // claim about the code rather than an output of it.
 //
-// The far lane is not built yet (Phase 3). Two things are therefore stated
-// rather than implemented:
+// When this demo first ran, the far lane did not exist: BridgeKind had no
+// `motif` member and the SHIP line was SPLICED into the rendered prompt by the
+// test itself, at a named position — immediately after the "Bridge token:"
+// line, before the member list.
 //
-//   - BridgeKind has no `motif` member yet, so the kind is a string literal.
-//   - The SHIP line is SPLICED in at a named position — immediately after the
-//     "Bridge token:" line, which is where the preamble establishes what kind
-//     of group this is, and before the member list. The far lane needs it
-//     there because its members have cohesion 0 BY CONSTRUCTION: the standard
-//     backward preamble says they "share the structural token", and without
-//     the SHIP line a model would reasonably infer they are also similar,
-//     which is the exact inference the far lane must prevent.
+// Phase 3 built both, at exactly that position and for exactly the stated
+// reason: the far lane's members have cohesion 0 BY CONSTRUCTION, the standard
+// backward preamble says they "share the structural token", and without the
+// SHIP line a model would reasonably infer they are also similar — the exact
+// inference the far lane must prevent. The splice is gone; what prints below
+// now comes from renderDiscoverPrompt itself, which is what the demo claimed to
+// be showing all along.
 //
 // Member data was read from the merged scratch corpus through knomit's fact
 // API (Facts().ReadFact + fact.ParseFact), not from the index.
@@ -39,9 +40,10 @@ func TestFarLaneDemo_RenderTheShipPrompt(t *testing.T) {
 
 	payload := DiscoverWorkPayload{
 		Direction: DiscoverBackward, // far lane routes backward → hypothesize
+		Lane:      LaneFar,
 		Bridge: BridgeSeedSet{
 			Token: motif,
-			Kind:  BridgeKind("motif"), // Phase-3 constant does not exist yet
+			Kind:  BridgeMotif,
 			Members: []factForLLM{
 				{
 					File:  "kb/gotchas/ai/agents/coding-agents/ui-testing/77b3e628.md",
@@ -85,15 +87,14 @@ func TestFarLaneDemo_RenderTheShipPrompt(t *testing.T) {
 
 	prompt := renderDiscoverPrompt(payload, "kb")
 
-	// The SHIP line, verbatim from blueprint §4, %q = the motif.
+	// The SHIP line now comes from the renderer. Asserted rather than spliced:
+	// a demo that printed a line the code does not produce would be a claim
+	// about the code instead of an output of it.
 	ship := fmt.Sprintf("These facts are NOT semantically similar. Each claims motif %q. "+
 		"Propose a keystone only if one mechanism genuinely underlies all members — default to NO.", motif)
-
-	anchor := fmt.Sprintf("Bridge token: %q (kind=%s)\n", payload.Bridge.Token, payload.Bridge.Kind)
-	if !strings.Contains(prompt, anchor) {
-		t.Fatalf("splice anchor not found — renderDiscoverPrompt changed shape")
+	if !strings.Contains(prompt, ship) {
+		t.Fatalf("renderDiscoverPrompt no longer emits the §4 far-lane SHIP line")
 	}
-	prompt = strings.Replace(prompt, anchor, anchor+"\n"+ship+"\n", 1)
 
 	facts, err := json.MarshalIndent(payload.Bridge.Members, "", "  ")
 	if err != nil {

--- a/internal/synthesize/motif_mn1_test.go
+++ b/internal/synthesize/motif_mn1_test.go
@@ -51,6 +51,16 @@ var vocabularyBearingItems = map[string]string{
 		"names the model would not otherwise have seen, because those motifs are " +
 		"already in front of it on the facts themselves.",
 
+	"discover": "§4/§5 bridging, and the exposure is DISTILL's class rather than " +
+		"backfill's (Phase-3 review, M2). The prompt names the group's OWN shared " +
+		"motif — the token the members are grouped BY, already on every member fact " +
+		"in the payload beside it — never candidates drawn from the wider corpus. It " +
+		"cannot bias minting toward a name the model would not otherwise have seen. " +
+		"Q8's concern is vocabulary shown at AUTHORING time distorting what gets " +
+		"written; here the vocabulary shown IS the input. Covered deterministically " +
+		"by TestMN1_DiscoverRendererCarriesOnlyTheGroupsOwnMotif, because a session " +
+		"produces a discover item only when a bridge happens to form.",
+
 	"reflect": "§3.3 health metrics. Reflect writes methodology, not facts about the " +
 		"corpus's subjects, and it receives aggregate COUNTS plus the vocabulary as " +
 		"context for reasoning about the corpus's own habits.",
@@ -124,14 +134,15 @@ func TestMN1_RenderedWorkItemsCarryNoUnauthorizedVocabulary(t *testing.T) {
 	// prune's response schema once passed here for want of the opportunity to
 	// fail.
 	//
-	// NOT COVERED: the DISCOVER renderer. Discovery does not run at
-	// EffortMedium, so no discover item exists to inspect here, and no
-	// deterministic render test covers it either. A vocabulary leak in
-	// discover's prompt or response schema would be invisible to this suite.
-	// Phase 2 adds `motifs` to discover's OUTPUT schema (MN11) but no
-	// vocabulary to its input, so there is nothing to leak today — this is a
-	// gap in the guard, not a known defect, and it is named so that whoever
-	// gives discover a vocabulary-bearing payload finds it named.
+	// STILL NOT COVERED HERE: the DISCOVER renderer. Discovery does not run at
+	// EffortMedium, so no discover item exists in THIS session to inspect.
+	//
+	// Phase 2 named this gap in advance — "whoever gives discover a
+	// vocabulary-bearing payload finds it named" — and Phase 3 is whoever: the
+	// far-lane prompt now prints the group's shared motif. The gap is closed by
+	// TestMN1_DiscoverRendererCarriesOnlyTheGroupsOwnMotif below, which renders
+	// the item directly rather than waiting for a bridge to form, and by the
+	// declared register entry above. Naming it worked; it is left named.
 	//
 	// markedReached is recorded rather than asserted for the reason above: it
 	// is a property of what this corpus clustered into, not of the rule.
@@ -141,9 +152,9 @@ func TestMN1_RenderedWorkItemsCarryNoUnauthorizedVocabulary(t *testing.T) {
 	// permission nobody needs, and one nobody notices going stale — the
 	// os.Stat-and-continue shape counts as no test.
 	for step := range vocabularyBearingItems {
-		if step == "distill" || step == "reflect" {
-			continue // covered by the template assertions below; not every
-			// session produces one
+		if step == "distill" || step == "reflect" || step == "discover" {
+			continue // covered by the deterministic renderer tests below; not
+			// every session produces one
 		}
 		require.Containsf(t, seen, step,
 			"%s is a declared vocabulary-bearing item but this session produced none — "+
@@ -259,4 +270,49 @@ func TestMN1_OrdinaryItemsNeverCarryVocabulary(t *testing.T) {
 	require.NotContains(t, clean.Prompt, marker,
 		"distill must never see a motif none of its input facts carries — that would "+
 			"be the corpus vocabulary, which is backfill's exception and not distill's")
+}
+
+// TestMN1_DiscoverRendererCarriesOnlyTheGroupsOwnMotif closes the gap Phase 2
+// named and Phase 3 walked into (review M2).
+//
+// Rendered directly rather than through a session: a session produces a discover
+// item only when a bridge happens to form, and a guard that depends on a gate
+// upstream of it can pass for want of the opportunity to fail — which is
+// exactly how a planted leak once survived the scan above.
+func TestMN1_DiscoverRendererCarriesOnlyTheGroupsOwnMotif(t *testing.T) {
+	const marker = "zzzmarker-unique-shape"
+	const foreign = "zzzforeign-other-shape"
+
+	members := []factForLLM{
+		{File: "kb/a.md", Title: "Alpha", Body: "a body", Motifs: []string{marker}},
+		{File: "kb/b.md", Title: "Bravo", Body: "another body", Motifs: []string{marker}},
+	}
+	payload := DiscoverWorkPayload{
+		Direction: DiscoverBackward, Lane: LaneFar,
+		Bridge: BridgeSeedSet{Token: marker, Kind: BridgeMotif, Members: members},
+	}
+	view := RenderDiscoverWorkItem(payload, "kb")
+
+	// The group's own token appears — that is the authorized exposure, and the
+	// far-lane SHIP line cannot say what the members claim without naming it.
+	require.Contains(t, view.Prompt, marker)
+
+	// The distinction that makes it distill's class rather than backfill's: a
+	// motif no member carries must never appear. If the corpus's vocabulary
+	// ever reaches this renderer, this is the assertion that fails.
+	require.NotContains(t, view.Prompt, foreign)
+	require.NotContains(t, view.ResponseSchema, foreign)
+	require.NotContains(t, view.ResponseSchema, marker,
+		"the response schema asks for motifs in the ABSTRACT; naming this corpus's "+
+			"vocabulary there would be the leak MN1 forbids")
+
+	// And a group whose members carry no motifs at all renders no motif
+	// vocabulary anywhere — the entity/domain bridges that share this renderer.
+	bare := RenderDiscoverWorkItem(DiscoverWorkPayload{
+		Direction: DiscoverForward,
+		Bridge: BridgeSeedSet{Token: "some-entity", Kind: BridgeEntity, Members: []factForLLM{
+			{File: "kb/c.md", Title: "Charlie", Body: "body"}}},
+	}, "kb")
+	require.NotContains(t, bare.Prompt, marker)
+	require.NotContains(t, bare.Prompt, foreign)
 }

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -525,6 +525,12 @@ func factFromSearchResult(sr store.SearchResult) fact.Fact {
 	f.Confidence = sr.Confidence
 	f.Sources = sr.Sources
 	f.Refs = sr.Refs
+	// EvidenceWeight is authored data like every field above it. It was missing
+	// here until the Phase-3 fresh-eyes review (finding M1a) — the identical
+	// omission the same commit had just repaired for Motifs, in the same
+	// function, found because the parity test was rebuilt to compare fields it
+	// was not told about.
+	f.EvidenceWeight = sr.EvidenceWeight
 	f.Origin = fact.Origin(sr.Origin)
 	return f
 }

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -516,6 +516,12 @@ func factFromSearchResult(sr store.SearchResult) fact.Fact {
 	f.Type = fact.Type(sr.Type)
 	f.Domain = sr.Domain
 	f.Entities = sr.Entities
+	// Motifs travel with the fact, like every other authored field above.
+	// They were missing here until Phase 3 (designer ruling 2026-08-23,
+	// .claude/plans/motif/2026-08-23-phase3-rulings-3.md), which meant the
+	// full-scan path and the incremental path disagreed about what a seed IS —
+	// and a full scan is what every FIRST session on a corpus runs.
+	f.Motifs = sr.Motifs
 	f.Confidence = sr.Confidence
 	f.Sources = sr.Sources
 	f.Refs = sr.Refs

--- a/internal/synthesize/pipeline_seed_parity_test.go
+++ b/internal/synthesize/pipeline_seed_parity_test.go
@@ -2,6 +2,8 @@ package synthesize
 
 import (
 	"context"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,6 +41,8 @@ func TestSeedScanPaths_ProduceTheSameFact(t *testing.T) {
 	f.Motifs = []string{"measure-becomes-target"}
 	f.Confidence = 0.8
 	f.Sources = 1
+	f.EvidenceWeight = 2.5
+	f.Refs = []string{"kb/gotchas/uitesting/other.md"}
 	content, err := fact.SerializeFact(f)
 	require.NoError(t, err)
 	_, err = env.svc.Facts().WriteFact(ctx, env.branch, path, content, "write", "test")
@@ -56,41 +60,65 @@ func TestSeedScanPaths_ProduceTheSameFact(t *testing.T) {
 	fromParse, err := fact.ParseFact(path, read.Content)
 	require.NoError(t, err)
 
-	// Field by field, but exhaustively and by NAME, so a field added to
-	// fact.Fact and forgotten in one projection shows up here.
-	require.Equal(t, fromParse.Path(), fromSearch.Path())
-	require.Equal(t, fromParse.Title, fromSearch.Title)
-	require.Equal(t, fromParse.Body, fromSearch.Body)
-	require.Equal(t, fromParse.Kind, fromSearch.Kind)
-	require.Equal(t, fromParse.Type, fromSearch.Type)
-	require.Equal(t, fromParse.Domain, fromSearch.Domain)
-	require.Equal(t, fromParse.Entities, fromSearch.Entities)
-	require.Equal(t, fromParse.Motifs, fromSearch.Motifs)
-	require.Equal(t, fromParse.Confidence, fromSearch.Confidence)
-	require.Equal(t, fromParse.Sources, fromSearch.Sources)
-	require.Equal(t, fromParse.Refs, fromSearch.Refs)
+	// GENERIC, by reflection over fact.Fact's exported fields.
+	//
+	// The first version of this test hand-enumerated the fields, under a
+	// comment claiming it was generic — and the review proved the claim false
+	// by finding EvidenceWeight divergent at HEAD and absent from the list.
+	// A field added to fact.Fact and forgotten in one projection now fails here
+	// without anyone remembering to add a line.
+	//
+	// Two divergences are DECLARED rather than compared, each with its reason;
+	// everything else must match exactly.
+	declared := map[string]string{
+		// ParseFact applies the type-aware default on read; the projection
+		// carries the elided value. Harmless at HEAD — every consumer tests for
+		// Discovered specifically, and SerializeFact never elides that — and
+		// owned by the origin contract, not by this phase (review M1).
+		"Origin": "parse defaults it, the projection carries the elided value",
+	}
 
-	// ORIGIN — a SECOND, DIFFERENT divergence this test found once it was
-	// written generically, and one this phase has deliberately not changed.
-	//
-	// ParseFact applies the type-aware default on read (an authored
-	// observation with no `origin:` in its frontmatter parses as "authored"),
-	// while the index stores the elided value and the projection copies it
-	// verbatim, so the full-scan path yields "". Nothing today is misled: every
-	// consumer tests for fact.Discovered specifically, and neither "" nor
-	// "authored" is that. It is pinned here rather than normalised away,
-	// because the day a consumer starts asking "is this authored?" the two scan
-	// paths will answer differently and this is the line that says so.
-	//
-	// Reported to the design authority; changing it is a decision for whoever
-	// owns the origin contract, not for the phase that noticed.
+	pv := reflect.ValueOf(fromParse)
+	sv := reflect.ValueOf(fromSearch)
+	typ := pv.Type()
+	compared := 0
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		if why, ok := declared[f.Name]; ok {
+			t.Logf("declared divergence on %s: %s", f.Name, why)
+			continue
+		}
+		// PARSE DIAGNOSTICS are not fact data: RefWarnings and MotifWarnings
+		// record what the lenient parser DISCARDED, they are never persisted,
+		// and no projection can carry them. They are asserted EMPTY on both
+		// sides rather than skipped — a clean fixture that starts producing
+		// warnings is a finding, and skipping them by name would hide it.
+		if strings.HasSuffix(f.Name, "Warnings") {
+			require.Emptyf(t, pv.Field(i).Interface(), "clean fixture produced %s", f.Name)
+			require.Emptyf(t, sv.Field(i).Interface(), "projection produced %s", f.Name)
+			continue
+		}
+		// PRECONDITION (lesson 5): the fixture must give this field a
+		// non-zero value, or "equal" is two zero values agreeing and the
+		// comparison proves nothing. EvidenceWeight was divergent AND unset by
+		// the old fixture — both halves of the miss.
+		require.Falsef(t, pv.Field(i).IsZero(),
+			"fixture must set %s to a non-zero value, or comparing it tests nothing "+
+				"(add it to the fixture above, do NOT exempt it here)", f.Name)
+		require.Equalf(t, pv.Field(i).Interface(), sv.Field(i).Interface(),
+			"scan paths disagree about %s", f.Name)
+		compared++
+	}
+	require.Positive(t, compared, "a parity test that compared no fields is not a test")
+
+	// The unexported path is not reachable by reflection; assert it directly.
+	require.Equal(t, fromParse.Path(), fromSearch.Path())
+
+	// And the declared divergence is asserted rather than merely excused, so it
+	// fails loudly the day someone fixes it and forgets this list.
 	require.Equal(t, fact.Authored, fromParse.Origin, "the parse path defaults it")
 	require.Empty(t, string(fromSearch.Origin), "the projection carries the elided value")
-
-	// And the precondition that makes the assertions above mean something: the
-	// fixture must actually CARRY the fields it claims to compare (lesson 5 —
-	// two empty values are equal and prove nothing).
-	require.NotEmpty(t, fromParse.Motifs)
-	require.NotEmpty(t, fromParse.Entities)
-	require.NotEmpty(t, fromParse.Domain)
 }

--- a/internal/synthesize/pipeline_seed_parity_test.go
+++ b/internal/synthesize/pipeline_seed_parity_test.go
@@ -1,0 +1,96 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// The seed scan has TWO paths to a fact.Fact — the full scan projects a search
+// hit (factFromSearchResult), the incremental scan parses the file
+// (fact.ParseFact) — and factFromSearchResult's own doc comment promises they
+// "yield the same type".
+//
+// This asserts that promise GENERICALLY rather than field by field. The defect
+// it was written for dropped Motifs, but a motif-shaped assertion would not
+// have caught the next field to go missing, and the bug is not "motifs were
+// forgotten" — it is "two projections of one thing were allowed to disagree".
+//
+// The consequence when they do disagree is invisible: a full-scan session (any
+// FIRST session on a corpus) hands prune, distill and bridging a different fact
+// from the one an incremental session hands them, and every test that happens
+// to run one path passes.
+func TestSeedScanPaths_ProduceTheSameFact(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+
+	const path = "kb/gotchas/uitesting/agentclicks.md"
+	f := fact.NewFact(path)
+	f.Title = "An agent testing a UI will execute JavaScript instead of clicking"
+	f.Body = "Driving app state directly bypasses the path the verifier believes it is checking."
+	f.Type = fact.Observation
+	f.Kind = fact.Epistemic
+	f.Domain = []string{"evaluation", "coding-agents"}
+	f.Entities = []string{"Cognition", "Devin"}
+	f.Motifs = []string{"measure-becomes-target"}
+	f.Confidence = 0.8
+	f.Sources = 1
+	content, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = env.svc.Facts().WriteFact(ctx, env.branch, path, content, "write", "test")
+	require.NoError(t, err)
+
+	// Path 1 — the full scan's projection of a search hit.
+	results, err := env.svc.Search().Search(ctx, env.branch, store.SearchOptions{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	fromSearch := factFromSearchResult(results[0])
+
+	// Path 2 — the incremental scan's parse of the same bytes.
+	read, err := env.svc.Facts().ReadFact(ctx, env.branch, path, nil)
+	require.NoError(t, err)
+	fromParse, err := fact.ParseFact(path, read.Content)
+	require.NoError(t, err)
+
+	// Field by field, but exhaustively and by NAME, so a field added to
+	// fact.Fact and forgotten in one projection shows up here.
+	require.Equal(t, fromParse.Path(), fromSearch.Path())
+	require.Equal(t, fromParse.Title, fromSearch.Title)
+	require.Equal(t, fromParse.Body, fromSearch.Body)
+	require.Equal(t, fromParse.Kind, fromSearch.Kind)
+	require.Equal(t, fromParse.Type, fromSearch.Type)
+	require.Equal(t, fromParse.Domain, fromSearch.Domain)
+	require.Equal(t, fromParse.Entities, fromSearch.Entities)
+	require.Equal(t, fromParse.Motifs, fromSearch.Motifs)
+	require.Equal(t, fromParse.Confidence, fromSearch.Confidence)
+	require.Equal(t, fromParse.Sources, fromSearch.Sources)
+	require.Equal(t, fromParse.Refs, fromSearch.Refs)
+
+	// ORIGIN — a SECOND, DIFFERENT divergence this test found once it was
+	// written generically, and one this phase has deliberately not changed.
+	//
+	// ParseFact applies the type-aware default on read (an authored
+	// observation with no `origin:` in its frontmatter parses as "authored"),
+	// while the index stores the elided value and the projection copies it
+	// verbatim, so the full-scan path yields "". Nothing today is misled: every
+	// consumer tests for fact.Discovered specifically, and neither "" nor
+	// "authored" is that. It is pinned here rather than normalised away,
+	// because the day a consumer starts asking "is this authored?" the two scan
+	// paths will answer differently and this is the line that says so.
+	//
+	// Reported to the design authority; changing it is a decision for whoever
+	// owns the origin contract, not for the phase that noticed.
+	require.Equal(t, fact.Authored, fromParse.Origin, "the parse path defaults it")
+	require.Empty(t, string(fromSearch.Origin), "the projection carries the elided value")
+
+	// And the precondition that makes the assertions above mean something: the
+	// fixture must actually CARRY the fields it claims to compare (lesson 5 —
+	// two empty values are equal and prove nothing).
+	require.NotEmpty(t, fromParse.Motifs)
+	require.NotEmpty(t, fromParse.Entities)
+	require.NotEmpty(t, fromParse.Domain)
+}

--- a/internal/synthesize/restatement_conformance_test.go
+++ b/internal/synthesize/restatement_conformance_test.go
@@ -190,8 +190,14 @@ func TestConformance_BridgeFilesUntouched(t *testing.T) {
 		if name == "" {
 			continue
 		}
-		require.NotRegexp(t, `^internal/synthesize/bridge.*\.go$`, name,
-			"phase 0 is independent of the bridge engine")
+		// The phase-0 clause that also lived here — "no internal/synthesize/
+		// bridge*.go may differ from the merge base" — was removed by Phase 3
+		// (designer ruling 2026-08-23,
+		// .claude/plans/motif/2026-08-23-phase3-rulings-1.md Q1). Its premise
+		// was that phase 0 is independent of the bridge engine; Phase 3 IS the
+		// bridge-engine phase, so the premise expired rather than the
+		// constraint being waived. MN5 below is the load-bearing half and is
+		// unaffected.
 		require.NotEqual(t, "internal/synthesize/review_effort_normal_test.go", name,
 			"MN5: the EffortNormal contract test stays byte-identical")
 	}

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -155,6 +155,13 @@ func newRestatementEnvWith(t *testing.T, n int, emb *restatementEmbedder) *resta
 		AgentBranch:  branch,
 		Svc:          svc,
 		OntologyRoot: "kb",
+		// The production discovery.quality defaults (config.Defaults()). A bare
+		// test instance leaves these zero, and a zero MaxMembers gates out
+		// EVERY bridge candidate on every axis — so a discovery test on a bare
+		// instance measures an engine that cannot emit anything, and passes.
+		Quality: &repos.TestQualityConfig{
+			CohFloor: 0.5, QualityFloor: 0.0, WCoh: 1.0, WGap: 1.0, WSpec: 1.0, MaxMembers: 5,
+		},
 	}
 	if emb != nil {
 		cfg.Embedder = emb

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -296,8 +296,13 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	if mErr != nil {
 		// Degrade rather than fail the session: the grounded work above is
 		// already queued, and an unavailable axis is not a reason to lose it.
+		// The failure is RECORDED in health, not just logged — a reader
+		// comparing two sessions must be able to tell an axis that found
+		// nothing from one that could not look (L6).
 		log.Warn().Err(mErr).Str("session", sess.ID).
 			Msg("review: motif bridging skipped this session")
+		motifHealth.Failure = mErr.Error()
+		nearMotif, farMotif = nil, nil
 	}
 	// Both motif lanes ride the FORWARD-discover priority band, backward items
 	// included. That is deliberate: the band is a property of the REVIEW

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -270,28 +270,66 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 		return wrapf(reviewTool, err, "build bridges")
 	}
 	sl := scopeLabel(d.Scope)
-	for i, b := range bridges {
+	rank := 0
+	for _, b := range bridges {
 		payload := DiscoverWorkPayload{Direction: DiscoverForward, Bridge: b, ScopeLabel: sl}
-		payloadJSON, err := json.Marshal(payload)
-		if err != nil {
-			return wrapf(reviewTool, err, "marshal discover payload %d", i)
+		if err := enqueueDiscover(ctx, d, sess, payload,
+			fmt.Sprintf("discover-fwd-%d", rank), forwardDiscoverPriority(rank)); err != nil {
+			return err
 		}
-		if err := d.Pipeline.InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
-			SessionID:  sess.ID,
-			StepType:   "discover",
-			ClusterKey: fmt.Sprintf("discover-fwd-%d", i),
-			FactsJSON:  string(payloadJSON),
-			Priority:   forwardDiscoverPriority(i),
-		}); err != nil {
-			return wrapf(reviewTool, err, "insert discover item %d", i)
-		}
+		rank++
 	}
+
+	// Motif bridging (§4/§5): the aspect axis, a peer grouping key of
+	// entity/domain with its own per-lane budgets so neither axis can starve
+	// the other (MN8).
+	//
+	// Enumerated HERE — in review, over the ordinary seed pool — because that
+	// is where the facts carrying motifs are. The LANE decides the direction:
+	// near routes forward like any bridge, far routes BACKWARD, which is what
+	// makes it a hypothesis under the blast-radius gate (2bc84184). The
+	// hypothesize tool's synthesis-only seed pool is untouched by this
+	// (designer ruling 2026-08-23, phase3-rulings-1 Q2).
+	nearMotif, farMotif, motifHealth, mErr := buildMotifBridges(ctx, d.Search, branch,
+		llmSeeds, cr, d.Effort, cfg, motifResolverFor(ctx, d, branch),
+		subjectLabelsFor(ctx, d, branch), meanSimFor(d, branch))
+	if mErr != nil {
+		// Degrade rather than fail the session: the grounded work above is
+		// already queued, and an unavailable axis is not a reason to lose it.
+		log.Warn().Err(mErr).Str("session", sess.ID).
+			Msg("review: motif bridging skipped this session")
+	}
+	// Both motif lanes ride the FORWARD-discover priority band, backward items
+	// included. That is deliberate: the band is a property of the REVIEW
+	// session's queue (these items must run after its grounded work and before
+	// reflect), not a claim about a discover item's direction. The headroom is
+	// asserted on the total in TestEffortBudget_StaysBelowPriorityBand — do not
+	// "fix" this by inventing a second band.
+	for _, b := range nearMotif {
+		payload := DiscoverWorkPayload{Direction: DiscoverForward, Bridge: b, ScopeLabel: sl, Lane: LaneNear}
+		if err := enqueueDiscover(ctx, d, sess, payload,
+			fmt.Sprintf("discover-motif-near-%d", rank), forwardDiscoverPriority(rank)); err != nil {
+			return err
+		}
+		rank++
+	}
+	for _, b := range farMotif {
+		payload := DiscoverWorkPayload{Direction: DiscoverBackward, Bridge: b, ScopeLabel: sl, Lane: LaneFar}
+		if err := enqueueDiscover(ctx, d, sess, payload,
+			fmt.Sprintf("discover-motif-far-%d", rank), forwardDiscoverPriority(rank)); err != nil {
+			return err
+		}
+		rank++
+	}
+	sess.Health = append(sess.Health, motifBridgeHealthLines(motifHealth, len(nearMotif), len(farMotif))...)
 
 	log.Info().
 		Str("session", sess.ID).
 		Int("prune_clusters", len(pruneClusters)).
 		Int("seeds", len(llmSeeds)).
 		Int("bridges", len(bridges)).
+		Int("motif_near", len(nearMotif)).
+		Int("motif_far", len(farMotif)).
 		Str("effort", string(d.Effort)).
 		Msg("review: work planned")
 	d.OnProgress(ProgressEvent{Phase: "review-start", Message: fmt.Sprintf("session %s: %d clusters, %d seeds, %d bridges", sess.ID, len(pruneClusters), len(llmSeeds), len(bridges))})

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -306,12 +306,13 @@ func applyDiscoverStep(ctx context.Context, tool string, d Deps, sess *store.Pip
 	// REINFORCE runs after the proposals, on the same decision. An agent that
 	// found the corpus already holds its keystone returns no proposal and one
 	// reinforcement, so this is usually the only half that does anything.
-	reinforced, rErr := applyReinforcements(ctx, d.Facts, d.Search, dec.payload,
+	// No error return: every rejection inside is per-reinforcement, warned and
+	// skipped, exactly like the proposal loop above. It returned one until the
+	// Phase-3 review (L7) pointed out the branch handling it was unreachable —
+	// a handled failure mode that did not exist reads as a risk that was
+	// considered, which is worse than no branch at all.
+	reinforced := applyReinforcements(ctx, d.Facts, d.Search, dec.payload,
 		dec.reinforcements, sess.Branch, fact.ID12(d.RI.ID()), d.OnProgress)
-	if rErr != nil {
-		log.Warn().Err(rErr).Str("tool", tool).Str("session", sess.ID).
-			Msg("apply reinforcements failed; continuing")
-	}
 	if len(reinforced) > 0 {
 		// Deliberately NOT counted into ReviewStats. Reinforcement creates no
 		// fact, so counting it as Synthesized would overstate what the session

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -244,9 +244,10 @@ type Strategy interface {
 // not parse on a retry either, so leaving it unanswered would wedge the
 // session on an unanswerable item.
 type discoverDecision struct {
-	payload   DiscoverWorkPayload
-	parsed    bool
-	proposals []DiscoveredFact
+	payload        DiscoverWorkPayload
+	parsed         bool
+	proposals      []DiscoveredFact
+	reinforcements []FactReinforcement
 }
 
 // decodeDiscoverStep is the shared Decode half of the discover step. tool
@@ -269,6 +270,7 @@ func decodeDiscoverStep(tool string, item *store.PipelineWorkItem, response stri
 	}
 	d.parsed = true
 	d.proposals = parsed.Proposals
+	d.reinforcements = parsed.Reinforcements
 	return d, nil
 }
 
@@ -299,6 +301,26 @@ func applyDiscoverStep(ctx context.Context, tool string, d Deps, sess *store.Pip
 	// created rather than leaving invisible.
 	if len(written) > 0 {
 		recordStats(ctx, tool, d, sess, &ReviewStats{Synthesized: len(written)})
+	}
+
+	// REINFORCE runs after the proposals, on the same decision. An agent that
+	// found the corpus already holds its keystone returns no proposal and one
+	// reinforcement, so this is usually the only half that does anything.
+	reinforced, rErr := applyReinforcements(ctx, d.Facts, d.Search, dec.payload,
+		dec.reinforcements, sess.Branch, fact.ID12(d.RI.ID()), d.OnProgress)
+	if rErr != nil {
+		log.Warn().Err(rErr).Str("tool", tool).Str("session", sess.ID).
+			Msg("apply reinforcements failed; continuing")
+	}
+	if len(reinforced) > 0 {
+		// Deliberately NOT counted into ReviewStats. Reinforcement creates no
+		// fact, so counting it as Synthesized would overstate what the session
+		// added; and store.PipelineSessionStats has no column of its own for
+		// it, so a new ReviewStats field would be dropped silently by
+		// recordStats — recorded-looking and gone. It surfaces as a
+		// detail-discover progress event per fact, and as this line.
+		log.Info().Str("tool", tool).Str("session", sess.ID).
+			Strs("facts", reinforced).Msg("discover: reinforced existing facts")
 	}
 	return nil
 }


### PR DESCRIPTION
Phase 3 of the motif roadmap: motif bridging live behind the effort dial. Stacked on #102 (phase 2). 23 commits: 14 implementation + 9 from the fresh-eyes review's remediation round.

**Acceptance: the knomit-kb bridge-yield subset enumerates at high effort and none of it at normal** — replayed read-only over the research fixtures through the shipped enumeration (443 facts: exact tier 20 groups / 33 pairs; token-2 113 / 289 after the union fix, with 12 strictly-contained duplicates suppressed and no pair lost). Operating point on that corpus: cut df 3, umbrella df 88, band ceiling 12 — every threshold a percentile of the corpus's own distributions, no absolute constant anywhere (MN13).

## What ships

- `BridgeMotif` as a peer grouping key of entity/domain in the review engine; enumeration pure over injected resolvers (no LLM, no index — MN2), gates in order: df band → subject-disjointness → separation ≥ 2.
- **The df-graded subject-disjointness gate (GATE rider 1):** a shared label blocks only when specific — df below a per-corpus percentile operating point, umbrella-aware, strict below a 50-label validity floor (where only the universal-label tautology exemption survives). The strict any-shared-tag test measurably rejected 4 of 5 genuine cross-domain windows; this one recovers them while still rejecting the same-event near-duplicate fixture.
- Lane split by SIMILAR_TO adjacency: near → forward → synthesis (existing bridgeQ), far → backward → hypothesis with inverted scoring `W·(1−meanSim)` and the §4 SHIP prompt line served from the renderer.
- **Recall-before-propose (rider 2)** on every discover item: condition (c) now requires a corpus query — novelty is verified, never assumed.
- **The REINFORCE verb (rider 3):** discovery's third outcome. On a recall hit the seeds join the existing fact's refs as an independent derivation path, sources increment, evidence_weight recomputes — under a meaning-preserving write contract: only refs/sources/evidence_weight lines may change in the stored bytes; lossy targets (dropped motifs, real origin changes) are skipped with a reason; extra agent-named refs discarded. Skip rate measured on real corpora: 0% (knomit-kb), ~0% (agentic-engineering), 4.4% (core — precisely the facts whose provenance a rewrite would corrupt).
- Per-lane sub-budgets (8+8 at high, additional to the entity/domain 48; priority-band headroom asserted on the sum), monotone effort ladder (exact → exact∪token-2), health descriptors with cause-attributed drop counters.

## Review record

Fresh-eyes review + re-verification: 2 HIGH / 5 MEDIUM / 11 LOW findings, all ruled and remediated, closed by re-measurement against the original failure scenarios; 18 sabotage verifications. The two HIGHs were the REINFORCE write path exceeding its mandate (silent motif deletion via the lenient-parser round-trip; arbitrary model-named refs) — both now contract-guarded at the stored-byte boundary. Also fixed under ruling: the full-scan seed projection dropped Motifs and EvidenceWeight (scan-path parity now enforced by a reflective test that fails on the next forgotten field).

## Deliberately carried to Phase 4

Served-set monotonicity measurement, lane-split semantics redesign, the §4 oversized-far-group trim, embedding-tier calibration (high effort sits at the token-2 floor until then), and the full register in `.claude/plans/motif/PHASE4-CARRIED-FORWARD.md`.