### PR TITLE
feat(motif): phase 4 — activation and measurement

### DIFF
--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -264,7 +264,7 @@ var mechanicsPaths = map[string][]string{
 	// token2PairsOf reports which canonical ids the token-2 tier WOULD fold,
 	// using the tier's own predicate. It decides nothing — the report is
 	// read-only and no branch consults it.
-	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary", "token2PairsOf"},
+	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary", "token2PairsOf", "seedRecurrence"},
 	// The gate that decides which motif groups the agent ever sees. It reads
 	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and
 	// names motifs only in describing what it gates. Listed with no permitted

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -233,7 +233,30 @@ var mechanicsPaths = map[string][]string{
 	"internal/synthesize/bridge_motif.go": {
 		"buildMotifBridges", "enumerateMotifCandidates", "sharedMotifSpecificity", "anyMotifs",
 		"motifResolverFor", "motifBridgeHealthLines", "verbatimGroups", "token2Families",
+		// Phase 4: buildMotifBridges' own loop, extracted so the measurement
+		// instrument and production drive the SAME enumeration and scoring
+		// rather than two implementations that agree until they do not. It IS
+		// the §4/§5 path MN6 designs motifs into — the same licence
+		// buildMotifBridges has always had, now naming the function that does
+		// the work instead of the wrapper that calls it.
+		"scoreMotifCandidates",
+		// The drop-cause taxonomy and its tally. They read the SCORER's
+		// components (cohesion, member count) and the lane, never a motif's
+		// content; they name motifs only in describing what was dropped.
+		// Declared rather than exempted, because the register's value is that
+		// a motif-touching function cannot appear here undeclared.
+		"motifDropCauseOf", "tallyMotifDrops",
 	},
+	// Phase 4's measurement entry point (Q3's sibling report). It is a
+	// read-only calibrate/dev path: it enumerates and scores through the
+	// shipped §4/§5 functions and returns rows. It decides nothing, writes
+	// nothing, and no production branch reads it — the same standing as
+	// BridgeComponentReport on the entity/domain axis. Listed so a function
+	// added to this file has to be declared rather than inheriting the file's
+	// silence.
+	// Summary renders the report as one human line and names the
+	// seeds-with-motifs count in it.
+	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary"},
 	// The gate that decides which motif groups the agent ever sees. It reads
 	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and
 	// names motifs only in describing what it gates. Listed with no permitted

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -256,7 +256,10 @@ var mechanicsPaths = map[string][]string{
 	// silence.
 	// Summary renders the report as one human line and names the
 	// seeds-with-motifs count in it.
-	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary"},
+	// token2PairsOf reports which canonical ids the token-2 tier WOULD fold,
+	// using the tier's own predicate. It decides nothing — the report is
+	// read-only and no branch consults it.
+	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary", "token2PairsOf"},
 	// The gate that decides which motif groups the agent ever sees. It reads
 	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and
 	// names motifs only in describing what it gates. Listed with no permitted

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -554,12 +554,65 @@ func TestMN13_MotifBridgeConstantsAreClassified(t *testing.T) {
 			"umbrellaPerCent":        "RATIO",
 		},
 		"internal/synthesize/bridge_motif.go": {
-			"motifDFCeilingFloor": "STATISTICAL-VALIDITY FLOOR",
+			"motifDFCeilingFloor":   "STATISTICAL-VALIDITY FLOOR",
+			"motifDFCeilingPerCent": "RATIO",
+			"motifActivationFloor":  "STATISTICAL-VALIDITY FLOOR",
+			"token2SharedStems":     "STRUCTURAL K",
 		},
 	} {
 		requireConstantsClassified(t, rel, want)
-
+		requireEveryNumericConstantClassified(t, rel)
 		requireNoUnnamedRatios(t, rel)
+	}
+}
+
+// requireEveryNumericConstantClassified closes the opt-in hole (review finding
+// M-6).
+//
+// requireConstantsClassified skips any constant absent from its map, so the
+// phase added three numeric constants and the test that is named after the
+// rule stayed green while none of them was checked — and the acceptance
+// package claimed otherwise. Adding three map entries would satisfy the ruling
+// once; making UNTRACKED constants fail stops the class recurring, which is
+// what a conformance check is for.
+//
+// Scope is numeric LITERALS, which is MN13's own subject ("every numeric
+// constant"). String enums and iota discriminants are excluded structurally
+// rather than by an exemption list: they carry no tuned value, so there is no
+// class to state, and a list would be one more thing to forget.
+func requireEveryNumericConstantClassified(t *testing.T, rel string) {
+	t.Helper()
+	for _, decl := range parseGo(t, rel).Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		blockDoc := gen.Doc.Text()
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			numeric := false
+			for _, v := range vs.Values {
+				if lit, ok := v.(*ast.BasicLit); ok &&
+					(lit.Kind == token.INT || lit.Kind == token.FLOAT) {
+					numeric = true
+				}
+			}
+			if !numeric {
+				continue
+			}
+			doc := blockDoc + vs.Doc.Text()
+			for _, name := range vs.Names {
+				require.Containsf(t, doc, "CONSTANT CLASSIFICATION",
+					"MN13: numeric const %s in %s states no class. Every numeric constant is a "+
+						"corpus-property constant (forbidden), a resource budget, or a "+
+						"statistical-validity floor, and the class must be stated where it is "+
+						"defined — a value whose paragraph is deleted is indistinguishable from "+
+						"the forbidden kind", name.Name, rel)
+			}
+		}
 	}
 }
 

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -251,6 +251,12 @@ var mechanicsPaths = map[string][]string{
 		// which of two nested groups is served. It reads the tier, never a
 		// motif's content, and it is inside the §4/§5 path.
 		"suppressContained",
+		// Phase 4: the activation floor. seedRecurrence counts the corpus's
+		// recurring motifs and motifActive decides whether the axis runs at
+		// all — both read motifs to answer "is there enough repeated
+		// vocabulary here", never to influence a dedup, cluster or ranking
+		// decision. This IS the §4/§5 path's own enablement.
+		"seedRecurrence", "motifActive",
 	},
 	// Phase 4's measurement entry point (Q3's sibling report). It is a
 	// read-only calibrate/dev path: it enumerates and scores through the
@@ -264,7 +270,7 @@ var mechanicsPaths = map[string][]string{
 	// token2PairsOf reports which canonical ids the token-2 tier WOULD fold,
 	// using the tier's own predicate. It decides nothing — the report is
 	// read-only and no branch consults it.
-	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary", "token2PairsOf", "seedRecurrence"},
+	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary", "token2PairsOf"},
 	// The gate that decides which motif groups the agent ever sees. It reads
 	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and
 	// names motifs only in describing what it gates. Listed with no permitted

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -260,6 +260,10 @@ var mechanicsPaths = map[string][]string{
 		// to. Same §4/§5 licence buildMotifBridges has always had; theyname the
 		// functions that now do the work.
 		"buildMotifBridgesWithRows",
+		// dedupThresholdFor now names motifs in its own doc (M-5: the
+		// MotifDedupThreshold override). It resolves a model's cosine
+		// threshold and reads no motif content.
+		"dedupThresholdFor",
 		// Phase 4: the activation floor. seedRecurrence counts the corpus's
 		// recurring motifs and motifActive decides whether the axis runs at
 		// all — both read motifs to answer "is there enough repeated

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -250,7 +250,16 @@ var mechanicsPaths = map[string][]string{
 		// motif tier a candidate came from (enumeratedMotif.family) to decide
 		// which of two nested groups is served. It reads the tier, never a
 		// motif's content, and it is inside the §4/§5 path.
-		"suppressContained",
+		// suppressContainedTracked replaces suppressContained as the function
+		// that reads the tier (M-4 remediation); suppressContained is now a
+		// two-line wrapper that mentions no motif, so it comes OFF the list —
+		// a permission nothing uses is what the bidirectional check exists to
+		// catch.
+		"suppressContainedTracked",
+		// The single-pass builder and the row-writing rank/cap it delegates
+		// to. Same §4/§5 licence buildMotifBridges has always had; theyname the
+		// functions that now do the work.
+		"buildMotifBridgesWithRows",
 		// Phase 4: the activation floor. seedRecurrence counts the corpus's
 		// recurring motifs and motifActive decides whether the axis runs at
 		// all — both read motifs to answer "is there enough repeated

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -246,6 +246,11 @@ var mechanicsPaths = map[string][]string{
 		// Declared rather than exempted, because the register's value is that
 		// a motif-touching function cannot appear here undeclared.
 		"motifDropCauseOf", "tallyMotifDrops",
+		// Phase-4 rulings-3: suppression became TIER-AWARE, so it now reads the
+		// motif tier a candidate came from (enumeratedMotif.family) to decide
+		// which of two nested groups is served. It reads the tier, never a
+		// motif's content, and it is inside the §4/§5 path.
+		"suppressContained",
 	},
 	// Phase 4's measurement entry point (Q3's sibling report). It is a
 	// read-only calibrate/dev path: it enumerates and scores through the

--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -283,7 +283,10 @@ var mechanicsPaths = map[string][]string{
 	// token2PairsOf reports which canonical ids the token-2 tier WOULD fold,
 	// using the tier's own predicate. It decides nothing — the report is
 	// read-only and no branch consults it.
-	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary", "token2PairsOf"},
+	"internal/synthesize/bridge_motif_report.go": {"MotifComponentReport", "Summary", "token2PairsOf",
+		// The row-to-report projection (M-8). It moves a candidate's own
+		// disposition into the reported shape and decides nothing.
+		"scoredMotifBridgeOf"},
 	// The gate that decides which motif groups the agent ever sees. It reads
 	// the SUBJECT axis — entities, domain tags, path tokens — to do it, and
 	// names motifs only in describing what it gates. Listed with no permitted

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -764,10 +764,45 @@ func buildMotifBridges(
 	labels store.SubjectLabelDF,
 	pairCos pairCosFn,
 ) ([]BridgeSeedSet, []BridgeSeedSet, motifEnumHealth, error) {
+	near, far, _, health, err := buildMotifBridgesWithRows(
+		ctx, idx, branch, seeds, clusters, eff, cfg, resolve, labels, pairCos)
+	return near, far, health, err
+}
+
+// buildMotifBridgesWithRows is buildMotifBridges plus the per-candidate rows,
+// with every disposition filled in — suppression and budget included.
+//
+// It exists so the measurement surface reads the SAME pass production serves
+// from. The report used to call scoreMotifCandidates and buildMotifBridges
+// separately, which enumerated twice and left the rows knowing nothing about
+// what happened after scoring: suppression drops a candidate inside
+// rankAndCap, so a row said `Kept: true, Cause: ""` for a group no agent ever
+// saw (review finding M-4).
+func buildMotifBridgesWithRows(
+	ctx context.Context,
+	idx SearchQuery,
+	branch string,
+	seeds []factForLLM,
+	clusters ClusterResult,
+	eff Effort,
+	cfg QualityConfig,
+	resolve motifResolver,
+	labels store.SubjectLabelDF,
+	pairCos pairCosFn,
+) ([]BridgeSeedSet, []BridgeSeedSet, []scoredMotifRow, motifEnumHealth, error) {
 	rows, health, err := scoreMotifCandidates(ctx, idx, branch, seeds, clusters, eff, cfg, resolve, labels, pairCos)
 	if err != nil {
-		return nil, nil, health, err
+		return nil, nil, rows, health, err
 	}
+	// Index rows by member set so a decision taken on a candidate can be
+	// written back to the row it came from. Keyed on members rather than Token
+	// because a token-2 family shares its Token with the verbatim group it
+	// folded — the same ambiguity enumeratedMotif.family exists for.
+	rowOf := map[string]int{}
+	for i, r := range rows {
+		rowOf[memberKey(r.cand)] = i
+	}
+
 	var near, far []enumeratedMotif
 	for _, r := range rows {
 		if !r.kept {
@@ -782,10 +817,51 @@ func buildMotifBridges(
 		}
 	}
 	nearBudget, farBudget := motifSubBudget(eff)
-	nearOut, nearSup := rankAndCap(near, nearBudget)
-	farOut, farSup := rankAndCap(far, farBudget)
+	nearOut, nearSup := rankAndCapRows(near, nearBudget, rows, rowOf)
+	farOut, farSup := rankAndCapRows(far, farBudget, rows, rowOf)
 	health.FamilySuppressedByExact = nearSup + farSup
-	return nearOut, farOut, health, nil
+	return nearOut, farOut, rows, health, nil
+}
+
+// memberKey identifies a candidate by its member set.
+func memberKey(c enumeratedMotif) string {
+	paths := make([]string, 0, len(c.Members))
+	for _, m := range c.Members {
+		paths = append(paths, m.File)
+	}
+	sort.Strings(paths)
+	return strings.Join(paths, "\x00")
+}
+
+// rankAndCapRows is rankAndCap, writing each decision back into the rows.
+func rankAndCapRows(in []enumeratedMotif, budget int, rows []scoredMotifRow, rowOf map[string]int) ([]BridgeSeedSet, int) {
+	if budget == 0 {
+		return nil, 0
+	}
+	kept, crossTier, dropped := suppressContainedTracked(in)
+	for k, cause := range dropped {
+		if i, ok := rowOf[k]; ok {
+			rows[i].kept = false
+			rows[i].cause = cause
+		}
+	}
+	sort.SliceStable(kept, func(i, j int) bool {
+		if kept[i].Q != kept[j].Q {
+			return kept[i].Q > kept[j].Q
+		}
+		return kept[i].Token < kept[j].Token
+	})
+	if len(kept) > budget {
+		kept = kept[:budget]
+	}
+	out := make([]BridgeSeedSet, 0, len(kept))
+	for _, c := range kept {
+		if i, ok := rowOf[memberKey(c)]; ok {
+			rows[i].served = true
+		}
+		out = append(out, c.BridgeSeedSet)
+	}
+	return out, crossTier
 }
 
 // scoredMotifRow is one enumerated candidate and everything the scorer decided
@@ -796,12 +872,21 @@ func buildMotifBridges(
 // from the engine that serves the bridges rather than from a second
 // implementation that agrees with it until it does not.
 type scoredMotifRow struct {
-	cand  enumeratedMotif
-	lane  BridgeLane
-	comp  BridgeComponents
-	q     float64
+	cand enumeratedMotif
+	lane BridgeLane
+	comp BridgeComponents
+	q    float64
+	// kept is the PRE-BUDGET verdict: the candidate passed every gate and
+	// survived suppression, so a session would serve it if a slot existed.
+	// kept is true exactly when cause is empty.
 	kept  bool
 	cause motifDropCause
+	// served reports that it actually reached a work item. A row with
+	// kept && !served is one that lost a slot to the per-lane budget — which
+	// IS register entry 3's vanish-rate population, and the reason budget is
+	// tracked here rather than folded into cause: it is not a defect in the
+	// candidate, it is scarcity.
+	served bool
 }
 
 // motifDropCause names why a candidate was not served. Empty when it was.
@@ -818,6 +903,18 @@ const (
 	motifNearOther   motifDropCause = "near-other"
 	motifFarOversize motifDropCause = "far-oversize"
 	motifFarOther    motifDropCause = "far-other"
+	// Suppression causes (review finding M-4). Suppression runs INSIDE
+	// rankAndCap, after the scorer has already said kept — so before this a row
+	// read `Kept: true, Cause: ""` for a group no agent ever saw, and the
+	// taxonomy whose whole purpose is that "a counter and the row it came from
+	// cannot drift" had a state it did not cover.
+	//
+	// The two are distinct because they mean different things to a reader: a
+	// same-tier drop is one question asked twice; a cross-tier drop is a looser
+	// grouping losing to the exact one it contained. One label for both would
+	// be the M4 counter-finding again.
+	motifSuppressedCrossTier motifDropCause = "suppressed-by-exact-tier"
+	motifSuppressedSameTier  motifDropCause = "suppressed-by-superset"
 )
 
 // scoreMotifCandidates enumerates, lane-splits and scores every motif bridge
@@ -1321,6 +1418,20 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 //
 // Runs before ranking and truncation, or it would free no slots.
 func suppressContained(in []enumeratedMotif) ([]enumeratedMotif, int) {
+	kept, crossTier, _ := suppressContainedTracked(in)
+	return kept, crossTier
+}
+
+// suppressContainedTracked is suppressContained, additionally naming WHICH
+// candidates it dropped and under which cause, keyed by member set.
+//
+// The causes are distinct because the two suppressions mean different things
+// to a reader: a same-tier drop is one question asked twice, and a cross-tier
+// drop is a looser grouping losing to the exact one it contained. Reporting
+// both as "suppressed" would put them under one label again, which is the M4
+// counter-finding's whole lesson.
+func suppressContainedTracked(in []enumeratedMotif) ([]enumeratedMotif, int, map[string]motifDropCause) {
+	dropped := map[string]motifDropCause{}
 	sets := make([]map[string]struct{}, len(in))
 	for i, g := range in {
 		sets[i] = make(map[string]struct{}, len(g.Members))
@@ -1331,7 +1442,7 @@ func suppressContained(in []enumeratedMotif) ([]enumeratedMotif, int) {
 	out := make([]enumeratedMotif, 0, len(in))
 	crossTier := 0
 	for i := range in {
-		drop := false
+		var cause motifDropCause
 		for j := range in {
 			if i == j {
 				continue
@@ -1339,22 +1450,24 @@ func suppressContained(in []enumeratedMotif) ([]enumeratedMotif, int) {
 			// Cross-tier: a FAMILY containing an exact group loses to it,
 			// whatever their sizes.
 			if in[i].family && !in[j].family && subsetOf(sets[j], sets[i]) {
-				drop = true
+				cause = motifSuppressedCrossTier
 				crossTier++
 				break
 			}
 			// Same tier: the strict superset survives.
 			if in[i].family == in[j].family &&
 				len(sets[j]) > len(sets[i]) && subsetOf(sets[i], sets[j]) {
-				drop = true
+				cause = motifSuppressedSameTier
 				break
 			}
 		}
-		if !drop {
+		if cause == motifKept {
 			out = append(out, in[i])
+			continue
 		}
+		dropped[memberKey(in[i])] = cause
 	}
-	return out, crossTier
+	return out, crossTier, dropped
 }
 
 func subsetOf(small, big map[string]struct{}) bool {

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -320,10 +320,7 @@ func token2Families(byToken map[string]map[string]factForLLM) []motifGroup {
 
 	toks := make([]map[string]struct{}, len(ids))
 	for i, id := range ids {
-		toks[i] = map[string]struct{}{}
-		for _, t := range textnorm.Tokens(textnorm.Canonicalize(id)) {
-			toks[i][t] = struct{}{}
-		}
+		toks[i] = motifStems(id)
 	}
 
 	// families[i] accumulates the members of the family keyed by ids[i].
@@ -337,13 +334,7 @@ func token2Families(byToken map[string]map[string]factForLLM) []motifGroup {
 			if folded[j] {
 				continue
 			}
-			shared := 0
-			for t := range toks[i] {
-				if _, ok := toks[j][t]; ok {
-					shared++
-				}
-			}
-			if shared < 2 {
+			if len(sharedMotifStems(toks[i], toks[j])) < token2SharedStems {
 				continue
 			}
 			if families[i] == nil {
@@ -371,6 +362,42 @@ func copyMembers(in map[string]factForLLM) map[string]factForLLM {
 	for k, v := range in {
 		out[k] = v
 	}
+	return out
+}
+
+// token2SharedStems is the tier's name: how many stemmed tokens two canonical
+// ids must share to join one family.
+//
+// CONSTANT CLASSIFICATION (MN13, class 2): a STRUCTURAL K with system
+// precedent — §4 names the tier "token-2" and the number IS the tier. It
+// claims nothing about any corpus's distribution.
+const token2SharedStems = 2
+
+// motifStems is the stemmed token set of a canonical motif id — the unit the
+// token-2 tier matches on.
+//
+// One definition, shared by the tier itself and by the measurement that
+// reports the tier's noise shape (carried-forward register entry 6). A second
+// copy in the instrument would let the measured noise drift from the shipped
+// matching, which is the exact class of error the instrument exists to avoid.
+func motifStems(id string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, t := range textnorm.Tokens(textnorm.Canonicalize(id)) {
+		out[t] = struct{}{}
+	}
+	return out
+}
+
+// sharedMotifStems returns the stems two canonical ids have in common, sorted
+// so callers that report them are deterministic.
+func sharedMotifStems(a, b map[string]struct{}) []string {
+	var out []string
+	for t := range a {
+		if _, ok := b[t]; ok {
+			out = append(out, t)
+		}
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -466,7 +466,100 @@ func laneOf(paths []string, g store.SimilarityGraph) BridgeLane {
 // graph cannot supply them: that graph is a top-K edge set, and in the far lane
 // it is empty by definition, so a "similarity" read off it would be the same
 // constant for every far candidate — a term that ranks nothing.
-type meanSimFn func(ctx context.Context, paths []string) (float64, error)
+// pairCosFn returns EVERY member-pair body cosine, not just their mean.
+//
+// The far lane only ever wanted the mean, but §8's novelty signals need the
+// distribution: "any pair over dedup" is a question about individual pairs that
+// a mean cannot answer — a group with one near-duplicate pair and three distant
+// ones has an unremarkable mean and is exactly the case the signal exists to
+// surface.
+type pairCosFn func(ctx context.Context, paths []string) ([]float64, error)
+
+// dedupThresholdFor reads the dedup cosine OverDedup is measured against.
+//
+// It is the model-dependent threshold discovery's own duplicate check uses
+// (store.EmbedderThresholds), never a number of this file's own — a novelty
+// signal calibrated against a different threshold from the gate it describes
+// would be measuring nothing anybody acts on.
+func dedupThresholdFor(idx SearchQuery) float64 {
+	if e, ok := idx.(interface{ Embedder() store.Embedder }); ok {
+		return store.EmbedderThresholds(e.Embedder()).Dedup
+	}
+	return store.EmbedderThresholds(nil).Dedup
+}
+
+// noveltyOf computes §8's seed-set novelty signals for one candidate.
+//
+// EntityJaccard needs no vectors and is always computed. The other two need a
+// vector source, so VectorsRead reports whether they mean anything — a zero
+// SeedCos from "no vectors" and a zero from "genuinely dissimilar" are opposite
+// findings and must not share a representation.
+func noveltyOf(ctx context.Context, members []factForLLM, paths []string, pairCos pairCosFn, dedup float64) (NoveltySignals, error) {
+	n := NoveltySignals{EntityJaccard: meanEntityJaccard(members)}
+	if pairCos == nil {
+		return n, nil
+	}
+	cs, err := pairCos(ctx, paths)
+	if err != nil {
+		return n, err
+	}
+	if len(cs) == 0 {
+		return n, nil
+	}
+	n.VectorsRead = true
+	var sum float64
+	over := 0
+	for _, c := range cs {
+		sum += c
+		if c >= dedup {
+			over++
+		}
+	}
+	n.SeedCos = sum / float64(len(cs))
+	n.OverDedup = float64(over) / float64(len(cs))
+	return n, nil
+}
+
+// meanEntityJaccard is the mean Jaccard overlap of member ENTITY sets over all
+// member pairs — the subject-axis counterpart to SeedCos.
+//
+// A pair with no entities on either side contributes 0, not 1: "two facts that
+// name nothing" is an absence of evidence about their subjects, and scoring it
+// as perfect disjointness would reward the corpus for being unlabelled.
+func meanEntityJaccard(members []factForLLM) float64 {
+	if len(members) < 2 {
+		return 0
+	}
+	sets := make([]map[string]struct{}, len(members))
+	for i, m := range members {
+		sets[i] = map[string]struct{}{}
+		for _, e := range m.Entities {
+			sets[i][strings.ToLower(e)] = struct{}{}
+		}
+	}
+	var sum float64
+	pairs := 0
+	for i := range sets {
+		for j := i + 1; j < len(sets); j++ {
+			inter, union := 0, len(sets[j])
+			for t := range sets[i] {
+				if _, ok := sets[j][t]; ok {
+					inter++
+				} else {
+					union++
+				}
+			}
+			pairs++
+			if union > 0 {
+				sum += float64(inter) / float64(union)
+			}
+		}
+	}
+	if pairs == 0 {
+		return 0
+	}
+	return sum / float64(pairs)
+}
 
 // scoreMotifCandidate scores one candidate on its lane.
 //
@@ -494,7 +587,7 @@ func scoreMotifCandidate(
 	clusterOf map[string]int,
 	cfg QualityConfig,
 	sharedSpec float64,
-	meanSim meanSimFn,
+	pairCos pairCosFn,
 ) (BridgeComponents, float64, bool, error) {
 	paths := make([]string, 0, len(cand.Members))
 	for _, m := range cand.Members {
@@ -511,6 +604,14 @@ func scoreMotifCandidate(
 		Spec:    sharedSpec,
 		Members: len(paths),
 	}
+	// §8's novelty signals. Computed for EVERY candidate, on both lanes and
+	// whether or not it is kept, because `calibrate bridges` is about the
+	// distribution the scorer sees rather than the slice it serves.
+	nov, err := noveltyOf(ctx, cand.Members, paths, pairCos, dedupThresholdFor(idx))
+	if err != nil {
+		return comp, 0, false, err
+	}
+	comp.Novelty = nov
 	if lane == LaneNear {
 		q, kept := bridgeQ(comp, cfg)
 		return comp, q, kept, nil
@@ -518,7 +619,7 @@ func scoreMotifCandidate(
 	if comp.Sep < 2 || comp.Members > cfg.MaxMembers {
 		return comp, 0, false, nil
 	}
-	ms, err := meanSim(ctx, paths)
+	ms, err := meanPairCos(ctx, paths, pairCos)
 	if err != nil {
 		// Propagated, never defaulted. A similarity that could not be read is
 		// not "maximally dissimilar", and treating it as 0 would hand every
@@ -661,9 +762,9 @@ func buildMotifBridges(
 	cfg QualityConfig,
 	resolve motifResolver,
 	labels store.SubjectLabelDF,
-	meanSim meanSimFn,
+	pairCos pairCosFn,
 ) ([]BridgeSeedSet, []BridgeSeedSet, motifEnumHealth, error) {
-	rows, health, err := scoreMotifCandidates(ctx, idx, branch, seeds, clusters, eff, cfg, resolve, labels, meanSim)
+	rows, health, err := scoreMotifCandidates(ctx, idx, branch, seeds, clusters, eff, cfg, resolve, labels, pairCos)
 	if err != nil {
 		return nil, nil, health, err
 	}
@@ -733,7 +834,7 @@ func scoreMotifCandidates(
 	cfg QualityConfig,
 	resolve motifResolver,
 	labels store.SubjectLabelDF,
-	meanSim meanSimFn,
+	pairCos pairCosFn,
 ) ([]scoredMotifRow, motifEnumHealth, error) {
 	// A corpus with no motifs costs nothing at all — not one index call. This
 	// is the mechanism behind MN5's vacuous pass, so it is stated here rather
@@ -785,7 +886,7 @@ func scoreMotifCandidates(
 		if err != nil {
 			return nil, health, err
 		}
-		comp, q, kept, err := scoreMotifCandidate(ctx, cand.BridgeSeedSet, lane, g, idx, branch, clusterOf, cfg, spec, meanSim)
+		comp, q, kept, err := scoreMotifCandidate(ctx, cand.BridgeSeedSet, lane, g, idx, branch, clusterOf, cfg, spec, pairCos)
 		if err != nil {
 			return nil, health, err
 		}
@@ -1051,11 +1152,11 @@ func subjectLabelsFor(ctx context.Context, search SearchQuery, branch string) st
 // The far lane cannot get them from the SIMILAR_TO graph — that graph is empty
 // there by definition — so this reaches for the vectors the graph was built
 // from.
-func meanSimFor(abstraction store.AbstractionIndex, branch string) meanSimFn {
-	return func(ctx context.Context, paths []string) (float64, error) {
+func pairCosFor(abstraction store.AbstractionIndex, branch string) pairCosFn {
+	return func(ctx context.Context, paths []string) ([]float64, error) {
 		ids, err := abstraction.FactIDsByPath(ctx, branch, paths)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
 		idList := make([]int64, 0, len(ids))
 		for _, id := range ids {
@@ -1063,28 +1164,45 @@ func meanSimFor(abstraction store.AbstractionIndex, branch string) meanSimFn {
 		}
 		vecs, err := abstraction.BodyVectorsByFactID(ctx, idList)
 		if err != nil {
-			return 0, err
+			return nil, err
 		}
-		var sum float64
-		var n int
+		var out []float64
 		for i := 0; i < len(idList); i++ {
 			for j := i + 1; j < len(idList); j++ {
 				a, b := vecs[idList[i]], vecs[idList[j]]
 				if len(a) == 0 || len(b) == 0 {
 					continue
 				}
-				sum += dot(a, b)
-				n++
+				out = append(out, dot(a, b))
 			}
 		}
-		if n == 0 {
-			// No vectors is NOT "maximally dissimilar". Returning 0 would hand
-			// every un-embedded group the highest far-lane score there is,
-			// which is the opposite of what missing evidence should buy.
-			return 1, nil
-		}
-		return sum / float64(n), nil
+		return out, nil
 	}
+}
+
+// meanPairCos is the far lane's view of the pair distribution.
+//
+// AN EMPTY DISTRIBUTION SCORES 1, NOT 0. No vectors is not "maximally
+// dissimilar": returning 0 would hand every un-embedded group the highest
+// far-lane score there is, which is the opposite of what missing evidence
+// should buy. That rule lived inside the old mean-only provider and is kept
+// here rather than lost in the refactor.
+func meanPairCos(ctx context.Context, paths []string, pairCos pairCosFn) (float64, error) {
+	if pairCos == nil {
+		return 1, nil
+	}
+	cs, err := pairCos(ctx, paths)
+	if err != nil {
+		return 0, err
+	}
+	if len(cs) == 0 {
+		return 1, nil
+	}
+	var sum float64
+	for _, c := range cs {
+		sum += c
+	}
+	return sum / float64(len(cs)), nil
 }
 
 // motifBridgeHealthLines are DESCRIPTORS: no branch in this package reads any

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -602,11 +602,80 @@ func buildMotifBridges(
 	labels store.SubjectLabelDF,
 	meanSim meanSimFn,
 ) ([]BridgeSeedSet, []BridgeSeedSet, motifEnumHealth, error) {
+	rows, health, err := scoreMotifCandidates(ctx, idx, branch, seeds, clusters, eff, cfg, resolve, labels, meanSim)
+	if err != nil {
+		return nil, nil, health, err
+	}
+	var near, far []BridgeSeedSet
+	for _, r := range rows {
+		if !r.kept {
+			continue
+		}
+		cand := r.cand
+		cand.Q = r.q
+		if r.lane == LaneNear {
+			near = append(near, cand)
+		} else {
+			far = append(far, cand)
+		}
+	}
+	nearBudget, farBudget := motifSubBudget(eff)
+	return rankAndCap(near, nearBudget), rankAndCap(far, farBudget), health, nil
+}
+
+// scoredMotifRow is one enumerated candidate and everything the scorer decided
+// about it — INCLUDING the ones that were dropped, with the cause.
+//
+// Production throws the dropped rows away; measurement is mostly about them.
+// Both read this one function, so the numbers Phase 4 sets constants on come
+// from the engine that serves the bridges rather than from a second
+// implementation that agrees with it until it does not.
+type scoredMotifRow struct {
+	cand  BridgeSeedSet
+	lane  BridgeLane
+	comp  BridgeComponents
+	q     float64
+	kept  bool
+	cause motifDropCause
+}
+
+// motifDropCause names why a candidate was not served. Empty when it was.
+//
+// One taxonomy, and the health counters are TALLIED FROM IT rather than
+// incremented alongside it — so a counter and the row it came from cannot
+// drift into disagreeing about the same group, which is the shape of the
+// review's M4 counter-finding.
+type motifDropCause string
+
+const (
+	motifKept        motifDropCause = ""
+	motifNearFloor   motifDropCause = "near-cohesion-floor"
+	motifNearOther   motifDropCause = "near-other"
+	motifFarOversize motifDropCause = "far-oversize"
+	motifFarOther    motifDropCause = "far-other"
+)
+
+// scoreMotifCandidates enumerates, lane-splits and scores every motif bridge
+// candidate, returning one row per candidate. It applies no budget and no
+// ranking: those belong to the caller that serves items, not to the caller
+// that measures them.
+func scoreMotifCandidates(
+	ctx context.Context,
+	idx SearchQuery,
+	branch string,
+	seeds []factForLLM,
+	clusters ClusterResult,
+	eff Effort,
+	cfg QualityConfig,
+	resolve motifResolver,
+	labels store.SubjectLabelDF,
+	meanSim meanSimFn,
+) ([]scoredMotifRow, motifEnumHealth, error) {
 	// A corpus with no motifs costs nothing at all — not one index call. This
 	// is the mechanism behind MN5's vacuous pass, so it is stated here rather
 	// than left to emerge from the gates downstream.
 	if !anyMotifs(seeds) {
-		return nil, nil, motifEnumHealth{}, nil
+		return nil, motifEnumHealth{}, nil
 	}
 
 	dfOf := func(canon string) int {
@@ -624,7 +693,7 @@ func buildMotifBridges(
 	cands, health := enumerateMotifCandidates(seeds, clusters, resolve, dfOf, labels, motifTier(eff))
 	clusterOf := bridgePathCommunities(seeds, clusters)
 
-	var near, far []BridgeSeedSet
+	rows := make([]scoredMotifRow, 0, len(cands))
 	for _, cand := range cands {
 		paths := make([]string, 0, len(cand.Members))
 		for _, m := range cand.Members {
@@ -632,47 +701,65 @@ func buildMotifBridges(
 		}
 		g, err := idx.SimilarityAdjacency(ctx, paths)
 		if err != nil {
-			return nil, nil, health, err
+			return nil, health, err
 		}
 		lane := laneOf(paths, g)
 
 		spec, err := sharedMotifSpecificity(ctx, idx, branch, cand, resolve)
 		if err != nil {
-			return nil, nil, health, err
+			return nil, health, err
 		}
 		comp, q, kept, err := scoreMotifCandidate(ctx, cand, lane, g, idx, branch, clusterOf, cfg, spec, meanSim)
 		if err != nil {
-			return nil, nil, health, err
+			return nil, health, err
 		}
-		if !kept {
-			// Attributed by CAUSE, from the components the scorer computed,
-			// rather than by "it was near and it went". Each lane names the
-			// cause its own Phase-4 decision turns on first — the near lane's
-			// cohesion floor (the crack between the lanes), the far lane's
-			// member cap (the unimplemented trim) — so each counter is an upper
-			// bound when a group trips both, and says so at its definition.
-			switch {
-			case lane == LaneNear && comp.Coh < cfg.CohFloor:
-				health.NearFloorDropped++
-			case lane == LaneNear:
-				health.NearOtherDropped++
-			case comp.Members > cfg.MaxMembers:
-				health.FarOversizeDropped++
-			default:
-				health.FarOtherDropped++
-			}
-			continue
-		}
-		cand.Q = q
-		if lane == LaneNear {
-			near = append(near, cand)
-		} else {
-			far = append(far, cand)
+		rows = append(rows, scoredMotifRow{
+			cand: cand, lane: lane, comp: comp, q: q, kept: kept,
+			cause: motifDropCauseOf(lane, comp, cfg, kept),
+		})
+	}
+	tallyMotifDrops(&health, rows)
+	return rows, health, nil
+}
+
+// motifDropCauseOf names why the scorer rejected a candidate.
+//
+// Attributed by CAUSE, from the components the scorer computed, rather than by
+// "it was near and it went". Each lane names the cause its own Phase-4
+// decision turns on FIRST — the near lane's cohesion floor (the crack between
+// the lanes), the far lane's member cap (§4's unimplemented trim) — so each is
+// an upper bound when a group trips both conditions, as the counters they feed
+// say at their definitions.
+func motifDropCauseOf(lane BridgeLane, comp BridgeComponents, cfg QualityConfig, kept bool) motifDropCause {
+	switch {
+	case kept:
+		return motifKept
+	case lane == LaneNear && comp.Coh < cfg.CohFloor:
+		return motifNearFloor
+	case lane == LaneNear:
+		return motifNearOther
+	case comp.Members > cfg.MaxMembers:
+		return motifFarOversize
+	default:
+		return motifFarOther
+	}
+}
+
+// tallyMotifDrops derives the health counters from the rows, so a counter and
+// the row it came from cannot disagree about the same group.
+func tallyMotifDrops(h *motifEnumHealth, rows []scoredMotifRow) {
+	for _, r := range rows {
+		switch r.cause {
+		case motifNearFloor:
+			h.NearFloorDropped++
+		case motifNearOther:
+			h.NearOtherDropped++
+		case motifFarOversize:
+			h.FarOversizeDropped++
+		case motifFarOther:
+			h.FarOtherDropped++
 		}
 	}
-
-	nearBudget, farBudget := motifSubBudget(eff)
-	return rankAndCap(near, nearBudget), rankAndCap(far, farBudget), health, nil
 }
 
 // anyMotifs reports whether the seed pool carries a motif at all.
@@ -731,8 +818,8 @@ func enqueueDiscover(ctx context.Context, d Deps, sess *store.PipelineSession, p
 // Read ONCE: the resolver is called per motif per fact, and a per-call query
 // would turn enumeration into a round-trip storm over a table that does not
 // change mid-session.
-func motifResolverFor(ctx context.Context, d Deps, branch string) motifResolver {
-	table, err := d.Motifs.AliasTable(ctx, branch)
+func motifResolverFor(ctx context.Context, motifs store.MotifIndex, branch string) motifResolver {
+	table, err := motifs.AliasTable(ctx, branch)
 	if err != nil {
 		// Degrade, but never silently: without the table every spelling is its
 		// own cluster, so synonyms stop bridging and the session's motif output
@@ -757,8 +844,8 @@ func motifResolverFor(ctx context.Context, d Deps, branch string) motifResolver 
 // disjointness gate. On failure it returns the zero value, whose operating
 // point is STRICT — the conservative direction, and the one that keeps a
 // near-duplicate out rather than letting it through.
-func subjectLabelsFor(ctx context.Context, d Deps, branch string) store.SubjectLabelDF {
-	labels, err := d.Search.SubjectLabelDF(ctx, branch)
+func subjectLabelsFor(ctx context.Context, search SearchQuery, branch string) store.SubjectLabelDF {
+	labels, err := search.SubjectLabelDF(ctx, branch)
 	if err != nil {
 		log.Warn().Err(err).Str("branch", branch).
 			Msg("review: subject-label distribution unreadable; disjointness gate falls back to strict")
@@ -772,9 +859,9 @@ func subjectLabelsFor(ctx context.Context, d Deps, branch string) store.SubjectL
 // The far lane cannot get them from the SIMILAR_TO graph — that graph is empty
 // there by definition — so this reaches for the vectors the graph was built
 // from.
-func meanSimFor(d Deps, branch string) meanSimFn {
+func meanSimFor(abstraction store.AbstractionIndex, branch string) meanSimFn {
 	return func(ctx context.Context, paths []string) (float64, error) {
-		ids, err := d.Abstraction.FactIDsByPath(ctx, branch, paths)
+		ids, err := abstraction.FactIDsByPath(ctx, branch, paths)
 		if err != nil {
 			return 0, err
 		}
@@ -782,7 +869,7 @@ func meanSimFor(d Deps, branch string) meanSimFn {
 		for _, id := range ids {
 			idList = append(idList, id)
 		}
-		vecs, err := d.Abstraction.BodyVectorsByFactID(ctx, idList)
+		vecs, err := abstraction.BodyVectorsByFactID(ctx, idList)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -481,11 +481,28 @@ type pairCosFn func(ctx context.Context, paths []string) ([]float64, error)
 // (store.EmbedderThresholds), never a number of this file's own — a novelty
 // signal calibrated against a different threshold from the gate it describes
 // would be measuring nothing anybody acts on.
-func dedupThresholdFor(idx SearchQuery) float64 {
-	if e, ok := idx.(interface{ Embedder() store.Embedder }); ok {
-		return store.EmbedderThresholds(e.Embedder()).Dedup
+func dedupThresholdFor(idx SearchQuery) (float64, bool) {
+	// A caller with no embedder but with the corpus's model identity — the
+	// calibrate surface — supplies the threshold itself. Structural, so no
+	// signature has to thread it through four layers, and it cannot be
+	// confused with "there is an embedder".
+	if s, ok := idx.(interface {
+		MotifDedupThreshold() (float64, bool)
+	}); ok {
+		return s.MotifDedupThreshold()
 	}
-	return store.EmbedderThresholds(nil).Dedup
+	if e, ok := idx.(interface{ Embedder() store.Embedder }); ok {
+		if emb := e.Embedder(); emb != nil {
+			return emb.Thresholds().Dedup, true
+		}
+	}
+	// UNKNOWN, not defaulted (review finding M-5). params.Defaults() is nomic's
+	// geometry; every corpus in this campaign is embeddinggemma, whose Dedup is
+	// 0.82 against the default 0.92. Returning the default here made
+	// `calibrate --kind motif` — which opens a store with no embedder — report
+	// OverDedup 0.000 for a pair genuinely above its corpus's own gate, breaking
+	// the one direction OverDedup's doc promises is safe.
+	return 0, false
 }
 
 // noveltyOf computes §8's seed-set novelty signals for one candidate.
@@ -494,8 +511,9 @@ func dedupThresholdFor(idx SearchQuery) float64 {
 // vector source, so VectorsRead reports whether they mean anything — a zero
 // SeedCos from "no vectors" and a zero from "genuinely dissimilar" are opposite
 // findings and must not share a representation.
-func noveltyOf(ctx context.Context, members []factForLLM, paths []string, pairCos pairCosFn, dedup float64) (NoveltySignals, error) {
-	n := NoveltySignals{EntityJaccard: meanEntityJaccard(members)}
+func noveltyOf(ctx context.Context, members []factForLLM, paths []string, pairCos pairCosFn,
+	dedup float64, dedupKnown bool) (NoveltySignals, error) {
+	n := NoveltySignals{EntityJaccard: meanEntityJaccard(members), DedupKnown: dedupKnown}
 	if pairCos == nil {
 		return n, nil
 	}
@@ -516,7 +534,9 @@ func noveltyOf(ctx context.Context, members []factForLLM, paths []string, pairCo
 		}
 	}
 	n.SeedCos = sum / float64(len(cs))
-	n.OverDedup = float64(over) / float64(len(cs))
+	if dedupKnown {
+		n.OverDedup = float64(over) / float64(len(cs))
+	}
 	return n, nil
 }
 
@@ -607,7 +627,8 @@ func scoreMotifCandidate(
 	// §8's novelty signals. Computed for EVERY candidate, on both lanes and
 	// whether or not it is kept, because `calibrate bridges` is about the
 	// distribution the scorer sees rather than the slice it serves.
-	nov, err := noveltyOf(ctx, cand.Members, paths, pairCos, dedupThresholdFor(idx))
+	dedup, dedupKnown := dedupThresholdFor(idx)
+	nov, err := noveltyOf(ctx, cand.Members, paths, pairCos, dedup, dedupKnown)
 	if err != nil {
 		return comp, 0, false, err
 	}

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -103,6 +103,29 @@ type motifEnumHealth struct {
 	// over the member cap, or under the quality floor. Separate because it is
 	// not evidence about the lane split.
 	NearOtherDropped int
+	// FarOversizeDropped counts groups assigned to the FAR lane and then
+	// dropped BECAUSE OF THE MEMBER CAP — the population §4's unimplemented
+	// trim would act on (carried-forward register entry 5).
+	//
+	// §4 specifies that an oversized far group is TRIMMED ("maximum community
+	// spread, then minimum mean similarity") rather than discarded. The trim
+	// was ruled deliberate-to-defer, and the group is dropped by MaxMembers
+	// instead — but nothing counted the drops, so the redesign that is supposed
+	// to happen on measured data had no denominator at all.
+	//
+	// IT IS AN UPPER BOUND, twice over, and both matter to whoever reads it as
+	// "bridges the trim would recover". A group counted here may also have been
+	// failing another gate (the cap is checked first, exactly as the near lane
+	// checks its floor first), and a group the trim shrank to fit could still
+	// fall under the quality floor afterwards. What the number means is "far
+	// groups the member cap rejected" — nothing more.
+	FarOversizeDropped int
+	// FarOtherDropped counts far-lane groups rejected for any other reason —
+	// under the quality floor, or spanning fewer than two communities. Kept
+	// apart for the same reason the near lane keeps its two apart: a counter
+	// purpose-built for one Phase-4 decision must not quietly carry a second
+	// cause under the first one's label (review M4's counter-finding).
+	FarOtherDropped int
 }
 
 // enumerateMotifCandidates is the §4 enumeration loop, with the gates applied
@@ -623,13 +646,20 @@ func buildMotifBridges(
 		}
 		if !kept {
 			// Attributed by CAUSE, from the components the scorer computed,
-			// rather than by "it was near and it went".
-			if lane == LaneNear {
-				if comp.Coh < cfg.CohFloor {
-					health.NearFloorDropped++
-				} else {
-					health.NearOtherDropped++
-				}
+			// rather than by "it was near and it went". Each lane names the
+			// cause its own Phase-4 decision turns on first — the near lane's
+			// cohesion floor (the crack between the lanes), the far lane's
+			// member cap (the unimplemented trim) — so each counter is an upper
+			// bound when a group trips both, and says so at its definition.
+			switch {
+			case lane == LaneNear && comp.Coh < cfg.CohFloor:
+				health.NearFloorDropped++
+			case lane == LaneNear:
+				health.NearOtherDropped++
+			case comp.Members > cfg.MaxMembers:
+				health.FarOversizeDropped++
+			default:
+				health.FarOtherDropped++
 			}
 			continue
 		}
@@ -812,6 +842,19 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 		lines = append(lines, fmt.Sprintf(
 			"motif near-lane other: %d group(s) dropped over the member cap or under "+
 				"the quality floor — not evidence about the lane split", h.NearOtherDropped))
+	}
+	if h.FarOversizeDropped > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"motif far-lane oversize: %d group(s) assigned far and dropped over the "+
+				"member cap — the population §4's unimplemented trim would act on "+
+				"(upper bound: a trimmed group could still fail another gate)",
+			h.FarOversizeDropped))
+	}
+	if h.FarOtherDropped > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"motif far-lane other: %d group(s) dropped under the quality floor or "+
+				"spanning one community — not evidence about the trim",
+			h.FarOtherDropped))
 	}
 	if len(h.OverCeilingNames) > 0 {
 		lines = append(lines, fmt.Sprintf(

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -126,6 +126,31 @@ type motifEnumHealth struct {
 	// purpose-built for one Phase-4 decision must not quietly carry a second
 	// cause under the first one's label (review M4's counter-finding).
 	FarOtherDropped int
+	// FamilySuppressedByExact counts token-2 families dropped because they
+	// strictly contained a verbatim group (Phase-4 rulings-3, amending L1).
+	//
+	// WHAT READS IT AND WHAT IT MEANS: it is the visible cost of the cross-tier
+	// rule. Each one is a looser grouping that did NOT reach an agent, and with
+	// it went whatever extra members it had — so a rising count means the token-2
+	// tier is mostly re-wrapping groups the exact tier already found, which is
+	// evidence about the TIER's value, not about the corpus. It does NOT mean
+	// "bridges lost": the exact group each of these contained was served in its
+	// place.
+	FamilySuppressedByExact int
+}
+
+// enumeratedMotif is an enumerated group plus the TIER that produced it.
+//
+// The tier is carried rather than re-derived because it cannot be re-derived:
+// a token-2 family is keyed by one of the canonical ids it folded, so its
+// Token is indistinguishable from a verbatim group's. Suppression has to know
+// which is which (see suppressContained), and a wrong guess there drops the
+// better group.
+type enumeratedMotif struct {
+	BridgeSeedSet
+	// family reports that this group came from the token-2 tier — a fold of
+	// several canonical ids — rather than from one id's own carriers.
+	family bool
 }
 
 // enumerateMotifCandidates is the §4 enumeration loop, with the gates applied
@@ -141,7 +166,7 @@ func enumerateMotifCandidates(
 	df motifDFFn,
 	labels store.SubjectLabelDF,
 	tier motifMatchTier,
-) ([]BridgeSeedSet, motifEnumHealth) {
+) ([]enumeratedMotif, motifEnumHealth) {
 	point := resolveDisjointnessPoint(labels)
 	ceiling := labels.LiveFacts * motifDFCeilingPerCent / 100
 	if ceiling < motifDFCeilingFloor {
@@ -186,7 +211,7 @@ func enumerateMotifCandidates(
 		groups = append(groups, token2Families(byToken)...)
 	}
 
-	var out []BridgeSeedSet
+	var out []enumeratedMotif
 	for _, g := range groups {
 		canon, members := g.key, g.members
 		// GATE 1 — the df band, `2 <= df <= max(12, 2%*N)` (§4). Below the
@@ -227,10 +252,13 @@ func enumerateMotifCandidates(
 			continue
 		}
 
-		out = append(out, BridgeSeedSet{
-			Token:   canon,
-			Kind:    BridgeMotif,
-			Members: kept,
+		out = append(out, enumeratedMotif{
+			BridgeSeedSet: BridgeSeedSet{
+				Token:   canon,
+				Kind:    BridgeMotif,
+				Members: kept,
+			},
+			family: g.family,
 		})
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].Token < out[j].Token })
@@ -633,7 +661,7 @@ func buildMotifBridges(
 	if err != nil {
 		return nil, nil, health, err
 	}
-	var near, far []BridgeSeedSet
+	var near, far []enumeratedMotif
 	for _, r := range rows {
 		if !r.kept {
 			continue
@@ -647,7 +675,10 @@ func buildMotifBridges(
 		}
 	}
 	nearBudget, farBudget := motifSubBudget(eff)
-	return rankAndCap(near, nearBudget), rankAndCap(far, farBudget), health, nil
+	nearOut, nearSup := rankAndCap(near, nearBudget)
+	farOut, farSup := rankAndCap(far, farBudget)
+	health.FamilySuppressedByExact = nearSup + farSup
+	return nearOut, farOut, health, nil
 }
 
 // scoredMotifRow is one enumerated candidate and everything the scorer decided
@@ -658,7 +689,7 @@ func buildMotifBridges(
 // from the engine that serves the bridges rather than from a second
 // implementation that agrees with it until it does not.
 type scoredMotifRow struct {
-	cand  BridgeSeedSet
+	cand  enumeratedMotif
 	lane  BridgeLane
 	comp  BridgeComponents
 	q     float64
@@ -732,11 +763,11 @@ func scoreMotifCandidates(
 		}
 		lane := laneOf(paths, g)
 
-		spec, err := sharedMotifSpecificity(ctx, idx, branch, cand, resolve)
+		spec, err := sharedMotifSpecificity(ctx, idx, branch, cand.BridgeSeedSet, resolve)
 		if err != nil {
 			return nil, health, err
 		}
-		comp, q, kept, err := scoreMotifCandidate(ctx, cand, lane, g, idx, branch, clusterOf, cfg, spec, meanSim)
+		comp, q, kept, err := scoreMotifCandidate(ctx, cand.BridgeSeedSet, lane, g, idx, branch, clusterOf, cfg, spec, meanSim)
 		if err != nil {
 			return nil, health, err
 		}
@@ -801,11 +832,11 @@ func anyMotifs(seeds []factForLLM) bool {
 
 // rankAndCap orders by Q descending, Token ascending, and truncates to the
 // lane's own budget. A zero budget means the lane is closed at this effort.
-func rankAndCap(in []BridgeSeedSet, budget int) []BridgeSeedSet {
+func rankAndCap(in []enumeratedMotif, budget int) ([]BridgeSeedSet, int) {
 	if budget == 0 {
-		return nil
+		return nil, 0
 	}
-	in = suppressContained(in)
+	in, crossTier := suppressContained(in)
 	sort.SliceStable(in, func(i, j int) bool {
 		if in[i].Q != in[j].Q {
 			return in[i].Q > in[j].Q
@@ -815,7 +846,11 @@ func rankAndCap(in []BridgeSeedSet, budget int) []BridgeSeedSet {
 	if len(in) > budget {
 		in = in[:budget]
 	}
-	return in
+	out := make([]BridgeSeedSet, 0, len(in))
+	for _, c := range in {
+		out = append(out, c.BridgeSeedSet)
+	}
+	return out, crossTier
 }
 
 // ── review-pipeline wiring ────────────────────────────────────────────────
@@ -970,6 +1005,12 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 				"spanning one community — not evidence about the trim",
 			h.FarOtherDropped))
 	}
+	if h.FamilySuppressedByExact > 0 {
+		lines = append(lines, fmt.Sprintf(
+			"motif tier suppression: %d token-2 family/families dropped in favour of the "+
+				"exact group they contained — the looser grouping did not reach an agent, "+
+				"and neither did its extra members", h.FamilySuppressedByExact))
+	}
 	if len(h.OverCeilingNames) > 0 {
 		lines = append(lines, fmt.Sprintf(
 			"motif df ceiling: %d motif(s) over the band, flagged for review splitting rather than bridged: %s",
@@ -978,21 +1019,37 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 	return lines
 }
 
-// suppressContained drops any group whose members are a strict subset of
-// another group's.
+// suppressContained resolves groups whose members are a strict subset of
+// another group's, and the rule DIFFERS depending on whether the two came from
+// the same tier. It returns the survivors and how many cross-tier families it
+// dropped.
 //
-// The token-2 tier makes these by construction: a family is kept only when it
-// has more members than its key's verbatim group, so the verbatim group is
-// always strictly contained in it, and both carry the SAME Bridge token. On the
-// measured corpus that was 12 of 113 groups, with three tokens each producing
-// two items (Phase-3 review, L1). On an axis judged as an observation-window
-// feeder with eight slots a lane, spending two of them on {A,B} and {A,B,C} is
-// spending two on one question.
+// WITHIN A TIER, the superset survives. The token-2 tier makes these by
+// construction: a family is kept only when it has more members than its key's
+// verbatim group, so that group is always strictly contained in it. On the
+// measured fixture that was 12 of 113 groups (Phase-3 review, L1). Spending two
+// of eight slots on {A,B} and {A,B,C} is spending two on one question, and the
+// superset carries strictly more evidence for the SAME shared mechanism.
 //
-// The SUPERSET survives: it carries strictly more evidence for the same shared
-// mechanism, and the agent can still decline the members it finds unconvincing.
+// ACROSS TIERS, THE EXACT GROUP WINS, and the family is dropped (designer
+// ruling, Phase-4 rulings-3, amending L1). The within-tier rationale does not
+// transfer: a token-2 family is a DIFFERENT, LOOSER grouping, not more evidence
+// for the same one, so "the superset carries strictly more evidence" is false
+// of it. Measured instance that produced the ruling — on the merged corpus at
+// high effort, the family keyed `invents-rather-than-asks` folded the genuine
+// verbatim pair `own-rather-than-rent` (owning vs renting compute) together
+// with a tool-parameter gotcha and a drug-discovery fact, joined by nothing but
+// the English construction "rather than". Under L1 as written the family
+// displaced the real pair and took the slot.
+//
+// WHAT THIS COSTS, said plainly: a dropped family's EXTRA members leave the
+// served set with it, so pairs only that family offered are no longer offered.
+// That is the intended trade — those pairs exist only because a looser tier
+// invented the grouping — but it is a real loss, not a free win, and the
+// acceptance assertion about it is tier-aware for that reason.
+//
 // Runs before ranking and truncation, or it would free no slots.
-func suppressContained(in []BridgeSeedSet) []BridgeSeedSet {
+func suppressContained(in []enumeratedMotif) ([]enumeratedMotif, int) {
 	sets := make([]map[string]struct{}, len(in))
 	for i, g := range in {
 		sets[i] = make(map[string]struct{}, len(g.Members))
@@ -1000,23 +1057,33 @@ func suppressContained(in []BridgeSeedSet) []BridgeSeedSet {
 			sets[i][m.File] = struct{}{}
 		}
 	}
-	out := make([]BridgeSeedSet, 0, len(in))
+	out := make([]enumeratedMotif, 0, len(in))
+	crossTier := 0
 	for i := range in {
-		contained := false
+		drop := false
 		for j := range in {
-			if i == j || len(sets[j]) <= len(sets[i]) {
+			if i == j {
 				continue
 			}
-			if subsetOf(sets[i], sets[j]) {
-				contained = true
+			// Cross-tier: a FAMILY containing an exact group loses to it,
+			// whatever their sizes.
+			if in[i].family && !in[j].family && subsetOf(sets[j], sets[i]) {
+				drop = true
+				crossTier++
+				break
+			}
+			// Same tier: the strict superset survives.
+			if in[i].family == in[j].family &&
+				len(sets[j]) > len(sets[i]) && subsetOf(sets[i], sets[j]) {
+				drop = true
 				break
 			}
 		}
-		if !contained {
+		if !drop {
 			out = append(out, in[i])
 		}
 	}
-	return out
+	return out, crossTier
 }
 
 func subsetOf(small, big map[string]struct{}) bool {

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -137,6 +137,12 @@ type motifEnumHealth struct {
 	// "bridges lost": the exact group each of these contained was served in its
 	// place.
 	FamilySuppressedByExact int
+	// Activation is the per-corpus enablement decision and the counts it was
+	// made on. Reported whether or not the axis ran, because "inactive" and
+	// "active and found nothing" are different statements about a corpus and a
+	// reader comparing sessions must be able to tell them apart (L6, one layer
+	// out again).
+	Activation motifActivation
 }
 
 // enumeratedMotif is an enumerated group plus the TIER that produced it.
@@ -736,6 +742,17 @@ func scoreMotifCandidates(
 		return nil, motifEnumHealth{}, nil
 	}
 
+	// THE ACTIVATION FLOOR (§8 as amended, phase4-rulings-4). Placed here,
+	// beside the motif-free short circuit and before the first index call, for
+	// the same reason that one is: an inactive corpus must cost nothing. It is
+	// recomputed every session from the pool in hand — level-triggered, no
+	// stored flag, nothing to migrate — so a corpus crosses the floor by
+	// accumulating recurrence and needs no one to switch it on.
+	act := motifActive(seeds, resolve)
+	if !act.Active {
+		return nil, motifEnumHealth{Activation: act}, nil
+	}
+
 	dfOf := func(canon string) int {
 		n, err := idx.TokenDF(ctx, branch, canon, string(BridgeMotif))
 		if err != nil {
@@ -749,6 +766,7 @@ func scoreMotifCandidates(
 	}
 
 	cands, health := enumerateMotifCandidates(seeds, clusters, resolve, dfOf, labels, motifTier(eff))
+	health.Activation = act
 	clusterOf := bridgePathCommunities(seeds, clusters)
 
 	rows := make([]scoredMotifRow, 0, len(cands))
@@ -817,6 +835,118 @@ func tallyMotifDrops(h *motifEnumHealth, rows []scoredMotifRow) {
 		case motifFarOther:
 			h.FarOtherDropped++
 		}
+	}
+}
+
+// seedRecurrence counts recurring clusters and the pairs they could bridge,
+// over the SEED POOL — the population the activation floor is set on.
+//
+// A carrier is counted once per canonical id however many spellings of it the
+// fact carries, matching what TokenDF and the vocabulary health both do: a
+// fact using two spellings of one mechanism is one carrier, not two, or a
+// single author's phrasing habit would read as recurrence.
+func seedRecurrence(seeds []factForLLM, resolve motifResolver) (df2Clusters, pairs int) {
+	carriers := map[string]map[string]struct{}{}
+	for _, f := range seeds {
+		// The SAME §7 exclusion enumeration applies: a discovered fact is never
+		// a seed, or discovery feeds on its own output (cf455b8f). Counting
+		// them here would let a corpus activate on recurrence that enumeration
+		// cannot see, and the axis would switch on and then find nothing --
+		// the activation number would not mean what its label says.
+		if f.Origin == string(fact.Discovered) {
+			continue
+		}
+		for _, m := range f.Motifs {
+			c := resolve(m)
+			if c == "" {
+				continue
+			}
+			if carriers[c] == nil {
+				carriers[c] = map[string]struct{}{}
+			}
+			carriers[c][f.File] = struct{}{}
+		}
+	}
+	for _, set := range carriers {
+		n := len(set)
+		if n < 2 {
+			continue
+		}
+		df2Clusters++
+		pairs += n * (n - 1) / 2
+	}
+	return df2Clusters, pairs
+}
+
+// motifActivationFloor is the minimum number of RECURRING canonical motifs a
+// corpus must carry before motif bridging enumerates anything.
+//
+// CONSTANT CLASSIFICATION (MN13, third class): a STATISTICAL-VALIDITY FLOOR.
+// It is a minimum POPULATION, not a proportion and not a claim about any
+// corpus's distribution: below it there are too few shared-motif pairs in
+// existence for the axis to be doing anything but spending discovery slots on
+// noise. Below the floor the mechanism DOES NOTHING, which is what
+// distinguishes this class from a threshold someone picked.
+//
+// WHY THIS QUANTITY. The blueprint's original condition was ~30% motif
+// coverage plus non-zero recurrence. Measured, coverage is a BACKFILL RATE
+// LIMIT — it tracks sessions elapsed, not corpus character — and the only
+// corpus in the gate annex that cleared 30% is the one the annex names as its
+// negative result (knomit-io-kb: 100% coverage, and zero recurring clusters
+// once the seed filter is applied). The population that can bridge at all is
+// what actually limits the axis. Designer ruling, phase4-rulings-4, replacing
+// the coverage condition; "non-zero recurrence" is the K=1 degenerate case of
+// this same condition and is not a second one.
+//
+// WHY 3, AND WHAT THAT IS WORTH. Measured post-AcceptSeed df>=2 counts:
+// agentic-engineering 4, merged 6, knomit-kb 1, knomit-io-kb 0, core 0. Any K
+// in 2..4 separates the two corpora the annex credits with producing value
+// from the three it does not; K=1 admits the machinery-only corpus and K=5
+// switches off the corpus where the value was measured. 3 sits in the middle
+// rather than on either edge. It is a fit through five points with the target
+// separation known in advance — recorded as such — redeemed by the fact that
+// the QUANTITY has an argument older than the table ("two shots is not a
+// sample", gate annex §4).
+//
+// SETTING IT LOW-INFORMATION IS SAFE BECAUSE ACTIVATION IS LEVEL-TRIGGERED.
+// It is recomputed from current counts every session (Q2: computed, never
+// configured). A corpus below the floor is not switched off, it is NOT YET ON,
+// and it turns itself on by accumulating recurrence — no flag, no migration,
+// no user action. So the asymmetry favours caution: too high costs a delay the
+// corpus resolves by itself, too low spends slots on a vocabulary that cannot
+// support them.
+const motifActivationFloor = 3
+
+// motifActivation is what the activation decision saw.
+type motifActivation struct {
+	// Evaluated reports that the decision was actually MADE. A zero value means
+	// the axis was never asked — a motif-free corpus short-circuits before the
+	// floor is consulted — and that is a different statement from "asked, and
+	// the corpus is below the floor". Without this the two are the same struct,
+	// and the health line would announce an inactive corpus for one that simply
+	// has no motifs (L6's distinction, one layer further down).
+	Evaluated bool
+	// Active reports whether the axis enumerates on this corpus this session.
+	Active bool
+	// DF2Clusters is the recurring-cluster count the decision was made on,
+	// over the SEED POOL (see seedRecurrence).
+	DF2Clusters int
+	// Pairs is the bridgeable-pair ceiling — reported beside the decision
+	// because one heavily-shared motif and three df-2 motifs are different
+	// situations with the same cluster count.
+	Pairs int
+}
+
+// motifActive decides whether this corpus has enough recurring vocabulary for
+// bridging to mean anything. Pure, and it costs no index call: the resolver is
+// already built and the seed pool is already in hand.
+func motifActive(seeds []factForLLM, resolve motifResolver) motifActivation {
+	clusters, pairs := seedRecurrence(seeds, resolve)
+	return motifActivation{
+		Evaluated:   true,
+		Active:      clusters >= motifActivationFloor,
+		DF2Clusters: clusters,
+		Pairs:       pairs,
 	}
 }
 
@@ -968,13 +1098,36 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 			"motif bridges unavailable this session: %s "+
 				"(no candidates — this is NOT a statement about the corpus)", h.Failure)}
 	}
+	if h.Activation.Evaluated && !h.Activation.Active {
+		return []string{fmt.Sprintf(
+			"motif bridging inactive: %d recurring motif(s) (%d bridgeable pair(s)), below the "+
+				"%d-motif validity floor — the corpus has too little repeated vocabulary for a "+
+				"shared-motif pair to mean anything yet. Recomputed every session; it activates "+
+				"itself as recurrence accumulates.",
+			h.Activation.DF2Clusters, h.Activation.Pairs, motifActivationFloor)}
+	}
 	if h.Candidates == 0 && len(h.OverCeilingNames) == 0 {
 		return nil
 	}
 	point := fmt.Sprintf("df <= %d (p%d of %d labels)", h.Point.Cut, disjointnessPercentile, h.Point.Labels)
 	if h.Point.Strict {
-		point = fmt.Sprintf("STRICT fallback — %d labels is below the %d-label validity floor, so any shared label blocks",
-			h.Point.Labels, minLabelsForPercentile)
+		// The two fallbacks are DIFFERENT diagnoses and the line says which.
+		// "Too few labels to estimate from" and "the estimate came back
+		// unsatisfiable" describe different corpora and want different
+		// responses; one wording for both would send a reader looking at the
+		// wrong thing.
+		switch h.Point.Fallback {
+		case degenerateCut:
+			point = fmt.Sprintf(
+				"STRICT fallback (degenerate cut) — %d labels is past the floor, but p%d of their "+
+					"df distribution is %d, and a SHARED label has df >= %d by definition, so that "+
+					"cut can never block. Any shared label blocks instead",
+				h.Point.Labels, disjointnessPercentile, h.Point.Cut, minUsableCut)
+		default:
+			point = fmt.Sprintf(
+				"STRICT fallback (label floor) — %d labels is below the %d-label validity floor, "+
+					"so any shared label blocks", h.Point.Labels, minLabelsForPercentile)
+		}
 	}
 	lines := []string{
 		fmt.Sprintf("motif bridges: %d candidates, %d near, %d far (df band 2..%d)",

--- a/internal/synthesize/bridge_motif_acceptance_test.go
+++ b/internal/synthesize/bridge_motif_acceptance_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -390,4 +391,104 @@ func TestMotifMeasurement_Token2FoldStems(t *testing.T) {
 		}
 		t.Logf("  %4d x  %s", k.n, k.stems)
 	}
+}
+
+// TestMotifMeasurement_WriteSupplementaryHarnessPack emits the H-track's
+// SUPPLEMENTARY arm: motif pairs from the harness fixture corpus.
+//
+// Why a supplement rather than more of the primary arm (Phase-4 rulings-6):
+// the real corpora serve one to three motif pairs each, so the primary MOTIF
+// arms cannot reach E1's size. This answers the different question — "when the
+// axis HAS population, are the pairs it produces good?" — and is never pooled
+// with the primary evidence.
+//
+// TWO CAVEATS, both structural and both stated in the emitted file so they
+// travel with the numbers:
+//
+//  1. LANELESS. The fixture is a labels file with no vectors, so there is no
+//     SIMILAR_TO graph, laneOf assigns everything FAR by construction and the
+//     cohesion floor never engages. These are ENUMERATED candidates, not
+//     SERVED ones — no scoring, no budget, no lane.
+//
+//  2. Its facts are titles and bodies from the harness's own extraction, not
+//     the corpus text a production judge would see.
+//
+//     KNOMIT_MOTIF_ACCEPTANCE=1 go test ./internal/synthesize/ -run TestMotifMeasurement_Write -v
+func TestMotifMeasurement_WriteSupplementaryHarnessPack(t *testing.T) {
+	if os.Getenv("KNOMIT_MOTIF_ACCEPTANCE") != "1" {
+		t.Skip("fixture replay; set KNOMIT_MOTIF_ACCEPTANCE=1")
+	}
+	outDir := os.Getenv("KNOMIT_HARNESS_OUT")
+	if outDir == "" {
+		t.Skip("set KNOMIT_HARNESS_OUT to the directory the pack should be written to")
+	}
+	facts := loadCanonCorpus(t, "knomit-kb")
+	require.NotEmpty(t, facts)
+
+	cands, _ := enumerateMotifCandidates(facts, ClusterResult{}, identityResolver,
+		motifDFFor(facts), labelsFor(facts), tierToken2)
+	kept, _ := suppressContained(cands)
+	require.NotEmpty(t, kept)
+
+	byPath := map[string]factForLLM{}
+	for _, f := range facts {
+		byPath[f.File] = f
+	}
+
+	// One pair per group, deterministic: the first two members in path order.
+	// No rng here — the fixture has no scoring to break ties with, so an
+	// arbitrary-but-fixed rule is more honest than a seeded draw that looks
+	// like sampling.
+	type item struct {
+		ID     string `json:"id"`
+		ATitle string `json:"a_title"`
+		ABody  string `json:"a_body"`
+		BTitle string `json:"b_title"`
+		BBody  string `json:"b_body"`
+	}
+	type keyRow struct {
+		ID    string `json:"id"`
+		Arm   string `json:"arm"`
+		Token string `json:"token"`
+		A     string `json:"a"`
+		B     string `json:"b"`
+	}
+	var pack []item
+	var key []keyRow
+	for _, g := range kept {
+		if len(g.Members) < 2 {
+			continue
+		}
+		ms := append([]factForLLM(nil), g.Members...)
+		sort.Slice(ms, func(i, j int) bool { return ms[i].File < ms[j].File })
+		a, b := ms[0], ms[1]
+		id := fmt.Sprintf("S%03d", len(pack)+1)
+		clip := func(s string) string {
+			s = strings.ReplaceAll(strings.TrimSpace(s), "\n", " ")
+			if len(s) > 400 {
+				s = s[:400]
+			}
+			return s
+		}
+		pack = append(pack, item{ID: id, ATitle: a.Title, ABody: clip(a.Body),
+			BTitle: b.Title, BBody: clip(b.Body)})
+		key = append(key, keyRow{ID: id, Arm: "MOTIF-FIXTURE", Token: g.Token, A: a.File, B: b.File})
+		if len(pack) >= 12 {
+			break
+		}
+	}
+	require.NotEmpty(t, pack)
+
+	payload := map[string]any{
+		"arm": "MOTIF-FIXTURE (SUPPLEMENTARY — never pooled with the primary arms)",
+		"n":   len(pack),
+		"caveat": "ENUMERATED candidates, not served: the fixture carries no vectors, so there is no " +
+			"SIMILAR_TO graph, every group is assigned FAR by construction, and neither the cohesion " +
+			"floor nor the per-lane budget ever runs. Text is the harness's own extraction.",
+		"pack": pack, "key": key,
+	}
+	blob, err := json.MarshalIndent(payload, "", " ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(outDir, "supplementary.json"), blob, 0o644))
+	t.Logf("wrote %d supplementary pairs from %d kept groups", len(pack), len(kept))
 }

--- a/internal/synthesize/bridge_motif_acceptance_test.go
+++ b/internal/synthesize/bridge_motif_acceptance_test.go
@@ -69,10 +69,36 @@ func loadCanonCorpus(t *testing.T, corpus string) []factForLLM {
 			Domain:   quotedList(reDomain, row.Input),
 			Entities: quotedList(reEntities, row.Input),
 			Motifs:   row.Output,
+			// Title and body are inert for enumeration — which is why they
+			// were not extracted until now — but the H-track pack cannot be
+			// judged without them, and a pack of empty pairs is what the blind
+			// judge received on the first run.
+			Title: canonField(row.Input, "title: "),
+			Body:  canonField(row.Input, "body: "),
 		})
 	}
 	require.NoError(t, sc.Err())
 	return out
+}
+
+// canonField pulls one labelled line out of the fixture's flattened input
+// blob. The body runs to the end of the record, so it is taken whole.
+func canonField(input, prefix string) string {
+	i := strings.Index(input, "\n"+prefix)
+	if i < 0 {
+		if !strings.HasPrefix(input, prefix) {
+			return ""
+		}
+		i = -1
+	}
+	rest := input[i+1+len(prefix):]
+	if prefix == "body: " {
+		return strings.TrimSpace(rest)
+	}
+	if j := strings.Index(rest, "\n"); j >= 0 {
+		rest = rest[:j]
+	}
+	return strings.TrimSpace(rest)
 }
 
 func quotedList(re *regexp.Regexp, input string) []string {
@@ -478,6 +504,13 @@ func TestMotifMeasurement_WriteSupplementaryHarnessPack(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, pack)
+	// A pack of blank pairs is judgeable-looking and worthless — the first run
+	// emitted twelve of them and the blind judge is what noticed. Assert the
+	// content is there rather than trusting the projection.
+	for _, it := range pack {
+		require.NotEmptyf(t, it.ATitle, "%s: pair A has no title", it.ID)
+		require.NotEmptyf(t, it.BTitle, "%s: pair B has no title", it.ID)
+	}
 
 	payload := map[string]any{
 		"arm": "MOTIF-FIXTURE (SUPPLEMENTARY — never pooled with the primary arms)",

--- a/internal/synthesize/bridge_motif_acceptance_test.go
+++ b/internal/synthesize/bridge_motif_acceptance_test.go
@@ -229,3 +229,140 @@ func TestMotifAcceptance_BridgeYieldPairs(t *testing.T) {
 		"token-2 must admit something exact does not, or the ladder is flat on real data")
 	require.Equal(t, hNormal.Ceiling, hHigh.Ceiling, "the band is a corpus property, not a tier one")
 }
+
+// ── Phase-4 measurement: the token-2 tier's noise shape (register entry 6) ──
+
+// TestMotifMeasurement_Token2FoldStems reports WHAT the token-2 tier folds on.
+//
+// Register entry 6 asks two things: whether a stopword tightening is warranted,
+// and — regardless — that "Phase-4 readers of tier numbers must know what
+// produced them". The Phase-3 review named the suspected culprit as connective
+// merges (`cost-of-delay`/`wolf-of-delay` on `of`+`delay`). This measures the
+// actual distribution rather than assuming that shape.
+//
+// It runs over the FIXTURE corpus because that is the only population with
+// enough recurring vocabulary for the tier to fold anything at scale: the real
+// corpora carry 0-3 folds each. Read-only replay of the harness labels file,
+// per the Phase-2 exception; nothing is imported from .claude/harness.
+//
+//	KNOMIT_MOTIF_ACCEPTANCE=1 go test ./internal/synthesize/ -run TestMotifMeasurement -v
+func TestMotifMeasurement_Token2FoldStems(t *testing.T) {
+	if os.Getenv("KNOMIT_MOTIF_ACCEPTANCE") != "1" {
+		t.Skip("measurement replay over the harness fixture; set KNOMIT_MOTIF_ACCEPTANCE=1")
+	}
+	facts := loadCanonCorpus(t, "knomit-kb")
+	require.NotEmpty(t, facts)
+
+	// The canonical ids this corpus's bridging population actually carries.
+	idSet := map[string]struct{}{}
+	for _, f := range facts {
+		for _, m := range f.Motifs {
+			idSet[m] = struct{}{}
+		}
+	}
+	ids := make([]string, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	stems := make([]map[string]struct{}, len(ids))
+	for i, id := range ids {
+		stems[i] = motifStems(id) // the SHIPPED predicate, not a copy
+	}
+
+	type kv struct {
+		stems string
+		n     int
+	}
+
+	// A fold is a pair of canonical ids the tier would join. Counted by the
+	// stem-set that did it, so the shape of the noise is visible rather than
+	// inferred.
+	byStems := map[string]int{}
+	folds := 0
+	for i := range ids {
+		for j := i + 1; j < len(ids); j++ {
+			sh := sharedMotifStems(stems[i], stems[j])
+			if len(sh) < token2SharedStems {
+				continue
+			}
+			folds++
+			byStems[strings.Join(sh, "+")]++
+		}
+	}
+
+	top := make([]kv, 0, len(byStems))
+	for s, n := range byStems {
+		top = append(top, kv{s, n})
+	}
+	sort.Slice(top, func(a, b int) bool {
+		if top[a].n != top[b].n {
+			return top[a].n > top[b].n
+		}
+		return top[a].stems < top[b].stems
+	})
+
+	// Two competing explanations for the noise, counted rather than assumed.
+	// CONNECTIVES are what the Phase-3 review suspected (`of`+`delay`). Stem
+	// PARTICIPATION tests the other hypothesis: that a few very common
+	// mechanism words carry the folds regardless of part of speech.
+	connectives := map[string]bool{
+		"of": true, "to": true, "by": true, "in": true, "on": true, "for": true,
+		"and": true, "or": true, "the": true, "a": true, "an": true, "at": true,
+		"as": true, "with": true, "from": true, "into": true, "over": true,
+		"under": true, "is": true, "are": true, "be": true, "it": true,
+		"its": true, "that": true, "this": true, "not": true, "no": true,
+		"than": true, "rather": true, "once": true, "when": true, "before": true,
+		"after": true, "per": true, "via": true,
+	}
+	connFolds := 0
+	participation := map[string]int{}
+	for i := range ids {
+		for j := i + 1; j < len(ids); j++ {
+			sh := sharedMotifStems(stems[i], stems[j])
+			if len(sh) < token2SharedStems {
+				continue
+			}
+			hasConn := false
+			for _, st := range sh {
+				participation[st]++
+				if connectives[st] {
+					hasConn = true
+				}
+			}
+			if hasConn {
+				connFolds++
+			}
+		}
+	}
+	partTop := make([]kv, 0, len(participation))
+	for s, n := range participation {
+		partTop = append(partTop, kv{s, n})
+	}
+	sort.Slice(partTop, func(a, b int) bool {
+		if partTop[a].n != partTop[b].n {
+			return partTop[a].n > partTop[b].n
+		}
+		return partTop[a].stems < partTop[b].stems
+	})
+
+	t.Logf("vocabulary: %d canonical ids; %d token-2 folds", len(ids), folds)
+	t.Logf("folds involving a CONNECTIVE stem: %d of %d (%.1f%%)",
+		connFolds, folds, 100*float64(connFolds)/float64(folds))
+	t.Logf("top participating stems (folds each stem appears in):")
+	for i, k := range partTop {
+		if i >= 12 {
+			break
+		}
+		t.Logf("  %4d  %s%s", k.n, k.stems, map[bool]string{true: "   [connective]"}[connectives[k.stems]])
+	}
+	require.Positive(t, folds, "precondition: the fixture must actually fold something")
+	for i, k := range top {
+		if i >= 25 {
+			t.Logf("... and %d more distinct stem-sets", len(top)-i)
+			break
+		}
+		t.Logf("  %4d x  %s", k.n, k.stems)
+	}
+}

--- a/internal/synthesize/bridge_motif_acceptance_test.go
+++ b/internal/synthesize/bridge_motif_acceptance_test.go
@@ -123,7 +123,7 @@ func motifDFFor(facts []factForLLM) motifDFFn {
 // merges canonical ids, so the same pair of facts can arrive under a different
 // group label at a higher effort. Keying on the token would make monotonicity
 // look violated by a relabelling.
-func pairsOf(groups []BridgeSeedSet) map[string]struct{} {
+func pairsOf(groups []enumeratedMotif) map[string]struct{} {
 	out := map[string]struct{}{}
 	for _, g := range groups {
 		for i := 0; i < len(g.Members); i++ {
@@ -193,15 +193,40 @@ func TestMotifAcceptance_BridgeYieldPairs(t *testing.T) {
 	// another, and therefore never reach a slot. The reviewer measured 12 of
 	// 113 at enumeration; this asserts the suppression actually removes them
 	// before the budget is spent.
-	kept := suppressContained(high)
-	t.Logf("contained-group suppression: %d of %d token-2 groups dropped",
-		len(high)-len(kept), len(high))
+	kept, crossTier := suppressContained(high)
+	t.Logf("contained-group suppression: %d of %d token-2 groups dropped (%d of them cross-tier)",
+		len(high)-len(kept), len(high), crossTier)
 	require.Positive(t, len(high)-len(kept),
 		"token-2 makes contained groups by construction — a run that suppresses none "+
 			"means the suppression is not reaching them")
-	require.Equal(t, pairsOf(high), pairsOf(kept),
-		"suppression must not lose a PAIR — a contained group's members all "+
-			"survive inside the superset that displaced it")
+
+	// TIER-AWARE, amended with the cross-tier ruling (Phase-4 rulings-3).
+	//
+	// The original assertion here was `pairsOf(high) == pairsOf(kept)` — "
+	// suppression must not lose a PAIR". That was true while the superset
+	// always survived: a contained group's members all lived on inside the
+	// group that displaced it. The cross-tier rule inverts that case on
+	// purpose — a token-2 family containing an exact group is DROPPED — so a
+	// family's EXTRA members leave with it, and pairs only that family offered
+	// are no longer offered. Equality is therefore the wrong assertion now, and
+	// weakening it to "subset" alone would assert almost nothing.
+	//
+	// What replaces it is the property the ruling actually protects: whatever
+	// else suppression removes, it never costs a pair the EXACT tier found.
+	require.Subset(t, pairsOf(high), pairsOf(kept),
+		"suppression only ever removes; it cannot invent a pair")
+	require.Subset(t, pairsOf(kept), pairsOf(normal),
+		"no pair the EXACT tier offers may be lost to suppression — that is what "+
+			"the cross-tier rule exists to protect")
+	// SAID PLAINLY, because a reader could take this block for a test OF the
+	// cross-tier rule and it is not one: both assertions above hold under the
+	// OLD rule too, and I verified that by sabotage — reverting to
+	// superset-always-wins leaves this test green. They are invariants that
+	// must survive the change, which is what the ruling asked be re-run. The
+	// rule itself is pinned by TestRankAndCap_CrossTierTheExactGroupWins, which
+	// does fail under that sabotage.
+	t.Logf("pairs: %d enumerated at token-2, %d after suppression, %d at exact",
+		len(pairsOf(high)), len(pairsOf(kept)), len(pairsOf(normal)))
 
 	// The measurement's headline: ten subject-disjoint pairs on knomit-kb. The
 	// shipped gate is FINER than the one that produced it (df-graded rather

--- a/internal/synthesize/bridge_motif_dynamics_test.go
+++ b/internal/synthesize/bridge_motif_dynamics_test.go
@@ -69,6 +69,7 @@ func TestMotifBridging_AcrossSessions(t *testing.T) {
 
 	// S2 — the motifs arrive on two subject-disjoint facts. The bridge forms,
 	// on a corpus whose alias table this session had to build for itself.
+	env.seedActivationVocabulary()
 	env.rewriteWithMotifs(uiPath,
 		"An agent testing a UI will execute JavaScript instead of clicking",
 		"Driving app state directly bypasses the path the verifier believes it is checking.",
@@ -79,17 +80,17 @@ func TestMotifBridging_AcrossSessions(t *testing.T) {
 		[]string{"measure-becomes-target"}, []string{"Terminal Bench"})
 
 	s2, h2 := env.motifBridgeSession(EffortHigh)
-	motifs2 := motifPayloads(s2)
+	motifs2 := motifPayloadsFor(s2, "measure-becomes-target")
 	require.Len(t, motifs2, 1, "the pair bridges once its motifs exist")
 	require.Equal(t, LaneFar, motifs2[0].Lane)
-	require.Contains(t, strings.Join(h2, "\n"), "motif bridges: 1 candidates")
+	require.Contains(t, strings.Join(h2, "\n"), "motif bridges:")
 
 	// S3 — nothing changed. The bridge is still THERE: enumeration is a
 	// function of the live corpus, not of what this session happens to have
 	// touched, so a standing bridge does not blink out because a session was
 	// quiet.
 	s3, _ := env.motifBridgeSession(EffortHigh)
-	require.Len(t, motifPayloads(s3), 1,
+	require.Len(t, motifPayloadsFor(s3, "measure-becomes-target"), 1,
 		"a bridge is a property of the corpus, not of the session's dirty set")
 
 	// S4 — one member is rewritten so the two now share a RARE entity. They are
@@ -101,7 +102,7 @@ func TestMotifBridging_AcrossSessions(t *testing.T) {
 		[]string{"measure-becomes-target"}, []string{"Cognition"})
 
 	s4, _ := env.motifBridgeSession(EffortHigh)
-	require.Empty(t, motifPayloads(s4),
+	require.Empty(t, motifPayloadsFor(s4, "measure-becomes-target"),
 		"the pair now shares a rare entity — level-triggered, so the gate re-decides")
 
 	// S5 — and back. The same edit reversed restores the bridge, which is what
@@ -112,7 +113,7 @@ func TestMotifBridging_AcrossSessions(t *testing.T) {
 		[]string{"measure-becomes-target"}, []string{"Terminal Bench"})
 
 	s5, _ := env.motifBridgeSession(EffortHigh)
-	require.Len(t, motifPayloads(s5), 1)
+	require.Len(t, motifPayloadsFor(s5, "measure-becomes-target"), 1)
 }
 
 // TestMotifBridging_EffortIsRecomputedPerSession — the same corpus, two
@@ -120,6 +121,7 @@ func TestMotifBridging_AcrossSessions(t *testing.T) {
 // effort must close the far lane on the very next session.
 func TestMotifBridging_EffortIsRecomputedPerSession(t *testing.T) {
 	env := motifDynamicsEnv(t)
+	env.seedActivationVocabulary()
 	env.rewriteWithMotifs("kb/gotchas/uitesting/agentclicks.md",
 		"An agent testing a UI will execute JavaScript instead of clicking",
 		"Driving app state directly bypasses the verifier's path.",
@@ -130,10 +132,10 @@ func TestMotifBridging_EffortIsRecomputedPerSession(t *testing.T) {
 		[]string{"measure-becomes-target"}, []string{"Terminal Bench"})
 
 	high, _ := env.motifBridgeSession(EffortHigh)
-	require.Len(t, motifPayloads(high), 1, "the far lane is open at high")
+	require.Len(t, motifPayloadsFor(high, "measure-becomes-target"), 1, "the far lane is open at high")
 
 	medium, _ := env.motifBridgeSession(EffortMedium)
-	require.Empty(t, motifPayloads(medium),
+	require.Empty(t, motifPayloadsFor(medium, "measure-becomes-target"),
 		"medium is near lane only, and this group is far — no state carries the item over")
 }
 
@@ -153,6 +155,7 @@ func TestMotifBridging_FromNothing(t *testing.T) {
 	// which needs an agent to answer its work item, and this test is about the
 	// mechanical derived state a session must build unaided — the alias table,
 	// the canonical id, the df — not about the judged half.
+	env.seedActivationVocabulary()
 	env.rewriteWithMotifs("kb/gotchas/caching/staleread.md",
 		"A cache served state the writer had already replaced",
 		"The reader observed a version the writer believed was gone.",
@@ -165,7 +168,7 @@ func TestMotifBridging_FromNothing(t *testing.T) {
 	var found bool
 	for i := 0; i < 4 && !found; i++ {
 		payloads, _ := env.motifBridgeSession(EffortHigh)
-		found = len(motifPayloads(payloads)) > 0
+		found = len(motifPayloadsFor(payloads, "stale-read-after-write")) > 0
 	}
 	require.True(t, found,
 		"a session must maintain the derived state its own bridging depends on")
@@ -192,4 +195,57 @@ func TestMotifBridging_ReinforcementSurvivesLaterSessions(t *testing.T) {
 	// And a second reinforcement attempt after that session is still a no-op.
 	require.Empty(t, env.apply(goodReinforcement()))
 	require.Equal(t, afterWrite.Sources, env.read(reinforcePath).Sources)
+}
+
+// seedActivationVocabulary gives the corpus enough RECURRING vocabulary to
+// clear the K=3 activation floor, on facts unrelated to whatever the calling
+// test is about.
+//
+// Every motif-bridging fixture in this package seeded exactly one recurring
+// motif, because one is all a bridge needs. The activation floor
+// (phase4-rulings-4) means one is no longer enough for the axis to run at all,
+// so a test about lane routing or payload contents has to bring a vocabulary
+// with it. The two extra regularities here are deliberately about nothing the
+// callers assert on: they exist to make the corpus eligible, not to be found.
+//
+// It writes its own paths (kb/act/*) so it cannot collide with a caller's
+// subject facts, and — the part that matters — each pair SHARES a rare entity,
+// so subject-disjointness rejects it and it never becomes a candidate. The
+// fillers therefore move the activation count and nothing else: a caller
+// asserting "one discover item" still gets one. Recurrence is counted over the
+// seed pool BEFORE any gate, which is what makes that possible.
+func (e *restatementEnv) seedActivationVocabulary() {
+	e.rewriteWithMotifs("kb/act/retrytopology.md",
+		"A retry storm formed when every client backed off by the same amount",
+		"Identical backoff turned independent retries into a synchronised wave.",
+		[]string{"synchronised-retry-wave"}, []string{"FillerAlpha"})
+	e.rewriteWithMotifs("kb/act/schedulerqueue.md",
+		"Batch jobs released on the hour arrived as one spike",
+		"A shared release time collapsed independent schedules onto one instant.",
+		[]string{"synchronised-retry-wave"}, []string{"FillerAlpha"})
+	e.rewriteWithMotifs("kb/act/configdrift.md",
+		"Two replicas diverged because only one reloaded its configuration",
+		"A reload that reached one process and not its peer left them disagreeing.",
+		[]string{"partial-reload-diverges"}, []string{"FillerBeta"})
+	e.rewriteWithMotifs("kb/act/certrotation.md",
+		"Half the fleet kept the old certificate after rotation",
+		"A rotation applied per-node left the fleet holding two truths at once.",
+		[]string{"partial-reload-diverges"}, []string{"FillerBeta"})
+}
+
+// motifPayloadsFor narrows to the bridge a test is actually about.
+//
+// Since the activation floor (phase4-rulings-4) a corpus must carry three
+// recurring motifs before any of them enumerates, so every fixture here now
+// brings filler vocabulary — and the fillers enumerate too. Asserting on the
+// total would be asserting on the fillers. Filtering by token asserts on the
+// subject, which is what these tests always meant.
+func motifPayloadsFor(payloads []DiscoverWorkPayload, token string) []DiscoverWorkPayload {
+	var out []DiscoverWorkPayload
+	for _, p := range motifPayloads(payloads) {
+		if p.Bridge.Token == token {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -143,6 +143,32 @@ type Token2Pair struct {
 	Shared []string `json:"shared_stems"`
 }
 
+// scoredMotifBridgeOf projects one internal row to its reported shape.
+//
+// Extracted so the projection can be tested (review finding M-8). It was
+// inline, and every field it carries was bound EXCEPT Served: hardcoding
+// `Served: true` left the whole suite green while harnesspack then admitted
+// the cross-tier-suppressed family into MOTIF-FAR as a third pair, and the
+// vanish-rate population — Kept && !Served — read empty by construction.
+// M-4's shape one field over.
+func scoredMotifBridgeOf(r scoredMotifRow) ScoredMotifBridge {
+	paths := make([]string, 0, len(r.cand.Members))
+	for _, m := range r.cand.Members {
+		paths = append(paths, m.File)
+	}
+	return ScoredMotifBridge{
+		Token:   r.cand.Token,
+		Members: paths,
+		Lane:    string(r.lane),
+		Family:  r.cand.family,
+		Comp:    r.comp,
+		Q:       r.q,
+		Kept:    r.kept,
+		Served:  r.served,
+		Cause:   string(r.cause),
+	}
+}
+
 // motifReportPopulation is the one-line population statement.
 //
 // It says "a FIRST session" deliberately. Production enumerates over the
@@ -224,21 +250,7 @@ func MotifComponentReport(
 	}
 
 	for _, r := range rows {
-		paths := make([]string, 0, len(r.cand.Members))
-		for _, m := range r.cand.Members {
-			paths = append(paths, m.File)
-		}
-		rep.Candidates = append(rep.Candidates, ScoredMotifBridge{
-			Token:   r.cand.Token,
-			Members: paths,
-			Lane:    string(r.lane),
-			Family:  r.cand.family,
-			Comp:    r.comp,
-			Q:       r.q,
-			Kept:    r.kept,
-			Served:  r.served,
-			Cause:   string(r.cause),
-		})
+		rep.Candidates = append(rep.Candidates, scoredMotifBridgeOf(r))
 	}
 
 	// The served set, from the same engine — so the report shows what a session

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -39,10 +39,18 @@ type ScoredMotifBridge struct {
 	Comp BridgeComponents
 	// Q is the lane's weighted quality score (0 when gated out).
 	Q float64
-	// Kept reports whether the scorer would serve this candidate, BEFORE the
-	// per-lane budget. A kept candidate can still miss a slot — which is the
-	// distinction the M3 vanish-rate measurement exists to size.
+	// Kept is the PRE-BUDGET verdict: the candidate passed every gate AND
+	// survived suppression, so a session would serve it if a slot existed.
+	// True exactly when Cause is empty.
 	Kept bool
+	// Served reports that it actually reached a work item.
+	//
+	// Kept && !Served is the vanish-rate population register entry 3 exists to
+	// size — a candidate that lost a slot to the per-lane budget. It is a
+	// separate field rather than a Cause because losing to scarcity is not a
+	// defect in the candidate, and folding it into Cause would put "this group
+	// was wrong" and "there were only eight slots" under one word.
+	Served bool
 	// Cause names why it was dropped, empty when kept. One taxonomy, shared
 	// with the health counters, which are tallied from it.
 	Cause string
@@ -188,7 +196,11 @@ func MotifComponentReport(
 	labels := subjectLabelsFor(ctx, idx, branch)
 	pairCos := pairCosFor(abstraction, branch)
 
-	rows, _, err := scoreMotifCandidates(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, pairCos)
+	// ONE pass. The report used to call scoreMotifCandidates and then
+	// buildMotifBridges separately: it enumerated twice, and the rows knew
+	// nothing about suppression, which happens inside rankAndCap (M-4).
+	near, far, rows, health, err := buildMotifBridgesWithRows(
+		ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, pairCos)
 	if err != nil {
 		return rep, err
 	}
@@ -205,18 +217,13 @@ func MotifComponentReport(
 			Comp:    r.comp,
 			Q:       r.q,
 			Kept:    r.kept,
+			Served:  r.served,
 			Cause:   string(r.cause),
 		})
 	}
 
 	// The served set, from the same engine — so the report shows what a session
 	// would enqueue, not only what enumeration found.
-	// buildMotifBridges' health is the SUPERSET: same enumeration, plus what
-	// suppression did — which only exists once the served set is built.
-	near, far, health, err := buildMotifBridges(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, pairCos)
-	if err != nil {
-		return rep, err
-	}
 	for _, b := range near {
 		rep.NearServed = append(rep.NearServed, b.Token)
 	}

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -71,6 +71,16 @@ type MotifReport struct {
 	Effort     string `json:"effort"`
 	// Seeds is the size of the pool the enumeration ran over.
 	Seeds int `json:"seeds"`
+	// SeedPaths is that pool, by path.
+	//
+	// Exported so a caller drawing CONTROL arms can draw them from the same
+	// population the measured arms came from. The H-track's RANDOM floor was
+	// drawn from a raw branch scan — 284 facts against the pool's 221 on
+	// agentic-engineering — so it could contain pragmatic and discovered facts
+	// the motif and token arms structurally cannot (review finding M-3). A
+	// floor measured on a different population than the thing it floors is the
+	// 8ad54ee8 class, in the instrument built to prevent it.
+	SeedPaths []string `json:"seed_paths"`
 	// SeedsWithMotifs is how many of them carried a motif at all. The axis can
 	// only act on these, and the gap between the two numbers is the coverage
 	// story restated in the population that matters.
@@ -185,6 +195,9 @@ func MotifComponentReport(
 		seeds = append(seeds, factsForLLM([]fact.Fact{f})...)
 	}
 	rep.Seeds = len(seeds)
+	for _, s := range seeds {
+		rep.SeedPaths = append(rep.SeedPaths, s.File)
+	}
 	for _, s := range seeds {
 		if len(s.Motifs) > 0 {
 			rep.SeedsWithMotifs++

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -35,6 +35,11 @@ type ScoredMotifBridge struct {
 	Members []string
 	// Lane is "near" or "far", as laneOf assigned it.
 	Lane string
+	// Family reports that this candidate came from the token-2 tier. Exposed
+	// because Token cannot tell you: a family is keyed by one of the canonical
+	// ids it folded, so its Token is indistinguishable from the verbatim
+	// group's (review finding L-4).
+	Family bool
 	// Comp holds the raw signal values the scorer computed.
 	Comp BridgeComponents
 	// Q is the lane's weighted quality score (0 when gated out).
@@ -214,6 +219,7 @@ func MotifComponentReport(
 			Token:   r.cand.Token,
 			Members: paths,
 			Lane:    string(r.lane),
+			Family:  r.cand.family,
 			Comp:    r.comp,
 			Q:       r.q,
 			Kept:    r.kept,

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -15,6 +15,7 @@ package synthesize
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"knomit/internal/fact"
 	"knomit/internal/store"
@@ -83,6 +84,24 @@ type MotifReport struct {
 	PointLabels        int      `json:"disjointness_labels"`
 	PointStrict        bool     `json:"disjointness_strict"`
 	HealthLines        []string `json:"health_lines"`
+
+	// Token2Pairs is every pair of canonical ids the token-2 tier would join,
+	// with the stems they share — carried-forward register entry 6's "readers
+	// of tier numbers must know what produced them".
+	//
+	// The tier's own predicate computes it (motifStems / sharedMotifStems), so
+	// the reported noise cannot drift from the shipped matching. It is a
+	// VOCABULARY property, not a candidate count: it says which ids COULD be
+	// folded together, before any gate has looked at the facts carrying them.
+	Token2Pairs []Token2Pair `json:"token2_pairs"`
+}
+
+// Token2Pair is one canonical-id pair the token-2 tier would fold into a
+// family, and the stems that did it.
+type Token2Pair struct {
+	A      string   `json:"a"`
+	B      string   `json:"b"`
+	Shared []string `json:"shared_stems"`
 }
 
 // motifReportPopulation is the one-line population statement.
@@ -199,6 +218,7 @@ func MotifComponentReport(
 	rep.PointLabels = health.Point.Labels
 	rep.PointStrict = health.Point.Strict
 	rep.HealthLines = motifBridgeHealthLines(health, len(near), len(far))
+	rep.Token2Pairs = token2PairsOf(seeds, resolve)
 
 	return rep, nil
 }
@@ -209,4 +229,39 @@ func (r MotifReport) Summary() string {
 		"%s @ %s: %d seeds (%d with motifs), %d candidates, %d near / %d far served (budgets %d/%d)",
 		r.Branch, r.Effort, r.Seeds, r.SeedsWithMotifs, len(r.Candidates),
 		len(r.NearServed), len(r.FarServed), r.NearBudget, r.FarBudget)
+}
+
+// token2PairsOf reports every canonical-id pair the token-2 tier would join.
+//
+// Computed over the ids the seed pool actually carries — the population the
+// tier acts on — rather than over the whole alias table, so the number means
+// "folds this corpus's bridging population would see".
+func token2PairsOf(seeds []factForLLM, resolve motifResolver) []Token2Pair {
+	idSet := map[string]struct{}{}
+	for _, f := range seeds {
+		for _, m := range f.Motifs {
+			if c := resolve(m); c != "" {
+				idSet[c] = struct{}{}
+			}
+		}
+	}
+	ids := make([]string, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	stems := make([]map[string]struct{}, len(ids))
+	for i, id := range ids {
+		stems[i] = motifStems(id)
+	}
+	var out []Token2Pair
+	for i := range ids {
+		for j := i + 1; j < len(ids); j++ {
+			if sh := sharedMotifStems(stems[i], stems[j]); len(sh) >= token2SharedStems {
+				out = append(out, Token2Pair{A: ids[i], B: ids[j], Shared: sh})
+			}
+		}
+	}
+	return out
 }

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -82,6 +82,7 @@ type MotifReport struct {
 	PointCut           int      `json:"disjointness_cut"`
 	PointUmbrella      int      `json:"disjointness_umbrella"`
 	PointLabels        int      `json:"disjointness_labels"`
+	FamilySuppressed   int      `json:"family_suppressed_by_exact"`
 	PointStrict        bool     `json:"disjointness_strict"`
 	HealthLines        []string `json:"health_lines"`
 
@@ -172,7 +173,7 @@ func MotifComponentReport(
 	labels := subjectLabelsFor(ctx, idx, branch)
 	meanSim := meanSimFor(abstraction, branch)
 
-	rows, health, err := scoreMotifCandidates(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, meanSim)
+	rows, _, err := scoreMotifCandidates(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, meanSim)
 	if err != nil {
 		return rep, err
 	}
@@ -195,7 +196,9 @@ func MotifComponentReport(
 
 	// The served set, from the same engine — so the report shows what a session
 	// would enqueue, not only what enumeration found.
-	near, far, _, err := buildMotifBridges(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, meanSim)
+	// buildMotifBridges' health is the SUPERSET: same enumeration, plus what
+	// suppression did — which only exists once the served set is built.
+	near, far, health, err := buildMotifBridges(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, meanSim)
 	if err != nil {
 		return rep, err
 	}
@@ -213,6 +216,7 @@ func MotifComponentReport(
 	rep.NearOtherDropped = health.NearOtherDropped
 	rep.FarOversizeDropped = health.FarOversizeDropped
 	rep.FarOtherDropped = health.FarOtherDropped
+	rep.FamilySuppressed = health.FamilySuppressedByExact
 	rep.PointCut = health.Point.Cut
 	rep.PointUmbrella = health.Point.Umbrella
 	rep.PointLabels = health.Point.Labels

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -1,0 +1,212 @@
+package synthesize
+
+// The motif axis's calibrate/measurement entry point — Phase-4 Q3's sibling to
+// BridgeComponentReport rather than a branch inside it.
+//
+// WHY A SIBLING. The two reports enumerate different populations over
+// different pools with different engines, and the gotcha this project already
+// carries about the entity/domain one (calibrate-bridges-floor-heuristic
+// 8ad54ee8) is precisely an aggregate whose population was not the production
+// population, surviving because nothing forced the population into the output.
+// Folding a second population behind a flag on one function is how that
+// recurs. Two reports, two stated populations, and both now say theirs in the
+// payload.
+
+import (
+	"context"
+	"fmt"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// ScoredMotifBridge is one enumerated motif bridge candidate — SERVED OR
+// DROPPED — with everything the shipped scorer decided about it.
+//
+// The dropped ones are the point. Production discards them, and every
+// measurement the Phase-4 carried-forward register asks for (the near-lane
+// crack, §4's unimplemented trim, the vanish rate, the token-2 noise shape) is
+// a question about candidates that never reached an agent.
+type ScoredMotifBridge struct {
+	// Token is the canonical motif id the group is keyed on.
+	Token string
+	// Members are the member facts' paths, as the enumerator ordered them.
+	Members []string
+	// Lane is "near" or "far", as laneOf assigned it.
+	Lane string
+	// Comp holds the raw signal values the scorer computed.
+	Comp BridgeComponents
+	// Q is the lane's weighted quality score (0 when gated out).
+	Q float64
+	// Kept reports whether the scorer would serve this candidate, BEFORE the
+	// per-lane budget. A kept candidate can still miss a slot — which is the
+	// distinction the M3 vanish-rate measurement exists to size.
+	Kept bool
+	// Cause names why it was dropped, empty when kept. One taxonomy, shared
+	// with the health counters, which are tallied from it.
+	Cause string
+}
+
+// MotifReport is one measurement run over one corpus at one effort.
+type MotifReport struct {
+	// Population states, in one line, what was enumerated over. Present
+	// because a number that travels without its population is how 8ad54ee8
+	// happened.
+	Population string `json:"population"`
+	Branch     string `json:"branch"`
+	Effort     string `json:"effort"`
+	// Seeds is the size of the pool the enumeration ran over.
+	Seeds int `json:"seeds"`
+	// SeedsWithMotifs is how many of them carried a motif at all. The axis can
+	// only act on these, and the gap between the two numbers is the coverage
+	// story restated in the population that matters.
+	SeedsWithMotifs int `json:"seeds_with_motifs"`
+
+	Candidates []ScoredMotifBridge `json:"candidates"`
+
+	// NearServed/FarServed are what a session would actually enqueue: kept
+	// candidates after suppression, ranking and the per-lane budget.
+	NearServed []string `json:"near_served"`
+	FarServed  []string `json:"far_served"`
+	NearBudget int      `json:"near_budget"`
+	FarBudget  int      `json:"far_budget"`
+
+	// The health picture, both as the numbers and as the lines a session emits.
+	Ceiling            int      `json:"df_ceiling"`
+	OverCeilingNames   []string `json:"over_ceiling_motifs"`
+	NearFloorDropped   int      `json:"near_floor_dropped"`
+	NearOtherDropped   int      `json:"near_other_dropped"`
+	FarOversizeDropped int      `json:"far_oversize_dropped"`
+	FarOtherDropped    int      `json:"far_other_dropped"`
+	PointCut           int      `json:"disjointness_cut"`
+	PointUmbrella      int      `json:"disjointness_umbrella"`
+	PointLabels        int      `json:"disjointness_labels"`
+	PointStrict        bool     `json:"disjointness_strict"`
+	HealthLines        []string `json:"health_lines"`
+}
+
+// motifReportPopulation is the one-line population statement.
+//
+// It says "a FIRST session" deliberately. Production enumerates over the
+// review session's seed pool, which is watermark-scoped: an incremental
+// session sees only what changed. This report reads the whole corpus, which is
+// what a no-watermark session sees and therefore the MAXIMUM the axis can
+// enumerate over — an upper bound on candidate counts, not a typical session.
+const motifReportPopulation = "live epistemic facts on the branch, projected and filtered by the review " +
+	"strategy's own AcceptSeed — i.e. what a FIRST (no-watermark) review session enumerates over. " +
+	"An incremental session sees a watermark-scoped subset, so candidate counts here are an upper bound."
+
+// MotifComponentReport enumerates, lane-splits and scores every motif bridge
+// candidate on a corpus, and reports the served set beside the dropped one.
+//
+// It drives the SHIPPED enumeration and scoring — scoreMotifCandidates, the
+// same function buildMotifBridges calls — so the numbers Phase 4 sets
+// constants on come from the engine that serves the bridges. The seed pool is
+// built with production's own projection (factFromSearchResult) and its own
+// filter (reviewStrategy.AcceptSeed) for the same reason.
+//
+// Read-only: it opens nothing, writes nothing, and plans no work.
+func MotifComponentReport(
+	ctx context.Context,
+	idx SearchQuery,
+	motifs store.MotifIndex,
+	abstraction store.AbstractionIndex,
+	branch string,
+	eff Effort,
+	resolution float64,
+	minCommunitySize int,
+	cfg QualityConfig,
+) (MotifReport, error) {
+	rep := MotifReport{
+		Population: motifReportPopulation,
+		Branch:     branch,
+		Effort:     string(eff),
+	}
+
+	results, err := idx.Search(ctx, branch, store.SearchOptions{Limit: 100000})
+	if err != nil {
+		return rep, err
+	}
+	var strat reviewStrategy
+	seeds := make([]factForLLM, 0, len(results))
+	for _, r := range results {
+		f := factFromSearchResult(r)
+		if !strat.AcceptSeed(f) {
+			continue
+		}
+		seeds = append(seeds, factsForLLM([]fact.Fact{f})...)
+	}
+	rep.Seeds = len(seeds)
+	for _, s := range seeds {
+		if len(s.Motifs) > 0 {
+			rep.SeedsWithMotifs++
+		}
+	}
+
+	groups, err := ScopedCluster(ctx, seeds, idx, resolution, minCommunitySize, func(ProgressEvent) {}, branch)
+	if err != nil {
+		return rep, err
+	}
+	cr := clusterResultFromGroups(groups)
+
+	resolve := motifResolverFor(ctx, motifs, branch)
+	labels := subjectLabelsFor(ctx, idx, branch)
+	meanSim := meanSimFor(abstraction, branch)
+
+	rows, health, err := scoreMotifCandidates(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, meanSim)
+	if err != nil {
+		return rep, err
+	}
+
+	for _, r := range rows {
+		paths := make([]string, 0, len(r.cand.Members))
+		for _, m := range r.cand.Members {
+			paths = append(paths, m.File)
+		}
+		rep.Candidates = append(rep.Candidates, ScoredMotifBridge{
+			Token:   r.cand.Token,
+			Members: paths,
+			Lane:    string(r.lane),
+			Comp:    r.comp,
+			Q:       r.q,
+			Kept:    r.kept,
+			Cause:   string(r.cause),
+		})
+	}
+
+	// The served set, from the same engine — so the report shows what a session
+	// would enqueue, not only what enumeration found.
+	near, far, _, err := buildMotifBridges(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, meanSim)
+	if err != nil {
+		return rep, err
+	}
+	for _, b := range near {
+		rep.NearServed = append(rep.NearServed, b.Token)
+	}
+	for _, b := range far {
+		rep.FarServed = append(rep.FarServed, b.Token)
+	}
+	rep.NearBudget, rep.FarBudget = motifSubBudget(eff)
+
+	rep.Ceiling = health.Ceiling
+	rep.OverCeilingNames = health.OverCeilingNames
+	rep.NearFloorDropped = health.NearFloorDropped
+	rep.NearOtherDropped = health.NearOtherDropped
+	rep.FarOversizeDropped = health.FarOversizeDropped
+	rep.FarOtherDropped = health.FarOtherDropped
+	rep.PointCut = health.Point.Cut
+	rep.PointUmbrella = health.Point.Umbrella
+	rep.PointLabels = health.Point.Labels
+	rep.PointStrict = health.Point.Strict
+	rep.HealthLines = motifBridgeHealthLines(health, len(near), len(far))
+
+	return rep, nil
+}
+
+// Summary is a one-line human rendering, population first.
+func (r MotifReport) Summary() string {
+	return fmt.Sprintf(
+		"%s @ %s: %d seeds (%d with motifs), %d candidates, %d near / %d far served (budgets %d/%d)",
+		r.Branch, r.Effort, r.Seeds, r.SeedsWithMotifs, len(r.Candidates),
+		len(r.NearServed), len(r.FarServed), r.NearBudget, r.FarBudget)
+}

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -97,8 +97,9 @@ type MotifReport struct {
 	// corpus's motif-bearing facts are pragmatic and can never bridge, so a
 	// floor set on the authored counts would be set on a population the axis
 	// cannot act on.
-	SeedDF2Clusters     int `json:"seed_df2_clusters"`
-	SeedBridgeablePairs int `json:"seed_bridgeable_pairs"`
+	ActivationActive    bool `json:"activation_active"`
+	SeedDF2Clusters     int  `json:"seed_df2_clusters"`
+	SeedBridgeablePairs int  `json:"seed_bridgeable_pairs"`
 
 	// Token2Pairs is every pair of canonical ids the token-2 tier would join,
 	// with the stems they share — carried-forward register entry 6's "readers
@@ -185,9 +186,9 @@ func MotifComponentReport(
 
 	resolve := motifResolverFor(ctx, motifs, branch)
 	labels := subjectLabelsFor(ctx, idx, branch)
-	meanSim := meanSimFor(abstraction, branch)
+	pairCos := pairCosFor(abstraction, branch)
 
-	rows, _, err := scoreMotifCandidates(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, meanSim)
+	rows, _, err := scoreMotifCandidates(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, pairCos)
 	if err != nil {
 		return rep, err
 	}
@@ -212,7 +213,7 @@ func MotifComponentReport(
 	// would enqueue, not only what enumeration found.
 	// buildMotifBridges' health is the SUPERSET: same enumeration, plus what
 	// suppression did — which only exists once the served set is built.
-	near, far, health, err := buildMotifBridges(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, meanSim)
+	near, far, health, err := buildMotifBridges(ctx, idx, branch, seeds, cr, eff, cfg, resolve, labels, pairCos)
 	if err != nil {
 		return rep, err
 	}
@@ -238,6 +239,7 @@ func MotifComponentReport(
 	rep.HealthLines = motifBridgeHealthLines(health, len(near), len(far))
 	rep.Token2Pairs = token2PairsOf(seeds, resolve)
 	rep.SeedDF2Clusters, rep.SeedBridgeablePairs = seedRecurrence(seeds, resolve)
+	rep.ActivationActive = health.Activation.Active
 
 	return rep, nil
 }

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -86,6 +86,20 @@ type MotifReport struct {
 	PointStrict        bool     `json:"disjointness_strict"`
 	HealthLines        []string `json:"health_lines"`
 
+	// SeedDF2Clusters and SeedBridgeablePairs are the ACTIVATION POPULATION:
+	// recurring clusters, and the fact pairs they could bridge, counted over
+	// the seed pool rather than over all authored facts.
+	//
+	// The distinction is the whole point and it is not small. The store's
+	// MotifCoverage/VocabularyHealth count AUTHORED facts; the bridging
+	// population is the review seed pool, which AcceptSeed filters to
+	// Kind == Epistemic. Between a quarter and a half of every measured
+	// corpus's motif-bearing facts are pragmatic and can never bridge, so a
+	// floor set on the authored counts would be set on a population the axis
+	// cannot act on.
+	SeedDF2Clusters     int `json:"seed_df2_clusters"`
+	SeedBridgeablePairs int `json:"seed_bridgeable_pairs"`
+
 	// Token2Pairs is every pair of canonical ids the token-2 tier would join,
 	// with the stems they share — carried-forward register entry 6's "readers
 	// of tier numbers must know what produced them".
@@ -223,6 +237,7 @@ func MotifComponentReport(
 	rep.PointStrict = health.Point.Strict
 	rep.HealthLines = motifBridgeHealthLines(health, len(near), len(far))
 	rep.Token2Pairs = token2PairsOf(seeds, resolve)
+	rep.SeedDF2Clusters, rep.SeedBridgeablePairs = seedRecurrence(seeds, resolve)
 
 	return rep, nil
 }
@@ -268,4 +283,36 @@ func token2PairsOf(seeds []factForLLM, resolve motifResolver) []Token2Pair {
 		}
 	}
 	return out
+}
+
+// seedRecurrence counts recurring clusters and the pairs they could bridge,
+// over the SEED POOL — the population the activation floor is set on.
+//
+// A carrier is counted once per canonical id however many spellings of it the
+// fact carries, matching what TokenDF and the vocabulary health both do: a
+// fact using two spellings of one mechanism is one carrier, not two, or a
+// single author's phrasing habit would read as recurrence.
+func seedRecurrence(seeds []factForLLM, resolve motifResolver) (df2Clusters, pairs int) {
+	carriers := map[string]map[string]struct{}{}
+	for _, f := range seeds {
+		for _, m := range f.Motifs {
+			c := resolve(m)
+			if c == "" {
+				continue
+			}
+			if carriers[c] == nil {
+				carriers[c] = map[string]struct{}{}
+			}
+			carriers[c][f.File] = struct{}{}
+		}
+	}
+	for _, set := range carriers {
+		n := len(set)
+		if n < 2 {
+			continue
+		}
+		df2Clusters++
+		pairs += n * (n - 1) / 2
+	}
+	return df2Clusters, pairs
 }

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -284,35 +284,3 @@ func token2PairsOf(seeds []factForLLM, resolve motifResolver) []Token2Pair {
 	}
 	return out
 }
-
-// seedRecurrence counts recurring clusters and the pairs they could bridge,
-// over the SEED POOL — the population the activation floor is set on.
-//
-// A carrier is counted once per canonical id however many spellings of it the
-// fact carries, matching what TokenDF and the vocabulary health both do: a
-// fact using two spellings of one mechanism is one carrier, not two, or a
-// single author's phrasing habit would read as recurrence.
-func seedRecurrence(seeds []factForLLM, resolve motifResolver) (df2Clusters, pairs int) {
-	carriers := map[string]map[string]struct{}{}
-	for _, f := range seeds {
-		for _, m := range f.Motifs {
-			c := resolve(m)
-			if c == "" {
-				continue
-			}
-			if carriers[c] == nil {
-				carriers[c] = map[string]struct{}{}
-			}
-			carriers[c][f.File] = struct{}{}
-		}
-	}
-	for _, set := range carriers {
-		n := len(set)
-		if n < 2 {
-			continue
-		}
-		df2Clusters++
-		pairs += n * (n - 1) / 2
-	}
-	return df2Clusters, pairs
-}

--- a/internal/synthesize/bridge_motif_review_test.go
+++ b/internal/synthesize/bridge_motif_review_test.go
@@ -49,6 +49,13 @@ func motifPayloads(in []DiscoverWorkPayload) []DiscoverWorkPayload {
 // motif connects them — which is the whole claim the axis makes.
 func (e *restatementEnv) seedMotifPair(motif string) {
 	e.t.Helper()
+	// The corpus needs enough RECURRING vocabulary to clear the activation
+	// floor before any of it enumerates (phase4-rulings-4). These fillers each
+	// share an entity within their pair, so disjointness rejects them and they
+	// never become candidates — they move the activation count and nothing
+	// else, which is what keeps every "one discover item" assertion below
+	// meaning what it says.
+	e.seedActivationVocabulary()
 	// rewriteWithMotifs, NOT writeFactWithMotifs: the latter stamps
 	// `domain: [alpha]` on every fact it writes, so a "subject-disjoint" pair
 	// built with it shares a domain tag. That went unnoticed while the umbrella
@@ -140,6 +147,7 @@ func TestReviewPlan_HealthReportsTheOperatingPoint(t *testing.T) {
 func TestReviewPlan_DiscoverItemsShareOneRankSpace(t *testing.T) {
 	env := newRestatementEnv(t, 4)
 	env.seedMotifPair("measure-becomes-target")
+	env.seedActivationVocabulary()
 	env.rewriteWithMotifs("kb/gotchas/caching/staleread.md",
 		"A cache read served state the writer had already replaced",
 		"The reader observed a version the writer believed was gone.",

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -1570,3 +1570,56 @@ func TestNoveltyOf_UnknownDedupThresholdIsNotADefault(t *testing.T) {
 		"precondition: the two thresholds genuinely disagree on this pair, or the "+
 			"test proves nothing about which one is used")
 }
+
+// M-7. Evaluated exists so a motif-FREE corpus is not announced as "inactive".
+// Only one direction was guarded: flipping Evaluated to false in motifActive
+// reddened a test, but making the motif-free short circuit claim
+// Evaluated=true left the suite green — as did deleting that short circuit
+// outright, since the floor then evaluates zero clusters and reports
+// "inactive" for a corpus that has no motifs to be inactive about.
+//
+// The corpus this protects is real: `core` holds 1683 seeds and zero motifs,
+// kept out of every live session by #103. Without this it would emit "0
+// recurring motif(s) … too little repeated vocabulary", sending an operator to
+// look at a vocabulary when the truth is that backfill has never run.
+func TestBuildMotifBridges_MotifFreeCorpusIsNotEvaluatedAtAll(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Entities: []string{"Alpha"}},
+		{File: "kb/b/2.md", Entities: []string{"Beta"}},
+	}
+	clusters, labels := oneCommunityEach(seeds)
+
+	near, far, health, err := buildMotifBridges(context.Background(), &countingIndex{}, "main",
+		seeds, clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constPairCos(0.1))
+
+	require.NoError(t, err)
+	require.Empty(t, near)
+	require.Empty(t, far)
+	require.False(t, health.Activation.Evaluated,
+		"a corpus with no motifs was never ASKED about its recurrence — "+
+			"'never asked' and 'asked, and below the floor' are different statements")
+	require.False(t, health.Activation.Active)
+
+	require.Empty(t, motifBridgeHealthLines(health, 0, 0),
+		"and so it says nothing at all — an inactive line here would send a reader "+
+			"to the vocabulary when the truth is that backfill has never run")
+}
+
+// The complement, so the pair covers both directions: a corpus that DOES carry
+// motifs and falls below the floor must say so.
+func TestBuildMotifBridges_BelowFloorCorpusIsEvaluatedAndSpeaks(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"lone-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/2.md", Motifs: []string{"lone-shape"}, Entities: []string{"Beta"}},
+	}
+	clusters, labels := oneCommunityEach(seeds)
+
+	_, _, health, err := buildMotifBridges(context.Background(), &pairwiseIndex{}, "main",
+		seeds, clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constPairCos(0.1))
+
+	require.NoError(t, err)
+	require.True(t, health.Activation.Evaluated, "this corpus WAS asked")
+	require.False(t, health.Activation.Active)
+	require.Contains(t, strings.Join(motifBridgeHealthLines(health, 0, 0), "\n"),
+		"motif bridging inactive", "and the answer is worth reporting")
+}

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -1623,3 +1623,47 @@ func TestBuildMotifBridges_BelowFloorCorpusIsEvaluatedAndSpeaks(t *testing.T) {
 	require.Contains(t, strings.Join(motifBridgeHealthLines(health, 0, 0), "\n"),
 		"motif bridging inactive", "and the answer is worth reporting")
 }
+
+// M-8. Every field the report projects must come from the row. Served was the
+// one that did not: hardcoding it true left the suite green, admitted the
+// cross-tier-suppressed family into MOTIF-FAR as a third pair, and emptied the
+// vanish-rate population (Kept && !Served) by construction.
+func TestScoredMotifBridgeOf_CarriesTheRowsOwnDisposition(t *testing.T) {
+	cand := enumeratedMotif{
+		BridgeSeedSet: BridgeSeedSet{Token: "shape", Members: []factForLLM{
+			{File: "kb/a/1.md"}, {File: "kb/b/2.md"}}},
+		family: true,
+	}
+
+	suppressed := scoredMotifBridgeOf(scoredMotifRow{
+		cand: cand, lane: LaneFar, q: 9,
+		kept: false, served: false, cause: motifSuppressedCrossTier,
+	})
+	served := scoredMotifBridgeOf(scoredMotifRow{
+		cand: cand, lane: LaneFar, q: 1, kept: true, served: true,
+	})
+	budgeted := scoredMotifBridgeOf(scoredMotifRow{
+		cand: cand, lane: LaneNear, q: 1, kept: true, served: false,
+	})
+
+	// Precondition: the three rows must DIFFER in served, or a hardcoded value
+	// would satisfy the assertions (lesson 5 — twice already this phase).
+	require.NotEqual(t, suppressed.Served, served.Served,
+		"precondition: the fixture must contain both served and unserved rows")
+
+	require.False(t, suppressed.Served, "a suppressed candidate reached no agent")
+	require.False(t, suppressed.Kept)
+	require.Equal(t, string(motifSuppressedCrossTier), suppressed.Cause)
+
+	require.True(t, served.Served)
+	require.True(t, served.Kept)
+	require.Empty(t, served.Cause)
+
+	require.True(t, budgeted.Kept, "kept is the pre-budget verdict")
+	require.False(t, budgeted.Served,
+		"Kept && !Served IS the vanish-rate population — if Served is hardcoded, "+
+			"register entry 3 can never be measured")
+
+	require.True(t, suppressed.Family, "and the tier comes from the row too")
+	require.Equal(t, string(LaneNear), budgeted.Lane)
+}

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -872,3 +872,90 @@ func (p *pairwiseIndex) SimilarityAdjacency(_ context.Context, paths []string) (
 	}
 	return store.NewSimilarityGraph(kept), nil
 }
+
+// ── register entry 5: the far lane's dropped population is counted ────────
+
+// §4's trim ("maximum community spread, then minimum mean similarity") is
+// unimplemented, so an oversized far group is DROPPED by MaxMembers. That was
+// ruled deliberate and carried to Phase 4 — but the population it carries was
+// never counted, so the redesign had no denominator. It has one now.
+func TestBuildMotifBridges_CountsOversizedFarGroups(t *testing.T) {
+	// Four members, ZERO similarity edges => density 0 => far lane. Each in its
+	// own community, so separation cannot be the cause. Cap at three.
+	seeds := []factForLLM{
+		{File: "kb/a/one.md", Motifs: []string{"wide-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/two.md", Motifs: []string{"wide-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/three.md", Motifs: []string{"wide-shape"}, Entities: []string{"Gamma"}},
+		{File: "kb/d/four.md", Motifs: []string{"wide-shape"}, Entities: []string{"Delta"}},
+	}
+	clusters := ClusterResult{Clusters: map[int][]string{}}
+	labels := labelsWith(200, nil)
+	for i, f := range seeds {
+		clusters.Clusters[i] = []string{f.File}
+		labels.DF[strings.ToLower(f.Entities[0])] = 2
+	}
+	idx := &pairwiseIndex{} // no edges at all
+	cfg := motifQualityConfig()
+	cfg.MaxMembers = 3
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, 1, health.Candidates, "precondition: the group enumerated")
+	require.Empty(t, near)
+	require.Empty(t, far, "four members against a cap of three")
+	require.Equal(t, 1, health.FarOversizeDropped,
+		"the trim's denominator: a far group the member cap dropped")
+	require.Zero(t, health.FarOtherDropped, "and attributed to the cap, not to 'other'")
+	require.Zero(t, health.NearFloorDropped, "a far-lane drop is not a near-lane drop")
+	require.Zero(t, health.NearOtherDropped)
+
+	lines := strings.Join(motifBridgeHealthLines(health, 0, 0), "\n")
+	require.Contains(t, lines, "motif far-lane oversize: 1 group(s)")
+}
+
+// The same counter-finding the near lane already carries (review M4): a
+// counter Phase 4 reads as evidence for the TRIM must count only what the trim
+// would act on. A far group rejected by the quality floor is not that.
+func TestBuildMotifBridges_AttributesFarLaneDropsByCause(t *testing.T) {
+	// Group A: four members, no edges => far, over a cap of three.
+	// Group B: two members, no edges => far, within the cap, but the quality
+	// floor is set above anything it can score.
+	seeds := []factForLLM{
+		{File: "kb/a/one.md", Motifs: []string{"wide-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/two.md", Motifs: []string{"wide-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/three.md", Motifs: []string{"wide-shape"}, Entities: []string{"Gamma"}},
+		{File: "kb/d/four.md", Motifs: []string{"wide-shape"}, Entities: []string{"Delta"}},
+		{File: "kb/e/five.md", Motifs: []string{"thin-shape"}, Entities: []string{"Epsilon"}},
+		{File: "kb/f/six.md", Motifs: []string{"thin-shape"}, Entities: []string{"Zeta"}},
+	}
+	clusters := ClusterResult{Clusters: map[int][]string{}}
+	labels := labelsWith(200, nil)
+	for i, f := range seeds {
+		clusters.Clusters[i] = []string{f.File}
+		labels.DF[strings.ToLower(f.Entities[0])] = 2
+	}
+	idx := &pairwiseIndex{}
+	cfg := motifQualityConfig()
+	cfg.MaxMembers = 3
+	cfg.QualityFloor = 99 // nothing can reach it
+
+	// Precondition (lesson 5): the two groups must differ in the property the
+	// attribution turns on, or the test cannot tell the causes apart.
+	require.NotEqual(t, 4, 2, "group sizes straddle the cap")
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, 2, health.Candidates, "precondition: both groups enumerated")
+	require.Empty(t, near)
+	require.Empty(t, far)
+	require.Equal(t, 1, health.FarOversizeDropped, "the wide group, and only it")
+	require.Equal(t, 1, health.FarOtherDropped, "the floor-failing group, counted apart")
+
+	lines := strings.Join(motifBridgeHealthLines(health, 0, 0), "\n")
+	require.Contains(t, lines, "motif far-lane oversize: 1 group(s)")
+	require.Contains(t, lines, "motif far-lane other: 1 group(s)")
+}

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -706,46 +706,88 @@ func TestMotifBridgeHealthLines_FailureIsNotSuccessShapedZeros(t *testing.T) {
 	require.Contains(t, found[0], "motif bridges: 2 candidates, 1 near, 1 far")
 }
 
-// ── L1: nested duplicate groups ───────────────────────────────────────────
+// ── L1 + the cross-tier amendment: nested duplicate groups ────────────────
 
-// Every token-2 family strictly CONTAINS its key's verbatim group by
-// construction, so the two compete for the same scarce slots and render the
-// same `Bridge token:` line with nested member sets. The contained one is
-// suppressed: an agent judging {A,B} and then {A,B,C} spends two of eight slots
-// on one question.
-func TestRankAndCap_SuppressesStrictlyContainedGroups(t *testing.T) {
-	small := BridgeSeedSet{Token: "shared-shape", Q: 9, Members: []factForLLM{
-		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}}}
-	big := BridgeSeedSet{Token: "shared-shape", Q: 1, Members: []factForLLM{
-		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}, {File: "kb/c/3.md"}}}
+// mc builds an enumerated candidate at a named tier. Explicit at every call
+// site, because the tier is now what decides which of two nested groups wins.
+func mc(token string, q float64, family bool, files ...string) enumeratedMotif {
+	ms := make([]factForLLM, 0, len(files))
+	for _, f := range files {
+		ms = append(ms, factForLLM{File: f})
+	}
+	return enumeratedMotif{
+		BridgeSeedSet: BridgeSeedSet{Token: token, Kind: BridgeMotif, Q: q, Members: ms},
+		family:        family,
+	}
+}
 
-	got := rankAndCap([]BridgeSeedSet{small, big}, 8)
+// CROSS-TIER: the exact group wins, and the family that contains it is dropped
+// (designer ruling, Phase-4 rulings-3, amending L1).
+//
+// The fixture is the measured case that produced the ruling, named after it.
+// On the merged corpus at high effort the token-2 family keyed
+// `invents-rather-than-asks` folded the genuine verbatim pair
+// `own-rather-than-rent` together with a tool-parameter gotcha and a
+// drug-discovery fact — joined by the English construction "rather than" and
+// nothing else. Under L1 as written the family displaced the real pair and
+// took the slot, even though it ranked lower.
+func TestRankAndCap_CrossTierTheExactGroupWins(t *testing.T) {
+	exact := mc("own-rather-than-rent", 1, false,
+		"kb/business/companies/oumi/products/0f4afbc1.md",
+		"kb/technology/ai/economics/enterprise/eaf6e38d.md")
+	family := mc("invents-rather-than-asks", 9, true,
+		"kb/business/companies/oumi/products/0f4afbc1.md",
+		"kb/technology/ai/economics/enterprise/eaf6e38d.md",
+		"kb/gotchas/ai/agents/tools/parameters/missing-arguments/2b9d15c8.md",
+		"kb/science/applied/biomedicine/ai-drug-discovery/robin/ac315cea.md")
 
-	require.Len(t, got, 1, "the contained group goes, whichever ranks higher")
-	require.Len(t, got[0].Members, 3, "the SUPERSET survives — it carries strictly more evidence")
+	// Precondition (lesson 5): the family must OUTRANK the exact group, or the
+	// test could pass on ranking rather than on the tier rule.
+	require.Greater(t, family.Q, exact.Q,
+		"precondition: the family must rank higher, so only the tier rule can drop it")
+
+	got, crossTier := rankAndCap([]enumeratedMotif{exact, family}, 8)
+
+	require.Len(t, got, 1)
+	require.Equal(t, "own-rather-than-rent", got[0].Token,
+		"the exact group is served; the looser fold is not")
+	require.Len(t, got[0].Members, 2)
+	require.Equal(t, 1, crossTier, "and the drop is counted")
+}
+
+// WITHIN A TIER the superset still survives — the original L1 rule, unchanged.
+// An agent judging {A,B} and then {A,B,C} of the SAME grouping spends two of
+// eight slots on one question.
+func TestRankAndCap_SameTierTheSupersetWins(t *testing.T) {
+	for _, family := range []bool{false, true} {
+		small := mc("shared-shape", 9, family, "kb/a/1.md", "kb/b/2.md")
+		big := mc("shared-shape", 1, family, "kb/a/1.md", "kb/b/2.md", "kb/c/3.md")
+
+		got, crossTier := rankAndCap([]enumeratedMotif{small, big}, 8)
+
+		require.Lenf(t, got, 1, "family=%v: the contained group goes, whichever ranks higher", family)
+		require.Lenf(t, got[0].Members, 3, "family=%v: the SUPERSET survives within a tier", family)
+		require.Zerof(t, crossTier, "family=%v: this is not a cross-tier drop", family)
+	}
 }
 
 // Overlapping-but-not-contained groups both survive: they are different
 // questions, and suppressing either would lose a bridge.
 func TestRankAndCap_KeepsOverlappingGroupsThatAreNotContained(t *testing.T) {
-	a := BridgeSeedSet{Token: "alpha-shape", Q: 2, Members: []factForLLM{
-		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}}}
-	b := BridgeSeedSet{Token: "bravo-shape", Q: 1, Members: []factForLLM{
-		{File: "kb/b/2.md"}, {File: "kb/c/3.md"}}}
+	a := mc("alpha-shape", 2, false, "kb/a/1.md", "kb/b/2.md")
+	b := mc("bravo-shape", 1, false, "kb/b/2.md", "kb/c/3.md")
 
-	require.Len(t, rankAndCap([]BridgeSeedSet{a, b}, 8), 2)
+	got, _ := rankAndCap([]enumeratedMotif{a, b}, 8)
+	require.Len(t, got, 2)
 }
 
 // Suppression happens BEFORE the budget is spent, or it saves no slots.
 func TestRankAndCap_SuppressionPrecedesTheBudget(t *testing.T) {
-	contained := BridgeSeedSet{Token: "shared-shape", Q: 9, Members: []factForLLM{
-		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}}}
-	superset := BridgeSeedSet{Token: "shared-shape", Q: 8, Members: []factForLLM{
-		{File: "kb/a/1.md"}, {File: "kb/b/2.md"}, {File: "kb/c/3.md"}}}
-	other := BridgeSeedSet{Token: "other-shape", Q: 1, Members: []factForLLM{
-		{File: "kb/d/4.md"}, {File: "kb/e/5.md"}}}
+	contained := mc("shared-shape", 9, true, "kb/a/1.md", "kb/b/2.md")
+	superset := mc("shared-shape", 8, true, "kb/a/1.md", "kb/b/2.md", "kb/c/3.md")
+	other := mc("other-shape", 1, false, "kb/d/4.md", "kb/e/5.md")
 
-	got := rankAndCap([]BridgeSeedSet{contained, superset, other}, 2)
+	got, _ := rankAndCap([]enumeratedMotif{contained, superset, other}, 2)
 
 	require.Len(t, got, 2)
 	require.Equal(t, "shared-shape", got[0].Token)
@@ -977,10 +1019,15 @@ func TestScoreMotifCandidates_KeptRowsAreExactlyWhatProductionServes(t *testing.
 	near, far, buildHealth, err := buildMotifBridges(context.Background(), idx, "main", seeds,
 		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
 	require.NoError(t, err)
-	require.Equal(t, rowHealth, buildHealth, "one enumeration, one health picture")
+	// buildMotifBridges' health carries ONE field the rows' does not:
+	// FamilySuppressedByExact, which only exists once suppression has run. Set
+	// it from the same rebuild below rather than excluding it, so the equality
+	// still covers every other field. (The first version compared the structs
+	// raw and passed only because this fixture has no cross-tier containment —
+	// a coincidence in the fixture, not a property.)
 
 	// Rebuild what production serves, from the rows alone.
-	var wantNear, wantFar []BridgeSeedSet
+	var wantNear, wantFar []enumeratedMotif
 	for _, r := range rows {
 		if !r.kept {
 			continue
@@ -994,6 +1041,11 @@ func TestScoreMotifCandidates_KeptRowsAreExactlyWhatProductionServes(t *testing.
 		}
 	}
 	nb, fb := motifSubBudget(EffortHigh)
+	gotNearPre, nearSup := rankAndCap(wantNear, nb)
+	gotFarPre, farSup := rankAndCap(wantFar, fb)
+	rowHealth.FamilySuppressedByExact = nearSup + farSup
+	require.Equal(t, rowHealth, buildHealth, "one enumeration, one health picture")
+	_, _ = gotNearPre, gotFarPre
 
 	require.NotEmpty(t, wantNear, "precondition: the fixture must serve something on each lane")
 	require.NotEmpty(t, wantFar, "precondition: the fixture must serve something on each lane")
@@ -1003,13 +1055,13 @@ func TestScoreMotifCandidates_KeptRowsAreExactlyWhatProductionServes(t *testing.
 	// this test could not — the sabotage passed. Assert the difference rather
 	// than trusting the fixture to keep it (lesson 5).
 	sizes := map[int]bool{}
-	for _, b := range append(append([]BridgeSeedSet{}, wantNear...), wantFar...) {
+	for _, b := range append(append([]enumeratedMotif{}, wantNear...), wantFar...) {
 		sizes[len(b.Members)] = true
 	}
 	require.Greater(t, len(sizes), 1,
 		"precondition: served groups must vary in member count, or this test is blind to a size filter")
-	require.Equal(t, rankAndCap(wantNear, nb), near)
-	require.Equal(t, rankAndCap(wantFar, fb), far)
+	require.Equal(t, gotNearPre, near)
+	require.Equal(t, gotFarPre, far)
 }
 
 // The rows carry the DROPPED candidates too, with the cause — which is the

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -1468,3 +1468,75 @@ func TestScoreMotifCandidate_UnembeddedFarGroupDoesNotOutrankAnEmbeddedOne(t *te
 		"a group with no vectors must not outrank a genuinely dissimilar one — missing "+
 			"evidence cannot buy the top of the far lane")
 }
+
+// M-4. The acceptance identity the review asked for:
+//
+//	count(Kept) == served + budget_dropped
+//
+// and every row in a state the taxonomy covers. Before the remediation a
+// suppressed candidate read `kept: true, cause: ""` — so a reader computing
+// the vanish rate the obvious way got 1 on merged@high and attributed it to
+// budget contention, when the budget was 8 and nothing contended.
+func TestBuildMotifBridgesWithRows_KeptEqualsServedPlusBudgetDropped(t *testing.T) {
+	// A fixture with a real cross-tier suppression in it: the verbatim pair and
+	// the family that contains it, plus filler to clear the activation floor.
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"own-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/2.md", Motifs: []string{"own-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/3.md", Motifs: []string{"own-shape", "invents-shape"}, Entities: []string{"Gamma"}},
+		{File: "kb/d/4.md", Motifs: []string{"invents-shape"}, Entities: []string{"Delta"}},
+	}
+	seeds = append(seeds, activationFillers()...)
+	clusters, labels := oneCommunityEach(seeds)
+
+	near, far, rows, health, err := buildMotifBridgesWithRows(context.Background(),
+		&pairwiseIndex{}, "main", seeds, clusters, EffortHigh, motifQualityConfig(),
+		identityResolver, labels, constPairCos(0.1))
+	require.NoError(t, err)
+	require.True(t, health.Activation.Active, "precondition: the axis ran")
+
+	kept, served, budget := 0, 0, 0
+	for _, r := range rows {
+		require.Equal(t, r.kept, r.cause == motifKept,
+			"kept is true exactly when there is no cause — %q", r.cause)
+		if r.kept {
+			kept++
+			if r.served {
+				served++
+			} else {
+				budget++
+			}
+		}
+		require.False(t, r.served && !r.kept, "a served row cannot carry a drop cause")
+	}
+	require.Equal(t, len(near)+len(far), served, "served rows are exactly the enqueued ones")
+	require.Equal(t, kept, served+budget, "count(Kept) == served + budget-dropped")
+}
+
+// And the state that had no cause at all: a suppressed candidate must say so.
+func TestBuildMotifBridgesWithRows_SuppressionReportsIntoTheRow(t *testing.T) {
+	// Verbatim {1,2}; a same-tier superset {1,2,3} that swallows it.
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"small-shape", "big-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/2.md", Motifs: []string{"small-shape", "big-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/3.md", Motifs: []string{"big-shape"}, Entities: []string{"Gamma"}},
+	}
+	seeds = append(seeds, activationFillers()...)
+	clusters, labels := oneCommunityEach(seeds)
+
+	_, _, rows, _, err := buildMotifBridgesWithRows(context.Background(),
+		&pairwiseIndex{}, "main", seeds, clusters, EffortHigh, motifQualityConfig(),
+		identityResolver, labels, constPairCos(0.1))
+	require.NoError(t, err)
+
+	var suppressed int
+	for _, r := range rows {
+		if r.cause == motifSuppressedSameTier || r.cause == motifSuppressedCrossTier {
+			suppressed++
+			require.False(t, r.kept, "a suppressed row is not kept")
+			require.False(t, r.served, "and was never served")
+		}
+	}
+	require.Positive(t, suppressed,
+		"precondition: this fixture must actually suppress something, or it proves nothing")
+}

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"knomit/internal/fact"
 	"knomit/internal/store"
 )
 
@@ -1341,4 +1342,74 @@ func TestMeanEntityJaccard_DisjointAndOverlapping(t *testing.T) {
 	// not perfect disjointness. Scoring them 1.0 would reward a corpus for
 	// being unlabelled.
 	require.Zero(t, meanEntityJaccard([]factForLLM{{}, {}}))
+}
+
+// H-2. seedRecurrence excludes discovered-origin facts, matching the §7
+// exclusion enumeration applies (cf455b8f). The fix was ratified by name in
+// rulings-5 and shipped with NO test: deleting the exclusion left the whole
+// suite green, because no lab corpus holds a motif-bearing discovered fact —
+// the annex never answered a discover item — so neither the fixtures nor the
+// measurements could see it.
+//
+// AcceptSeed filters on Kind == Epistemic only, never on origin, so discovered
+// facts genuinely do reach the seed pool. Without the exclusion a corpus can
+// ACTIVATE on recurrence that enumeration cannot see: the axis switches on,
+// announces "3 recurring motifs", enumerates nothing, and does it again every
+// session. It is also self-amplifying — the corpus activating on its own
+// discovery output is cf455b8f's idempotency concern one layer out.
+func TestSeedRecurrence_DoesNotCountDiscoveredFacts(t *testing.T) {
+	authored := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"first-shape"}},
+		{File: "kb/b/2.md", Motifs: []string{"first-shape"}},
+		{File: "kb/c/3.md", Motifs: []string{"second-shape"}},
+		{File: "kb/d/4.md", Motifs: []string{"second-shape"}},
+	}
+	// The case no lab corpus holds: a DISCOVERED fact carrying motifs. MN11 puts
+	// `motifs` on discover's output schema, so this is reachable the moment
+	// discovery answers an item.
+	discovered := []factForLLM{
+		{File: "kb/e/5.md", Motifs: []string{"third-shape"}, Origin: string(fact.Discovered)},
+		{File: "kb/f/6.md", Motifs: []string{"third-shape"}, Origin: string(fact.Discovered)},
+	}
+
+	base, basePairs := seedRecurrence(authored, identityResolver)
+	require.Equal(t, 2, base, "precondition: two recurring clusters from authored facts")
+	require.Equal(t, 2, basePairs)
+
+	withDiscovered, pairs := seedRecurrence(append(append([]factForLLM{}, authored...), discovered...),
+		identityResolver)
+	require.Equal(t, base, withDiscovered,
+		"a discovered fact's motifs must not count toward recurrence — enumeration cannot see them, "+
+			"so an activation counting them does not mean its label")
+	require.Equal(t, basePairs, pairs)
+}
+
+// The consequence at the boundary that matters: a corpus whose third recurring
+// cluster exists only on discovered facts must NOT activate.
+//
+// Asserted through buildMotifBridges rather than through seedRecurrence alone,
+// because "the axis switched on and found nothing" is the failure, and that is
+// visible only where activation meets enumeration (lesson 8).
+func TestBuildMotifBridges_DiscoveredRecurrenceDoesNotActivateTheAxis(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"first-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/2.md", Motifs: []string{"first-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/3.md", Motifs: []string{"second-shape"}, Entities: []string{"Gamma"}},
+		{File: "kb/d/4.md", Motifs: []string{"second-shape"}, Entities: []string{"Delta"}},
+		{File: "kb/e/5.md", Motifs: []string{"third-shape"}, Entities: []string{"Epsilon"},
+			Origin: string(fact.Discovered)},
+		{File: "kb/f/6.md", Motifs: []string{"third-shape"}, Entities: []string{"Zeta"},
+			Origin: string(fact.Discovered)},
+	}
+	clusters, labels := oneCommunityEach(seeds)
+
+	near, far, health, err := buildMotifBridges(context.Background(), &pairwiseIndex{}, "main", seeds,
+		clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constPairCos(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, 2, health.Activation.DF2Clusters,
+		"the discovered pair's cluster is not a third recurring motif")
+	require.False(t, health.Activation.Active, "so the axis stays off")
+	require.Empty(t, near)
+	require.Empty(t, far)
 }

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -261,13 +261,13 @@ func TestScoreMotifCandidate_FarLaneRewardsDissimilarity(t *testing.T) {
 	clusterOf := map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1}
 
 	_, distant, keptA, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
-		clusterOf, motifQualityConfig(), 0.5, constMeanSim(0.1))
+		clusterOf, motifQualityConfig(), 0.5, constPairCos(0.1))
 	require.NoError(t, err)
 	require.True(t, keptA,
 		"the far lane must not apply the cohesion floor — cohesion is 0 there by construction")
 
 	_, close, keptB, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
-		clusterOf, motifQualityConfig(), 0.5, constMeanSim(0.9))
+		clusterOf, motifQualityConfig(), 0.5, constPairCos(0.9))
 	require.NoError(t, err)
 	require.True(t, keptB)
 
@@ -296,7 +296,7 @@ func TestScoreMotifCandidate_SeparationIsAGateInBothLanes(t *testing.T) {
 	cfg.CohFloor = 0 // so only separation can be what rejects
 
 	_, _, keptFar, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar,
-		store.NewSimilarityGraph(nil), idx, "main", sameCommunity, cfg, 0.5, constMeanSim(0))
+		store.NewSimilarityGraph(nil), idx, "main", sameCommunity, cfg, 0.5, constPairCos(0))
 	require.NoError(t, err)
 	require.False(t, keptFar)
 
@@ -324,25 +324,34 @@ func TestScoreMotifCandidate_FarLaneDropsOversizedGroups(t *testing.T) {
 	cfg.MaxMembers = 3
 
 	_, _, kept, err := scoreMotifCandidate(ctx, cand, LaneFar, store.NewSimilarityGraph(nil),
-		idx, "main", clusterOf, cfg, 0.5, constMeanSim(0.1))
+		idx, "main", clusterOf, cfg, 0.5, constPairCos(0.1))
 	require.NoError(t, err)
 	require.False(t, kept)
 }
 
 // A far-lane group whose members carry no vectors must not read as maximally
 // dissimilar — that would hand every unembedded group the top score. The
-// caller's meanSim contract says so; this pins the scorer's half of it.
-func TestScoreMotifCandidate_FarLanePropagatesMeanSimErrors(t *testing.T) {
+// caller's pair-cosine contract says so; this pins the scorer's half of it.
+func TestScoreMotifCandidate_FarLanePropagatesPairCosErrors(t *testing.T) {
 	ctx, idx := motifScoreEnv(t, "kb/alpha/1.md", "kb/beta/2.md")
 	_, _, _, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, store.NewSimilarityGraph(nil),
 		idx, "main", map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1},
 		motifQualityConfig(), 0.5,
-		func(context.Context, []string) (float64, error) { return 0, errors.New("no vectors") })
+		func(context.Context, []string) ([]float64, error) { return nil, errors.New("no vectors") })
 	require.Error(t, err, "an unreadable similarity is not a licence to score the group high")
 }
 
-func constMeanSim(v float64) meanSimFn {
-	return func(context.Context, []string) (float64, error) { return v, nil }
+// constPairCos gives every member pair the same cosine, so the far-lane mean
+// is exactly v however many members a fixture has.
+func constPairCos(v float64) pairCosFn {
+	return func(_ context.Context, paths []string) ([]float64, error) {
+		n := len(paths) * (len(paths) - 1) / 2
+		out := make([]float64, n)
+		for i := range out {
+			out[i] = v
+		}
+		return out, nil
+	}
 }
 
 // ── shared-motif specificity: a rank boost, never a gate (§4) ─────────────
@@ -573,7 +582,7 @@ func TestBuildMotifBridges_NormalEmitsAtMostTwoNearAndNoFar(t *testing.T) {
 	idx := &allAdjacentIndex{} // every group is a near-lane group
 
 	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortNormal, permissiveMotifConfig(), identityResolver, labels, constMeanSim(0))
+		clusters, EffortNormal, permissiveMotifConfig(), identityResolver, labels, constPairCos(0))
 
 	require.NoError(t, err)
 	require.Equal(t, 6, health.Candidates, "precondition: more candidates than the budget")
@@ -590,7 +599,7 @@ func TestBuildMotifBridges_NormalEmitsNothingForFarLaneGroups(t *testing.T) {
 	idx := &countingSearchIndex{} // no adjacency: every group is far
 
 	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortNormal, permissiveMotifConfig(), identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortNormal, permissiveMotifConfig(), identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Equal(t, 6, health.Candidates, "precondition: the candidates exist")
@@ -603,7 +612,7 @@ func TestBuildMotifBridges_HighOpensBothLanesWithinTheirBudgets(t *testing.T) {
 	idx := &countingSearchIndex{} // no SIMILAR_TO edges => every group is far
 
 	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, permissiveMotifConfig(), identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, permissiveMotifConfig(), identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Equal(t, 20, health.Candidates)
@@ -621,7 +630,7 @@ func TestBuildMotifBridges_LanesCannotStarveEachOther(t *testing.T) {
 	idx := &laneSplittingIndex{nearPair: [2]string{"kb/a00/fa00.md", "kb/b00/fb00.md"}}
 
 	near, far, _, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, permissiveMotifConfig(), identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, permissiveMotifConfig(), identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Len(t, near, 1, "the one adjacent group takes a near slot")
@@ -816,7 +825,7 @@ func TestBuildMotifBridges_CountsGroupsLostAtTheNearFloor(t *testing.T) {
 	cfg := motifQualityConfig() // CohFloor 0.5
 
 	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, cfg, identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Equal(t, 1, health.Candidates, "precondition: the group enumerated")
@@ -873,7 +882,7 @@ func TestBuildMotifBridges_AttributesNearLaneDropsByCause(t *testing.T) {
 	cfg.MaxMembers = 3 // group B has four
 
 	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, cfg, identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Equal(t, 2, health.Candidates, "precondition: both groups enumerated")
@@ -944,7 +953,7 @@ func TestBuildMotifBridges_CountsOversizedFarGroups(t *testing.T) {
 	cfg.MaxMembers = 3
 
 	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, cfg, identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Equal(t, 1, health.Candidates, "precondition: the group enumerated")
@@ -992,7 +1001,7 @@ func TestBuildMotifBridges_AttributesFarLaneDropsByCause(t *testing.T) {
 	require.NotEqual(t, 4, 2, "group sizes straddle the cap")
 
 	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, cfg, identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Equal(t, 2, health.Candidates, "precondition: both groups enumerated")
@@ -1017,11 +1026,11 @@ func TestScoreMotifCandidates_KeptRowsAreExactlyWhatProductionServes(t *testing.
 	seeds, clusters, labels, idx, cfg := laneMixtureFixture(t)
 
 	rows, rowHealth, err := scoreMotifCandidates(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, cfg, identityResolver, labels, constPairCos(0.1))
 	require.NoError(t, err)
 
 	near, far, buildHealth, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, cfg, identityResolver, labels, constPairCos(0.1))
 	require.NoError(t, err)
 	// buildMotifBridges' health carries ONE field the rows' does not:
 	// FamilySuppressedByExact, which only exists once suppression has run. Set
@@ -1075,7 +1084,7 @@ func TestScoreMotifCandidates_CarryDroppedCandidatesWithTheirCause(t *testing.T)
 	seeds, clusters, labels, idx, cfg := laneMixtureFixture(t)
 
 	rows, health, err := scoreMotifCandidates(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, cfg, identityResolver, labels, constPairCos(0.1))
 	require.NoError(t, err)
 
 	byCause := map[motifDropCause]int{}
@@ -1165,7 +1174,7 @@ func TestBuildMotifBridges_BelowTheActivationFloorEnumeratesNothing(t *testing.T
 	idx := &countingIndex{pairwiseIndex: pairwiseIndex{edges: nil}}
 
 	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Equal(t, 2, health.Activation.DF2Clusters, "precondition: below the floor of 3")
@@ -1195,7 +1204,7 @@ func TestBuildMotifBridges_AtTheActivationFloorEnumeratesNormally(t *testing.T) 
 	idx := &pairwiseIndex{}
 
 	_, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
-		clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constMeanSim(0.1))
+		clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constPairCos(0.1))
 
 	require.NoError(t, err)
 	require.Equal(t, motifActivationFloor, health.Activation.DF2Clusters,
@@ -1282,4 +1291,54 @@ func activationFillers() []factForLLM {
 		{File: "kb/fill/b1.md", Motifs: []string{"filler-shape-two"}, Entities: []string{"FillerBeta"}},
 		{File: "kb/fill/b2.md", Motifs: []string{"filler-shape-two"}, Entities: []string{"FillerBeta"}},
 	}
+}
+
+// ── P3: §8's novelty signals ──────────────────────────────────────────────
+
+func TestNoveltyOf_VectorsReadDistinguishesUnknownFromZero(t *testing.T) {
+	members := []factForLLM{{File: "kb/a/1.md"}, {File: "kb/b/2.md"}}
+	paths := []string{"kb/a/1.md", "kb/b/2.md"}
+
+	// No provider at all: SeedCos and OverDedup are UNKNOWN, and the flag is
+	// what says so. Their zeros must not be read as measurements.
+	none, err := noveltyOf(context.Background(), members, paths, nil, 0.92)
+	require.NoError(t, err)
+	require.False(t, none.VectorsRead)
+	require.Zero(t, none.SeedCos)
+
+	// A provider returning genuinely-zero cosines: same zeros, opposite meaning.
+	zeroed, err := noveltyOf(context.Background(), members, paths, constPairCos(0), 0.92)
+	require.NoError(t, err)
+	require.True(t, zeroed.VectorsRead, "the flag is the ONLY thing separating these two results")
+	require.Zero(t, zeroed.SeedCos)
+}
+
+func TestNoveltyOf_OverDedupIsAFractionOfPairs(t *testing.T) {
+	members := []factForLLM{{File: "a"}, {File: "b"}, {File: "c"}}
+	paths := []string{"a", "b", "c"}
+	// Three pairs; one of them at/above the threshold.
+	pc := func(context.Context, []string) ([]float64, error) {
+		return []float64{0.95, 0.10, 0.20}, nil
+	}
+	got, err := noveltyOf(context.Background(), members, paths, pc, 0.92)
+	require.NoError(t, err)
+	require.InDelta(t, 1.0/3.0, got.OverDedup, 1e-9)
+	require.InDelta(t, (0.95+0.10+0.20)/3, got.SeedCos, 1e-9,
+		"SeedCos is the MEAN, so one near-duplicate pair does not dominate it — "+
+			"which is exactly why OverDedup is reported beside it")
+}
+
+func TestMeanEntityJaccard_DisjointAndOverlapping(t *testing.T) {
+	disjoint := []factForLLM{
+		{Entities: []string{"Redis"}}, {Entities: []string{"SWIFT"}}}
+	require.Zero(t, meanEntityJaccard(disjoint))
+
+	overlap := []factForLLM{
+		{Entities: []string{"Redis", "Kafka"}}, {Entities: []string{"Redis"}}}
+	require.InDelta(t, 0.5, meanEntityJaccard(overlap), 1e-9, "one shared of two distinct")
+
+	// Two facts naming NOTHING are an absence of evidence about their subjects,
+	// not perfect disjointness. Scoring them 1.0 would reward a corpus for
+	// being unlabelled.
+	require.Zero(t, meanEntityJaccard([]factForLLM{{}, {}}))
 }

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -1302,13 +1302,13 @@ func TestNoveltyOf_VectorsReadDistinguishesUnknownFromZero(t *testing.T) {
 
 	// No provider at all: SeedCos and OverDedup are UNKNOWN, and the flag is
 	// what says so. Their zeros must not be read as measurements.
-	none, err := noveltyOf(context.Background(), members, paths, nil, 0.92)
+	none, err := noveltyOf(context.Background(), members, paths, nil, 0.92, true)
 	require.NoError(t, err)
 	require.False(t, none.VectorsRead)
 	require.Zero(t, none.SeedCos)
 
 	// A provider returning genuinely-zero cosines: same zeros, opposite meaning.
-	zeroed, err := noveltyOf(context.Background(), members, paths, constPairCos(0), 0.92)
+	zeroed, err := noveltyOf(context.Background(), members, paths, constPairCos(0), 0.92, true)
 	require.NoError(t, err)
 	require.True(t, zeroed.VectorsRead, "the flag is the ONLY thing separating these two results")
 	require.Zero(t, zeroed.SeedCos)
@@ -1321,7 +1321,7 @@ func TestNoveltyOf_OverDedupIsAFractionOfPairs(t *testing.T) {
 	pc := func(context.Context, []string) ([]float64, error) {
 		return []float64{0.95, 0.10, 0.20}, nil
 	}
-	got, err := noveltyOf(context.Background(), members, paths, pc, 0.92)
+	got, err := noveltyOf(context.Background(), members, paths, pc, 0.92, true)
 	require.NoError(t, err)
 	require.InDelta(t, 1.0/3.0, got.OverDedup, 1e-9)
 	require.InDelta(t, (0.95+0.10+0.20)/3, got.SeedCos, 1e-9,
@@ -1539,4 +1539,34 @@ func TestBuildMotifBridgesWithRows_SuppressionReportsIntoTheRow(t *testing.T) {
 	}
 	require.Positive(t, suppressed,
 		"precondition: this fixture must actually suppress something, or it proves nothing")
+}
+
+// M-5. An unresolved dedup threshold must leave OverDedup UNCOMPUTED, never
+// silently defaulted. params.Defaults() is nomic's geometry (Dedup 0.92) and
+// every corpus in this campaign is embeddinggemma (0.82), so a default would
+// report 0.000 for a pair genuinely above its corpus's own gate — breaking the
+// one direction OverDedup's doc promises is safe.
+func TestNoveltyOf_UnknownDedupThresholdIsNotADefault(t *testing.T) {
+	members := []factForLLM{{File: "a"}, {File: "b"}}
+	paths := []string{"a", "b"}
+	// A pair at 0.85: above embeddinggemma's 0.82, below the 0.92 default.
+	pc := func(context.Context, []string) ([]float64, error) { return []float64{0.85}, nil }
+
+	unknown, err := noveltyOf(context.Background(), members, paths, pc, 0, false)
+	require.NoError(t, err)
+	require.False(t, unknown.DedupKnown)
+	require.Zero(t, unknown.OverDedup, "not computed — and the flag is what says so")
+
+	known, err := noveltyOf(context.Background(), members, paths, pc, 0.82, true)
+	require.NoError(t, err)
+	require.True(t, known.DedupKnown)
+	require.Equal(t, 1.0, known.OverDedup,
+		"at the corpus's own threshold this pair IS a near-copy — which the nomic "+
+			"default would have hidden")
+
+	wrongDefault, err := noveltyOf(context.Background(), members, paths, pc, 0.92, true)
+	require.NoError(t, err)
+	require.Zero(t, wrongDefault.OverDedup,
+		"precondition: the two thresholds genuinely disagree on this pair, or the "+
+			"test proves nothing about which one is used")
 }

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -1413,3 +1413,58 @@ func TestBuildMotifBridges_DiscoveredRecurrenceDoesNotActivateTheAxis(t *testing
 	require.Empty(t, near)
 	require.Empty(t, far)
 }
+
+// H-3. "No vectors scores 1, never 0" had no test in either branch, and the
+// rule was MOVED this phase in the pairCosFn refactor — rulings-6 ratified it
+// as "preserved", and nothing proved it arrived.
+//
+// Why 0 would be a production ranking inversion rather than a rounding
+// difference: the far lane scores Q = WSpec·Spec + WGap·Gap + WCoh·(1 − meanSim).
+// At meanSim 0 an un-embedded group collects the maximum dissimilarity reward
+// available, so on a corpus mid-backfill — or one whose vectors were dropped by
+// the model-drift drop-and-recreate path — every group with NO evidence
+// outranks every group with evidence and takes all eight far slots. Missing
+// evidence would buy the top of the lane the axis exists for.
+func TestMeanPairCos_NoVectorsScoresOneNotZero(t *testing.T) {
+	paths := []string{"kb/a/1.md", "kb/b/2.md"}
+
+	// Branch 1: no provider at all.
+	got, err := meanPairCos(context.Background(), paths, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1.0, got, "a nil provider is missing evidence, not maximal dissimilarity")
+
+	// Branch 2: a provider that returns no pairs — the un-embedded corpus.
+	empty := func(context.Context, []string) ([]float64, error) { return nil, nil }
+	got, err = meanPairCos(context.Background(), paths, empty)
+	require.NoError(t, err)
+	require.Equal(t, 1.0, got, "an empty distribution is missing evidence, not maximal dissimilarity")
+
+	// And the rule must not swallow a real reading: a genuine 0 stays 0.
+	real := func(context.Context, []string) ([]float64, error) { return []float64{0}, nil }
+	got, err = meanPairCos(context.Background(), paths, real)
+	require.NoError(t, err)
+	require.Zero(t, got,
+		"a measured zero is a measurement — only ABSENT evidence scores 1, or the rule "+
+			"would hide the far lane's best case")
+}
+
+// The consequence at the scorer, which is where the inversion would happen:
+// an un-embedded far group must not outrank an embedded dissimilar one.
+func TestScoreMotifCandidate_UnembeddedFarGroupDoesNotOutrankAnEmbeddedOne(t *testing.T) {
+	ctx, idx := motifScoreEnv(t, "kb/alpha/1.md", "kb/beta/2.md")
+	g := store.NewSimilarityGraph(nil)
+	clusterOf := map[string]int{"kb/alpha/1.md": 0, "kb/beta/2.md": 1}
+
+	_, embedded, _, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
+		clusterOf, motifQualityConfig(), 0.5, constPairCos(0.1))
+	require.NoError(t, err)
+
+	noVectors := func(context.Context, []string) ([]float64, error) { return nil, nil }
+	_, unembedded, _, err := scoreMotifCandidate(ctx, motifCandidate(), LaneFar, g, idx, "main",
+		clusterOf, motifQualityConfig(), 0.5, noVectors)
+	require.NoError(t, err)
+
+	require.Less(t, unembedded, embedded,
+		"a group with no vectors must not outrank a genuinely dissimilar one — missing "+
+			"evidence cannot buy the top of the far lane")
+}

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -808,6 +808,7 @@ func TestBuildMotifBridges_CountsGroupsLostAtTheNearFloor(t *testing.T) {
 		{File: "kb/b/two.md", Motifs: []string{"shared-shape"}, Entities: []string{"Beta"}},
 		{File: "kb/c/three.md", Motifs: []string{"shared-shape"}, Entities: []string{"Gamma"}},
 	}
+	seeds = append(seeds, activationFillers()...)
 	clusters := ClusterResult{Clusters: map[int][]string{
 		0: {"kb/a/one.md"}, 1: {"kb/b/two.md"}, 2: {"kb/c/three.md"}}}
 	labels := labelsWith(200, map[string]int{"alpha": 2, "beta": 2, "gamma": 2})
@@ -851,6 +852,7 @@ func TestBuildMotifBridges_AttributesNearLaneDropsByCause(t *testing.T) {
 		{File: "kb/f/six.md", Motifs: []string{"crowded-shape"}, Entities: []string{"Zeta"}},
 		{File: "kb/g/seven.md", Motifs: []string{"crowded-shape"}, Entities: []string{"Eta"}},
 	}
+	seeds = append(seeds, activationFillers()...)
 	clusters := ClusterResult{Clusters: map[int][]string{}}
 	labels := labelsWith(200, nil)
 	for i, f := range seeds {
@@ -930,6 +932,7 @@ func TestBuildMotifBridges_CountsOversizedFarGroups(t *testing.T) {
 		{File: "kb/c/three.md", Motifs: []string{"wide-shape"}, Entities: []string{"Gamma"}},
 		{File: "kb/d/four.md", Motifs: []string{"wide-shape"}, Entities: []string{"Delta"}},
 	}
+	seeds = append(seeds, activationFillers()...)
 	clusters := ClusterResult{Clusters: map[int][]string{}}
 	labels := labelsWith(200, nil)
 	for i, f := range seeds {
@@ -972,6 +975,7 @@ func TestBuildMotifBridges_AttributesFarLaneDropsByCause(t *testing.T) {
 		{File: "kb/e/five.md", Motifs: []string{"thin-shape"}, Entities: []string{"Epsilon"}},
 		{File: "kb/f/six.md", Motifs: []string{"thin-shape"}, Entities: []string{"Zeta"}},
 	}
+	seeds = append(seeds, activationFillers()...)
 	clusters := ClusterResult{Clusters: map[int][]string{}}
 	labels := labelsWith(200, nil)
 	for i, f := range seeds {
@@ -1126,6 +1130,7 @@ func laneMixtureFixture(t *testing.T) ([]factForLLM, ClusterResult, store.Subjec
 		mk("kb/h/8.md", "wide-shape", "Theta"), mk("kb/i/9.md", "wide-shape", "Iota"),
 		mk("kb/j/10.md", "wide-shape", "Kappa"), mk("kb/k/11.md", "wide-shape", "Lambda"),
 	}
+	seeds = append(seeds, activationFillers()...)
 	clusters := ClusterResult{Clusters: map[int][]string{}}
 	labels := labelsWith(200, nil)
 	for i, f := range seeds {
@@ -1142,4 +1147,139 @@ func laneMixtureFixture(t *testing.T) ([]factForLLM, ClusterResult, store.Subjec
 	cfg := motifQualityConfig()
 	cfg.MaxMembers = 3
 	return seeds, clusters, labels, idx, cfg
+}
+
+// ── P2: the activation floor (K=3, phase4-rulings-4) ──────────────────────
+
+// A corpus below the floor enumerates NOTHING, and it costs no index call to
+// find that out — the same property that keeps MN5's vacuous pass vacuous.
+func TestBuildMotifBridges_BelowTheActivationFloorEnumeratesNothing(t *testing.T) {
+	// Two recurring clusters. The floor is three.
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"first-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/2.md", Motifs: []string{"first-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/3.md", Motifs: []string{"second-shape"}, Entities: []string{"Gamma"}},
+		{File: "kb/d/4.md", Motifs: []string{"second-shape"}, Entities: []string{"Delta"}},
+	}
+	clusters, labels := oneCommunityEach(seeds)
+	idx := &countingIndex{pairwiseIndex: pairwiseIndex{edges: nil}}
+
+	near, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, 2, health.Activation.DF2Clusters, "precondition: below the floor of 3")
+	require.False(t, health.Activation.Active)
+	require.Empty(t, near)
+	require.Empty(t, far)
+	require.Zero(t, health.Candidates, "an inactive corpus enumerates nothing")
+	require.Zero(t, idx.calls, "and costs no index call to decide it")
+
+	lines := strings.Join(motifBridgeHealthLines(health, 0, 0), "\n")
+	require.Contains(t, lines, "motif bridging inactive")
+	require.Contains(t, lines, "2 recurring")
+}
+
+// At the floor it enumerates normally. The two tests differ by ONE cluster, so
+// the assertion is about the floor rather than about the fixtures.
+func TestBuildMotifBridges_AtTheActivationFloorEnumeratesNormally(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"first-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/2.md", Motifs: []string{"first-shape"}, Entities: []string{"Beta"}},
+		{File: "kb/c/3.md", Motifs: []string{"second-shape"}, Entities: []string{"Gamma"}},
+		{File: "kb/d/4.md", Motifs: []string{"second-shape"}, Entities: []string{"Delta"}},
+		{File: "kb/e/5.md", Motifs: []string{"third-shape"}, Entities: []string{"Epsilon"}},
+		{File: "kb/f/6.md", Motifs: []string{"third-shape"}, Entities: []string{"Zeta"}},
+	}
+	clusters, labels := oneCommunityEach(seeds)
+	idx := &pairwiseIndex{}
+
+	_, far, health, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constMeanSim(0.1))
+
+	require.NoError(t, err)
+	require.Equal(t, motifActivationFloor, health.Activation.DF2Clusters,
+		"precondition: exactly at the floor, one cluster above the previous test")
+	require.True(t, health.Activation.Active)
+	require.Equal(t, 3, health.Candidates)
+	require.Len(t, far, 3, "and the candidates are served")
+}
+
+// The floor counts RECURRING clusters, not motifed facts: a corpus can carry
+// plenty of motifs and still have nothing that repeats.
+func TestMotifActive_CountsRecurrenceNotVolume(t *testing.T) {
+	var hapax []factForLLM
+	for i := range 40 {
+		hapax = append(hapax, factForLLM{
+			File:   fmt.Sprintf("kb/h/%d.md", i),
+			Motifs: []string{fmt.Sprintf("unique-shape-%d", i)},
+		})
+	}
+	got := motifActive(hapax, identityResolver)
+	require.False(t, got.Active, "forty motifs, none of them recurring")
+	require.Zero(t, got.DF2Clusters)
+	require.Zero(t, got.Pairs)
+}
+
+// A fact spelling one mechanism two ways is ONE carrier. Otherwise a single
+// author's phrasing habit would activate the axis by itself.
+func TestSeedRecurrence_TwoSpellingsOnOneFactAreOneCarrier(t *testing.T) {
+	resolve := func(m string) string {
+		if m == "silent-drop" || m == "drops-silently" {
+			return "silent-drop"
+		}
+		return m
+	}
+	seeds := []factForLLM{{File: "kb/a/1.md", Motifs: []string{"silent-drop", "drops-silently"}}}
+
+	clusters, pairs := seedRecurrence(seeds, resolve)
+	require.Zero(t, clusters, "one fact cannot make a motif recur")
+	require.Zero(t, pairs)
+}
+
+// oneCommunityEach puts every seed in its own community and gives every entity
+// a df that clears the disjointness gate.
+func oneCommunityEach(seeds []factForLLM) (ClusterResult, store.SubjectLabelDF) {
+	clusters := ClusterResult{Clusters: map[int][]string{}}
+	labels := labelsWith(200, nil)
+	for i, f := range seeds {
+		clusters.Clusters[i] = []string{f.File}
+		if len(f.Entities) > 0 {
+			labels.DF[strings.ToLower(f.Entities[0])] = 2
+		}
+	}
+	return clusters, labels
+}
+
+// countingIndex records whether the enumeration touched the index at all.
+type countingIndex struct {
+	pairwiseIndex
+	calls int
+}
+
+func (c *countingIndex) TokenDF(ctx context.Context, b, t, k string) (int, error) {
+	c.calls++
+	return c.pairwiseIndex.TokenDF(ctx, b, t, k)
+}
+
+func (c *countingIndex) SimilarityAdjacency(ctx context.Context, paths []string) (store.SimilarityGraph, error) {
+	c.calls++
+	return c.pairwiseIndex.SimilarityAdjacency(ctx, paths)
+}
+
+// activationFillers are four facts carrying two recurring motifs, present only
+// to clear the K=3 activation floor in tests about something else.
+//
+// Each pair SHARES a rare entity, so subject-disjointness rejects it and it
+// never enumerates as a candidate. That is the whole trick: recurrence is
+// counted over the seed pool BEFORE any gate, so these move the activation
+// count and leave every candidate assertion untouched. A filler that enumerated
+// would silently change the numbers the calling test is about.
+func activationFillers() []factForLLM {
+	return []factForLLM{
+		{File: "kb/fill/a1.md", Motifs: []string{"filler-shape-one"}, Entities: []string{"FillerAlpha"}},
+		{File: "kb/fill/a2.md", Motifs: []string{"filler-shape-one"}, Entities: []string{"FillerAlpha"}},
+		{File: "kb/fill/b1.md", Motifs: []string{"filler-shape-two"}, Entities: []string{"FillerBeta"}},
+		{File: "kb/fill/b2.md", Motifs: []string{"filler-shape-two"}, Entities: []string{"FillerBeta"}},
+	}
 }

--- a/internal/synthesize/bridge_motif_test.go
+++ b/internal/synthesize/bridge_motif_test.go
@@ -959,3 +959,135 @@ func TestBuildMotifBridges_AttributesFarLaneDropsByCause(t *testing.T) {
 	require.Contains(t, lines, "motif far-lane oversize: 1 group(s)")
 	require.Contains(t, lines, "motif far-lane other: 1 group(s)")
 }
+
+// ── T1: the measurement reads the engine, not a second implementation ─────
+
+// The rule this asserts: what the Phase-4 instrument measures is what a review
+// session would serve. Production filters and ranks the rows; if it ever grew
+// a filter of its own, the numbers the phase sets constants on would quietly
+// stop describing the shipped axis. Both sides drive scoreMotifCandidates, and
+// this is what pins that they still do.
+func TestScoreMotifCandidates_KeptRowsAreExactlyWhatProductionServes(t *testing.T) {
+	seeds, clusters, labels, idx, cfg := laneMixtureFixture(t)
+
+	rows, rowHealth, err := scoreMotifCandidates(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+	require.NoError(t, err)
+
+	near, far, buildHealth, err := buildMotifBridges(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+	require.NoError(t, err)
+	require.Equal(t, rowHealth, buildHealth, "one enumeration, one health picture")
+
+	// Rebuild what production serves, from the rows alone.
+	var wantNear, wantFar []BridgeSeedSet
+	for _, r := range rows {
+		if !r.kept {
+			continue
+		}
+		c := r.cand
+		c.Q = r.q
+		if r.lane == LaneNear {
+			wantNear = append(wantNear, c)
+		} else {
+			wantFar = append(wantFar, c)
+		}
+	}
+	nb, fb := motifSubBudget(EffortHigh)
+
+	require.NotEmpty(t, wantNear, "precondition: the fixture must serve something on each lane")
+	require.NotEmpty(t, wantFar, "precondition: the fixture must serve something on each lane")
+	// PRECONDITION, and it is load-bearing: the served groups must DIFFER in
+	// member count. A fixture whose served groups all have two members cannot
+	// see a production-side filter on member count, and the first version of
+	// this test could not — the sabotage passed. Assert the difference rather
+	// than trusting the fixture to keep it (lesson 5).
+	sizes := map[int]bool{}
+	for _, b := range append(append([]BridgeSeedSet{}, wantNear...), wantFar...) {
+		sizes[len(b.Members)] = true
+	}
+	require.Greater(t, len(sizes), 1,
+		"precondition: served groups must vary in member count, or this test is blind to a size filter")
+	require.Equal(t, rankAndCap(wantNear, nb), near)
+	require.Equal(t, rankAndCap(wantFar, fb), far)
+}
+
+// The rows carry the DROPPED candidates too, with the cause — which is the
+// whole reason the instrument exists, since production throws them away and
+// every carried-forward measurement is about them.
+func TestScoreMotifCandidates_CarryDroppedCandidatesWithTheirCause(t *testing.T) {
+	seeds, clusters, labels, idx, cfg := laneMixtureFixture(t)
+
+	rows, health, err := scoreMotifCandidates(context.Background(), idx, "main", seeds,
+		clusters, EffortHigh, cfg, identityResolver, labels, constMeanSim(0.1))
+	require.NoError(t, err)
+
+	byCause := map[motifDropCause]int{}
+	for _, r := range rows {
+		byCause[r.cause]++
+		require.Equal(t, r.kept, r.cause == motifKept,
+			"a row is kept exactly when it has no drop cause")
+	}
+	require.Positive(t, byCause[motifKept], "precondition: something survived")
+	require.Positive(t, byCause[motifNearFloor], "precondition: the fixture drops one at the near floor")
+	require.Positive(t, byCause[motifFarOversize], "precondition: and one over the far cap")
+
+	// The counters are TALLIED from these rows, so they cannot disagree about
+	// the same group — the M4 counter-finding made structurally impossible
+	// rather than re-checked by hand.
+	require.Equal(t, byCause[motifNearFloor], health.NearFloorDropped)
+	require.Equal(t, byCause[motifNearOther], health.NearOtherDropped)
+	require.Equal(t, byCause[motifFarOversize], health.FarOversizeDropped)
+	require.Equal(t, byCause[motifFarOther], health.FarOtherDropped)
+	require.Equal(t, byCause[motifKept], health.Candidates-
+		(health.NearFloorDropped+health.NearOtherDropped+health.FarOversizeDropped+health.FarOtherDropped),
+		"every enumerated candidate is either served or attributed to one cause")
+}
+
+// laneMixtureFixture builds a corpus that exercises every outcome at once: a
+// cohesive near group that survives, a sparse near group killed by the floor, a
+// dissimilar far group that survives, and an oversized far group killed by the
+// cap. Deliberately non-degenerate (lesson 5) — the four groups differ in the
+// properties the attribution turns on, and the test asserts that as a
+// precondition rather than trusting the construction.
+func laneMixtureFixture(t *testing.T) ([]factForLLM, ClusterResult, store.SubjectLabelDF, *pairwiseIndex, QualityConfig) {
+	t.Helper()
+	mk := func(file, motif, entity string) factForLLM {
+		return factForLLM{File: file, Motifs: []string{motif}, Entities: []string{entity}}
+	}
+	seeds := []factForLLM{
+		// tight-shape: two members, one edge => cohesion 1.0 => near, survives.
+		mk("kb/a/1.md", "tight-shape", "Alpha"), mk("kb/b/2.md", "tight-shape", "Beta"),
+		// dense-shape: THREE members, all three pairs edged => cohesion 1.0 =>
+		// near, survives, and is the only served group with more than two
+		// members. Without it every served group coincides at size 2 and a
+		// production-side member filter is invisible to the equivalence test
+		// (lesson 5, found by sabotaging exactly that).
+		mk("kb/l/12.md", "dense-shape", "Mu"), mk("kb/m/13.md", "dense-shape", "Nu"),
+		mk("kb/n/14.md", "dense-shape", "Xi"),
+		// sparse-shape: three members, one edge => density 0.33 => near, floored.
+		mk("kb/c/3.md", "sparse-shape", "Gamma"), mk("kb/d/4.md", "sparse-shape", "Delta"),
+		mk("kb/e/5.md", "sparse-shape", "Epsilon"),
+		// apart-shape: two members, no edge => far, survives.
+		mk("kb/f/6.md", "apart-shape", "Zeta"), mk("kb/g/7.md", "apart-shape", "Eta"),
+		// wide-shape: four members, no edges => far, over the cap of three.
+		mk("kb/h/8.md", "wide-shape", "Theta"), mk("kb/i/9.md", "wide-shape", "Iota"),
+		mk("kb/j/10.md", "wide-shape", "Kappa"), mk("kb/k/11.md", "wide-shape", "Lambda"),
+	}
+	clusters := ClusterResult{Clusters: map[int][]string{}}
+	labels := labelsWith(200, nil)
+	for i, f := range seeds {
+		clusters.Clusters[i] = []string{f.File}
+		labels.DF[strings.ToLower(f.Entities[0])] = 2
+	}
+	idx := &pairwiseIndex{edges: [][2]string{
+		{"kb/a/1.md", "kb/b/2.md"}, // tight-shape: the only pair, so cohesion 1.0
+		{"kb/c/3.md", "kb/d/4.md"}, // sparse-shape: one of three pairs
+		// dense-shape: all three pairs, so cohesion is 1.0 at three members
+		{"kb/l/12.md", "kb/m/13.md"}, {"kb/l/12.md", "kb/n/14.md"},
+		{"kb/m/13.md", "kb/n/14.md"},
+	}}
+	cfg := motifQualityConfig()
+	cfg.MaxMembers = 3
+	return seeds, clusters, labels, idx, cfg
+}

--- a/internal/synthesize/bridge_score.go
+++ b/internal/synthesize/bridge_score.go
@@ -15,6 +15,39 @@ type BridgeComponents struct {
 	Gap     float64 // derivation gap (computed in Task 8; zero until then)
 	Spec    float64 // specificity signal (computed in Task 8; zero until then)
 	Members int     // number of member facts in the seed set
+	// Novelty holds §8's per-seed-set novelty signals, for `calibrate bridges`.
+	// Diagnostic only: bridgeQ does not read them and no gate consults them.
+	Novelty NoveltySignals
+}
+
+// NoveltySignals are blueprint §8's novelty measures for one bridge seed set.
+//
+// SEED-SET properties, computed at scoring time. §8 also asks for SURVIVAL,
+// which is deliberately NOT here: survival is a property of a fact that does
+// not exist yet when a candidate is scored, so a field for it would be filled
+// in before there was anything to survive (Phase-4 Q4 ruling). It is reported
+// separately, against discovered facts, by the survival report.
+type NoveltySignals struct {
+	// VectorsRead reports whether a vector source was available. Without it
+	// SeedCos and OverDedup are not computed, and their zeros mean "unknown"
+	// rather than "zero" — opposite findings that must not share a shape.
+	VectorsRead bool
+	// SeedCos is the mean body cosine over member pairs. Low means the members
+	// are textually unalike, which on the far lane is the point.
+	SeedCos float64
+	// EntityJaccard is the mean entity-set overlap over member pairs. Computed
+	// whether or not vectors are available.
+	EntityJaccard float64
+	// OverDedup is the fraction of member pairs at or above the dedup
+	// threshold.
+	//
+	// READ IT AS A FLOOR, NOT AN ALL-CLEAR. The dedup gate catches VERBATIM
+	// duplicates only — semantic restatements sail past it, which is why
+	// discovery's novelty rests on the agent's default-skip rather than on the
+	// gate (gotcha 90d69628). So OverDedup > 0 does mean this group contains a
+	// near-copy; OverDedup == 0 does NOT mean the members are saying different
+	// things.
+	OverDedup float64
 }
 
 // QualityConfig holds the tunable knobs for the bridge quality scorer. Fields

--- a/internal/synthesize/bridge_score.go
+++ b/internal/synthesize/bridge_score.go
@@ -38,6 +38,13 @@ type NoveltySignals struct {
 	// EntityJaccard is the mean entity-set overlap over member pairs. Computed
 	// whether or not vectors are available.
 	EntityJaccard float64
+	// DedupKnown reports that the corpus's dedup threshold was resolved. When
+	// false, OverDedup is NOT computed and its zero means "unknown" — the same
+	// principle as VectorsRead, applied to the other input the signal needs.
+	// A silently-defaulted threshold would be worse than no number: the
+	// defaults are nomic's and every corpus in this campaign is embeddinggemma,
+	// whose Dedup is 0.82 against the default 0.92.
+	DedupKnown bool
 	// OverDedup is the fraction of member pairs at or above the dedup
 	// threshold.
 	//

--- a/internal/synthesize/cluster.go
+++ b/internal/synthesize/cluster.go
@@ -6,6 +6,7 @@ package synthesize
 import (
 	"context"
 	"path"
+	"sort"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -128,6 +129,24 @@ func ScopedCluster(ctx context.Context,
 	for p := range subgraph {
 		paths = append(paths, p)
 	}
+	// SORTED, and it is load-bearing rather than tidy. louvainCommunities
+	// numbers its graph nodes in the order of this slice, and gonum's
+	// Modularize breaks ties by node id — so an unsorted slice feeds Go's
+	// RANDOMISED map iteration straight into the partition. The seeded PCG in
+	// louvain.go cannot rescue that: it fixes the algorithm's own randomness,
+	// not the ordering of what it is handed.
+	//
+	// Everything downstream inherits the wobble — dedup clusters, prune groups,
+	// distill groups, and the Sep>=2 gate on both bridge axes. Measured on the
+	// merged lab corpus before this line existed: a motif bridge candidate
+	// enumerated in four runs of five and vanished in the fifth.
+	//
+	// A sorted-map container was considered and declined (designer, Phase-4
+	// rulings-2): same asymptotics with worse constants for a
+	// build-once-iterate-once map, a new dependency, and signature churn
+	// wherever the subgraph flows. The guarantee lives in
+	// cluster_determinism_test.go, not in the data structure.
+	sort.Strings(paths)
 
 	edges, err := idx.SubgraphEdges(ctx, paths)
 	if err != nil {

--- a/internal/synthesize/cluster_determinism_test.go
+++ b/internal/synthesize/cluster_determinism_test.go
@@ -1,0 +1,94 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// ScopedCluster builds its node list by ranging over a map, and Go randomises
+// map iteration order. Louvain IS seeded — the determinism was intended — but a
+// fixed seed cannot help when the node ordering handed to Modularize changes
+// every run, because its tie-breaking is order-dependent. So the same corpus
+// clustered differently from one session to the next, and everything
+// downstream (dedup, prune groups, distill groups, both bridge axes' Sep>=2
+// gate) inherited the wobble.
+//
+// Measured before the fix: on the merged lab corpus a motif bridge candidate
+// enumerated in four runs of five and vanished in the fifth.
+//
+// These two tests are the durable guarantee — the designer considered and
+// declined a sorted-map container, on the grounds that the test is what holds
+// the property, not the data structure.
+
+const determinismSeedCount = 20
+
+// The PROPERTY: the node ordering handed to Louvain is the same every run.
+//
+// Twenty paths over twenty runs. If the ordering were still drawn from map
+// iteration, all twenty coincidences would need to happen at once, which does
+// not occur. Stated as the property rather than as the mechanism, so a future
+// implementation that achieves determinism some other way still passes.
+func TestScopedCluster_HandsLouvainTheSameNodeOrderEveryRun(t *testing.T) {
+	var seen [][]string
+	for range determinismSeedCount {
+		seen = append(seen, capturePathOrder(t))
+	}
+
+	// Precondition: enough nodes that a random order would differ — asserted rather
+	// than assumed, because this test is worthless on a two-element slice.
+	require.Len(t, seen[0], determinismSeedCount,
+		"precondition: the subgraph must be large enough that a random order would differ")
+
+	for i := 1; i < len(seen); i++ {
+		require.Equalf(t, seen[0], seen[i],
+			"run %d handed Louvain a different node order — the partition is not reproducible", i)
+	}
+}
+
+// The MECHANISM, asserted separately because the property test above is
+// probabilistic in principle and this one fails outright the moment the sort
+// is removed. A check that can only fail by luck is not the whole guarantee.
+func TestScopedCluster_NodeOrderIsSorted(t *testing.T) {
+	got := capturePathOrder(t)
+	require.True(t, slices.IsSorted(got),
+		"the paths handed to SubgraphEdges must be in a fixed order; sorted is the one we chose")
+}
+
+// capturePathOrder runs ScopedCluster once and returns the path slice it handed
+// to SubgraphEdges — the exact ordering that becomes Louvain's node numbering.
+func capturePathOrder(t *testing.T) []string {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	idx := NewMockSearchIndex(ctrl)
+	branch := "agent/x"
+
+	seeds := make([]factForLLM, 0, determinismSeedCount)
+	for i := range determinismSeedCount {
+		// Names deliberately NOT in insertion order alphabetically, so a test
+		// that passes cannot be passing because the map happened to be walked
+		// in the order the slice was built.
+		seeds = append(seeds, factForLLM{
+			File:  fmt.Sprintf("kb/%02d-%c.md", determinismSeedCount-i, 'a'+rune(i%26)),
+			Title: fmt.Sprintf("fact %d", i),
+		})
+	}
+
+	idx.EXPECT().Search(gomock.Any(), branch, gomock.Any()).Return(nil, nil).AnyTimes()
+
+	var captured []string
+	idx.EXPECT().SubgraphEdges(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, paths []string) ([][2]string, error) {
+			captured = append([]string(nil), paths...)
+			return nil, nil
+		}).Times(1)
+
+	_, err := ScopedCluster(context.Background(), seeds, idx, 1.0, 2, nil, branch)
+	require.NoError(t, err)
+	require.NotEmpty(t, captured, "SubgraphEdges must have been called with the node list")
+	return captured
+}

--- a/internal/synthesize/motif_disjoint.go
+++ b/internal/synthesize/motif_disjoint.go
@@ -68,9 +68,50 @@ type disjointnessPoint struct {
 	Umbrella int
 	// Labels is how many distinct labels the point was derived from.
 	Labels int
-	// Strict reports the validity-floor fallback.
+	// Strict reports that a conservative fallback is in force: any shared
+	// non-universal label blocks.
 	Strict bool
+	// Fallback names WHICH one, because they are different diagnoses of the
+	// same corpus and a reader debugging one that bridges nothing needs to
+	// tell them apart: "too few labels to estimate from" is not "the estimate
+	// came back meaningless".
+	Fallback disjointnessFallback
 }
+
+// disjointnessFallback names why the gate is running conservatively.
+type disjointnessFallback string
+
+const (
+	noFallback disjointnessFallback = ""
+	// labelFloor: fewer labels than the percentile needs to be an estimate.
+	labelFloor disjointnessFallback = "label-floor"
+	// degenerateCut: enough labels, but the percentile came back below 2.
+	degenerateCut disjointnessFallback = "degenerate-cut"
+)
+
+// minUsableCut is the smallest cut a percentile can yield and still gate
+// anything.
+//
+// CONSTANT CLASSIFICATION (MN13, third class): a STATISTICAL-VALIDITY FLOOR,
+// on the value the estimator YIELDS rather than on the population it is
+// estimated from — the same logic as minLabelsForPercentile, one step later.
+//
+// The gate blocks when a shared label's df <= Cut, and a SHARED label has
+// df >= 2 by construction. A cut of 1 is therefore unsatisfiable: not a strict
+// gate, not a loose gate, NO gate. It is what p90 returns whenever >=90% of a
+// corpus's labels are hapax, which a young repo dominated by path and uuid
+// tokens is — measured at 57 labels / 46 live facts, past the label floor and
+// so getting no protection from it either.
+//
+// Below the label floor the strict fallback covers the corpus; with a mature
+// distribution p90 lands at 3-5 and the percentile covers it; between them
+// there was a band with neither, and the health line said `df <= 1` as though
+// the gate were working. Designer ruling, phase4-rulings-5: fall back to
+// strict, because at the scale real repos actually reach — hundreds of facts,
+// not thousands — that band is near the STEADY STATE, and strict costs the
+// axis nothing under the gems framing (a genuine cross-domain pair shares no
+// labels and passes strict untouched).
+const minUsableCut = 2
 
 // resolveDisjointnessPoint derives the operating point from a corpus's own
 // label distribution.
@@ -81,6 +122,7 @@ func resolveDisjointnessPoint(d store.SubjectLabelDF) disjointnessPoint {
 	}
 	if len(d.DF) < minLabelsForPercentile {
 		p.Strict = true
+		p.Fallback = labelFloor
 		return p
 	}
 	vals := make([]int, 0, len(d.DF))
@@ -94,6 +136,10 @@ func resolveDisjointnessPoint(d store.SubjectLabelDF) disjointnessPoint {
 		idx--
 	}
 	p.Cut = vals[idx]
+	if p.Cut < minUsableCut {
+		p.Strict = true
+		p.Fallback = degenerateCut
+	}
 	return p
 }
 

--- a/internal/synthesize/motif_disjoint_test.go
+++ b/internal/synthesize/motif_disjoint_test.go
@@ -2,6 +2,7 @@ package synthesize
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -217,4 +218,90 @@ func TestSubjectDisjoint_UnknownLabelIsTreatedAsSpecific(t *testing.T) {
 	b := factForLLM{File: "kb/beta/2.md", Entities: []string{"Unmapped Thing"}}
 	require.Zero(t, labels.DF["unmapped"], "precondition: the shared token is unknown here")
 	require.False(t, subjectDisjoint(a, b, labels, p))
+}
+
+// ── the degenerate cut (Phase-4 deviation #4, phase4-rulings-5) ───────────
+
+// A derived cut of 1 is NOT a conservative gate — it is no gate at all. The
+// gate blocks when a shared label's df <= cut, and a SHARED label has df >= 2
+// by definition, so at cut=1 nothing can ever block.
+//
+// It happens in a real band: a corpus past the 50-label floor whose labels are
+// >=90% hapax, which a young repo dominated by path and uuid tokens is.
+// Measured on the dynamics fixture at 57 labels / 46 live facts. Below the
+// floor the strict fallback protects; with a mature distribution p90 is 3-5 and
+// the percentile protects; between them there was nothing.
+func TestResolveDisjointnessPoint_DegenerateCutFallsBackToStrict(t *testing.T) {
+	// 60 labels, past the floor, 57 of them hapax => p90 is 1.
+	d := store.SubjectLabelDF{LiveFacts: 46, DF: map[string]int{}}
+	for i := range 57 {
+		d.DF[fmt.Sprintf("hapax%d", i)] = 1
+	}
+	d.DF["shared-a"] = 2
+	d.DF["shared-b"] = 2
+	d.DF["shared-c"] = 3
+
+	p := resolveDisjointnessPoint(d)
+
+	require.GreaterOrEqual(t, len(d.DF), minLabelsForPercentile,
+		"precondition: past the label floor, so the label-floor fallback is NOT what fires")
+	require.True(t, p.Strict, "a cut below 2 is unsatisfiable by any shared label")
+	require.Equal(t, degenerateCut, p.Fallback, "and the health line must say WHICH fallback fired")
+}
+
+// The two fallbacks are distinct, and the health line has to tell them apart:
+// one says "too few labels to estimate", the other says "the estimate came
+// back meaningless". A reader debugging a corpus that bridges nothing needs to
+// know which.
+func TestResolveDisjointnessPoint_NamesWhichFallbackFired(t *testing.T) {
+	small := store.SubjectLabelDF{LiveFacts: 6, DF: map[string]int{"a": 2, "b": 2}}
+	p := resolveDisjointnessPoint(small)
+	require.True(t, p.Strict)
+	require.Equal(t, labelFloor, p.Fallback)
+
+	lines := motifBridgeHealthLines(motifEnumHealth{
+		Candidates: 1, Ceiling: 12, Point: p,
+		Activation: motifActivation{Evaluated: true, Active: true, DF2Clusters: 3},
+	}, 1, 0)
+	joined := strings.Join(lines, "\n")
+	require.Contains(t, joined, "below the")
+	require.Contains(t, joined, "label validity floor")
+	require.NotContains(t, joined, "degenerate")
+}
+
+// A healthy distribution still gets a real percentile — the fallback must not
+// swallow the ordinary case.
+func TestResolveDisjointnessPoint_HealthyDistributionKeepsItsPercentile(t *testing.T) {
+	d := store.SubjectLabelDF{LiveFacts: 400, DF: map[string]int{}}
+	for i := range 60 {
+		d.DF[fmt.Sprintf("hapax%d", i)] = 1
+	}
+	for i := range 40 {
+		d.DF[fmt.Sprintf("common%d", i)] = 2 + i%6
+	}
+
+	p := resolveDisjointnessPoint(d)
+
+	require.False(t, p.Strict, "a usable distribution is not a fallback case")
+	require.GreaterOrEqual(t, p.Cut, 2, "precondition: the cut must be satisfiable, or this proves nothing")
+	require.Equal(t, noFallback, p.Fallback)
+}
+
+// The property the whole ruling protects, asserted at the gate rather than at
+// the point: in the degenerate band a pair sharing a rare entity must be
+// REJECTED. Before the fix it passed.
+func TestSubjectDisjoint_DegenerateBandStillBlocksASharedRareEntity(t *testing.T) {
+	d := store.SubjectLabelDF{LiveFacts: 46, DF: map[string]int{}}
+	for i := range 57 {
+		d.DF[fmt.Sprintf("hapax%d", i)] = 1
+	}
+	d.DF["cognition"] = 2
+
+	p := resolveDisjointnessPoint(d)
+	require.True(t, p.Strict, "precondition: this fixture is in the degenerate band")
+
+	a := factForLLM{File: "kb/gotchas/uitesting/x.md", Entities: []string{"Cognition"}}
+	b := factForLLM{File: "kb/technology/benchmarks/y.md", Entities: []string{"Cognition"}}
+	require.False(t, subjectDisjoint(a, b, d, p),
+		"a shared rare entity is one subject, whatever the percentile came back as")
 }

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -292,7 +292,7 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	// (designer ruling 2026-08-23, phase3-rulings-1 Q2).
 	nearMotif, farMotif, motifHealth, mErr := buildMotifBridges(ctx, d.Search, branch,
 		llmSeeds, cr, d.Effort, cfg, motifResolverFor(ctx, d.Motifs, branch),
-		subjectLabelsFor(ctx, d.Search, branch), meanSimFor(d.Abstraction, branch))
+		subjectLabelsFor(ctx, d.Search, branch), pairCosFor(d.Abstraction, branch))
 	if mErr != nil {
 		// Degrade rather than fail the session: the grounded work above is
 		// already queued, and an unavailable axis is not a reason to lose it.

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -291,8 +291,8 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	// hypothesize tool's synthesis-only seed pool is untouched by this
 	// (designer ruling 2026-08-23, phase3-rulings-1 Q2).
 	nearMotif, farMotif, motifHealth, mErr := buildMotifBridges(ctx, d.Search, branch,
-		llmSeeds, cr, d.Effort, cfg, motifResolverFor(ctx, d, branch),
-		subjectLabelsFor(ctx, d, branch), meanSimFor(d, branch))
+		llmSeeds, cr, d.Effort, cfg, motifResolverFor(ctx, d.Motifs, branch),
+		subjectLabelsFor(ctx, d.Search, branch), meanSimFor(d.Abstraction, branch))
 	if mErr != nil {
 		// Degrade rather than fail the session: the grounded work above is
 		// already queued, and an unavailable axis is not a reason to lose it.

--- a/tools/calibrate/bridges.go
+++ b/tools/calibrate/bridges.go
@@ -58,6 +58,15 @@ paths, and token frequencies — no embedding model is loaded or needed.`,
 			if err := eff.Validate(); err != nil {
 				return fmt.Errorf("--effort: %w", err)
 			}
+			// MOTIF is a SIBLING report, not a kind of this one (Phase-4 Q3).
+			// The two enumerate different populations over different pools with
+			// different engines, and 8ad54ee8 is precisely an aggregate whose
+			// population was not the production population, surviving because
+			// nothing forced the population into the output. Folding a second
+			// population behind a flag on one function is how that recurs.
+			if kindStr == "motif" {
+				return runMotifReport(cmd, dbPath, branch, effortStr, resolution, minCommunity, cfg)
+			}
 			kind := synthesize.BridgeKindFromString(kindStr)
 
 			// Open the index without an embedder — the scoring path is embedder-free.
@@ -76,6 +85,14 @@ paths, and token frequencies — no embedding model is loaded or needed.`,
 			}
 
 			out := cmd.OutOrStdout()
+			// POPULATION FIRST, before any number. A figure that travels
+			// without the population it was computed over is how 8ad54ee8
+			// happened: a suggested floor derived from unreshaped candidates,
+			// read as if it described the production ones.
+			fmt.Fprintf(out, "POPULATION: %s bridge candidates over live SYNTHESIS facts on %q, "+
+				"scored UNRESHAPED (production applies cohFloor AFTER reshapeCohesiveSubset, "+
+				"so the suggested floor below is a lower bound, not the production floor)\n\n",
+				kindStr, branch)
 			if len(report) == 0 {
 				fmt.Fprintln(out, "no bridge candidates found")
 				return nil
@@ -133,7 +150,7 @@ paths, and token frequencies — no embedding model is loaded or needed.`,
 	f.String("db", "", "path to knomit index DB (required)")
 	f.String("branch", "main", "branch name to query")
 	f.String("effort", "medium", "discovery effort level (normal/medium/high)")
-	f.String("kind", "both", "bridge kind to enumerate (domain/entity/both)")
+	f.String("kind", "both", "bridge kind to enumerate (domain/entity/both/motif)")
 	f.Float64("resolution", 2.0, "Louvain resolution for clustering")
 	f.Int("min-community", 2, "minimum community size for clustering")
 	// Q-knob overrides: register with config.Defaults().Discovery values as the
@@ -204,4 +221,71 @@ func sortedCopy(vs []float64) []float64 {
 	copy(cp, vs)
 	sort.Float64s(cp)
 	return cp
+}
+
+// runMotifReport prints the motif axis's component report.
+//
+// Separate from the entity/domain path deliberately (Phase-4 Q3): different
+// population, different pool, different engine. It states all three in its own
+// header rather than inheriting a sentence written about another axis.
+func runMotifReport(cmd *cobra.Command, dbPath, branch, effortStr string,
+	resolution float64, minCommunity int, cfg synthesize.QualityConfig) error {
+	eff := synthesize.NormalizeEffort(synthesize.Effort(effortStr))
+	if err := eff.Validate(); err != nil {
+		return fmt.Errorf("--effort: %w", err)
+	}
+	svc, err := store.Open(dbPath)
+	if err != nil {
+		return fmt.Errorf("open index %q: %w", dbPath, err)
+	}
+	defer svc.Close()
+
+	rep, err := synthesize.MotifComponentReport(cmd.Context(), svc.Search(), svc.Motifs(),
+		svc.Abstraction(), branch, eff, resolution, minCommunity, cfg)
+	if err != nil {
+		return fmt.Errorf("motif component report: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "POPULATION: %s\n\n", rep.Population)
+	fmt.Fprintf(out, "%s\n", rep.Summary())
+	if !rep.ActivationActive {
+		fmt.Fprintf(out, "\nAXIS INACTIVE: %d recurring motif(s) — below the activation floor. "+
+			"Nothing below is a statement about this corpus's bridges; the axis did not run.\n",
+			rep.SeedDF2Clusters)
+	}
+	fmt.Fprintf(out, "activation population: %d recurring motif(s), %d bridgeable pair(s)\n\n",
+		rep.SeedDF2Clusters, rep.SeedBridgeablePairs)
+
+	if len(rep.Candidates) == 0 {
+		fmt.Fprintln(out, "no motif bridge candidates found")
+		return nil
+	}
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "TOKEN\tLANE\tMEMBERS\tCOH\tSEP\tGAP\tSPEC\tSEEDCOS\tEJACC\tOVERDUP\tQ\tKEPT/CAUSE")
+	for _, b := range rep.Candidates {
+		verdict := "yes"
+		if !b.Kept {
+			verdict = b.Cause
+		}
+		seedCos, overDup := "n/a", "n/a"
+		if b.Comp.Novelty.VectorsRead {
+			seedCos = fmt.Sprintf("%.3f", b.Comp.Novelty.SeedCos)
+			overDup = fmt.Sprintf("%.3f", b.Comp.Novelty.OverDedup)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%.3f\t%d\t%.3f\t%.3f\t%s\t%.3f\t%s\t%.3f\t%s\n",
+			b.Token, b.Lane, len(b.Members), b.Comp.Coh, b.Comp.Sep, b.Comp.Gap, b.Comp.Spec,
+			seedCos, b.Comp.Novelty.EntityJaccard, overDup, b.Q, verdict)
+	}
+	tw.Flush()
+
+	fmt.Fprintf(out, "\nserved: %d near, %d far (budgets %d/%d)\n",
+		len(rep.NearServed), len(rep.FarServed), rep.NearBudget, rep.FarBudget)
+	fmt.Fprintln(out, "\nNOTE: OVERDUP counts member pairs at or above the dedup cosine, which "+
+		"catches VERBATIM duplicates only (90d69628). A zero does NOT mean the members say "+
+		"different things.")
+	for _, l := range rep.HealthLines {
+		fmt.Fprintf(out, "  health: %s\n", l)
+	}
+	return nil
 }

--- a/tools/calibrate/bridges.go
+++ b/tools/calibrate/bridges.go
@@ -262,11 +262,18 @@ func runMotifReport(cmd *cobra.Command, dbPath, branch, effortStr string,
 		return nil
 	}
 	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "TOKEN\tLANE\tMEMBERS\tCOH\tSEP\tGAP\tSPEC\tSEEDCOS\tEJACC\tOVERDUP\tQ\tKEPT/CAUSE")
+	fmt.Fprintln(tw, "TOKEN\tLANE\tMEMBERS\tCOH\tSEP\tGAP\tSPEC\tSEEDCOS\tEJACC\tOVERDUP\tQ\tDISPOSITION")
 	for _, b := range rep.Candidates {
-		verdict := "yes"
-		if !b.Kept {
-			verdict = b.Cause
+		// One column, every state named. It read "yes" for candidates absent
+		// from the served line — suppression happens after the scorer's
+		// verdict, so "kept" and "served" are different questions and the
+		// table now answers both (review finding M-4).
+		verdict := "served"
+		switch {
+		case !b.Kept:
+			verdict = "dropped: " + b.Cause
+		case !b.Served:
+			verdict = "kept, no slot (budget)"
 		}
 		seedCos, overDup := "n/a", "n/a"
 		if b.Comp.Novelty.VectorsRead {

--- a/tools/calibrate/bridges.go
+++ b/tools/calibrate/bridges.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sort"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 	"knomit/internal/config"
+	"knomit/internal/embeddings"
 	"knomit/internal/store"
 	"knomit/internal/synthesize"
 )
@@ -240,7 +242,15 @@ func runMotifReport(cmd *cobra.Command, dbPath, branch, effortStr string,
 	}
 	defer svc.Close()
 
-	rep, err := synthesize.MotifComponentReport(cmd.Context(), svc.Search(), svc.Motifs(),
+	// M-5: resolve the CORPUS's own model thresholds. This command opens the
+	// store without an embedder — correct, the scoring path needs none — but
+	// OverDedup is measured against a cosine, and the default is nomic's while
+	// every corpus in this campaign is embeddinggemma (0.82 vs 0.92). An
+	// unknown model yields "not computed", never a default.
+	idx := motifThresholdIndex{SearchQuery: svc.Search()}
+	idx.dedup, idx.known = corpusDedupThreshold(dbPath)
+
+	rep, err := synthesize.MotifComponentReport(cmd.Context(), idx, svc.Motifs(),
 		svc.Abstraction(), branch, eff, resolution, minCommunity, cfg)
 	if err != nil {
 		return fmt.Errorf("motif component report: %w", err)
@@ -254,8 +264,15 @@ func runMotifReport(cmd *cobra.Command, dbPath, branch, effortStr string,
 			"Nothing below is a statement about this corpus's bridges; the axis did not run.\n",
 			rep.SeedDF2Clusters)
 	}
-	fmt.Fprintf(out, "activation population: %d recurring motif(s), %d bridgeable pair(s)\n\n",
+	fmt.Fprintf(out, "activation population: %d recurring motif(s), %d bridgeable pair(s)\n",
 		rep.SeedDF2Clusters, rep.SeedBridgeablePairs)
+	if idx.known {
+		fmt.Fprintf(out, "dedup threshold: %.3f (this corpus's own embedding model)\n\n", idx.dedup)
+	} else {
+		fmt.Fprintf(out, "dedup threshold: UNKNOWN — OverDedup not computed. "+
+			"The corpus does not record a recognised embedding model, and the shipped "+
+			"default belongs to a different one.\n\n")
+	}
 
 	if len(rep.Candidates) == 0 {
 		fmt.Fprintln(out, "no motif bridge candidates found")
@@ -278,7 +295,9 @@ func runMotifReport(cmd *cobra.Command, dbPath, branch, effortStr string,
 		seedCos, overDup := "n/a", "n/a"
 		if b.Comp.Novelty.VectorsRead {
 			seedCos = fmt.Sprintf("%.3f", b.Comp.Novelty.SeedCos)
-			overDup = fmt.Sprintf("%.3f", b.Comp.Novelty.OverDedup)
+			if b.Comp.Novelty.DedupKnown {
+				overDup = fmt.Sprintf("%.3f", b.Comp.Novelty.OverDedup)
+			}
 		}
 		fmt.Fprintf(tw, "%s\t%s\t%d\t%.3f\t%d\t%.3f\t%.3f\t%s\t%.3f\t%s\t%.3f\t%s\n",
 			b.Token, b.Lane, len(b.Members), b.Comp.Coh, b.Comp.Sep, b.Comp.Gap, b.Comp.Spec,
@@ -295,4 +314,41 @@ func runMotifReport(cmd *cobra.Command, dbPath, branch, effortStr string,
 		fmt.Fprintf(out, "  health: %s\n", l)
 	}
 	return nil
+}
+
+// motifThresholdIndex carries the corpus's own dedup threshold to the scorer,
+// which otherwise has no embedder to ask.
+//
+// Structural rather than a new parameter: synthesize looks for the method, so
+// nothing had to thread a threshold through four call layers, and "the caller
+// knows it" cannot be confused with "there is an embedder".
+type motifThresholdIndex struct {
+	synthesize.SearchQuery
+	dedup float64
+	known bool
+}
+
+func (m motifThresholdIndex) MotifDedupThreshold() (float64, bool) { return m.dedup, m.known }
+
+// corpusDedupThreshold reads meta.embed_model_id from the corpus and resolves
+// that model's Dedup.
+//
+// Raw read, and read-only: this command is documented as needing no embedding
+// model, which stays true — a model IDENTITY is not a model. UNKNOWN is a real
+// answer here and is reported as one.
+func corpusDedupThreshold(dbPath string) (float64, bool) {
+	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
+	if err != nil {
+		return 0, false
+	}
+	defer db.Close()
+	var id string
+	if err := db.QueryRow(`SELECT value FROM meta WHERE key = 'embed_model_id'`).Scan(&id); err != nil {
+		return 0, false
+	}
+	m, err := embeddings.Lookup(id)
+	if err != nil {
+		return 0, false
+	}
+	return m.Thresholds.Dedup, true
 }

--- a/tools/calibrate/bridges_test.go
+++ b/tools/calibrate/bridges_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"bytes"
+	"database/sql"
+	"knomit/internal/embeddings"
+	"knomit/internal/embeddings/params"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -93,4 +97,53 @@ func TestBridgesMissingDB(t *testing.T) {
 		strings.Contains(err.Error(), "db") || strings.Contains(buf.String(), "db"),
 		"error should mention 'db', got err=%q out=%q", err, buf.String(),
 	)
+}
+
+// M-5. The command opens a store with no embedder, so the dedup threshold has
+// to come from the corpus's recorded model identity. Unknown must stay
+// unknown: params.Defaults() is nomic's geometry and every corpus in this
+// campaign is embeddinggemma, so a silent default reports OverDedup 0.000 for
+// a pair genuinely above its corpus's own gate.
+func TestCorpusDedupThreshold_UnknownIsNotADefault(t *testing.T) {
+	dir := t.TempDir()
+
+	// No meta table at all.
+	empty := filepath.Join(dir, "empty.db")
+	db, err := sql.Open("sqlite3", empty)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE unrelated (x TEXT)`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	_, known := corpusDedupThreshold(empty)
+	require.False(t, known, "no meta table is unknown, not default")
+
+	// A meta table naming a model nothing registers.
+	unknown := filepath.Join(dir, "unknown.db")
+	db, err = sql.Open("sqlite3", unknown)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE meta (key TEXT, value TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO meta VALUES ('embed_model_id','no-such-model')`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	_, known = corpusDedupThreshold(unknown)
+	require.False(t, known, "an unrecognised model is unknown, not default")
+
+	// A recognised one resolves, and to the model's own value.
+	real := filepath.Join(dir, "real.db")
+	db, err = sql.Open("sqlite3", real)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE meta (key TEXT, value TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO meta VALUES ('embed_model_id','embeddinggemma')`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	got, known := corpusDedupThreshold(real)
+	require.True(t, known)
+	m, err := embeddings.Lookup("embeddinggemma")
+	require.NoError(t, err)
+	require.Equal(t, m.Thresholds.Dedup, got)
+	require.NotEqual(t, params.Defaults().Dedup, got,
+		"precondition: this model's threshold must DIFFER from the default, or the "+
+			"test cannot tell which one was used")
 }

--- a/tools/motifannex/bridgeable.go
+++ b/tools/motifannex/bridgeable.go
@@ -1,0 +1,47 @@
+package main
+
+// bridgeablePairs returns how many fact pairs share a canonical motif at all,
+// given each cluster's df.
+//
+// WHAT READS THIS NUMBER, AND WHAT IT MEANS. Phase 4's activation floor is set
+// on it (Q1 ruling), and the gate annex's "starved, not broken" finding is a
+// hand computation of it: knomit-io-kb reached 100% coverage and a saturated
+// 22-cluster vocabulary, and still offered exactly TWO candidate pairs — "two
+// shots is not a sample".
+//
+// It is a CEILING and nothing more. Every gate the engine applies — df band,
+// subject-disjointness, separation, cohesion, the member cap, the per-lane
+// budgets — can only take pairs away from this number. So a corpus with a high
+// count may still bridge nothing, and reading it as "pairs the agent will see"
+// is wrong in the direction that flatters the axis. What it rules out is the
+// other direction: below it, no mechanism can find anything, because there is
+// nothing of the right shape to find.
+//
+// Hapax contribute zero by construction, which is the same reason the df band's
+// floor is 2: a motif carried by one fact joins nothing to anything.
+//
+// ONE PLACE THE LABEL COULD DRIFT FROM THE NUMBER. This sums C(df,2) per
+// cluster, so it counts CLUSTER-PAIR INCIDENCES. A reader takes it as DISTINCT
+// FACT PAIRS, and the two differ as soon as one pair of facts shares two
+// motifs. Measured 2026-08-24 on the lab corpora, they do not differ yet
+// (agentic-engineering 8 = 8, merged 16 = 16) — but "equal today" is not
+// "the same quantity", and a corpus with a richer vocabulary will separate
+// them. Whoever needs distinct fact pairs must count them, not read this.
+//
+// CORRECTION TO A PUBLISHED FIGURE. The gate annex §9 states this ceiling as
+// 7 on agentic-engineering. It is 8: the corpus carries one df-3 cluster
+// (instrument-fault-mimics-signal) and five df-2 clusters, giving 3 + 5. The
+// annex's own §4 table lists the 6 recurring clusters this is computed from,
+// so the slip is in the arithmetic, not the data. It changes no conclusion —
+// 8 is as starved as 7 — and is recorded because a number nobody re-derived
+// is how the annex's own §11 item 4 happened.
+func bridgeablePairs(dfs []int) int {
+	total := 0
+	for _, df := range dfs {
+		if df < 2 {
+			continue
+		}
+		total += df * (df - 1) / 2
+	}
+	return total
+}

--- a/tools/motifannex/bridgeable_test.go
+++ b/tools/motifannex/bridgeable_test.go
@@ -56,3 +56,34 @@ func TestBridgeablePairs_AgenticEngineeringIsEightNotSeven(t *testing.T) {
 	require.Equal(t, 8, bridgeablePairs(dfs))
 	require.NotEqual(t, 7, bridgeablePairs(dfs))
 }
+
+// L-1. The T7 record and the acceptance package both said the lab
+// vocabularies hold "155 clusters". They hold 156: 37 + 71 + 26 + 20 is not
+// the sum — it is 37 + 71 + 26 + 22, and the 22 is knomit-io-kb's cluster
+// count, not its definition count (18).
+//
+// Pinned by a test for the same reason the gate annex's 7→8 correction was:
+// the T0-T2 record's own words are that "a number nobody re-derived is
+// exactly how the annex's own §11 item 4 happened", and that applies to its
+// sibling record verbatim. The 133 definitions figure was always right
+// (34+61+20+18).
+func TestLabVocabularyTotals(t *testing.T) {
+	clusters := map[string]int{
+		"agentic-engineering": 37, "merged": 71, "knomit-kb": 26, "knomit-io-kb": 22,
+	}
+	definitions := map[string]int{
+		"agentic-engineering": 34, "merged": 61, "knomit-kb": 20, "knomit-io-kb": 18,
+	}
+	require.Equal(t, 156, sumOf(clusters), "the T7/T8 cluster population is 156, not 155")
+	require.Equal(t, 133, sumOf(definitions), "the real-definition count was always right")
+	require.NotEqual(t, sumOf(clusters), sumOf(definitions),
+		"precondition: the two totals differ, which is how 22 and 18 got swapped")
+}
+
+func sumOf(m map[string]int) int {
+	n := 0
+	for _, v := range m {
+		n += v
+	}
+	return n
+}

--- a/tools/motifannex/bridgeable_test.go
+++ b/tools/motifannex/bridgeable_test.go
@@ -58,14 +58,21 @@ func TestBridgeablePairs_AgenticEngineeringIsEightNotSeven(t *testing.T) {
 }
 
 // L-1. The T7 record and the acceptance package both said the lab
-// vocabularies hold "155 clusters". They hold 156: 37 + 71 + 26 + 20 is not
-// the sum — it is 37 + 71 + 26 + 22, and the 22 is knomit-io-kb's cluster
-// count, not its definition count (18).
+// vocabularies hold "155 clusters". They hold 156 — 37 + 71 + 26 + 22.
+//
+// WHERE THE 155 CAME FROM (corrected; the first version of this comment got
+// its own arithmetic wrong and said "37 + 71 + 26 + 20", which is 154, not the
+// 155 that was actually published). The 155 is 37 + **70** + 26 + 22: merged's
+// RAW-SQL cluster count, not the shipped VocabularyHealth figure of 71. That
+// is precisely the discrepancy the T0-T2 record documented and resolved in
+// favour of the shipped API — "correct instrument, wrong habit" — and it then
+// leaked into a sibling record's total anyway.
 //
 // Pinned by a test for the same reason the gate annex's 7→8 correction was:
-// the T0-T2 record's own words are that "a number nobody re-derived is
-// exactly how the annex's own §11 item 4 happened", and that applies to its
-// sibling record verbatim. The 133 definitions figure was always right
+// the T0-T2 record's own words are that "a number nobody re-derived is exactly
+// how the annex's own §11 item 4 happened". Which applies to the first draft of
+// this very comment: a causal story nobody re-derived, inside the test built
+// against that failure mode. The 133 definitions figure was always right
 // (34+61+20+18).
 func TestLabVocabularyTotals(t *testing.T) {
 	clusters := map[string]int{
@@ -76,8 +83,19 @@ func TestLabVocabularyTotals(t *testing.T) {
 	}
 	require.Equal(t, 156, sumOf(clusters), "the T7/T8 cluster population is 156, not 155")
 	require.Equal(t, 133, sumOf(definitions), "the real-definition count was always right")
+	// The published 155 is reproducible from the raw-SQL merged count, which is
+	// what makes the causal story above checkable rather than asserted.
+	rawSQLMerged := map[string]int{} // a COPY: assigning the map would alias it
+	for k, v := range clusters {
+		rawSQLMerged[k] = v
+	}
+	rawSQLMerged["merged"] = 70
+	require.Equal(t, 155, sumOf(rawSQLMerged),
+		"the published 155 is the shipped total with merged's raw-SQL count substituted")
+	require.Equal(t, 156, sumOf(clusters), "and the original is untouched by that substitution")
 	require.NotEqual(t, sumOf(clusters), sumOf(definitions),
-		"precondition: the two totals differ, which is how 22 and 18 got swapped")
+		"precondition: cluster and definition totals differ, or this test could not "+
+			"tell one from the other")
 }
 
 func sumOf(m map[string]int) int {

--- a/tools/motifannex/bridgeable_test.go
+++ b/tools/motifannex/bridgeable_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// bridgeablePairs is the CEILING on motif bridging: the number of fact pairs
+// that share a canonical motif at all. Nothing the engine does can exceed it,
+// so it is the population the Phase-4 activation floor is set on (Q1 ruling).
+
+func TestBridgeablePairs_HapaxCannotBridge(t *testing.T) {
+	require.Equal(t, 0, bridgeablePairs(nil))
+	require.Equal(t, 0, bridgeablePairs([]int{1, 1, 1, 1, 1}),
+		"a motif on one fact joins nothing to anything")
+	require.Equal(t, 0, bridgeablePairs([]int{0, 1}))
+}
+
+func TestBridgeablePairs_CountsUnorderedPairsPerCluster(t *testing.T) {
+	require.Equal(t, 1, bridgeablePairs([]int{2}))
+	require.Equal(t, 3, bridgeablePairs([]int{3}))
+	require.Equal(t, 10, bridgeablePairs([]int{5}))
+}
+
+func TestBridgeablePairs_SumsAcrossClustersAndIgnoresHapax(t *testing.T) {
+	// Deliberately non-degenerate: four distinct df values, two of them below
+	// the band floor, and a total that no single term produces.
+	got := bridgeablePairs([]int{1, 2, 3, 5})
+	require.Equal(t, 0+1+3+10, got)
+	require.NotEqual(t, 10, got, "precondition: the total must not equal its largest term")
+}
+
+// The published figure this reproduces: the gate annex says knomit-io-kb's
+// whole saturated vocabulary offers TWO candidate pairs ("two shots is not a
+// sample"). Its vocabulary is 22 clusters, 2 of them at df 2.
+func TestBridgeablePairs_ReproducesTheAnnexKnomitIoKbFigure(t *testing.T) {
+	dfs := make([]int, 0, 22)
+	dfs = append(dfs, 2, 2)
+	for len(dfs) < 22 {
+		dfs = append(dfs, 1)
+	}
+	require.Equal(t, 2, bridgeablePairs(dfs))
+}
+
+// agentic-engineering's real df shape, read off the lab corpus 2026-08-24:
+// one df-3 cluster and five df-2 clusters among 37. The annex §9 states this
+// ceiling as 7; it is 8. Pinned here so the correction is executable rather
+// than only written down.
+func TestBridgeablePairs_AgenticEngineeringIsEightNotSeven(t *testing.T) {
+	dfs := make([]int, 0, 37)
+	dfs = append(dfs, 3, 2, 2, 2, 2, 2)
+	for len(dfs) < 37 {
+		dfs = append(dfs, 1)
+	}
+	require.Equal(t, 8, bridgeablePairs(dfs))
+	require.NotEqual(t, 7, bridgeablePairs(dfs))
+}

--- a/tools/motifannex/bridges.go
+++ b/tools/motifannex/bridges.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"knomit/internal/synthesize"
+)
+
+// bridges dumps every motif bridge candidate a corpus produces at one effort —
+// SERVED AND DROPPED, with the drop cause — as JSON.
+//
+// This is Phase 4's measurement instrument, and it is deliberately a thin shell
+// over synthesize.MotifComponentReport: the report drives the SHIPPED
+// enumeration and scoring, so what is measured here is the engine that serves
+// the bridges rather than a second implementation of it that agrees until it
+// does not. A Python re-derivation would measure the re-derivation.
+//
+// Read-only. It plans no work, answers no item and writes nothing — and the
+// corpus it opens is a lab copy, enforced by refuseLivePath in open().
+func bridges(ctx context.Context, corpus, scratch, effortStr string) error {
+	eff := synthesize.NormalizeEffort(synthesize.Effort(effortStr))
+	if err := eff.Validate(); err != nil {
+		return fmt.Errorf("-effort: %w", err)
+	}
+
+	svc, ri, branch, closeAll, err := open(ctx, corpus, scratch)
+	if err != nil {
+		return err
+	}
+	defer closeAll()
+
+	rep, err := synthesize.MotifComponentReport(ctx, svc.Search(), svc.Motifs(), svc.Abstraction(),
+		branch, eff, ri.ClusterResolution(), ri.ClusterMinCommunitySize(),
+		synthesize.QualityConfigFromRepo(ri))
+	if err != nil {
+		return fmt.Errorf("motif component report: %w", err)
+	}
+	fmt.Fprintln(os.Stderr, rep.Summary())
+	return emit(rep)
+}

--- a/tools/motifannex/calibpack.go
+++ b/tools/motifannex/calibpack.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+)
+
+// calibpack builds the T8 labelling pack: a stratified sample of motif pairs,
+// blinded, for a judge to label same-mechanism / different-mechanism.
+//
+// It emits TWO files' worth of data on stdout — the pack (what the judge sees)
+// and the key (what it means) — so the judge can be handed the pack alone.
+//
+// THE TRANSFORM AND RENDERING ARE FIXED HERE, and that is deliberate: labels
+// attach to strings, so labelling a string the shipped tier will not use wastes
+// the pass. Per phase4-rulings-4:
+//
+//   - rendering: `<canonical_id>: <definition>` (name+def), the calibrated
+//     tier's string. The alias pre-block keeps name-only and its percentile,
+//     untouched.
+//   - transform: mean-CENTERED, by the corpus's own vocabulary mean — the same
+//     per-corpus mean production will store as derived state, so a cosine here
+//     is the number production would compute for that pair in that corpus.
+//
+// Centering per corpus rather than over a pooled population is the faithful
+// choice even though the point being derived is per-MODEL: each pair is scored
+// the way the corpus carrying it would score it, and the pooled label set then
+// says whether one threshold serves them all. Pooling first would measure a
+// population no deployment ever sees.
+func calibpack(ctx context.Context, scratch string, corpora []string) error {
+	type scored struct {
+		A, B   string // the rendered name+def strings
+		AID    string
+		BID    string
+		Corpus string
+		Cos    float64
+	}
+	var all []scored
+	seen := map[string]bool{}
+
+	for _, corpus := range corpora {
+		svc, ri, branch, closeAll, err := open(ctx, corpus, scratch)
+		if err != nil {
+			return err
+		}
+		clusters, err := svc.Motifs().Clusters(ctx, branch)
+		if err != nil {
+			closeAll()
+			return fmt.Errorf("%s clusters: %w", corpus, err)
+		}
+		var ids, texts []string
+		for _, c := range clusters {
+			def, ok, derr := svc.Motifs().Definition(ctx, branch, c.ClusterKey)
+			if derr != nil {
+				closeAll()
+				return derr
+			}
+			t := c.CanonicalID
+			if ok && def != "" {
+				t = c.CanonicalID + ": " + def
+			}
+			ids = append(ids, c.CanonicalID)
+			texts = append(texts, t)
+		}
+		if len(texts) < 2 {
+			closeAll()
+			continue
+		}
+		emb := ri.Embedder()
+		vecs, err := emb.EmbedShortStrings(ctx, texts)
+		if err != nil {
+			closeAll()
+			return err
+		}
+		mean := meanOf(vecs)
+		for i := range ids {
+			for j := i + 1; j < len(ids); j++ {
+				// Dedupe across corpora on the id pair: merged was seeded from
+				// agentic-engineering, so most of ag's vocabulary appears twice
+				// and a pooled sample would double-weight it.
+				k := ids[i] + "\x00" + ids[j]
+				if ids[j] < ids[i] {
+					k = ids[j] + "\x00" + ids[i]
+				}
+				if seen[k] {
+					continue
+				}
+				seen[k] = true
+				all = append(all, scored{
+					A: texts[i], B: texts[j], AID: ids[i], BID: ids[j],
+					Corpus: corpus, Cos: round4(pairCos(vecs[i], vecs[j], mean)),
+				})
+			}
+		}
+		closeAll()
+	}
+	if len(all) == 0 {
+		return fmt.Errorf("no pairs")
+	}
+
+	// STRATA. The decision region gets the sample; the extremes get controls.
+	// Without the controls a pass cannot tell "the threshold is here" from
+	// "the judge says yes to everything" — 349c0ab6's floor-and-ceiling rule.
+	type stratum struct {
+		name     string
+		lo, hi   float64
+		want     int
+		isBand   bool
+		selected []scored
+	}
+	strata := []*stratum{
+		{name: "control-low", lo: -1, hi: 0.05, want: 30},
+		{name: "band-lower", lo: 0.05, hi: 0.15, want: 60, isBand: true},
+		{name: "band-core", lo: 0.15, hi: 0.25, want: 80, isBand: true},
+		{name: "band-upper", lo: 0.25, hi: 0.40, want: 60, isBand: true},
+		{name: "control-high", lo: 0.40, hi: 2, want: 30},
+	}
+
+	// Deterministic selection: sort each stratum and take an even spread across
+	// it, so the sample covers the stratum rather than clustering at one end,
+	// and a rerun draws the same pack.
+	byStratum := map[string][]scored{}
+	for _, s := range all {
+		for _, st := range strata {
+			if s.Cos >= st.lo && s.Cos < st.hi {
+				byStratum[st.name] = append(byStratum[st.name], s)
+				break
+			}
+		}
+	}
+	for _, st := range strata {
+		pool := byStratum[st.name]
+		sort.Slice(pool, func(a, b int) bool {
+			if pool[a].Cos != pool[b].Cos {
+				return pool[a].Cos < pool[b].Cos
+			}
+			return pool[a].AID+pool[a].BID < pool[b].AID+pool[b].BID
+		})
+		if len(pool) <= st.want {
+			st.selected = pool
+			continue
+		}
+		step := float64(len(pool)) / float64(st.want)
+		for i := 0; i < st.want; i++ {
+			st.selected = append(st.selected, pool[int(math.Floor(float64(i)*step))])
+		}
+	}
+
+	// Blind ids, and a stable shuffle by hash of the id pair so the pack's
+	// order carries no information about stratum or cosine.
+	type packItem struct {
+		ID string `json:"id"`
+		A  string `json:"a"`
+		B  string `json:"b"`
+	}
+	type keyItem struct {
+		ID      string  `json:"id"`
+		Stratum string  `json:"stratum"`
+		Cos     float64 `json:"centered_cos"`
+		AID     string  `json:"a_id"`
+		BID     string  `json:"b_id"`
+		Corpus  string  `json:"corpus"`
+	}
+	var flat []scored
+	counts := map[string]int{}
+	for _, st := range strata {
+		flat = append(flat, st.selected...)
+		counts[st.name] = len(st.selected)
+		for range st.selected {
+			_ = st
+		}
+	}
+	stratumOf := map[string]string{}
+	for _, st := range strata {
+		for _, s := range st.selected {
+			stratumOf[s.AID+"\x00"+s.BID] = st.name
+		}
+	}
+	sort.Slice(flat, func(a, b int) bool {
+		return fnv(flat[a].AID+flat[a].BID) < fnv(flat[b].AID+flat[b].BID)
+	})
+
+	var pack []packItem
+	var key []keyItem
+	for i, s := range flat {
+		id := fmt.Sprintf("P%03d", i+1)
+		pack = append(pack, packItem{ID: id, A: s.A, B: s.B})
+		key = append(key, keyItem{
+			ID: id, Stratum: stratumOf[s.AID+"\x00"+s.BID], Cos: s.Cos,
+			AID: s.AID, BID: s.BID, Corpus: s.Corpus,
+		})
+	}
+
+	fmt.Fprintf(os.Stderr, "pairs=%d selected=%d strata=%v\n", len(all), len(flat), counts)
+	return emit(map[string]any{
+		"total_pairs":     len(all),
+		"selected":        len(flat),
+		"stratum_counts":  counts,
+		"rendering":       "<canonical_id>: <definition>",
+		"transform":       "mean-centered by the corpus's own vocabulary mean",
+		"pack":            pack,
+		"key":             key,
+		"preregistration": "phase4-rulings-4 / T8 preamble: fewer than 20 positives inside the band strata means the soft tier is measured and explicitly re-deferred, never given a number",
+	})
+}
+
+// fnv is a small stable hash, used only to shuffle the pack deterministically.
+func fnv(s string) uint64 {
+	var h uint64 = 14695981039346656037
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= 1099511628211
+	}
+	return h
+}

--- a/tools/motifannex/checkpoint_test.go
+++ b/tools/motifannex/checkpoint_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// H-1. lab_guard.go's scope note promises that snapshot's one touch of a live
+// home is "a read and a checkpoint, no session, no migration". It has to be
+// true, not aspirational: an operator reads that sentence before pointing this
+// tool at their real corpus.
+//
+// The test is behavioural rather than a source grep. It hands
+// checkpointLiveHome a database that is NOT a knomit store — one plain table,
+// WAL mode — and requires it to come back with exactly that table. store.Open
+// would run migrate.All and leave dozens of knomit tables behind, so restoring
+// it turns this red.
+func TestCheckpointLiveHome_DoesNotMigrateOrCreateASession(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notaknomitstore.db")
+
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	_, err = db.Exec(`PRAGMA journal_mode=WAL`)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE only_mine (x TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO only_mine VALUES ('a')`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	before := tableNames(t, path)
+	require.Equal(t, []string{"only_mine"}, before, "precondition: one table, and not a knomit schema")
+
+	require.NoError(t, checkpointLiveHome(path))
+
+	require.Equal(t, before, tableNames(t, path),
+		"checkpointing a live home must not migrate it — this database gained tables")
+
+	// And no session sidecar left behind next to the user's data.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.NotContains(t, e.Name(), "sessions",
+			"checkpointing a live home must not write a session database beside it")
+	}
+}
+
+func tableNames(t *testing.T, path string) []string {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	require.NoError(t, err)
+	defer db.Close()
+	rows, err := db.Query(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var n string
+		require.NoError(t, rows.Scan(&n))
+		out = append(out, n)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}

--- a/tools/motifannex/harnesspack.go
+++ b/tools/motifannex/harnesspack.go
@@ -146,8 +146,14 @@ func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 			}
 		}
 
-		// RANDOM and TRAP need the seed pool, so read it the way the report does.
-		seeds, err := harnessSeeds(ctx, svc, branch)
+		// RANDOM and SAME-SUBJECT are drawn from the SAME post-AcceptSeed pool
+		// the measured arms came from (review finding M-3). harnessSeeds used
+		// to run a raw branch Search — 284 facts against the pool's 221 on
+		// agentic-engineering, 440 against 313 on knomit-kb — so the controls
+		// could contain pragmatic and discovered facts the MOTIF and TOKEN
+		// arms structurally cannot. A floor measured on a different population
+		// than the thing it floors flatters every rate against it.
+		seeds, err := harnessSeeds(ctx, svc, branch, rep.SeedPaths)
 		if err != nil {
 			closeAll()
 			return err
@@ -281,11 +287,31 @@ func factText(ctx context.Context, svc *store.Service, branch, path string) (tit
 	return f.Title, strings.ReplaceAll(b, "\n", " "), true
 }
 
-// harnessSeeds reads the corpus's bridging population — the same projection and
-// filter the motif report uses, so RANDOM and TRAP are drawn from the same pool
-// the other arms came from rather than from a different corpus view.
-func harnessSeeds(ctx context.Context, svc *store.Service, branch string) ([]store.SearchResult, error) {
-	return svc.Search().Search(ctx, branch, store.SearchOptions{Limit: 100000})
+// harnessSeeds narrows a branch scan to the report's own seed pool, so the
+// controls are drawn from the population the measured arms came from.
+//
+// Filtering a full scan rather than re-deriving the pool: the paths come from
+// MotifComponentReport, which built them with production's projection and
+// filter, and SearchResult carries the motifs and labels SAME-SUBJECT needs.
+// Re-deriving would be a second implementation of AcceptSeed in a measurement
+// tool, which is the drift this phase spent its instrument work avoiding.
+func harnessSeeds(ctx context.Context, svc *store.Service, branch string,
+	pool []string) ([]store.SearchResult, error) {
+	all, err := svc.Search().Search(ctx, branch, store.SearchOptions{Limit: 100000})
+	if err != nil {
+		return nil, err
+	}
+	keep := make(map[string]struct{}, len(pool))
+	for _, p := range pool {
+		keep[p] = struct{}{}
+	}
+	out := make([]store.SearchResult, 0, len(pool))
+	for _, r := range all {
+		if _, ok := keep[r.Path]; ok {
+			out = append(out, r)
+		}
+	}
+	return out, nil
 }
 
 func randomPairs(ctx context.Context, svc *store.Service, branch, corpus string,

--- a/tools/motifannex/harnesspack.go
+++ b/tools/motifannex/harnesspack.go
@@ -104,6 +104,15 @@ func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 			return fmt.Errorf("%s motif report: %w", corpus, err)
 		}
 
+		// CROSS-CHECK: the motif arms must total exactly what the report says
+		// was served. Not circular — the arms are built from per-row Served
+		// while this compares against NearServed/FarServed, which the builder
+		// produced from the ranked-and-capped output. When Served was
+		// unbound, hardcoding it true admitted the cross-tier-suppressed
+		// family as a third MOTIF-FAR pair and nothing noticed (M-8).
+		wantMotif := len(rep.NearServed) + len(rep.FarServed)
+		gotMotif := 0
+
 		// Arm membership comes from the ROW, never from a token lookup
 		// (review finding L-4). A token-2 family is keyed by one of the
 		// canonical ids it folded, so two candidates can share a Token; if the
@@ -121,11 +130,18 @@ func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 				continue
 			}
 			p.Arm = motifArmOf(c)
+			gotMotif++
 			if p.Arm == "MOTIF-FAR" {
 				motifFar = append(motifFar, p)
 			} else {
 				motifNear = append(motifNear, p)
 			}
+		}
+		if gotMotif != wantMotif {
+			closeAll()
+			return fmt.Errorf("%s: %d candidates report Served but the builder served %d — "+
+				"the arms and the served set disagree, so one of them is not measuring "+
+				"what it says", corpus, gotMotif, wantMotif)
 		}
 
 		// TOKEN — the shipped entity/domain report, kept bridges only.

--- a/tools/motifannex/harnesspack.go
+++ b/tools/motifannex/harnesspack.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"strings"
+
+	"knomit/internal/store"
+	"knomit/internal/synthesize"
+)
+
+// harnessSeed fixes every draw in this file. Same value E1 used, so a rerun of
+// either is comparable with itself.
+const harnessSeed = 42
+
+// harnessArmN is the arm size E1 used. The MOTIF arms cannot reach it on real
+// corpora and are reported at whatever size they have — that shortfall is the
+// measurement, not a defect in the draw (Phase-4 rulings-6).
+const harnessArmN = 12
+
+type harnessPair struct {
+	ID     string `json:"id"`
+	Arm    string `json:"-"`
+	Corpus string `json:"-"`
+	Token  string `json:"-"`
+	APath  string `json:"-"`
+	BPath  string `json:"-"`
+	ATitle string `json:"a_title"`
+	ABody  string `json:"a_body"`
+	BTitle string `json:"b_title"`
+	BBody  string `json:"b_body"`
+}
+
+// harnesspack builds the Phase-4 blind judging pack.
+//
+// ARMS (Phase-4 rulings-6, option ii):
+//
+//   - MOTIF-NEAR / MOTIF-FAR — the SERVED sets from the shipped engine on the
+//     real corpora. This is the PRIMARY evidence and it is reported at whatever
+//     size it has.
+//   - TOKEN — the production entity/domain axis on the same corpora, via the
+//     shipped BridgeComponentReport. E1's own comparison arm.
+//   - RANDOM — seeded uniform pairs. The floor control.
+//   - TRAP — pairs that SHARE a canonical motif and ALSO share a subject label.
+//     Drawn from real data rather than fabricated: these are what the
+//     disjointness gate exists to reject, so a judge calling them MECH is
+//     visible and the MECH rates have an upper control (349c0ab6).
+//
+// Group→pair projection: one pair per served group, chosen by a seeded draw
+// over the group's member pairs, so no group can dominate an arm. That matches
+// how E1's own TOKEN arm was built.
+func harnesspack(ctx context.Context, scratch string, corpora []string) error {
+	rng := rand.New(rand.NewSource(harnessSeed))
+	var motifNear, motifFar, token, random, trap []harnessPair
+
+	for _, corpus := range corpora {
+		svc, ri, branch, closeAll, err := open(ctx, corpus, scratch)
+		if err != nil {
+			return err
+		}
+		cfg := synthesize.QualityConfigFromRepo(ri)
+		rep, err := synthesize.MotifComponentReport(ctx, svc.Search(), svc.Motifs(),
+			svc.Abstraction(), branch, synthesize.EffortHigh,
+			ri.ClusterResolution(), ri.ClusterMinCommunitySize(), cfg)
+		if err != nil {
+			closeAll()
+			return fmt.Errorf("%s motif report: %w", corpus, err)
+		}
+
+		served := map[string]bool{}
+		for _, t := range rep.NearServed {
+			served[t] = true
+		}
+		farServed := map[string]bool{}
+		for _, t := range rep.FarServed {
+			farServed[t] = true
+		}
+		for _, c := range rep.Candidates {
+			if !served[c.Token] && !farServed[c.Token] {
+				continue
+			}
+			p, ok := projectPair(ctx, svc, branch, corpus, c.Token, c.Members, rng)
+			if !ok {
+				continue
+			}
+			if farServed[c.Token] {
+				p.Arm = "MOTIF-FAR"
+				motifFar = append(motifFar, p)
+			} else {
+				p.Arm = "MOTIF-NEAR"
+				motifNear = append(motifNear, p)
+			}
+		}
+
+		// TOKEN — the shipped entity/domain report, kept bridges only.
+		tk, err := synthesize.BridgeComponentReport(ctx, svc.Search(), branch,
+			synthesize.BridgeKindFromString("both"), synthesize.EffortHigh,
+			ri.ClusterResolution(), ri.ClusterMinCommunitySize(), cfg)
+		if err != nil {
+			closeAll()
+			return fmt.Errorf("%s token report: %w", corpus, err)
+		}
+		for _, b := range tk {
+			if !b.Kept {
+				continue
+			}
+			if p, ok := projectPair(ctx, svc, branch, corpus, b.Token, b.Members, rng); ok {
+				p.Arm = "TOKEN"
+				token = append(token, p)
+			}
+		}
+
+		// RANDOM and TRAP need the seed pool, so read it the way the report does.
+		seeds, err := harnessSeeds(ctx, svc, branch)
+		if err != nil {
+			closeAll()
+			return err
+		}
+		random = append(random, randomPairs(ctx, svc, branch, corpus, seeds, rng, harnessArmN)...)
+		trap = append(trap, trapPairs(ctx, svc, branch, corpus, seeds, rng)...)
+		closeAll()
+	}
+
+	pick := func(in []harnessPair, n int) []harnessPair {
+		sort.Slice(in, func(a, b int) bool { return in[a].APath+in[a].BPath < in[b].APath+in[b].BPath })
+		if len(in) <= n {
+			return in
+		}
+		rng.Shuffle(len(in), func(a, b int) { in[a], in[b] = in[b], in[a] })
+		return in[:n]
+	}
+
+	all := append([]harnessPair{}, motifNear...)
+	all = append(all, motifFar...)
+	all = append(all, pick(token, harnessArmN)...)
+	all = append(all, pick(random, harnessArmN)...)
+	all = append(all, pick(trap, 6)...)
+
+	// Blind: shuffle, then id. The id carries no arm information.
+	rng.Shuffle(len(all), func(a, b int) { all[a], all[b] = all[b], all[a] })
+	var pack, key []map[string]any
+	for i := range all {
+		all[i].ID = fmt.Sprintf("H%03d", i+1)
+		pack = append(pack, map[string]any{
+			"id": all[i].ID, "a_title": all[i].ATitle, "a_body": all[i].ABody,
+			"b_title": all[i].BTitle, "b_body": all[i].BBody,
+		})
+		key = append(key, map[string]any{
+			"id": all[i].ID, "arm": all[i].Arm, "corpus": all[i].Corpus,
+			"token": all[i].Token, "a": all[i].APath, "b": all[i].BPath,
+		})
+	}
+
+	counts := map[string]int{}
+	for _, p := range all {
+		counts[p.Arm]++
+	}
+	fmt.Fprintf(os.Stderr, "arms=%v total=%d\n", counts, len(all))
+	return emit(map[string]any{
+		"seed":        harnessSeed,
+		"arm_target":  harnessArmN,
+		"arm_counts":  counts,
+		"projection":  "one pair per served group, seeded draw over its member pairs (E1's TOKEN-arm shape)",
+		"populations": "PRIMARY: real lab corpora only. The fixture supplement is a separate pack and is never pooled with this one.",
+		"pack":        pack,
+		"key":         key,
+	})
+}
+
+// projectPair turns a served group into one judged pair.
+func projectPair(ctx context.Context, svc *store.Service, branch, corpus, token string,
+	members []string, rng *rand.Rand) (harnessPair, bool) {
+	if len(members) < 2 {
+		return harnessPair{}, false
+	}
+	sorted := append([]string(nil), members...)
+	sort.Strings(sorted)
+	i := rng.Intn(len(sorted))
+	j := rng.Intn(len(sorted) - 1)
+	if j >= i {
+		j++
+	}
+	a, b := sorted[i], sorted[j]
+	if b < a {
+		a, b = b, a
+	}
+	at, ab, ok1 := factText(ctx, svc, branch, a)
+	bt, bb, ok2 := factText(ctx, svc, branch, b)
+	if !ok1 || !ok2 {
+		return harnessPair{}, false
+	}
+	return harnessPair{Corpus: corpus, Token: token, APath: a, BPath: b,
+		ATitle: at, ABody: ab, BTitle: bt, BBody: bb}, true
+}
+
+func factText(ctx context.Context, svc *store.Service, branch, path string) (title, body string, ok bool) {
+	f, err := svc.FactQuery().GetByPath(ctx, branch, path)
+	if err != nil || f == nil {
+		return "", "", false
+	}
+	b := strings.TrimSpace(f.Body)
+	if len(b) > 400 {
+		b = b[:400]
+	}
+	return f.Title, strings.ReplaceAll(b, "\n", " "), true
+}
+
+// harnessSeeds reads the corpus's bridging population — the same projection and
+// filter the motif report uses, so RANDOM and TRAP are drawn from the same pool
+// the other arms came from rather than from a different corpus view.
+func harnessSeeds(ctx context.Context, svc *store.Service, branch string) ([]store.SearchResult, error) {
+	return svc.Search().Search(ctx, branch, store.SearchOptions{Limit: 100000})
+}
+
+func randomPairs(ctx context.Context, svc *store.Service, branch, corpus string,
+	seeds []store.SearchResult, rng *rand.Rand, n int) []harnessPair {
+	if len(seeds) < 2 {
+		return nil
+	}
+	var out []harnessPair
+	for range n * 3 {
+		i, j := rng.Intn(len(seeds)), rng.Intn(len(seeds))
+		if i == j {
+			continue
+		}
+		p, ok := projectPair(ctx, svc, branch, corpus, "",
+			[]string{seeds[i].Path, seeds[j].Path}, rng)
+		if !ok {
+			continue
+		}
+		p.Arm = "RANDOM"
+		out = append(out, p)
+		if len(out) >= n {
+			break
+		}
+	}
+	return out
+}
+
+// trapPairs are the ceiling control: two facts that share a canonical motif AND
+// share a subject label, i.e. exactly what subject-disjointness rejects.
+//
+// Drawn from real data rather than fabricated. A judge who calls these
+// MECH is calling "same subject, same mechanism" a bridge, and the MECH rate
+// on the real arms cannot be read without knowing that.
+func trapPairs(ctx context.Context, svc *store.Service, branch, corpus string,
+	seeds []store.SearchResult, rng *rand.Rand) []harnessPair {
+	byMotif := map[string][]store.SearchResult{}
+	for _, s := range seeds {
+		for _, m := range s.Motifs {
+			byMotif[m] = append(byMotif[m], s)
+		}
+	}
+	var out []harnessPair
+	keys := make([]string, 0, len(byMotif))
+	for k := range byMotif {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fs := byMotif[k]
+		for i := range fs {
+			for j := i + 1; j < len(fs); j++ {
+				if !sharesSubjectLabel(fs[i], fs[j]) {
+					continue
+				}
+				p, ok := projectPair(ctx, svc, branch, corpus, k,
+					[]string{fs[i].Path, fs[j].Path}, rng)
+				if !ok {
+					continue
+				}
+				p.Arm = "TRAP"
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+func sharesSubjectLabel(a, b store.SearchResult) bool {
+	set := map[string]struct{}{}
+	for _, e := range append(append([]string{}, a.Entities...), a.Domain...) {
+		set[strings.ToLower(e)] = struct{}{}
+	}
+	for _, e := range append(append([]string{}, b.Entities...), b.Domain...) {
+		if _, ok := set[strings.ToLower(e)]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/motifannex/harnesspack.go
+++ b/tools/motifannex/harnesspack.go
@@ -41,13 +41,28 @@ type harnessPair struct {
 //   - MOTIF-NEAR / MOTIF-FAR — the SERVED sets from the shipped engine on the
 //     real corpora. This is the PRIMARY evidence and it is reported at whatever
 //     size it has.
+//
 //   - TOKEN — the production entity/domain axis on the same corpora, via the
 //     shipped BridgeComponentReport. E1's own comparison arm.
+//
 //   - RANDOM — seeded uniform pairs. The floor control.
-//   - TRAP — pairs that SHARE a canonical motif and ALSO share a subject label.
-//     Drawn from real data rather than fabricated: these are what the
-//     disjointness gate exists to reject, so a judge calling them MECH is
-//     visible and the MECH rates have an upper control (349c0ab6).
+//
+//   - SAME-SUBJECT — pairs that share a canonical motif AND at least one raw
+//     subject label. Drawn from real data rather than fabricated.
+//
+//     NAMED FOR WHAT IT IS, not for what it was first assumed to be. It was
+//     called TRAP, on the belief that these are pairs the disjointness gate
+//     rejects. They are not: the gate is df-GRADED (rider 1), so a shared label
+//     blocks only when it is SPECIFIC — below a per-corpus percentile, not
+//     umbrella, not universal. Measured on the served near pair, the four
+//     shared labels were df 284 (universal, = LiveFacts), 66 (umbrella, > 56),
+//     26 and 28 (both > the cut of 5). Every one deliberately permitted.
+//
+//     So a MECH verdict in this arm is NOT evidence of a gate failure, and
+//     reporting it as one would indict the rider for working. What the arm
+//     still does — its actual job — is bound the MECH rate from above: a judge
+//     that calls same-subject pairs MECH is visible, and without that the other
+//     arms' rates cannot be read (349c0ab6).
 //
 // Group→pair projection: one pair per served group, chosen by a seeded draw
 // over the group's member pairs, so no group can dominate an arm. That matches
@@ -55,6 +70,25 @@ type harnessPair struct {
 func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 	rng := rand.New(rand.NewSource(harnessSeed))
 	var motifNear, motifFar, token, random, trap []harnessPair
+
+	// DEDUPE ACROSS CORPORA. merged was seeded from agentic-engineering, so the
+	// same facts and the same bridges exist in both and the naive draw emits
+	// each twice — three pairs of the first pack were exact repeats, which the
+	// blind judge noticed before I did. A repeated pair is not extra evidence;
+	// it is one pair counted twice, and in an arm of three that is most of the
+	// arm.
+	// Deduping happens ONCE, at the end, in ARM PRIORITY order — not inline as
+	// each corpus is read.
+	//
+	// Inline deduping silently cost the primary evidence: merged is read before
+	// agentic-engineering, so a TOKEN pair from merged claimed a pair that was
+	// also ag's only MOTIF-NEAR bridge, and the scarce arm lost its single
+	// member to a control. Priority order means the arm that can least afford
+	// to lose a pair keeps it.
+	//
+	// A pair claimed by two arms is also worth KNOWING about rather than
+	// quietly resolving — the motif and entity/domain axes agreeing on the same
+	// two facts is a finding — so collisions are reported.
 
 	for _, corpus := range corpora {
 		svc, ri, branch, closeAll, err := open(ctx, corpus, scratch)
@@ -119,10 +153,37 @@ func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 			closeAll()
 			return err
 		}
+		// fresh() applies to EVERY arm, not just the two it was written for.
+		// The first fix deduped MOTIF and TOKEN and left RANDOM and TRAP alone,
+		// which still let one duplicate through — a guard applied to some of
+		// the things it protects is a guard with a hole in it.
 		random = append(random, randomPairs(ctx, svc, branch, corpus, seeds, rng, harnessArmN)...)
 		trap = append(trap, trapPairs(ctx, svc, branch, corpus, seeds, rng)...)
 		closeAll()
 	}
+
+	// Priority order: the scarce primary arms first, then the comparison arm,
+	// then the controls.
+	claimedBy := map[string]string{}
+	droppedTo := map[string]int{} // "TOKEN->MOTIF-FAR" etc.
+	dedupe := func(in []harnessPair) []harnessPair {
+		var out []harnessPair
+		for _, p := range in {
+			k := p.APath + "\x00" + p.BPath
+			if first, dup := claimedBy[k]; dup {
+				droppedTo[p.Arm+"->"+first]++
+				continue
+			}
+			claimedBy[k] = p.Arm
+			out = append(out, p)
+		}
+		return out
+	}
+	motifNear = dedupe(motifNear)
+	motifFar = dedupe(motifFar)
+	token = dedupe(token)
+	trap = dedupe(trap)
+	random = dedupe(random)
 
 	pick := func(in []harnessPair, n int) []harnessPair {
 		sort.Slice(in, func(a, b int) bool { return in[a].APath+in[a].BPath < in[b].APath+in[b].BPath })
@@ -155,18 +216,31 @@ func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 	}
 
 	counts := map[string]int{}
+	uniq := map[string]bool{}
 	for _, p := range all {
 		counts[p.Arm]++
+		uniq[p.APath+"\x00"+p.BPath] = true
+	}
+	if len(uniq) != len(all) {
+		return fmt.Errorf("pack contains %d duplicate pair(s): a repeated pair is one pair "+
+			"counted twice, and in a three-pair arm that is most of the arm", len(all)-len(uniq))
 	}
 	fmt.Fprintf(os.Stderr, "arms=%v total=%d\n", counts, len(all))
 	return emit(map[string]any{
-		"seed":        harnessSeed,
-		"arm_target":  harnessArmN,
-		"arm_counts":  counts,
-		"projection":  "one pair per served group, seeded draw over its member pairs (E1's TOKEN-arm shape)",
-		"populations": "PRIMARY: real lab corpora only. The fixture supplement is a separate pack and is never pooled with this one.",
-		"pack":        pack,
-		"key":         key,
+		"seed":       harnessSeed,
+		"arm_target": harnessArmN,
+		"arm_counts": counts,
+		// Every drop, by WHICH arm lost the pair and WHICH kept it. The first
+		// version reported a single "token pairs also claimed by a motif arm"
+		// number that was really "token pairs dropped for any reason" —
+		// including token-vs-token duplicates between merged and the corpus it
+		// was seeded from, which is most of them. A count that does not mean
+		// its label is worse than no count.
+		"deduped_by_arm_pair": droppedTo,
+		"projection":          "one pair per served group, seeded draw over its member pairs (E1's TOKEN-arm shape)",
+		"populations":         "PRIMARY: real lab corpora only. The fixture supplement is a separate pack and is never pooled with this one.",
+		"pack":                pack,
+		"key":                 key,
 	})
 }
 
@@ -240,12 +314,9 @@ func randomPairs(ctx context.Context, svc *store.Service, branch, corpus string,
 	return out
 }
 
-// trapPairs are the ceiling control: two facts that share a canonical motif AND
-// share a subject label, i.e. exactly what subject-disjointness rejects.
-//
-// Drawn from real data rather than fabricated. A judge who calls these
-// MECH is calling "same subject, same mechanism" a bridge, and the MECH rate
-// on the real arms cannot be read without knowing that.
+// trapPairs builds the SAME-SUBJECT ceiling control: two facts sharing a
+// canonical motif and at least one raw subject label. See the arm's note above
+// for why raw overlap is NOT the same as "what the gate rejects".
 func trapPairs(ctx context.Context, svc *store.Service, branch, corpus string,
 	seeds []store.SearchResult, rng *rand.Rand) []harnessPair {
 	byMotif := map[string][]store.SearchResult{}
@@ -272,7 +343,7 @@ func trapPairs(ctx context.Context, svc *store.Service, branch, corpus string,
 				if !ok {
 					continue
 				}
-				p.Arm = "TRAP"
+				p.Arm = "SAME-SUBJECT"
 				out = append(out, p)
 			}
 		}

--- a/tools/motifannex/harnesspack.go
+++ b/tools/motifannex/harnesspack.go
@@ -104,27 +104,26 @@ func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 			return fmt.Errorf("%s motif report: %w", corpus, err)
 		}
 
-		served := map[string]bool{}
-		for _, t := range rep.NearServed {
-			served[t] = true
-		}
-		farServed := map[string]bool{}
-		for _, t := range rep.FarServed {
-			farServed[t] = true
-		}
+		// Arm membership comes from the ROW, never from a token lookup
+		// (review finding L-4). A token-2 family is keyed by one of the
+		// canonical ids it folded, so two candidates can share a Token; if the
+		// disjointness trim drops one of an edged pair from the family, the
+		// two land in DIFFERENT lanes and a token lookup labels both by
+		// whichever map it checked first — putting a near-lane group under the
+		// far arm's verdict. Served and Lane are per-candidate facts and cannot
+		// be ambiguous.
 		for _, c := range rep.Candidates {
-			if !served[c.Token] && !farServed[c.Token] {
+			if !c.Served {
 				continue
 			}
 			p, ok := projectPair(ctx, svc, branch, corpus, c.Token, c.Members, rng)
 			if !ok {
 				continue
 			}
-			if farServed[c.Token] {
-				p.Arm = "MOTIF-FAR"
+			p.Arm = motifArmOf(c)
+			if p.Arm == "MOTIF-FAR" {
 				motifFar = append(motifFar, p)
 			} else {
-				p.Arm = "MOTIF-NEAR"
 				motifNear = append(motifNear, p)
 			}
 		}
@@ -362,4 +361,16 @@ func sharesSubjectLabel(a, b store.SearchResult) bool {
 		}
 	}
 	return false
+}
+
+// motifArmOf names a served candidate's arm from the candidate itself.
+//
+// Keyed on Lane, which the scorer assigned to THIS row, rather than on whether
+// some served-token list contains its Token. See the call site for why the
+// token is ambiguous.
+func motifArmOf(c synthesize.ScoredMotifBridge) string {
+	if c.Lane == string(synthesize.LaneFar) {
+		return "MOTIF-FAR"
+	}
+	return "MOTIF-NEAR"
 }

--- a/tools/motifannex/harnesspack_test.go
+++ b/tools/motifannex/harnesspack_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/synthesize"
+)
+
+// L-4. Two candidates SHARING a Token in different lanes — reachable because a
+// token-2 family is keyed by one of the ids it folded, and the disjointness
+// trim can drop one of an edged pair from the family, leaving it with no edge
+// while the verbatim group keeps one.
+//
+// The old classification asked "is this Token in the far-served list?", so
+// both rows got the same arm and a near-lane group was judged under the far
+// arm's verdict. No lab corpus can exercise it (no candidate set has a
+// duplicate token), which is exactly why it needs a fixture rather than a
+// measurement.
+func TestMotifArmOf_SameTokenDifferentLanesClassifySeparately(t *testing.T) {
+	// TIER AND LANE ARE DELIBERATELY CROSSED. The first version of this fixture
+	// paired verbatim-with-near and family-with-far, so classifying by the
+	// FAMILY FLAG gave the same answers as classifying by lane and the sabotage
+	// passed — lesson 5's coinciding values, in the test written to close a
+	// mislabelling. Crossed, only the lane can produce both answers.
+	//
+	// The crossing is realistic: a verbatim pair with no edge is FAR, and the
+	// family that folds it can gain a member that creates an edge, making the
+	// family NEAR.
+	verbatimFar := synthesize.ScoredMotifBridge{
+		Token: "shared-key", Lane: string(synthesize.LaneFar), Served: true, Family: false,
+	}
+	familyNear := synthesize.ScoredMotifBridge{
+		Token: "shared-key", Lane: string(synthesize.LaneNear), Served: true, Family: true,
+	}
+
+	require.Equal(t, verbatimFar.Token, familyNear.Token,
+		"precondition: the two rows must share a Token, or the ambiguity is not exercised")
+	require.NotEqual(t, verbatimFar.Family, familyNear.Family,
+		"precondition: tier must differ from lane, or classifying by tier passes too")
+
+	require.Equal(t, "MOTIF-FAR", motifArmOf(verbatimFar),
+		"the arm comes from the row's own lane — not its tier, and not a token lookup")
+	require.Equal(t, "MOTIF-NEAR", motifArmOf(familyNear))
+}

--- a/tools/motifannex/judgepack.go
+++ b/tools/motifannex/judgepack.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// judgepack combines the primary and supplementary packs into ONE blind pack
+// with a UNIFORM id space.
+//
+// Review finding M-1: the first run interleaved `H###` and `S###` ids, and the
+// prefix was a perfect membership oracle for the supplementary arm — all 12
+// `S###` were MOTIF-FIXTURE and nothing else was. The record claimed "ids carry
+// no arm information" and the judge's own reply disproved it, characterising
+// "the S-pairs" as a group. A judge that has identified twelve pairs as one
+// homogeneous set can drift across them in either direction, whatever its
+// intent.
+//
+// Uniform `P###` ids, ordered by a hash of the pair's own paths so neither the
+// source file nor the arm survives into the ordering. The two populations stay
+// separate in the KEY, which is what rulings-6 requires — never pooled in
+// analysis, only in the pack the judge reads.
+func judgepack(dir string) error {
+	type packItem struct {
+		ID     string `json:"id"`
+		ATitle string `json:"a_title"`
+		ABody  string `json:"a_body"`
+		BTitle string `json:"b_title"`
+		BBody  string `json:"b_body"`
+	}
+	type keyItem struct {
+		ID         string `json:"id"`
+		Arm        string `json:"arm"`
+		Population string `json:"population"`
+		Corpus     string `json:"corpus,omitempty"`
+		Token      string `json:"token,omitempty"`
+		A          string `json:"a"`
+		B          string `json:"b"`
+	}
+
+	var primary struct {
+		Pack []packItem `json:"pack"`
+		Key  []keyItem  `json:"key"`
+	}
+	var supp struct {
+		Pack []packItem `json:"pack"`
+		Key  []keyItem  `json:"key"`
+	}
+	if err := readJSON(filepath.Join(dir, "primary.json"), &primary); err != nil {
+		return err
+	}
+	if err := readJSON(filepath.Join(dir, "supplementary.json"), &supp); err != nil {
+		return err
+	}
+
+	type row struct {
+		item packItem
+		key  keyItem
+	}
+	var rows []row
+	add := func(pack []packItem, key []keyItem, population string) error {
+		if len(pack) != len(key) {
+			return fmt.Errorf("%s: pack has %d items and key has %d", population, len(pack), len(key))
+		}
+		byID := map[string]keyItem{}
+		for _, k := range key {
+			byID[k.ID] = k
+		}
+		for _, p := range pack {
+			k, ok := byID[p.ID]
+			if !ok {
+				return fmt.Errorf("%s: pack item %s has no key row", population, p.ID)
+			}
+			k.Population = population
+			rows = append(rows, row{item: p, key: k})
+		}
+		return nil
+	}
+	if err := add(primary.Pack, primary.Key, "primary"); err != nil {
+		return err
+	}
+	if err := add(supp.Pack, supp.Key, "supplementary"); err != nil {
+		return err
+	}
+
+	// Order by a hash of the PAIR's paths: stable across runs, and carrying
+	// nothing about which file a pair arrived in or which arm it belongs to.
+	sort.Slice(rows, func(i, j int) bool {
+		return fnv(rows[i].key.A+rows[i].key.B) < fnv(rows[j].key.A+rows[j].key.B)
+	})
+
+	var pack []packItem
+	var key []keyItem
+	md := []string{"# Fact pair pack", "", "For each pair, give one verdict. Output JSON only.", ""}
+	for i := range rows {
+		id := fmt.Sprintf("P%03d", i+1)
+		rows[i].item.ID, rows[i].key.ID = id, id
+		pack = append(pack, rows[i].item)
+		key = append(key, rows[i].key)
+		md = append(md,
+			"## "+id,
+			"FACT 1: "+rows[i].item.ATitle, "  "+rows[i].item.ABody,
+			"FACT 2: "+rows[i].item.BTitle, "  "+rows[i].item.BBody, "")
+	}
+
+	// The judge must never see the key, so it is written separately and the
+	// pack is the only file handed over.
+	if err := os.WriteFile(filepath.Join(dir, "judge_pack.md"), []byte(join(md)), 0o644); err != nil {
+		return err
+	}
+	if err := writeJSON(filepath.Join(dir, "combined.key.json"), key); err != nil {
+		return err
+	}
+	counts := map[string]int{}
+	for _, k := range key {
+		counts[k.Arm]++
+	}
+	fmt.Fprintf(os.Stderr, "combined %d pairs, uniform ids; arms=%v\n", len(pack), counts)
+	return emit(map[string]any{"pairs": len(pack), "arms": counts})
+}
+
+func readJSON(path string, v any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+
+func writeJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", " ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}
+
+func join(lines []string) string {
+	out := ""
+	for i, l := range lines {
+		if i > 0 {
+			out += "\n"
+		}
+		out += l
+	}
+	return out
+}
+
+var _ = context.Background

--- a/tools/motifannex/lab_guard.go
+++ b/tools/motifannex/lab_guard.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// liveReposRoot is where the user's real knowledge bases live.
+func liveReposRoot(home string) string {
+	return filepath.Join(home, ".knomit", "repos")
+}
+
+// refuseLivePath rejects any corpus path that resolves inside the live repos
+// root.
+//
+// WHY THIS EXISTS AT ALL. This tool opens a corpus and runs real review
+// sessions against it — sessions that write motifs onto facts and that migrate
+// the schema on open. Both are fine on a lab copy and neither is acceptable on
+// a real knowledge base. The annex's rule ("copies only, never a live KB") was
+// held by discipline; Phase 4 holds it with a check, because Phase 4 is the
+// phase that reads numbers off these corpora and a number taken from a mutated
+// corpus is worse than no number.
+//
+// SCOPE, deliberately narrow: this guards OPENING a corpus. `snapshot` still
+// touches a live home exactly once, to flush its WAL before a byte copy — a
+// read and a checkpoint, no session, no migration, and documented at its own
+// call site. Widening this guard to cover that would break the only supported
+// way to make a lab copy in the first place.
+//
+// RESOLVE, THEN DECIDE. A lab path can be a symlink into the live root, and a
+// lexical check waves that through — so symlinks are evaluated first, on both
+// sides, for the longest existing ancestor of a path that does not exist yet
+// (the guard runs before a copy is made). Comparison is separator-aware, so a
+// sibling merely NAMED like the root (`repos-lab`) is not caught by it: a false
+// positive here teaches the next reader to weaken the check, which is how a
+// guard stops guarding.
+func refuseLivePath(path, home string) error {
+	live, err := resolveDeepest(liveReposRoot(home))
+	if err != nil {
+		return fmt.Errorf("resolve live repos root: %w", err)
+	}
+	target, err := resolveDeepest(path)
+	if err != nil {
+		return fmt.Errorf("resolve corpus path %q: %w", path, err)
+	}
+	if target == live || strings.HasPrefix(target, live+string(filepath.Separator)) {
+		return fmt.Errorf(
+			"refusing to open %q: it resolves to %q, inside the live knowledge-base root %q. "+
+				"Phase-4 measurement runs on COPIES only — take a snapshot and point -scratch at it",
+			path, target, live)
+	}
+	return nil
+}
+
+// resolveDeepest returns an absolute, symlink-resolved form of path. When path
+// does not exist, it resolves the deepest ancestor that does and re-appends the
+// missing tail — so a path that has not been created yet is still judged
+// against where it WOULD land, rather than being waved through for not
+// existing.
+func resolveDeepest(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	rest := ""
+	cur := filepath.Clean(abs)
+	for {
+		resolved, err := filepath.EvalSymlinks(cur)
+		if err == nil {
+			return filepath.Join(resolved, rest), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the root without finding anything that exists; nothing
+			// was resolvable, so the lexical form is the best answer there is.
+			return filepath.Join(cur, rest), nil
+		}
+		rest = filepath.Join(filepath.Base(cur), rest)
+		cur = parent
+	}
+}

--- a/tools/motifannex/lab_guard_test.go
+++ b/tools/motifannex/lab_guard_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The rule under test: this tool may OPEN a corpus only at a lab path. The
+// user's real knowledge bases live under ~/.knomit/repos, and the annex writes
+// motifs onto facts — so opening one in place would both mutate a real corpus
+// and migrate its schema. `snapshot` deliberately touches a live home once, to
+// checkpoint its WAL before a byte copy; that is a read and a flush, not an
+// open-as-a-corpus, and it is out of this guard's scope on purpose.
+
+func TestRefuseLivePath_RejectsInsideTheLiveReposRoot(t *testing.T) {
+	home := t.TempDir()
+	live := liveReposRoot(home)
+	require.NoError(t, os.MkdirAll(live, 0o755))
+
+	err := refuseLivePath(filepath.Join(live, "core.db"), home)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "live", "the error must name the rule it enforces")
+}
+
+func TestRefuseLivePath_RejectsTheRootItself(t *testing.T) {
+	home := t.TempDir()
+	live := liveReposRoot(home)
+	require.NoError(t, os.MkdirAll(live, 0o755))
+
+	require.Error(t, refuseLivePath(live, home))
+}
+
+func TestRefuseLivePath_AllowsASiblingLabDirectory(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(liveReposRoot(home), 0o755))
+	lab := filepath.Join(home, ".knomit", "motif-phase4-lab", "corpora")
+	require.NoError(t, os.MkdirAll(lab, 0o755))
+
+	require.NoError(t, refuseLivePath(filepath.Join(lab, "merged.db"), home))
+}
+
+// A sibling whose NAME merely starts with the root's name. A string-prefix
+// check refuses this, and refusing it would be a false positive that pushes
+// the next person to weaken the guard rather than fix it.
+func TestRefuseLivePath_AllowsAPathThatOnlyPREFIXMatchesTheRoot(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(liveReposRoot(home), 0o755))
+	sibling := filepath.Join(home, ".knomit", "repos-lab")
+	require.NoError(t, os.MkdirAll(sibling, 0o755))
+
+	require.NoError(t, refuseLivePath(filepath.Join(sibling, "core.db"), home))
+}
+
+// THE MEDIUM THE VIOLATION WOULD ACTUALLY APPEAR IN (lesson 3). A lab path
+// that is a symlink INTO the live root passes any lexical check and opens a
+// real corpus. The guard has to resolve before it decides.
+func TestRefuseLivePath_ResolvesSymlinksBeforeDeciding(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	home := t.TempDir()
+	live := liveReposRoot(home)
+	require.NoError(t, os.MkdirAll(live, 0o755))
+	realDB := filepath.Join(live, "core.db")
+	require.NoError(t, os.WriteFile(realDB, []byte("not really a db"), 0o644))
+
+	lab := filepath.Join(home, ".knomit", "motif-phase4-lab")
+	require.NoError(t, os.MkdirAll(lab, 0o755))
+	link := filepath.Join(lab, "core.db")
+	require.NoError(t, os.Symlink(realDB, link))
+
+	// Precondition: the path is lexically outside the live root, so this test
+	// fails for the right reason rather than by accident.
+	require.False(t, strings.HasPrefix(link, live+string(filepath.Separator)),
+		"precondition: the link path must be lexically outside the live root")
+
+	require.Error(t, refuseLivePath(link, home),
+		"a symlink into the live root must be refused")
+}
+
+// A lab path that does not exist yet must still be judged — the guard runs
+// before the copy exists, and an unresolvable path is not a licence to proceed.
+func TestRefuseLivePath_JudgesPathsThatDoNotExistYet(t *testing.T) {
+	home := t.TempDir()
+	live := liveReposRoot(home)
+	require.NoError(t, os.MkdirAll(live, 0o755))
+
+	require.Error(t, refuseLivePath(filepath.Join(live, "absent.db"), home),
+		"a not-yet-created path inside the live root is still a live path")
+	require.NoError(t, refuseLivePath(filepath.Join(home, "lab", "absent.db"), home),
+		"a not-yet-created path outside it is still fine")
+}

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -19,6 +19,7 @@
 //	motifannex report    -corpus <name>            vocabulary/coverage/health snapshot
 //	motifannex bridges   -corpus <name> -effort h  motif bridge candidates, served and dropped
 //	motifannex namedef   -corpus <name>            name / name+def cosine ladders, centered and not
+//	motifannex survival  -corpus <name>            discovered-fact survival per bridge axis
 //	motifannex calibpack                           T8 stratified labelling pack + key (all lab corpora)
 package main
 
@@ -101,6 +102,8 @@ func main() {
 		fatal(bridges(ctx, *corpus, *scratch, *effort))
 	case "namedef":
 		fatal(namedef(ctx, *corpus, *scratch))
+	case "survival":
+		fatal(survival(ctx, *corpus, *scratch))
 	case "calibpack":
 		fatal(calibpack(ctx, *scratch, []string{
 			"merged", "agentic-engineering", "knomit-kb", "knomit-io-kb",

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -19,6 +19,7 @@
 //	motifannex report    -corpus <name>            vocabulary/coverage/health snapshot
 //	motifannex bridges   -corpus <name> -effort h  motif bridge candidates, served and dropped
 //	motifannex namedef   -corpus <name>            name / name+def cosine ladders, centered and not
+//	motifannex harnesspack                         the Phase-4 blind judging pack (primary arms)
 //	motifannex survival  -corpus <name>            discovered-fact survival per bridge axis
 //	motifannex calibpack                           T8 stratified labelling pack + key (all lab corpora)
 package main
@@ -102,6 +103,8 @@ func main() {
 		fatal(bridges(ctx, *corpus, *scratch, *effort))
 	case "namedef":
 		fatal(namedef(ctx, *corpus, *scratch))
+	case "harnesspack":
+		fatal(harnesspack(ctx, *scratch, []string{"merged", "agentic-engineering", "knomit-kb"}))
 	case "survival":
 		fatal(survival(ctx, *corpus, *scratch))
 	case "calibpack":

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -20,6 +20,7 @@
 //	motifannex bridges   -corpus <name> -effort h  motif bridge candidates, served and dropped
 //	motifannex namedef   -corpus <name>            name / name+def cosine ladders, centered and not
 //	motifannex roundtrip -corpus <name>            READ-ONLY parse/serialize fidelity audit
+//	motifannex judgepack -scratch <dir>            combine primary+supplementary into one blind pack
 //	motifannex harnesspack                         the Phase-4 blind judging pack (primary arms)
 //	motifannex survival  -corpus <name>            discovered-fact survival per bridge axis
 //	motifannex calibpack                           T8 stratified labelling pack + key (all lab corpora)
@@ -107,6 +108,8 @@ func main() {
 		fatal(namedef(ctx, *corpus, *scratch))
 	case "roundtrip":
 		fatal(roundtrip(ctx, *corpus, *scratch))
+	case "judgepack":
+		fatal(judgepack(*scratch))
 	case "harnesspack":
 		fatal(harnesspack(ctx, *scratch, []string{"merged", "agentic-engineering", "knomit-kb"}))
 	case "survival":

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -18,6 +18,7 @@
 //	motifannex answer    -corpus <name> -in a.json apply answers, report health
 //	motifannex report    -corpus <name>            vocabulary/coverage/health snapshot
 //	motifannex bridges   -corpus <name> -effort h  motif bridge candidates, served and dropped
+//	motifannex namedef   -corpus <name>            name / name+def cosine ladders, centered and not
 package main
 
 import (
@@ -53,7 +54,7 @@ var corpora = map[string]string{
 
 func main() {
 	if len(os.Args) < 2 {
-		fatal(fmt.Errorf("usage: motifannex <snapshot|session|answer|report|bridges> -corpus <name>"))
+		fatal(fmt.Errorf("usage: motifannex <snapshot|session|answer|report|bridges|namedef> -corpus <name>"))
 	}
 	cmd := os.Args[1]
 	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
@@ -97,6 +98,8 @@ func main() {
 		fatal(report(ctx, *corpus, *scratch))
 	case "bridges":
 		fatal(bridges(ctx, *corpus, *scratch, *effort))
+	case "namedef":
+		fatal(namedef(ctx, *corpus, *scratch))
 	default:
 		fatal(fmt.Errorf("unknown command %q", cmd))
 	}

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -19,6 +19,7 @@
 //	motifannex report    -corpus <name>            vocabulary/coverage/health snapshot
 //	motifannex bridges   -corpus <name> -effort h  motif bridge candidates, served and dropped
 //	motifannex namedef   -corpus <name>            name / name+def cosine ladders, centered and not
+//	motifannex calibpack                           T8 stratified labelling pack + key (all lab corpora)
 package main
 
 import (
@@ -100,6 +101,10 @@ func main() {
 		fatal(bridges(ctx, *corpus, *scratch, *effort))
 	case "namedef":
 		fatal(namedef(ctx, *corpus, *scratch))
+	case "calibpack":
+		fatal(calibpack(ctx, *scratch, []string{
+			"merged", "agentic-engineering", "knomit-kb", "knomit-io-kb",
+		}))
 	default:
 		fatal(fmt.Errorf("unknown command %q", cmd))
 	}

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -677,6 +677,15 @@ func skipBodyFor(af answerFile) string {
 // ── report ────────────────────────────────────────────────────────────────
 
 type corpusReport struct {
+	// Population states what every count below is over. It is ITS OWN
+	// sentence, deliberately not shared with MotifReport.Population: the two
+	// reports count different things under near-identical labels — this one's
+	// bridgeable_pairs is over live AUTHORED facts (8 / 16 / 2 / 2 / 0 on the
+	// lab corpora) while MotifReport's seed_bridgeable_pairs is over the
+	// post-AcceptSeed pool (6 / 13 / 1 / 0 / 0). Up to 3x apart, and honesty
+	// item 7 records that exactly this confusion nearly set K on the wrong
+	// population (review finding L-3).
+	Population   string  `json:"population"`
 	Corpus       string  `json:"corpus"`
 	Branch       string  `json:"branch"`
 	AuthoredLive int     `json:"authored_live"`
@@ -702,7 +711,13 @@ func report(ctx context.Context, corpus, scratch string) error {
 	}
 	defer closeAll()
 
-	r := corpusReport{Corpus: corpus, Branch: branch}
+	r := corpusReport{
+		Corpus: corpus, Branch: branch,
+		Population: "live AUTHORED facts on the branch — NOT the post-AcceptSeed bridging pool. " +
+			"bridgeable_pairs here counts pairs over authored facts; the axis enumerates over " +
+			"epistemic seeds only, so MotifReport.seed_bridgeable_pairs is the smaller number " +
+			"and the one an activation decision is made on.",
+	}
 	if with, total, err := svc.Motifs().MotifCoverage(ctx, branch); err == nil {
 		r.WithMotifs, r.AuthoredLive = with, total
 		if total > 0 {

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -186,8 +186,15 @@ func copyFile(src, dst string) error {
 }
 
 // open builds a store + repo instance over the COPY, with the real embedder.
+//
+// The lab guard runs FIRST — before the stat, and before store.Open, because
+// store.Open migrates the schema of whatever it is handed. See refuseLivePath.
 func open(ctx context.Context, corpus, scratch string) (*store.Service, *repos.RepoInstance, string, func(), error) {
+	home, _ := os.UserHomeDir()
 	path := copyPath(scratch, corpus)
+	if err := refuseLivePath(path, home); err != nil {
+		return nil, nil, "", nil, err
+	}
 	if _, err := os.Stat(path); err != nil {
 		return nil, nil, "", nil, fmt.Errorf("no snapshot for %s — run `snapshot` first: %w", corpus, err)
 	}
@@ -195,7 +202,6 @@ func open(ctx context.Context, corpus, scratch string) (*store.Service, *repos.R
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
-	home, _ := os.UserHomeDir()
 	// The corpora were embedded with this model (meta.embed_model_id); the
 	// annex must use the SAME one or every stored vector is unreadable and
 	// every similarity is nonsense.
@@ -616,7 +622,12 @@ type corpusReport struct {
 	Recurrence   float64  `json:"recurrence_rate"`
 	MintToLink   float64  `json:"mint_to_link"`
 	NeedDefine   int      `json:"clusters_needing_definition"`
-	TopMotifs    []string `json:"top_motifs"`
+	// BridgeablePairs is the CEILING on motif bridging — see bridgeablePairs.
+	// Reported next to Recurring because the two answer different questions:
+	// Recurring counts CLUSTERS that could bridge, this counts the PAIRS they
+	// could bridge, and one heavily-shared motif separates them sharply.
+	BridgeablePairs int      `json:"bridgeable_pairs"`
+	TopMotifs       []string `json:"top_motifs"`
 }
 
 func report(ctx context.Context, corpus, scratch string) error {
@@ -641,6 +652,11 @@ func report(ctx context.Context, corpus, scratch string) error {
 		r.NeedDefine = len(need)
 	}
 	if cs, err := svc.Motifs().Clusters(ctx, branch); err == nil {
+		dfs := make([]int, 0, len(cs))
+		for _, c := range cs {
+			dfs = append(dfs, c.DF)
+		}
+		r.BridgeablePairs = bridgeablePairs(dfs)
 		for i, c := range cs {
 			if i >= 20 {
 				break

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -19,6 +19,7 @@
 //	motifannex report    -corpus <name>            vocabulary/coverage/health snapshot
 //	motifannex bridges   -corpus <name> -effort h  motif bridge candidates, served and dropped
 //	motifannex namedef   -corpus <name>            name / name+def cosine ladders, centered and not
+//	motifannex roundtrip -corpus <name>            READ-ONLY parse/serialize fidelity audit
 //	motifannex harnesspack                         the Phase-4 blind judging pack (primary arms)
 //	motifannex survival  -corpus <name>            discovered-fact survival per bridge axis
 //	motifannex calibpack                           T8 stratified labelling pack + key (all lab corpora)
@@ -103,6 +104,8 @@ func main() {
 		fatal(bridges(ctx, *corpus, *scratch, *effort))
 	case "namedef":
 		fatal(namedef(ctx, *corpus, *scratch))
+	case "roundtrip":
+		fatal(roundtrip(ctx, *corpus, *scratch))
 	case "harnesspack":
 		fatal(harnesspack(ctx, *scratch, []string{"merged", "agentic-engineering", "knomit-kb"}))
 	case "survival":

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -17,6 +17,7 @@
 //	motifannex session   -corpus <name>            run one session, dump its items
 //	motifannex answer    -corpus <name> -in a.json apply answers, report health
 //	motifannex report    -corpus <name>            vocabulary/coverage/health snapshot
+//	motifannex bridges   -corpus <name> -effort h  motif bridge candidates, served and dropped
 package main
 
 import (
@@ -31,6 +32,7 @@ import (
 	"sort"
 	"strings"
 
+	"knomit/internal/config"
 	"knomit/internal/embeddings"
 	"knomit/internal/fact"
 	"knomit/internal/repos"
@@ -51,12 +53,13 @@ var corpora = map[string]string{
 
 func main() {
 	if len(os.Args) < 2 {
-		fatal(fmt.Errorf("usage: motifannex <snapshot|session|answer|report> -corpus <name>"))
+		fatal(fmt.Errorf("usage: motifannex <snapshot|session|answer|report|bridges> -corpus <name>"))
 	}
 	cmd := os.Args[1]
 	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
 	corpus := fs.String("corpus", "", "corpus name")
 	in := fs.String("in", "", "answers JSON (answer)")
+	effort := fs.String("effort", "high", "discovery effort for `bridges` (normal|medium|high)")
 	scratch := fs.String("scratch", defaultScratch(), "working directory for copies")
 	_ = fs.Parse(os.Args[2:])
 
@@ -92,6 +95,8 @@ func main() {
 		fatal(prunebase(ctx, *scratch))
 	case "report":
 		fatal(report(ctx, *corpus, *scratch))
+	case "bridges":
+		fatal(bridges(ctx, *corpus, *scratch, *effort))
 	default:
 		fatal(fmt.Errorf("unknown command %q", cmd))
 	}
@@ -230,8 +235,36 @@ func open(ctx context.Context, corpus, scratch string) (*store.Service, *repos.R
 	}
 	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
 		Name: corpus, AgentBranch: branch, Svc: svc, OntologyRoot: "kb", Embedder: emb,
+		Quality: productionQuality(),
 	})
 	return svc, ri, branch, func() { emb.Close(); svc.Close() }, nil
+}
+
+// productionQuality gives the instance the SHIPPED bridge-quality knobs.
+//
+// WITHOUT IT THE TOOL MEASURES AN ENGINE THAT CANNOT EMIT. A bare test
+// instance leaves MaxMembers at zero, and a zero member cap gates out every
+// bridge candidate there is — so a `bridges` run reports "0 near, 0 far" on
+// every corpus and it reads as a finding about the corpora. It is not; it is a
+// finding about the harness. Phase-3's rulings-3 already caught this once in
+// the test harness (deviation #3) and TestInstanceConfig.Quality's own doc
+// comment warns about it in as many words; this tool walked into it anyway,
+// which is why the values are now READ rather than re-typed.
+//
+// Read from config.Defaults() rather than restated: the Phase-3 review noted
+// that the test harness's re-typed copies could drift from the real defaults
+// and only a sibling test pinned them. A measurement tool that drifts from
+// production configuration is measuring a different engine, quietly.
+func productionQuality() *repos.TestQualityConfig {
+	d := config.Defaults().Discovery
+	return &repos.TestQualityConfig{
+		CohFloor:     d.CohFloor,
+		QualityFloor: d.QualityFloor,
+		WCoh:         d.WCoh,
+		WGap:         d.WGap,
+		WSpec:        d.WSpec,
+		MaxMembers:   d.MaxMembers,
+	}
 }
 
 // branchOf finds the branch carrying the most facts — the corpus's own agent
@@ -612,16 +645,16 @@ func skipBodyFor(af answerFile) string {
 // ── report ────────────────────────────────────────────────────────────────
 
 type corpusReport struct {
-	Corpus       string   `json:"corpus"`
-	Branch       string   `json:"branch"`
-	AuthoredLive int      `json:"authored_live"`
-	WithMotifs   int      `json:"with_motifs"`
-	Coverage     float64  `json:"coverage"`
-	Clusters     int      `json:"clusters"`
-	Recurring    int      `json:"recurring_df2plus"`
-	Recurrence   float64  `json:"recurrence_rate"`
-	MintToLink   float64  `json:"mint_to_link"`
-	NeedDefine   int      `json:"clusters_needing_definition"`
+	Corpus       string  `json:"corpus"`
+	Branch       string  `json:"branch"`
+	AuthoredLive int     `json:"authored_live"`
+	WithMotifs   int     `json:"with_motifs"`
+	Coverage     float64 `json:"coverage"`
+	Clusters     int     `json:"clusters"`
+	Recurring    int     `json:"recurring_df2plus"`
+	Recurrence   float64 `json:"recurrence_rate"`
+	MintToLink   float64 `json:"mint_to_link"`
+	NeedDefine   int     `json:"clusters_needing_definition"`
 	// BridgeablePairs is the CEILING on motif bridging — see bridgeablePairs.
 	// Reported next to Recurring because the two answer different questions:
 	// Recurring counts CLUSTERS that could bridge, this counts the PAIRS they

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -27,6 +27,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -180,16 +181,30 @@ func snapshot(ctx context.Context, corpus, id, scratch string) error {
 // checkpointLiveHome flushes a live corpus's WAL into its .db file so a
 // file-level copy is self-contained.
 //
+// RAW CONNECTION, NEVER store.Open (review finding H-1). This is the one
+// moment the tool touches a real knowledge base, and refuseLivePath's scope
+// note promises that touch is "a read and a checkpoint, no session, no
+// migration". store.Open makes that promise false: it runs migrate.All against
+// whatever it is handed and writes a session sidecar beside it. An operator
+// reading the guard's scope note before pointing this tool at their corpus
+// would have been reading the opposite of what happened.
+//
+// The plain "sqlite3" driver is deliberate over the store's own
+// "sqlite3_knomit": the custom driver is registered lazily by store.Open, and
+// a checkpoint needs none of what it carries. Nothing here can migrate,
+// because nothing here knows what a migration is.
+//
 // Reported rather than ignored on failure: a snapshot that could not checkpoint
 // is a snapshot that may be short of facts, and the whole point of the annex is
 // that its inputs are what they claim to be.
 func checkpointLiveHome(path string) error {
-	svc, err := store.Open(path)
+	db, err := sql.Open("sqlite3", "file:"+path+"?_busy_timeout=5000")
 	if err != nil {
 		return err
 	}
-	defer svc.Close()
-	return svc.Checkpoint()
+	defer db.Close()
+	_, err = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	return err
 }
 
 func copyFile(src, dst string) error {

--- a/tools/motifannex/namedef.go
+++ b/tools/motifannex/namedef.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+
+	"knomit/internal/store"
+)
+
+// namedef measures the cosine geometry of motif name+definition strings — the
+// distribution the `motif_match soft` tier's operating point has to be derived
+// from (carried-forward register entry 1), and with it the bridge-tier
+// embedding points (entry 2).
+//
+// FOUR DISTRIBUTIONS, not one, because two choices were open and neither can
+// be settled by reasoning:
+//
+//  1. RENDERING — name alone, or name+definition. No shipped code renders a
+//     name+def string today; the tier was deferred before one was needed. MN9's
+//     own lesson is that a measured anchor transfers only under the measured
+//     string, so the rendering is measured rather than assumed, and whichever
+//     ships must be the one the operating point came from.
+//
+//  2. CENTERING — the shipped EmbedShortStrings does NOT mean-center, and every
+//     research measurement behind this campaign DID (task_sweep.py, dryrun.py,
+//     replay.py, score3b.py, canonicalize.py all do `V = V - V.mean(0)`),
+//     including the sweep that settled MN9's template and the E3 recall
+//     figures. That has not mattered so far because the one shipped consumer,
+//     the alias pre-block, takes a PERCENTILE of its own distribution each
+//     session, and a percentile is invariant to centering. It matters here:
+//     the soft tier needs an ABSOLUTE point, and short-string embeddings are
+//     anisotropic (kb/gotchas/embeddings/short-strings/1d564e96), so a point
+//     measured one way does not transfer to the other.
+//
+// Read-only, on a lab copy. It embeds locally and writes nothing.
+func namedef(ctx context.Context, corpus, scratch string) error {
+	svc, ri, branch, closeAll, err := open(ctx, corpus, scratch)
+	if err != nil {
+		return err
+	}
+	defer closeAll()
+
+	clusters, err := svc.Motifs().Clusters(ctx, branch)
+	if err != nil {
+		return fmt.Errorf("clusters: %w", err)
+	}
+
+	var names, withDefs []string
+	defined := 0
+	for _, c := range clusters {
+		def, ok, derr := svc.Motifs().Definition(ctx, branch, c.ClusterKey)
+		if derr != nil {
+			return fmt.Errorf("definition %s: %w", c.ClusterKey, derr)
+		}
+		names = append(names, c.CanonicalID)
+		if ok && def != "" {
+			defined++
+			withDefs = append(withDefs, c.CanonicalID+": "+def)
+		} else {
+			// A cluster with no definition still belongs in the population —
+			// dropping it would measure the definition pass's coverage instead
+			// of the vocabulary's geometry. It contributes its bare name, which
+			// is what a real query would have to match against too.
+			withDefs = append(withDefs, c.CanonicalID)
+		}
+	}
+	if len(names) < 2 {
+		return fmt.Errorf("%s: %d clusters — no pair distribution to measure", corpus, len(names))
+	}
+
+	emb := ri.Embedder()
+	if emb == nil {
+		return fmt.Errorf("no embedder")
+	}
+
+	out := map[string]any{
+		"corpus":            corpus,
+		"branch":            branch,
+		"clusters":          len(clusters),
+		"with_definition":   defined,
+		"rendering_namedef": "<canonical_id>: <definition>  (bare id when undefined)",
+		"template_note": "both renderings go through the SHIPPED EmbedShortStrings, i.e. the MN9 " +
+			"ShortStringTemplate; nothing here re-implements the rendering",
+	}
+
+	for label, texts := range map[string][]string{"name": names, "namedef": withDefs} {
+		vecs, eerr := emb.EmbedShortStrings(ctx, texts)
+		if eerr != nil {
+			return fmt.Errorf("embed %s: %w", label, eerr)
+		}
+		out[label+"_uncentered"] = cosineLadder(vecs, false)
+		out[label+"_centered"] = cosineLadder(vecs, true)
+	}
+
+	// THE ONLY GROUND TRUTH THIS CORPUS HAS. A cluster carrying two or more
+	// distinct spellings is a pair of strings a human or the alias judge
+	// declared to mean the same mechanism — the only labelled POSITIVES
+	// available anywhere (the judge's merges are the same handful; after a
+	// merge the two ids become one cluster, so the spellings are where the
+	// label survives).
+	//
+	// Reported with its n, which is tiny. It cannot place an operating point
+	// and is not offered as one: it is a sanity check on whether the geometry
+	// puts known-equivalent strings above the bulk at all.
+	pos, perr := knownEquivalentPairs(ctx, svc, branch, emb)
+	if perr != nil {
+		return perr
+	}
+	out["known_equivalent_pairs"] = pos
+
+	fmt.Fprintf(os.Stderr, "%s: %d clusters, %d with definitions\n", corpus, len(clusters), defined)
+	return emit(out)
+}
+
+// cosineLadder returns the percentile ladder of all pairwise cosines, with the
+// vectors optionally mean-centered first.
+//
+// Centering happens BEFORE normalisation, matching what the research scripts
+// did (`V = V - V.mean(0)` then row-normalise). Doing it the other way measures
+// a third thing that neither production nor the research used.
+func cosineLadder(in [][]float32, center bool) map[string]any {
+	if len(in) < 2 {
+		return map[string]any{"pairs": 0}
+	}
+	dim := len(in[0])
+	v := make([][]float64, len(in))
+	for i, row := range in {
+		v[i] = make([]float64, dim)
+		for j, f := range row {
+			v[i][j] = float64(f)
+		}
+	}
+	if center {
+		mean := make([]float64, dim)
+		for _, row := range v {
+			for j, x := range row {
+				mean[j] += x
+			}
+		}
+		for j := range mean {
+			mean[j] /= float64(len(v))
+		}
+		for _, row := range v {
+			for j := range row {
+				row[j] -= mean[j]
+			}
+		}
+	}
+	for _, row := range v {
+		var n float64
+		for _, x := range row {
+			n += x * x
+		}
+		n = math.Sqrt(n)
+		if n < 1e-9 {
+			continue
+		}
+		for j := range row {
+			row[j] /= n
+		}
+	}
+
+	var cos []float64
+	for i := range v {
+		for j := i + 1; j < len(v); j++ {
+			var d float64
+			for k := range v[i] {
+				d += v[i][k] * v[j][k]
+			}
+			cos = append(cos, d)
+		}
+	}
+	sort.Float64s(cos)
+
+	q := func(p float64) float64 {
+		if len(cos) == 0 {
+			return 0
+		}
+		idx := int(p * float64(len(cos)-1))
+		return cos[idx]
+	}
+	var sum float64
+	for _, c := range cos {
+		sum += c
+	}
+	return map[string]any{
+		"pairs": len(cos),
+		"mean":  round4(sum / float64(len(cos))),
+		"min":   round4(cos[0]),
+		"p50":   round4(q(0.50)),
+		"p90":   round4(q(0.90)),
+		"p95":   round4(q(0.95)),
+		"p99":   round4(q(0.99)),
+		"p999":  round4(q(0.999)),
+		"max":   round4(cos[len(cos)-1]),
+	}
+}
+
+func round4(f float64) float64 { return math.Round(f*10000) / 10000 }
+
+// knownEquivalentPairs returns the cosine of every within-cluster spelling pair
+// — strings the vocabulary already says mean the same mechanism — under both
+// centerings, so they can be read against the bulk ladder above.
+func knownEquivalentPairs(ctx context.Context, svc *store.Service, branch string, emb store.BatchEmbedder) ([]map[string]any, error) {
+	// AliasTable is spelling -> canonical id, which is exactly the grouping
+	// needed: two spellings sharing a canonical id are two strings the
+	// vocabulary says name one mechanism.
+	table, err := svc.Motifs().AliasTable(ctx, branch)
+	if err != nil {
+		return nil, fmt.Errorf("alias table: %w", err)
+	}
+	byCluster := map[string][]string{}
+	for spelling, canon := range table {
+		byCluster[canon] = append(byCluster[canon], spelling)
+	}
+
+	// Embed the WHOLE vocabulary once, and take the centering mean over all of
+	// it. Centering a pair by its own two-vector mean makes the two vectors
+	// exact opposites and every cosine -1 — which is what the first version of
+	// this function did, and it produced a confident -1.000 for every positive.
+	// The mean has to be the POPULATION's, because that is the anisotropy being
+	// removed; a mean over the thing being measured measures nothing.
+	all := make([]string, 0, len(table))
+	for spelling := range table {
+		all = append(all, spelling)
+	}
+	sort.Strings(all)
+	if len(all) < 2 {
+		return nil, nil
+	}
+	vecs, err := emb.EmbedShortStrings(ctx, all)
+	if err != nil {
+		return nil, err
+	}
+	idx := map[string]int{}
+	for i, sp := range all {
+		idx[sp] = i
+	}
+	mean := meanOf(vecs)
+
+	canons := make([]string, 0, len(byCluster))
+	for c, ms := range byCluster {
+		if len(ms) >= 2 {
+			canons = append(canons, c)
+		}
+	}
+	sort.Strings(canons)
+
+	var out []map[string]any
+	for _, c := range canons {
+		ms := byCluster[c]
+		sort.Strings(ms)
+		for i := range ms {
+			for j := i + 1; j < len(ms); j++ {
+				a, b := vecs[idx[ms[i]]], vecs[idx[ms[j]]]
+				out = append(out, map[string]any{
+					"a":          ms[i],
+					"b":          ms[j],
+					"uncentered": round4(pairCos(a, b, nil)),
+					"centered":   round4(pairCos(a, b, mean)),
+				})
+			}
+		}
+	}
+	return out, nil
+}
+
+func meanOf(v [][]float32) []float64 {
+	if len(v) == 0 {
+		return nil
+	}
+	m := make([]float64, len(v[0]))
+	for _, row := range v {
+		for j, x := range row {
+			m[j] += float64(x)
+		}
+	}
+	for j := range m {
+		m[j] /= float64(len(v))
+	}
+	return m
+}
+
+func pairCos(a, b []float32, mean []float64) float64 {
+	x := make([]float64, len(a))
+	y := make([]float64, len(b))
+	for i := range a {
+		x[i], y[i] = float64(a[i]), float64(b[i])
+		if mean != nil {
+			x[i] -= mean[i]
+			y[i] -= mean[i]
+		}
+	}
+	var d, nx, ny float64
+	for i := range x {
+		d += x[i] * y[i]
+		nx += x[i] * x[i]
+		ny += y[i] * y[i]
+	}
+	if nx < 1e-18 || ny < 1e-18 {
+		return 0
+	}
+	return d / (math.Sqrt(nx) * math.Sqrt(ny))
+}

--- a/tools/motifannex/quality_guard_test.go
+++ b/tools/motifannex/quality_guard_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/config"
+	"knomit/internal/repos"
+	"knomit/internal/synthesize"
+)
+
+// The trap this closes, stated once: a bare test RepoInstance leaves
+// MaxMembers at ZERO, and a zero member cap gates out every bridge candidate.
+// A measurement tool configured that way reports "0 near, 0 far" on every
+// corpus, and the zeros read as a finding about the corpora rather than about
+// the harness. rulings-3 caught it in the test harness; this tool reproduced it
+// on its first run.
+
+func TestProductionQuality_IsNotTheGateEverythingOutDefault(t *testing.T) {
+	q := productionQuality()
+	require.NotNil(t, q)
+	require.Positive(t, q.MaxMembers,
+		"a zero member cap gates out EVERY bridge candidate; the tool would measure an engine that cannot emit")
+}
+
+// Read, never re-typed. The Phase-3 review noted the test harness's copies of
+// these values could drift from the real defaults with only a sibling test
+// pinning them. A measurement tool that drifts from production configuration
+// measures a different engine, quietly — so this asserts identity with the
+// shipped defaults rather than with a second list of numbers.
+func TestProductionQuality_MatchesTheShippedDefaultsExactly(t *testing.T) {
+	d := config.Defaults().Discovery
+	q := productionQuality()
+
+	require.Equal(t, d.CohFloor, q.CohFloor)
+	require.Equal(t, d.QualityFloor, q.QualityFloor)
+	require.Equal(t, d.WCoh, q.WCoh)
+	require.Equal(t, d.WGap, q.WGap)
+	require.Equal(t, d.WSpec, q.WSpec)
+	require.Equal(t, d.MaxMembers, q.MaxMembers)
+}
+
+// And the thing the two above are really protecting: what the engine is handed.
+// Asserted at the boundary the scorer actually reads (lesson 8) rather than at
+// the struct the tool happens to build.
+func TestProductionQuality_ReachesTheScorerAsProductionValues(t *testing.T) {
+	d := config.Defaults().Discovery
+	ri := testInstanceWithQuality(t)
+
+	got := synthesize.QualityConfigFromRepo(ri)
+
+	require.Equal(t, d.MaxMembers, got.MaxMembers)
+	require.Equal(t, d.CohFloor, got.CohFloor)
+	require.Positive(t, got.MaxMembers, "precondition: production's cap is non-zero, or this test proves nothing")
+}
+
+// testInstanceWithQuality builds the same RepoInstance shape open() builds,
+// minus the store and embedder, so the quality knobs can be asserted where the
+// scorer reads them without opening a corpus.
+func testInstanceWithQuality(t *testing.T) *repos.RepoInstance {
+	t.Helper()
+	return repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name: "lab", AgentBranch: "main", OntologyRoot: "kb",
+		Quality: productionQuality(),
+	})
+}

--- a/tools/motifannex/roundtrip.go
+++ b/tools/motifannex/roundtrip.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"knomit/internal/fact"
+)
+
+// roundtrip is carried-forward register entry 12's READ-ONLY audit: for every
+// live fact, parse the stored bytes and re-serialize them, and classify every
+// difference.
+//
+// WHAT THE QUESTION IS. `ParseFact → mutate → SerializeFact → WriteFact` is a
+// shape several write paths share — REINFORCE (remediated by the Phase-3 write
+// contract), prune's merge, update. Where the round trip is not the identity,
+// any of those paths silently rewrites bytes it was not asked to touch. The
+// Phase-3 fidelity measurement found 66 core facts whose illegal stored
+// type/origin pairing is reattributed to `authored` by a non-skipping rewrite;
+// this re-measures on the current corpus state and looks for classes beyond it.
+//
+// NOTHING IS WRITTEN, and no live KB is opened — refuseLivePath makes that
+// structural rather than a promise. The re-serialized bytes exist only in
+// memory, long enough to be compared.
+func roundtrip(ctx context.Context, corpus, scratch string) error {
+	_, _, branch, closeAll, err := open(ctx, corpus, scratch)
+	if err != nil {
+		return err
+	}
+	defer closeAll()
+
+	db, err := openReadOnly(copyPath(scratch, corpus))
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT bf.path, o.data
+		  FROM branch_facts bf
+		  JOIN facts f ON f.id = bf.fact_id
+		  JOIN objects o ON o.hash = f.blob_hash
+		 WHERE bf.branch_id = (SELECT id FROM branches WHERE name = ?)
+		 ORDER BY bf.path`, branch)
+	if err != nil {
+		return fmt.Errorf("read stored blobs: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]int{}
+	examples := map[string][]string{}
+	total, identical, unparsable := 0, 0, 0
+
+	for rows.Next() {
+		var path string
+		var data []byte
+		if err := rows.Scan(&path, &data); err != nil {
+			return err
+		}
+		total++
+		stored := string(data)
+
+		f, perr := fact.ParseFact(path, stored)
+		if perr != nil {
+			unparsable++
+			note(counts, examples, "unparsable", path)
+			continue
+		}
+		out, serr := fact.SerializeFact(f)
+		if serr != nil {
+			note(counts, examples, "unserializable", path)
+			continue
+		}
+		if out == stored {
+			identical++
+			// A fact whose motifs the parser dropped is NOT identical-safe just
+			// because the bytes matched: check it anyway below.
+		}
+
+		if len(f.MotifWarnings) > 0 {
+			note(counts, examples, "motif-loss", path)
+		}
+		if out == stored {
+			continue
+		}
+		// RE-PARSE THE OUTPUT before classifying. Whether a changed origin line
+		// is a semantic no-op or a silent reattribution cannot be read off the
+		// bytes — it depends on what ParseFact makes of the NEW bytes. Asserting
+		// it from the diff alone would be claiming a construction property
+		// without reading the output (the annex's own §11 corollary).
+		//
+		// COMPARE AGAINST THE STORED BYTES, NOT THE PARSED STRUCT. The first
+		// version compared reparsed.Origin to f.Origin — both of them ParseFact
+		// output — and reported every one of these as a semantic no-op. It
+		// cannot see the loss, because the loss happens AT parse: ParseFact
+		// normalises an illegal `discovered observation` to `authored`, so both
+		// sides of that comparison already say authored. This is the Phase-3
+		// review's H1 finding committed a second time in the tool written to
+		// measure it, and the fix is the same one: read the boundary the corpus
+		// actually stores.
+		reparsed, rerr := fact.ParseFact(path, out)
+		storedOrigin := frontmatterValue(stored, "origin")
+		lostOrigin := rerr == nil && storedOrigin != "" && string(reparsed.Origin) != storedOrigin
+		for _, cls := range classifyDiff(stored, out, f) {
+			if cls == "line-removed:origin" || cls == "origin-materialised-DIFFERENT" {
+				if lostOrigin {
+					cls = fmt.Sprintf("origin-REATTRIBUTED-%s-to-%s", storedOrigin, reparsed.Origin)
+				} else {
+					cls = "origin-line-changed-semantic-noop"
+				}
+			}
+			note(counts, examples, cls, path)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	classes := make([]map[string]any, 0, len(keys))
+	for _, k := range keys {
+		classes = append(classes, map[string]any{
+			"class": k, "facts": counts[k],
+			"pct":      round4(float64(counts[k]) / float64(max(total, 1))),
+			"examples": examples[k],
+		})
+	}
+
+	fmt.Fprintf(os.Stderr, "%s: %d live facts, %d byte-identical, classes=%v\n",
+		corpus, total, identical, counts)
+	return emit(map[string]any{
+		"corpus":     corpus,
+		"branch":     branch,
+		"instrument": "stored git blob -> fact.ParseFact -> fact.SerializeFact -> byte diff. READ-ONLY.",
+		"population": "every live fact on the branch",
+		"live_facts": total,
+		"identical":  identical,
+		"unparsable": unparsable,
+		"classes":    classes,
+		"motif_caveat": "the motif-loss column is meaningful for the FIRST time here, because these " +
+			"copies carry motifs where the Phase-3 measurement's corpora carried none — and the motifs " +
+			"it describes are ANNEX-WRITTEN, not production ones, so it is evidence about the parser " +
+			"and not about any deployed corpus.",
+	})
+}
+
+func note(counts map[string]int, examples map[string][]string, class, path string) {
+	counts[class]++
+	if len(examples[class]) < 5 {
+		examples[class] = append(examples[class], path)
+	}
+}
+
+// classifyDiff names every way the re-serialized bytes differ from the stored
+// ones.
+//
+// Line-set based rather than positional: a reordered frontmatter key is not a
+// value change, and reporting it as one would bury the classes that matter
+// under noise. Every difference lands in a named bucket or in "other" —
+// "other" is not a catch-all to be tidied away later, it is the bucket a class
+// nobody anticipated shows up in, which is the reason to run this at all.
+func classifyDiff(stored, out string, f fact.Fact) []string {
+	var classes []string
+	sLines := frontmatterLines(stored)
+	oLines := frontmatterLines(out)
+
+	added, removed := lineDelta(sLines, oLines)
+
+	// A quote-only change appears TWICE in the delta — once as a removed line
+	// and once as the requoted addition — so it has to be recognised on BOTH
+	// sides or one change is reported as two classes. The first run did exactly
+	// that: "line-added:refs 157" and "quote-style-only 157" were the same 157
+	// facts, and the first name made a rendering difference look like a
+	// structural one.
+	for _, l := range added {
+		key := lineKey(l)
+		if quoteOnly(l, removed) {
+			classes = append(classes, "quote-style-only")
+			continue
+		}
+		switch {
+		case key == "origin":
+			if strings.TrimSpace(strings.TrimPrefix(l, "origin:")) == string(f.Origin) {
+				classes = append(classes, "origin-materialised-to-parse-default")
+			} else {
+				classes = append(classes, "origin-materialised-DIFFERENT")
+			}
+		case key == "type" || key == "kind":
+			classes = append(classes, "type-or-kind-rewritten")
+		default:
+			classes = append(classes, "line-added:"+key)
+		}
+	}
+	for _, l := range removed {
+		key := lineKey(l)
+		if quoteOnly(l, added) {
+			classes = append(classes, "quote-style-only")
+			continue
+		}
+		classes = append(classes, "line-removed:"+key)
+	}
+	if len(classes) == 0 && stored != out {
+		classes = append(classes, "other-body-or-whitespace")
+	}
+	return dedupeStrings(classes)
+}
+
+func frontmatterLines(s string) []string {
+	parts := strings.SplitN(s, "---\n", 3)
+	if len(parts) < 3 {
+		return nil
+	}
+	return strings.Split(strings.TrimRight(parts[1], "\n"), "\n")
+}
+
+func lineKey(l string) string {
+	if i := strings.Index(l, ":"); i > 0 {
+		return strings.TrimSpace(l[:i])
+	}
+	return strings.TrimSpace(l)
+}
+
+// quoteOnly reports whether a removed line reappears among the added ones with
+// only quote characters differing — YAML rendering, not a value change
+// (rulings-5 clause 3).
+func quoteOnly(removed string, added []string) bool {
+	strip := func(s string) string {
+		return strings.NewReplacer("'", "", `"`, "", " ", "").Replace(s)
+	}
+	for _, a := range added {
+		if strip(a) == strip(removed) {
+			return true
+		}
+	}
+	return false
+}
+
+func lineDelta(before, after []string) (added, removed []string) {
+	b := map[string]int{}
+	for _, l := range before {
+		b[l]++
+	}
+	a := map[string]int{}
+	for _, l := range after {
+		a[l]++
+	}
+	for l, n := range a {
+		if b[l] < n {
+			added = append(added, l)
+		}
+	}
+	for l, n := range b {
+		if a[l] < n {
+			removed = append(removed, l)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	return added, removed
+}
+
+func dedupeStrings(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+var _ = sql.ErrNoRows
+
+// frontmatterValue reads one frontmatter value out of the STORED bytes,
+// deliberately without parsing.
+//
+// Every question about what a round trip LOSES has to be asked against the
+// stored bytes: a parsed struct has already had the normalisation applied, so
+// comparing one parse to another compares two copies of the same loss.
+func frontmatterValue(stored, key string) string {
+	for _, l := range frontmatterLines(stored) {
+		if lineKey(l) == key {
+			if i := strings.Index(l, ":"); i > 0 {
+				return strings.TrimSpace(l[i+1:])
+			}
+		}
+	}
+	return ""
+}

--- a/tools/motifannex/survival.go
+++ b/tools/motifannex/survival.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+)
+
+// discoverCommit matches the provenance line every discovered fact is written
+// under (`internal/synthesize/discovery.go`).
+//
+// THE COMMIT MESSAGE IS THE INSTRUMENT, and that is a choice worth stating.
+// The obvious alternative is the discover work-item table, which records the
+// bridge kind and lane directly — but work items live in the SESSIONS database,
+// which does not travel with a corpus copy and is pruned in the ordinary course
+// of running. The commit log travels with the repo, is append-only, and is the
+// only record that survives long enough to answer a question about survival.
+//
+// Lesson 9 applies squarely: "did this fact survive?" is a temporal question,
+// and the live index answers "is it here now" while saying nothing about what
+// was ever written. Counting only live discovered facts would report 100%
+// survival on every corpus, by construction.
+var discoverCommit = regexp.MustCompile(`^discover-(forward|backward): emergent fact via bridge "(.+)"$`)
+
+// survival reports how many discovered facts each bridge axis produced and how
+// many are still live — blueprint §8's "survival after N review/harden sessions
+// >= the token-bridge baseline".
+func survival(ctx context.Context, corpus, scratch string) error {
+	svc, _, branch, closeAll, err := open(ctx, corpus, scratch)
+	if err != nil {
+		return err
+	}
+	defer closeAll()
+
+	// The vocabulary decides the axis: a motif bridge's token is a canonical
+	// motif id, an entity/domain bridge's is a tag. Anything the alias table
+	// knows is a motif.
+	table, err := svc.Motifs().AliasTable(ctx, branch)
+	if err != nil {
+		return fmt.Errorf("alias table: %w", err)
+	}
+	isMotif := map[string]bool{}
+	for spelling, canon := range table {
+		isMotif[spelling] = true
+		isMotif[canon] = true
+	}
+
+	// RAW READ OF commit_log, DISCLOSED. The store exposes no "walk every
+	// commit" API — its history surface is per-path or per-commit-hash, and
+	// this question is neither. Adding one to internal/store for a measurement
+	// tool would be product surface grown for a report, so the tool reads the
+	// table directly, read-only, on a lab COPY.
+	//
+	// This is NOT the habit the annex's §11.2 warned about. That was using a
+	// live-index read to answer a temporal question; here the commit log IS the
+	// temporal record and the live index is what would give the wrong answer.
+	db, err := openReadOnly(copyPath(scratch, corpus))
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	rows, err := discoverCommits(ctx, db)
+	if err != nil {
+		return fmt.Errorf("commit log: %w", err)
+	}
+
+	type arm struct{ Written, Live int }
+	arms := map[string]*arm{"motif": {}, "entity-domain": {}}
+	type row struct {
+		Path, Token, Direction, Axis string
+		Live                         bool
+	}
+	var detail []row
+
+	// ONE ROW PER FACT, not per commit. commit_log is keyed (commit_hash,
+	// path), and a fact can be touched by more than one discover-provenance
+	// commit — its write, then a later edit under the same message. Counting
+	// rows would report "4 discovered facts" for two, which is the unit
+	// silently not matching the label.
+	seenPath := map[string]bool{}
+	for _, c := range rows {
+		m := discoverCommit.FindStringSubmatch(c.Message)
+		if m == nil {
+			continue
+		}
+		if seenPath[c.Path] {
+			continue
+		}
+		seenPath[c.Path] = true
+		axis := "entity-domain"
+		if isMotif[m[2]] {
+			axis = "motif"
+		}
+		live := false
+		if _, err := svc.FactQuery().GetByPath(ctx, branch, c.Path); err == nil {
+			live = true
+		}
+		arms[axis].Written++
+		if live {
+			arms[axis].Live++
+		}
+		detail = append(detail, row{Path: c.Path, Token: m[2], Direction: m[1], Axis: axis, Live: live})
+	}
+	sort.Slice(detail, func(i, j int) bool { return detail[i].Path < detail[j].Path })
+
+	out := map[string]any{
+		"corpus": corpus,
+		"branch": branch,
+		"instrument": "commit-log walk for the discover provenance line, joined to branch_facts for " +
+			"liveness. NOT a live-index scan: counting only live discovered facts would report 100% " +
+			"survival on every corpus by construction (lesson 9).",
+		"attribution": "a bridge token the alias table knows is a motif; anything else is entity/domain. " +
+			"A token used by BOTH axes would be misattributed to motif — measured incidence below.",
+		"unit": "one row per distinct FACT PATH written under a discover provenance line, " +
+			"not per commit — a fact touched by two such commits counts once.",
+		"detail": detail,
+	}
+	for name, a := range arms {
+		e := map[string]any{"written": a.Written, "live": a.Live}
+		if a.Written > 0 {
+			e["survival"] = round4(float64(a.Live) / float64(a.Written))
+		}
+		out[name] = e
+	}
+	// The attribution's own failure mode, counted rather than assumed away.
+	collisions := 0
+	for _, d := range detail {
+		if d.Axis == "motif" && !isMotif[d.Token] {
+			collisions++
+		}
+	}
+	out["ambiguous_tokens"] = collisions
+
+	fmt.Fprintf(os.Stderr, "%s: motif %d/%d live, entity-domain %d/%d live\n", corpus,
+		arms["motif"].Live, arms["motif"].Written,
+		arms["entity-domain"].Live, arms["entity-domain"].Written)
+	return emit(out)
+}
+
+type commitRow struct {
+	Path    string
+	Message string
+}
+
+// openReadOnly opens the lab copy for the commit-log walk. The lab guard has
+// already run in open(); this is the same file, opened again for reading only.
+func openReadOnly(path string) (*sql.DB, error) {
+	return sql.Open("sqlite3", "file:"+path+"?mode=ro")
+}
+
+func discoverCommits(ctx context.Context, db *sql.DB) ([]commitRow, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT path, message FROM commit_log WHERE message LIKE 'discover-%' ORDER BY committed_at`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []commitRow
+	for rows.Next() {
+		var c commitRow
+		if err := rows.Scan(&c.Path, &c.Message); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}


### PR DESCRIPTION
Phase 4 of the motif roadmap, the FINAL implementation phase: per-corpus activation, novelty metrics, the calibration verdicts, and the blind-harness rerun. Stacked on #105 (phase 3). 27 commits: measurement tracks + product surfaces + two fresh-eyes review remediation rounds.

**The honest headline: the instrument work is solid, the measurements reproduce, and the axis's value on real corpora is unproven — the far lane's only direct evidence is negative at n=2, with judge variance now MEASURED (95.8% agreement on the mechanism boundary) rather than assumed.** The phase's genuine positive: the df-graded subject-disjointness gate (GATE rider 1) measurably does what it was designed for — the one blind-judged MECH pair passed through four shared labels the gate deliberately permitted, where the old strict criterion would have killed it on any one.

## What ships

- **Per-corpus activation, computed not configured**: a statistical-validity floor of 3 recurring canonical motif clusters in the post-AcceptSeed bridging population (the original ≈30%-coverage condition was measurably falsified — only the annex's negative-result corpus cleared it). Level-triggered; below-floor corpora activate themselves as recurrence accumulates. Two honesty guards: an Evaluated flag ("never asked" ≠ "asked, below floor") and a degenerate-cut strict fallback closing a dead band where the disjointness gate was silently off on hapax-dominated young corpora.
- **Novelty signals on BridgeComponents** (seed body-cosine, entity-Jaccard, over-dedup) + `calibrate bridges --kind motif` via a sibling report — both reports state their POPULATION before any number. Survival reported separately (at enumeration time nothing exists to survive).
- **Calibration verdicts, measured**: the `motif_match soft` tier re-defers on a pre-registered criterion (1 in-band positive vs a floor of 20, across 192 blind-labelled pairs; controls valid both directions) — at real corpus scale (hundreds of facts) this is likely the permanent, correct state. Centering (per-model stored mean, self-tuning derived state) and name+def rendering are settled for any future attempt.
- **The §8 blind-harness rerun**, arms from the shipped engine, uniform-id blinding, controls drawn from the same population as the arms, TRAP + RANDOM controls (0%/100% bracket), judge variance measured across two runs on 24 common pairs. §8's comparison recorded POPULATION-LIMITED per the amended acceptance; rerun trigger: a corpus serving 12 pairs per lane (today's max: 2).
- **Cross-tier suppression amendment**: an exact-match group is never displaced by a token-2 family that contains it (measured live doing exactly that); costs the permissive tier a third of its fixture pairs, by design.
- **The entry-12 round-trip audit**: zero motif loss on 179 real motif instances; the origin-reattribution class measured as BROADER than recorded (any illegal type/origin pairing, not just "discovered observation") — filed as its own issue.
- **A production determinism fix**: ScopedCluster fed Louvain a randomized node order, making community assignment nondeterministic corpus-wide (dedup/prune/distill/bridges); one sorted line + property test.
- Instrument hardening: motifannex's copies-only guard is structural (symlink-resolving refuseLivePath); snapshot checkpoints via a raw connection that cannot migrate a live KB.

## Review record

Fresh-eyes review + two remediation rounds: 3 HIGH, 8 MEDIUM-class, 6 LOW — all ruled, remediated, and bound by tests the reviewer broke itself. Every load-bearing number reproduced from the shipped instruments on every verification pass. MN5's EffortNormal test file is byte-identical across all six phases of the campaign.

## Deliberately carried forward

The lane-split redesign and oversized-far-group trim (denominators now counted), the vanish-rate measurement (populations not yet contended), the soft-tier un-defer trigger (~20 genuine in-band synonym pairs), and prune's merge-path audit — full register in `.claude/plans/motif/PHASE4-CARRIED-FORWARD.md`.