### PR TITLE
fix(synthesize): dedup merge must not re-judge refs both facts already carried

### DIFF
--- a/internal/store/derived_from.go
+++ b/internal/store/derived_from.go
@@ -248,16 +248,21 @@ func (si *searchIndex) graphAddDerivedFromAtCommitTx(
 			return fmt.Errorf("graphAddDerivedFromAtCommitTx: resolve %s: %w", refPath, err)
 		}
 		if !ok {
-			// With the knomit_learn/knomit_update ref gate in place this is
-			// unreachable for anything written through MCP: a local ref that
-			// will not resolve is rejected before the write. Reaching here
-			// means the fact arrived another way — a direct git push to the
-			// KB branch, a remote reconcile, or a history rewrite — which is
-			// worth seeing. Skipping the edge is still correct; failing the
-			// index is not.
-			log.Warn().Str("branch", branch).Str("source", sourcePath).
+			// The ref gate stops a NEWLY ADDED local ref from being written
+			// unresolvable, but it deliberately exempts refs a fact already
+			// carried — internal/refs does not re-judge the past. So this is
+			// reachable through ordinary MCP writes too: a dedup merge grafts
+			// the loser's carried refs onto the winner, and on a corpus that
+			// predates the gate, or whose targets fell past the walk-back
+			// horizon, those refs land here on every index sync. That is
+			// expected, not a bypass — hence Debug, not Warn. A fact that
+			// arrived another way (a direct git push to the KB branch, a
+			// remote reconcile, a history rewrite) also lands here and is
+			// indistinguishable at this point. Skipping the edge is still
+			// correct; failing the index is not.
+			log.Debug().Str("branch", branch).Str("source", sourcePath).
 				Str("ref", refPath).Str("source_commit", sourceCommit).
-				Msg("derived_from: local ref did not resolve; edge skipped (bypassed the ref gate?)")
+				Msg("derived_from: local ref did not resolve; edge skipped")
 			continue
 		}
 

--- a/internal/synthesize/dedup.go
+++ b/internal/synthesize/dedup.go
@@ -72,6 +72,32 @@ func loserCorroborations(loser factForLLM) int {
 	return loser.Sources
 }
 
+// dedupMergeRefs returns the winner's post-merge ref list and, as a separate
+// list, the refs the two operands already carried — the `prior` the ref gate
+// exempts from re-judging.
+//
+// The two are computed from the SAME three inputs and are therefore equal
+// today: a mechanical merge introduces no citation, so every element of the
+// write list was carried by the winner, carried by the loser, or is the
+// loser's own path. They are nonetheless built separately, and that is the
+// whole point of this function. Handing the write list to Gate.Apply in both
+// argument positions would read identically and behave identically now, and
+// would exempt whatever a later change appends to the write list at the call
+// site — a lineage pointer to a synthesized parent, an annex ref — leaving a
+// gate call that can never reject anything (0ee925f4). `prior` has to be able
+// to diverge from `refs` for the check to mean what it says, so the carried
+// set is derived from the operands, where "this was already carried" is
+// provably true, and never from the list being written.
+func dedupMergeRefs(winnerRefs, loserRefs []string, loserPath string) (write, carried []string) {
+	write = fact.UnionStrings(winnerRefs, loserRefs)
+	write = fact.AppendUnique(write, loserPath)
+
+	carried = fact.UnionStrings(winnerRefs, loserRefs)
+	carried = fact.AppendUnique(carried, loserPath)
+
+	return write, carried
+}
+
 // applyGreedyMerges sorts pairs by similarity descending and selects pairs
 // such that each fact index participates in at most one merge.
 func applyGreedyMerges(pairs []mergePair) []mergePair {
@@ -204,24 +230,37 @@ func dedupCluster(
 
 		onProgress(ProgressEvent{Phase: "dedup-merge", Message: fmt.Sprintf("%s <- %s (%.2f)", winnerFact.File, loserFact.File, p.similarity)})
 
+		// Every failure from here to the end of the iteration is scoped to
+		// THIS pair: warn, skip it, keep going — the same shape the merge and
+		// discovery loops use. A single member that cannot be read or parsed
+		// (frontmatter from an older serializer, a hand-edit on the KB branch)
+		// otherwise aborts the whole review session before it plans anything,
+		// which is the #103 failure again from a different cause and just as
+		// permanent across retries. Skipping leaves both facts live, so the
+		// next pass is free to try the pair again.
+
 		// Read the winner's full fact from git to get its Refs.
 		winnerResult, err := gs.ReadFact(ctx, agentBranch, winnerFact.File, nil)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: read winner %q: %w", winnerFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup read winner %s: %v", winnerFact.File, err)})
+			continue
 		}
 		fullWinner, err := fact.ParseFact(winnerFact.File, winnerResult.Content)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: parse winner %q: %w", winnerFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup parse winner %s: %v", winnerFact.File, err)})
+			continue
 		}
 
 		// Read the loser's full fact to get its Refs.
 		loserResult, err := gs.ReadFact(ctx, agentBranch, loserFact.File, nil)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: read loser %q: %w", loserFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup read loser %s: %v", loserFact.File, err)})
+			continue
 		}
 		fullLoser, err := fact.ParseFact(loserFact.File, loserResult.Content)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: parse loser %q: %w", loserFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup parse loser %s: %v", loserFact.File, err)})
+			continue
 		}
 
 		// Apply merged fields to the full winner fact.
@@ -235,40 +274,71 @@ func dedupCluster(
 		// location, and without it the loser's motifs are simply deleted along
 		// with the loser, losing authored data that no derived state can rebuild.
 		fullWinner.Motifs = fact.MergeMotifs(fullWinner.Motifs, fullLoser.Motifs)
-		// Refs = union of both refs + loser's path.
-		mergedRefs := fact.UnionStrings(fullWinner.Refs, fullLoser.Refs)
-		mergedRefs = fact.AppendUnique(mergedRefs, loserFact.File)
+		// Refs = union of both refs + loser's path, and — separately — the
+		// snapshot of what the two operands already carried.
+		mergedRefs, carriedRefs := dedupMergeRefs(fullWinner.Refs, fullLoser.Refs, loserFact.File)
 
-		// Same gate as every other write path. The loser is passed as retracted
-		// because it is deleted immediately below and the winner cites it as
-		// lineage — that citation is the record of the merge, not a dead ref.
-		canonRefs, _, gerr := gate.Apply(ctx, winnerFact.File, mergedRefs, []string{loserFact.File})
+		// Same gate as every other write path — but this merge ADDS no
+		// citation, so the whole carried set goes in as prior.
+		//
+		// Both operands are facts already in the corpus: each carried its refs
+		// from its own commit, where they were checked once, and grafting the
+		// loser's lineage onto the winner is a transfer, not the author making
+		// a fresh claim about today's index. internal/refs is explicit that
+		// such refs are never re-judged — "a retraction anywhere in history
+		// makes every fact that ever cited it uneditable" is exactly the
+		// failure re-judging produces. Here it was worse than uneditable: one
+		// cluster member citing a fact that no longer resolves aborted the
+		// whole review session — every pass in the run lost, and lost again on
+		// every retry (#103). Dropping the offending refs instead would trade
+		// the abort for silent provenance loss, and those targets are usually
+		// still reachable through the commit their referrer pinned.
+		//
+		// The loser's own path is prior for the reason it always was: it is
+		// deleted immediately below and the winner cites it as lineage — that
+		// citation is the record of the merge, not a dead ref.
+		//
+		// The check is therefore structurally satisfied today. It stays for
+		// Canonicalize, and because carriedRefs is built from the operands
+		// rather than from mergedRefs, anything a later change appends to the
+		// write list here is still gated (0ee925f4).
+		canonRefs, _, gerr := gate.Apply(ctx, winnerFact.File, mergedRefs, carriedRefs)
 		if gerr != nil {
-			return nil, fmt.Errorf("dedupCluster: refs for winner %q: %w", winnerFact.File, gerr)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup merge %s rejected: %v", winnerFact.File, gerr)})
+			continue
 		}
 		fullWinner.Refs = canonRefs
 
 		// Serialize and write the winner back to git.
 		newContent, err := fact.SerializeFact(fullWinner)
 		if err != nil {
-			return nil, fmt.Errorf("dedupCluster: serialize winner %q: %w", winnerFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup serialize winner %s: %v", winnerFact.File, err)})
+			continue
 		}
 		if _, err := gs.WriteFact(ctx, agentBranch, winnerFact.File, newContent, fmt.Sprintf("dedup: merge %s into %s [%s]", loserFact.File, winnerFact.File, recipeName), "subsume"); err != nil {
-			return nil, fmt.Errorf("dedupCluster: write winner %q: %w", winnerFact.File, err)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup write winner %s: %v", winnerFact.File, err)})
+			continue
 		}
 
-		// Delete the loser from git.
-		if _, err := gs.DeleteFact(ctx, agentBranch, loserFact.File, fmt.Sprintf("dedup: remove duplicate %s (merged into %s) [%s]", loserFact.File, winnerFact.File, recipeName)); err != nil {
-			return nil, fmt.Errorf("dedupCluster: delete loser %q: %w", loserFact.File, err)
-		}
-
-		removedPaths[loserFact.File] = true
-
-		// Update the in-memory fact for the winner in case subsequent searches see it.
+		// Update the in-memory fact for the winner in case subsequent searches
+		// see it. This happens BEFORE the delete below, so the in-memory copy
+		// matches what is on the branch even if the delete is what fails.
 		updatedWinner := winnerFact
 		updatedWinner.Confidence = fullWinner.Confidence
 		updatedWinner.Sources = fullWinner.Sources
 		clusterByPath[winnerFact.File] = updatedWinner
+
+		// Delete the loser from git. A failure here leaves the winner merged
+		// and the loser still live: the pair stays a near-duplicate for this
+		// pass, and the winner's citation of it resolves either way. The loser
+		// stays in the surviving cluster, so nothing downstream is handed a
+		// path that is still there.
+		if _, err := gs.DeleteFact(ctx, agentBranch, loserFact.File, fmt.Sprintf("dedup: remove duplicate %s (merged into %s) [%s]", loserFact.File, winnerFact.File, recipeName)); err != nil {
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("dedup delete loser %s: %v", loserFact.File, err)})
+			continue
+		}
+
+		removedPaths[loserFact.File] = true
 	}
 
 	// Build surviving cluster (exclude losers).

--- a/internal/synthesize/dedup_prior_refs_test.go
+++ b/internal/synthesize/dedup_prior_refs_test.go
@@ -128,7 +128,7 @@ func TestDedupCluster_KeepsUnresolvableCarriedRefs(t *testing.T) {
 // objects — and reddens when the helper returns one slice for both. The
 // construction half, which no runtime assertion can see because a copy and a
 // derivation are indistinguishable at every input, is bound structurally by
-// TestDedupMergeRefs_CarriedIsNotBuiltFromTheWriteList below.
+// TestDedupMergeRefs_CarriedIsBuiltOnlyFromTheOperands below.
 //
 // The gate calls at the end are CONTROLS on the gate, not sabotage targets:
 // no edit to the helper can redden them. They record what the exemption does
@@ -185,34 +185,38 @@ func TestDedupMergeRefs_CarriedIsAnIndependentSnapshot(t *testing.T) {
 	require.Contains(t, err.Error(), ghost)
 }
 
-// TestDedupMergeRefs_CarriedIsNotBuiltFromTheWriteList binds the property the
+// TestDedupMergeRefs_CarriedIsBuiltOnlyFromTheOperands binds the property the
 // helper exists for, which is a property of its CONSTRUCTION and therefore
-// invisible to any runtime assertion: `carried` is derived from the operands,
-// never from `write`.
+// invisible to any runtime assertion: the carried set is derived from the
+// operands, never from the list being written.
 //
-// Both rejected shapes produce a `carried` that is element-for-element equal
-// to `write` and lives in its own array, so they satisfy every behavioural
-// check — including this file's NotSame — at every possible input:
+// The rejected shape produces a `carried` element-for-element equal to the
+// write list, in its own array, at every possible input:
 //
 //	carried = append([]string(nil), write...)   // a copy of the write list
-//	carried = slices.Clone(write)               // the same thing
 //
-// They are wrong for the reason 0ee925f4 gives: a snapshot of the write list
-// is only as good as its position, so a later change that appends a ref above
-// it is exempted and the same change below it is gated. Deriving from the
-// operands makes divergence hold wherever the append lands. That difference
-// is real and unobservable, which is exactly when a source-level check is the
-// honest instrument — the MN4/MN6 pattern, applied to one function.
-func TestDedupMergeRefs_CarriedIsNotBuiltFromTheWriteList(t *testing.T) {
+// It is wrong for the reason 0ee925f4 gives: a snapshot of the write list is
+// only as good as its position, so a later change appending a ref above it is
+// exempted from the gate and the same change below it is checked. Deriving
+// from the operands makes divergence hold wherever the append lands. The
+// difference is real and unobservable, which is when a source-level check is
+// the honest instrument — the MN4/MN6 pattern, applied to one function.
+//
+// This is a WHITELIST, and it has to be. An earlier version blacklisted the
+// identifier `write`, which left the property one refactor wide: hoist the
+// write-list construction into a local `w` — to log it, to assert on it, to
+// reuse it — build the carried set from `w`, and the helper is the rejected
+// positional-copy shape under a name the check does not know. That version
+// also reddened a pure rename of the results, with a message naming an
+// identifier that no longer existed. Reading the declaration fixes both: the
+// operands are whatever the parameters are called, and anything else an
+// assignment reaches for is a local the carried set must not be built from.
+func TestDedupMergeRefs_CarriedIsBuiltOnlyFromTheOperands(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "dedup.go", nil, 0)
 	require.NoError(t, err)
 
-	const (
-		fn      = "dedupMergeRefs"
-		carried = "carried"
-		write   = "write"
-	)
+	const fn = "dedupMergeRefs"
 
 	var decl *ast.FuncDecl
 	ast.Inspect(file, func(n ast.Node) bool {
@@ -222,6 +226,45 @@ func TestDedupMergeRefs_CarriedIsNotBuiltFromTheWriteList(t *testing.T) {
 		return decl == nil
 	})
 	require.NotNil(t, decl, "%s must exist for this check to mean anything", fn)
+
+	// The operands, as the function itself declares them: a rename must follow
+	// automatically rather than redden correct code.
+	allowed := map[string]bool{}
+	for _, f := range decl.Type.Params.List {
+		for _, n := range f.Names {
+			allowed[n.Name] = true
+		}
+	}
+	require.Greater(t, len(allowed), 0, "%s must take the operands as parameters", fn)
+
+	require.NotNil(t, decl.Type.Results, "%s must declare named results", fn)
+	var results []string
+	for _, f := range decl.Type.Results.List {
+		for _, n := range f.Names {
+			results = append(results, n.Name)
+		}
+	}
+	require.Len(t, results, 2, "%s returns the write list and the carried set, in that order", fn)
+	carried := results[1]
+	// The carried set may be built up from itself. The write list is
+	// deliberately NOT whitelisted: it must not appear here at all.
+	allowed[carried] = true
+
+	// Package qualifiers, read from this file's own imports, plus the
+	// predeclared identifiers a construction legitimately uses.
+	for _, imp := range file.Imports {
+		name := strings.Trim(imp.Path.Value, `"`)
+		if i := strings.LastIndex(name, "/"); i >= 0 {
+			name = name[i+1:]
+		}
+		if imp.Name != nil {
+			name = imp.Name.Name
+		}
+		allowed[name] = true
+	}
+	for _, b := range []string{"append", "make", "copy", "len", "cap", "nil", "string", "new"} {
+		allowed[b] = true
+	}
 
 	assignments := 0
 	ast.Inspect(decl.Body, func(n ast.Node) bool {
@@ -239,26 +282,39 @@ func TestDedupMergeRefs_CarriedIsNotBuiltFromTheWriteList(t *testing.T) {
 			return true
 		}
 		assignments++
-		for _, rhs := range as.Rhs {
-			ast.Inspect(rhs, func(n ast.Node) bool {
-				id, ok := n.(*ast.Ident)
-				if !ok || id.Name != write {
+		var check func(ast.Node) bool
+		check = func(n ast.Node) bool {
+			switch v := n.(type) {
+			case *ast.SelectorExpr:
+				// The member name (fact.UnionStrings) is not an identifier this
+				// check has an opinion about. The qualifier is, so walk only it.
+				ast.Inspect(v.X, check)
+				return false
+			case *ast.Ident:
+				if allowed[v.Name] {
 					return true
 				}
-				t.Fatalf("%s at %s builds %s from %s. A snapshot of the write list is only "+
-					"as good as the line it sits on: a later change appending a ref above "+
-					"it is silently exempted from the gate, one below it is checked "+
-					"(0ee925f4). Derive it from the operands instead.",
-					fn, fset.Position(id.Pos()), carried, write)
+				t.Fatalf("%s builds %s from %q at %s, which is neither an operand nor %s "+
+					"itself. The carried set must be derived from the parameters, where "+
+					"'this was already carried' is provably true — never from the list being "+
+					"written, nor from a local standing in for it. A snapshot of the write "+
+					"list is only as good as the line it sits on: a later change appending a "+
+					"ref above it is silently exempted from the gate, one below it is checked "+
+					"(0ee925f4).",
+					fn, carried, v.Name, fset.Position(v.Pos()), carried)
 				return false
-			})
+			}
+			return true
+		}
+		for _, rhs := range as.Rhs {
+			ast.Inspect(rhs, check)
 		}
 		return true
 	})
 
-	// A body that never assigns `carried` returns the zero value or the write
-	// list under its own name — the aliasing shape — and would otherwise pass
-	// a check that only inspects assignments.
+	// A body that never assigns the carried result returns the zero value or
+	// the write list under its own name — the aliasing shape — and would
+	// otherwise pass a check that only inspects assignments.
 	require.Greater(t, assignments, 0,
 		"%s must build %s explicitly, or there is no snapshot to speak of", fn, carried)
 }

--- a/internal/synthesize/dedup_prior_refs_test.go
+++ b/internal/synthesize/dedup_prior_refs_test.go
@@ -1,0 +1,174 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"knomit/internal/fact"
+	"knomit/internal/refs"
+	"knomit/internal/store"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fixedPairSearch is a SearchQuery whose Search returns a canned result set,
+// so a dedup pair can be forced without standing up an embedder. Every other
+// method — crucially FactExistsAt, which the ref gate resolves through — is
+// the real one.
+type fixedPairSearch struct {
+	SearchQuery
+	results []store.SearchResult
+}
+
+func (f *fixedPairSearch) Search(context.Context, string, store.SearchOptions) ([]store.SearchResult, error) {
+	return f.results, nil
+}
+
+// searchHit is a result above any dedup threshold — dedupCluster divides Score
+// by 100 to get the cosine it compares against the threshold.
+func searchHit(path string) store.SearchResult {
+	return store.SearchResult{
+		FactWithBody: store.FactWithBody{FactRecord: store.FactRecord{Path: path}},
+		Score:        96,
+	}
+}
+
+// TestDedupCluster_KeepsUnresolvableCarriedRefs regresses knomit#103: a dedup
+// merge grafts the loser's refs onto the winner and used to hand the whole
+// union to the ref gate with only the loser's path as prior, re-litigating
+// citations both facts had carried for months against today's live index. One
+// stale citation anywhere in one cluster then aborted the entire review
+// session — every pass in the run lost, not just the affected merge — and it
+// aborted again on every retry, so the corpus could never be reviewed until
+// the facts were hand-edited.
+//
+// internal/refs' contract: "A ref is checked ONCE, against the commit the write
+// lands on. Refs a fact ALREADY carried are never re-checked." A mechanical
+// merge introduces no new citation, so nothing in the union is new.
+//
+// The seeds go in through the store rather than a write path, which is not a
+// test shortcut: it is how a corpus acquires facts whose refs no longer
+// resolve — written before the gate existed, or their target retracted past
+// the walk-back horizon, or the citing repo's history rewritten. The gate's
+// `prior` parameter exists precisely because this state is real and must stay
+// editable.
+func TestDedupCluster_KeepsUnresolvableCarriedRefs(t *testing.T) {
+	ctx := context.Background()
+	svc, branch := newSourcesTestRepo(t)
+
+	const (
+		winnerPath  = "kb/technology/winner.md"
+		loserPath   = "kb/technology/loser.md"
+		winnerStale = "kb/technology/winner-cited-gone.md"
+		loserStale  = "kb/technology/loser-cited-gone.md"
+		liveRefPath = "kb/technology/still-here.md"
+	)
+
+	// Precondition: the confidences that pick the winner must actually differ,
+	// or "the winner survived" is an assertion about a coin toss.
+	const winnerConf, loserConf = 0.9, 0.5
+	require.NotEqual(t, winnerConf, loserConf)
+
+	// A real, resolvable citation alongside the stale ones, so the assertion
+	// below distinguishes "refs survived" from "ref list was emptied".
+	seedOriginFact(t, svc, branch, liveRefPath, fact.Observation, fact.Authored, 0.7, 1, nil)
+	seedOriginFact(t, svc, branch, winnerPath, fact.Observation, fact.Authored, winnerConf, 1,
+		[]string{winnerStale, liveRefPath})
+	seedOriginFact(t, svc, branch, loserPath, fact.Observation, fact.Authored, loserConf, 1,
+		[]string{loserStale})
+
+	cluster := []factForLLM{
+		{File: winnerPath, Title: "winner", Body: "b", Type: string(fact.Observation), Confidence: winnerConf, Sources: 1},
+		{File: loserPath, Title: "loser", Body: "b", Type: string(fact.Observation), Confidence: loserConf, Sources: 1},
+	}
+	idx := &fixedPairSearch{
+		SearchQuery: svc.Search(),
+		results: []store.SearchResult{
+			searchHit(winnerPath),
+			searchHit(loserPath),
+		},
+	}
+
+	surviving, err := dedupCluster(ctx, cluster, svc.Facts(), idx, 0.92, "test",
+		func(ProgressEvent) {}, branch, bareRefFixture)
+	require.NoError(t, err, "a carried ref that no longer resolves must not abort the dedup pass")
+
+	require.Len(t, surviving, 1)
+	require.Equal(t, winnerPath, surviving[0].File)
+
+	rf, err := svc.Facts().ReadFact(ctx, branch, winnerPath, nil)
+	require.NoError(t, err)
+	merged, err := fact.ParseFact(winnerPath, rf.Content)
+	require.NoError(t, err)
+
+	// Provenance survives: dropping the unresolvable refs to satisfy a check
+	// that should never have run on them destroys the lineage the merge exists
+	// to preserve.
+	require.Contains(t, merged.Refs, winnerStale, "winner's own carried ref was dropped")
+	require.Contains(t, merged.Refs, loserStale, "loser's carried ref was not grafted onto the winner")
+	require.Contains(t, merged.Refs, liveRefPath)
+	require.Contains(t, merged.Refs, loserPath, "the merge must cite the fact it subsumed")
+}
+
+// TestDedupMergeRefs_CarriedIsAnIndependentSnapshot guards 0ee925f4: passing
+// the same slice as both `refs` and `prior` to refs.Gate.Apply exempts every
+// local ref in the write, unconditionally, and the call still compiles, still
+// canonicalizes, and still reads like a gate. Because this merge's write list
+// happens to be entirely carried today, the aliased form would be correct FOR
+// TODAY'S CODE — and would launder the first ref a later change appends here.
+//
+// So the property under test is not "prior equals the write list" (it does),
+// it is "prior was built from the operands and can diverge from the write
+// list". The two assertions below are the two halves of that, and each is
+// meant to go red under its own sabotage: return `carried = write` from the
+// helper, and the aliasing check fails; build `carried` from `write` after a
+// later append, and the divergence check fails.
+func TestDedupMergeRefs_CarriedIsAnIndependentSnapshot(t *testing.T) {
+	ctx := context.Background()
+	svc, branch := newSourcesTestRepo(t)
+
+	const (
+		winnerPath = "kb/technology/winner.md"
+		loserPath  = "kb/technology/loser.md"
+		staleRef   = "kb/technology/cited-gone.md"
+		liveRef    = "kb/technology/still-here.md"
+	)
+	seedOriginFact(t, svc, branch, liveRef, fact.Observation, fact.Authored, 0.7, 1, nil)
+	seedOriginFact(t, svc, branch, loserPath, fact.Observation, fact.Authored, 0.5, 1, nil)
+
+	winnerRefs := []string{staleRef}
+	loserRefs := []string{liveRef}
+	// Precondition: the operands must carry DIFFERENT refs, or a union that
+	// dropped one of them would still look right.
+	require.NotEqual(t, winnerRefs, loserRefs)
+
+	write, carried := dedupMergeRefs(winnerRefs, loserRefs, loserPath)
+
+	// The merge's own behaviour is unchanged: union of both, plus the loser.
+	require.ElementsMatch(t, []string{staleRef, liveRef, loserPath}, write)
+
+	// Structurally satisfied today — nothing in the write list is new — which
+	// is what keeps a carried-but-unresolvable ref out of the gate's way.
+	require.ElementsMatch(t, write, carried)
+
+	// ...but not by aliasing. Same backing array means `prior` can never
+	// differ from `refs`, whatever a later change does to the write list.
+	require.NotSame(t, &write[0], &carried[0],
+		"prior must be its own list, not the write list under a second name")
+
+	gate := refs.New(bareRefFixture, refs.FromFactQuery(svc.Search(), branch))
+
+	// Positive control: the carried set, unresolvable member and all, passes.
+	// This is the #103 case and it must not be rejected.
+	_, _, err := gate.Apply(ctx, winnerPath, write, carried)
+	require.NoError(t, err, "a ref both operands carried must not be re-judged")
+
+	// The divergence the snapshot exists for: a ref the merge did not carry,
+	// of the kind a later change might append here (a lineage pointer to a
+	// synthesized parent), is still gated.
+	const ghost = "kb/technology/never-existed.md"
+	extended := append(append([]string(nil), write...), ghost)
+	_, _, err = gate.Apply(ctx, winnerPath, extended, carried)
+	require.Error(t, err, "a ref that was never carried must still be rejected")
+	require.Contains(t, err.Error(), ghost)
+}

--- a/internal/synthesize/dedup_prior_refs_test.go
+++ b/internal/synthesize/dedup_prior_refs_test.go
@@ -2,6 +2,11 @@ package synthesize
 
 import (
 	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
 	"testing"
 
 	"knomit/internal/fact"
@@ -119,10 +124,17 @@ func TestDedupCluster_KeepsUnresolvableCarriedRefs(t *testing.T) {
 //
 // So the property under test is not "prior equals the write list" (it does),
 // it is "prior was built from the operands and can diverge from the write
-// list". The two assertions below are the two halves of that, and each is
-// meant to go red under its own sabotage: return `carried = write` from the
-// helper, and the aliasing check fails; build `carried` from `write` after a
-// later append, and the divergence check fails.
+// list". This test binds the RUNTIME half — the two lists are distinct
+// objects — and reddens when the helper returns one slice for both. The
+// construction half, which no runtime assertion can see because a copy and a
+// derivation are indistinguishable at every input, is bound structurally by
+// TestDedupMergeRefs_CarriedIsNotBuiltFromTheWriteList below.
+//
+// The gate calls at the end are CONTROLS on the gate, not sabotage targets:
+// no edit to the helper can redden them. They record what the exemption does
+// and does not cover — a carried ref that no longer resolves passes, a ref
+// that was never carried is still rejected — which is the behaviour the two
+// arguments are meant to produce.
 func TestDedupMergeRefs_CarriedIsAnIndependentSnapshot(t *testing.T) {
 	ctx := context.Background()
 	svc, branch := newSourcesTestRepo(t)
@@ -163,12 +175,131 @@ func TestDedupMergeRefs_CarriedIsAnIndependentSnapshot(t *testing.T) {
 	_, _, err := gate.Apply(ctx, winnerPath, write, carried)
 	require.NoError(t, err, "a ref both operands carried must not be re-judged")
 
-	// The divergence the snapshot exists for: a ref the merge did not carry,
-	// of the kind a later change might append here (a lineage pointer to a
-	// synthesized parent), is still gated.
+	// The other half of the control: the exemption is not blanket. A ref the
+	// merge did not carry, of the kind a later change might append here (a
+	// lineage pointer to a synthesized parent), is still gated.
 	const ghost = "kb/technology/never-existed.md"
 	extended := append(append([]string(nil), write...), ghost)
 	_, _, err = gate.Apply(ctx, winnerPath, extended, carried)
 	require.Error(t, err, "a ref that was never carried must still be rejected")
 	require.Contains(t, err.Error(), ghost)
+}
+
+// TestDedupMergeRefs_CarriedIsNotBuiltFromTheWriteList binds the property the
+// helper exists for, which is a property of its CONSTRUCTION and therefore
+// invisible to any runtime assertion: `carried` is derived from the operands,
+// never from `write`.
+//
+// Both rejected shapes produce a `carried` that is element-for-element equal
+// to `write` and lives in its own array, so they satisfy every behavioural
+// check — including this file's NotSame — at every possible input:
+//
+//	carried = append([]string(nil), write...)   // a copy of the write list
+//	carried = slices.Clone(write)               // the same thing
+//
+// They are wrong for the reason 0ee925f4 gives: a snapshot of the write list
+// is only as good as its position, so a later change that appends a ref above
+// it is exempted and the same change below it is gated. Deriving from the
+// operands makes divergence hold wherever the append lands. That difference
+// is real and unobservable, which is exactly when a source-level check is the
+// honest instrument — the MN4/MN6 pattern, applied to one function.
+func TestDedupMergeRefs_CarriedIsNotBuiltFromTheWriteList(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "dedup.go", nil, 0)
+	require.NoError(t, err)
+
+	const (
+		fn      = "dedupMergeRefs"
+		carried = "carried"
+		write   = "write"
+	)
+
+	var decl *ast.FuncDecl
+	ast.Inspect(file, func(n ast.Node) bool {
+		if f, ok := n.(*ast.FuncDecl); ok && f.Name.Name == fn {
+			decl = f
+		}
+		return decl == nil
+	})
+	require.NotNil(t, decl, "%s must exist for this check to mean anything", fn)
+
+	assignments := 0
+	ast.Inspect(decl.Body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		assigns := false
+		for _, lhs := range as.Lhs {
+			if id, ok := lhs.(*ast.Ident); ok && id.Name == carried {
+				assigns = true
+			}
+		}
+		if !assigns {
+			return true
+		}
+		assignments++
+		for _, rhs := range as.Rhs {
+			ast.Inspect(rhs, func(n ast.Node) bool {
+				id, ok := n.(*ast.Ident)
+				if !ok || id.Name != write {
+					return true
+				}
+				t.Fatalf("%s at %s builds %s from %s. A snapshot of the write list is only "+
+					"as good as the line it sits on: a later change appending a ref above "+
+					"it is silently exempted from the gate, one below it is checked "+
+					"(0ee925f4). Derive it from the operands instead.",
+					fn, fset.Position(id.Pos()), carried, write)
+				return false
+			})
+		}
+		return true
+	})
+
+	// A body that never assigns `carried` returns the zero value or the write
+	// list under its own name — the aliasing shape — and would otherwise pass
+	// a check that only inspects assignments.
+	require.Greater(t, assignments, 0,
+		"%s must build %s explicitly, or there is no snapshot to speak of", fn, carried)
+}
+
+// TestFactForLLM_CarriesNoRefs pins the premise the annex §6.2 correction
+// rests on. #103 named decision.go's merge and distill gate calls as the
+// dedup sites that omit `prior`; they are not — they write NEW facts whose
+// refs are wholly LLM-authored, so there is nothing carried to exempt and
+// `prior: nil` is correct. That verdict holds only because the model never
+// sees the cluster members' citations: factForLLM is the whole of what those
+// paths show it, and it has no Refs field.
+//
+// Add one and both sites become wrong the moment the model starts copying a
+// member's refs into its output — the #103 failure, in the two places #103
+// wrongly accused, with nothing to announce the change. Reading the three
+// sites and agreeing is still a reading; this is the tripwire, and it names
+// where to look when it fires.
+func TestFactForLLM_CarriesNoRefs(t *testing.T) {
+	typ := reflect.TypeOf(factForLLM{})
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		name := strings.ToLower(f.Name)
+		tag := strings.ToLower(f.Tag.Get("json"))
+		require.NotEqualf(t, "refs", name,
+			"factForLLM.%s exposes carried refs to the LLM. decision.go's merge (:214) and "+
+				"distill (:324) gate calls pass prior: nil BECAUSE the model cannot copy a "+
+				"member's citations into its output — see the gate annex §6.2 correction and "+
+				"knomit#103. If this field is intended, those two call sites must be revisited "+
+				"in the same change.", f.Name)
+		require.NotEqualf(t, "refs", strings.Split(tag, ",")[0],
+			"factForLLM.%s is serialized to the model as %q — same consequence as a Refs "+
+				"field, see above.", f.Name, tag)
+	}
+	// Preconditions: the walk must actually be inspecting a populated struct,
+	// or an empty loop passes as a guarantee.
+	require.Greater(t, typ.NumField(), 5)
+	require.NotEqual(t, -1, func() int {
+		f, ok := typ.FieldByName("File")
+		if !ok {
+			return -1
+		}
+		return f.Index[0]
+	}(), "factForLLM must still be the struct this guards")
 }

--- a/internal/synthesize/dedup_test.go
+++ b/internal/synthesize/dedup_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"knomit/internal/fact"
 	"knomit/internal/store"
+
+	"github.com/stretchr/testify/require"
 )
 
 // ctxCapturingSearchIndex is a minimal SearchIndex stub that records
@@ -120,4 +123,63 @@ func errorsIs(err, target error) bool {
 		err = u.Unwrap()
 	}
 	return false
+}
+
+// TestDedupCluster_SkipsUnparsableMember regresses the other half of knomit#103:
+// the run must survive a bad member, not just a bad ref. dedupCluster used to
+// return an error from every per-merge step, so one cluster member whose stored
+// content no longer parses — frontmatter from an older serializer, a hand-edit
+// on the KB branch — aborted StartSession before it planned anything, and did
+// so again on every retry. Every sibling write path in decision.go and
+// discovery.go warns and continues; this one now does too.
+func TestDedupCluster_SkipsUnparsableMember(t *testing.T) {
+	ctx := context.Background()
+	svc, branch := newSourcesTestRepo(t)
+
+	const (
+		winnerPath = "kb/technology/winner.md"
+		loserPath  = "kb/technology/loser.md"
+	)
+
+	// Precondition: the confidences that decide which member is read as the
+	// winner must differ, or which one is corrupted below is a coin toss.
+	const winnerConf, loserConf = 0.9, 0.5
+	require.NotEqual(t, winnerConf, loserConf)
+
+	seedOriginFact(t, svc, branch, winnerPath, fact.Observation, fact.Authored, winnerConf, 1, nil)
+	seedOriginFact(t, svc, branch, loserPath, fact.Observation, fact.Authored, loserConf, 1, nil)
+
+	// Corrupt the loser in place: still a blob at that path, no longer a
+	// parsable fact. The cluster and the index still know about it, which is
+	// exactly the state that used to be unrecoverable.
+	_, err := svc.Facts().WriteFact(ctx, branch, loserPath, "not a fact any more\n", "corrupt", "")
+	require.NoError(t, err)
+
+	cluster := []factForLLM{
+		{File: winnerPath, Title: "winner", Body: "b", Type: string(fact.Observation), Confidence: winnerConf, Sources: 1},
+		{File: loserPath, Title: "loser", Body: "b", Type: string(fact.Observation), Confidence: loserConf, Sources: 1},
+	}
+	idx := &fixedPairSearch{
+		SearchQuery: svc.Search(),
+		results: []store.SearchResult{
+			searchHit(winnerPath),
+			searchHit(loserPath),
+		},
+	}
+
+	var warnings []string
+	surviving, err := dedupCluster(ctx, cluster, svc.Facts(), idx, 0.92, "test",
+		func(e ProgressEvent) {
+			if e.Phase == "warn" {
+				warnings = append(warnings, e.Message)
+			}
+		}, branch, bareRefFixture)
+	require.NoError(t, err, "an unparsable cluster member must cost its own merge, not the whole pass")
+
+	require.Len(t, warnings, 1, "the skipped merge must be reported, not swallowed")
+	require.Contains(t, warnings[0], loserPath)
+
+	// The merge was skipped whole: both facts are still live and still in the
+	// surviving cluster, so a later pass can try the pair again.
+	require.Len(t, surviving, 2)
 }

--- a/internal/synthesize/motif_dynamics_test.go
+++ b/internal/synthesize/motif_dynamics_test.go
@@ -191,3 +191,47 @@ func readFactFromStore(t *testing.T, e *restatementEnv, path string) fact.Fact {
 	require.NoError(t, err)
 	return f
 }
+
+// TestMotifDynamics_ReviewMergeTrimsToTheCapWinnerFirst binds the other half
+// of the merge's motif semantics through dedupCluster: the union is capped at
+// fact.MaxMotifs, and it is the WINNER's axis that survives the trim. The
+// sibling test above pins the ordering with two motifs, where nothing is
+// dropped; here the operands overflow the cap, which is the case where
+// ordering stops being cosmetic and decides what is deleted with the loser.
+func TestMotifDynamics_ReviewMergeTrimsToTheCapWinnerFirst(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+	ctx := context.Background()
+
+	winnerMotifs := []string{"stale-read-window", "silent-fallback"}
+	loserMotifs := []string{"unmonitored-expiry", "retry-storm", "cold-start-stall"}
+
+	// Preconditions: the sets must be disjoint and must overflow the cap, or
+	// "trimmed winner-first" is asserted about a union that never trimmed.
+	require.Greater(t, len(winnerMotifs)+len(loserMotifs), fact.MaxMotifs)
+	for _, w := range winnerMotifs {
+		require.NotContains(t, loserMotifs, w)
+	}
+
+	env.writeFactWithMotifsConf("kb/alpha/winner.md", "Cache invalidation on write",
+		"one account of it", winnerMotifs, 0.9)
+	env.writeFactWithMotifsConf("kb/alpha/loser.md", "Cache invalidation on write",
+		"one account of it", loserMotifs, 0.5)
+
+	cluster := []factForLLM{
+		{File: "kb/alpha/winner.md", Title: "Cache invalidation on write", Body: "one account of it",
+			Type: string(fact.Observation), Confidence: 0.9, Sources: 1},
+		{File: "kb/alpha/loser.md", Title: "Cache invalidation on write", Body: "one account of it",
+			Type: string(fact.Observation), Confidence: 0.5, Sources: 1},
+	}
+
+	out, err := dedupCluster(ctx, cluster, env.svc.Facts(), env.svc.Search(), 0,
+		"test", func(ProgressEvent) {}, env.branch, bareRefFixture)
+	require.NoError(t, err)
+	require.Len(t, out, 1, "the fixture must actually have merged, or this proves nothing")
+
+	survivor := readFactFromStore(t, env, out[0].File)
+	require.Equal(t, []string{"stale-read-window", "silent-fallback", "unmonitored-expiry"},
+		survivor.Motifs,
+		"the cap keeps the winner's whole axis and as much of the loser's as fits — "+
+			"merging loser-first would drop the winner's own motifs instead")
+}


### PR DESCRIPTION
Fixes #103. This is #104's fix ported onto the top of the motif stack (#99 → #100 → #102 → #105 → #106), so the stack merges with the fix included. #104 itself targets `dev` and its disposition is the designer's.

Not a cherry-pick: the stack's `internal/synthesize/dedup.go` differs from dev's — Phase 1 added the motif union (`fact.MergeMotifs`, winner-first, deterministic trim at 3) between the merged-field block and the ref merge. That line is untouched here, and its behaviour is now bound by two tests rather than one (below).

## ⚠️ Merge-order disclosure (#107)

This PR is what unblocks review sessions on `core`, and `core` alone carries the 61 facts of #107's class — facts whose stored `origin` is illegal for their type and is replaced by the parse default on any read-modify-write. Prune-merge's sibling path shares that round-trip shape and is **not** remediated: it has been measured on this branch silently deleting a stored `origin: distilled` line end to end. **Hold review sessions on `core` until #107's guard is decided.** Unblocking the dedup path does not make the merge path safe for that corpus; the annex §6 note says the same.

## The bug

`dedupCluster` grafts the loser's refs onto the winner and then calls the ref gate with `prior` set to the loser's path alone:

```go
mergedRefs := fact.UnionStrings(fullWinner.Refs, fullLoser.Refs)
mergedRefs = fact.AppendUnique(mergedRefs, loserFact.File)
gate.Apply(ctx, winnerFact.File, mergedRefs, []string{loserFact.File})
```

Every citation the two facts had carried from their own commits is therefore treated as newly added and re-litigated against today's live index — precisely what `internal/refs`' temporal contract forbids: *"a retraction anywhere in history makes every fact that ever cited it uneditable."*

`dedupCluster` returned the error rather than warning and skipping, so one stale citation anywhere in one cluster aborted the whole review session before it planned anything — and aborted again on every retry. A mature corpus could never be reviewed until the offending facts were hand-edited (measured on `core`: 21 of 1,688 live facts carry refs to 25 targets that no longer resolve).

## The fix

The merge introduces no new citation — everything in the union was carried by the winner, carried by the loser, or is the loser's own path — so the whole carried set goes in as `prior`. The gate call stays for `Canonicalize`, and this write path still meets the gate if a genuinely new ref is ever introduced here.

Not fixed by dropping the unresolvable refs: those targets are usually still reachable through the commit their referrer pinned, and dropping them destroys provenance to satisfy a check that should never have run.

### Deliberate deviation from #104 head's shape (designer-approved)

#104's head builds the snapshot inline as `carriedRefs := append([]string(nil), mergedRefs...)`. That is a copy of the **write list at one line**: a later change that appends a ref *above* it is silently exempted, one *below* it is gated, so the gate's usefulness depends on where the next author types.

This port keeps the identical semantics in a small pure helper that derives the carried set from the **operands**:

```go
func dedupMergeRefs(winnerRefs, loserRefs []string, loserPath string) (write, carried []string)
```

Divergence then holds by construction regardless of line order — anything a later change appends to the write list at the call site cannot reach `carried`. Recorded gotcha `0ee925f4`: passing the same slice as both `refs` and `prior` silently disables the gate.

The two shapes are *behaviourally indistinguishable* — a copy of the write list and a derivation off the operands agree element-for-element at every input, in separate arrays — so no runtime test can tell them apart, as the reviewer demonstrated by lifting the copy shape into the helper and watching the package stay green. The construction is therefore pinned at the source (`TestDedupMergeRefs_CarriedIsBuiltOnlyFromTheOperands`, the MN4/MN6 pattern applied to one function), and the contract it enforces is the strong one: **`carried` is built only from the operands, by construction of the check.** The check reads the operands from the function's own parameter list and the carried set from its second result, then requires every identifier an assignment to that result reaches for to be one of those, a package qualifier, or a predeclared builtin — so an intermediate local standing in for the write list is caught, and renaming any of them cannot redden correct code.

## Second half: failure isolation

Every per-merge step returned an error, so a member that cannot be read or parsed (frontmatter from an older serializer, a hand-edit on the KB branch) aborts `StartSession` the same way, from a different cause and just as permanently. Each step now warns and skips the pair, matching every sibling write path in `decision.go`/`discovery.go`; both facts stay live so a later pass can retry. The winner's in-memory update moves above the delete so it matches the branch even when the delete is what fails.

## Scope note

The issue's fix direction names `decision.go:214` and `:324`. Those are the prune-merge and distill paths, and their `prior = nil` is correct: both write **new** facts whose refs are wholly LLM-authored. `factForLLM` (`types.go:89`) carries no `Refs` field, so the model never sees the cluster members' citations and cannot copy them forward; both warn and skip rather than abort, so neither produces the reported symptom. `internal/mcp/learn.go`'s dedup-on-learn merge already passes the existing fact's refs as `prior`. The single site that grafts pre-existing refs — and the one that aborts — is `dedup.go`. That premise now has a tripwire rather than two agreeing readings: `TestFactForLLM_CarriesNoRefs`.

## Tests

Each guard, and the sabotage that reddens it:

| test | sabotage |
|---|---|
| `TestDedupCluster_KeepsUnresolvableCarriedRefs` | the pre-fix `prior` (loser path only) — reproduces #103's error verbatim |
| `TestDedupMergeRefs_CarriedIsAnIndependentSnapshot` | the helper returns one slice for both values |
| `TestDedupMergeRefs_CarriedIsBuiltOnlyFromTheOperands` | `carried = append([]string(nil), write...)`; `slices.Clone(write)`; building it from an intermediate local (`w := …; carried = append([]string(nil), w...)`); dropping the assignment for `return write, write`. Counter-check: renaming the results to `refsOut, priorOut` must **not** redden it |
| `TestDedupCluster_SkipsUnparsableMember` | restoring abort-on-parse-failure |
| `TestMotifDynamics_ReviewMergeTrimsToTheCapWinnerFirst` (new) | swapping `MergeMotifs`' operands — the winner's whole axis is dropped |
| `TestFactForLLM_CarriesNoRefs` | adding a `Refs` field, or any field serialized as `"refs"` |

The gate calls at the end of `TestDedupMergeRefs_CarriedIsAnIndependentSnapshot` are **controls, not sabotage targets** — no edit to the helper can redden them. They record what the exemption covers: a carried ref that no longer resolves passes; a ref that was never carried is still rejected.

The pre-existing `TestMotifDynamics_ReviewMergePreservesLoserMotifs` pins winner-first ordering and also reddens on an operand swap; the new test binds the case it does not reach, where the union overflows the cap and ordering decides what is deleted.

`internal/synthesize/review_effort_normal_test.go` is byte-identical to `dev` at every commit (MN5). Full suite green by exit code.
