### PR TITLE
fix(mcp): reject unknown argument keys, and say what the seed scan did (#122)

### DIFF
--- a/internal/mcp/args.go
+++ b/internal/mcp/args.go
@@ -3,6 +3,9 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
@@ -31,4 +34,79 @@ func unmarshalArg[T any](req mcpgo.CallToolRequest, key string, target *T) error
 		return fmt.Errorf("invalid %s format: %v", key, err)
 	}
 	return nil
+}
+
+// rejectUnknownArguments fails a call carrying an argument key the tool does
+// not declare (knomit#122).
+//
+// WHY THIS IS AN ERROR AND NOT A WARNING. An MCP tool call is a JSON object
+// with no arity check: a caller can invent a parameter, the server never reads
+// it, and the call runs a DIFFERENT, VALID, SILENT operation. On knomit-kb that
+// was `{"effort": "medium", "scope": "{\"entities\": [...]}"}` — a `scope` key,
+// which knomit_review does not have, holding stringified JSON. Every such call
+// ran as a whole-corpus incremental pass, and an unscoped completion advances
+// the review watermark, so one malformed call turned a populated corpus into
+// permanent sub-millisecond done:true walls (#121). A warning returned in a
+// field the caller is not reading would be the same silence one level up.
+//
+// ORDER MATTERS. This runs BEFORE any per-argument type validation. The
+// original proposal was to type-check the known keys, and it would not have
+// caught this bug at all: the failing key is never read, so no amount of
+// validating `domain` and `entities` sees it.
+//
+// The valid set is DERIVED FROM THE TOOL'S OWN SCHEMA rather than listed here.
+// A hand-maintained list beside the schema is a second declaration of the same
+// thing; the two drift the first time a parameter is added, and the failure
+// mode is the guard rejecting the tool's own new parameter.
+func rejectUnknownArguments(req mcpgo.CallToolRequest, tool mcpgo.Tool) error {
+	args := req.GetArguments()
+	if args == nil {
+		// Arguments were not a JSON object (GetArguments type-asserts and
+		// yields nil otherwise). There is nothing to enumerate, so there is
+		// nothing this check can say; the ordinary per-argument accessors
+		// handle it. Refusing here would reject callers on the shape of their
+		// transport rather than the content of their call.
+		return nil
+	}
+
+	var unknown []string
+	for key := range args {
+		// Transport metadata is not a caller mistake. MCP reserves `_meta`,
+		// and clients attach underscore-prefixed keys of their own accord;
+		// rejecting those would break working clients to catch a bug they do
+		// not have.
+		if strings.HasPrefix(key, "_") {
+			continue
+		}
+		if _, declared := tool.InputSchema.Properties[key]; !declared {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	// Sorted so the message is deterministic — a caller diffing two error
+	// strings should see a difference only when the calls differ.
+	sort.Strings(unknown)
+	valid := make([]string, 0, len(tool.InputSchema.Properties))
+	for key := range tool.InputSchema.Properties {
+		valid = append(valid, key)
+	}
+	sort.Strings(valid)
+
+	// The message names the offending keys AND the valid set: a caller that
+	// invented a parameter cannot correct itself from "invalid arguments", and
+	// the one that produced #121 would simply have re-sent the same call.
+	return fmt.Errorf("unknown argument %s for %s; valid arguments are: %s",
+		quotedList(unknown), tool.Name, strings.Join(valid, ", "))
+}
+
+// quotedList renders names as `"a", "b"` for an error message.
+func quotedList(names []string) string {
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = strconv.Quote(n)
+	}
+	return strings.Join(quoted, ", ")
 }

--- a/internal/mcp/args.go
+++ b/internal/mcp/args.go
@@ -61,11 +61,26 @@ func unmarshalArg[T any](req mcpgo.CallToolRequest, key string, target *T) error
 func rejectUnknownArguments(req mcpgo.CallToolRequest, tool mcpgo.Tool) error {
 	args := req.GetArguments()
 	if args == nil {
-		// Arguments were not a JSON object (GetArguments type-asserts and
-		// yields nil otherwise). There is nothing to enumerate, so there is
-		// nothing this check can say; the ordinary per-argument accessors
-		// handle it. Refusing here would reject callers on the shape of their
-		// transport rather than the content of their call.
+		// GetArguments type-asserts to map[string]any and yields nil for
+		// ANYTHING else — including `arguments` that is present but is a
+		// string, number or array. Those two cases need opposite answers.
+		//
+		// Absent arguments is legitimate: calling with none is the documented
+		// way to start a session, and there is nothing to enumerate.
+		//
+		// Present-but-not-an-object is NOT. An earlier version of this comment
+		// claimed "the ordinary per-argument accessors handle it" — they do
+		// not, they silently default, which is exactly the failure mode this
+		// function exists to close. Left unrejected, a caller sending the #121
+		// payload as a JSON string reached an unscoped whole-corpus pass and
+		// advanced the watermark: the same consequence as an unknown key, by a
+		// second route. It is wire-reachable, because mcp-go unmarshals
+		// `arguments` into a bare `any` and does no schema validation on the
+		// server path.
+		if req.GetRawArguments() != nil {
+			return fmt.Errorf("invalid arguments for %s: expected a JSON object, got %T",
+				tool.Name, req.GetRawArguments())
+		}
 		return nil
 	}
 

--- a/internal/mcp/hypothesize.go
+++ b/internal/mcp/hypothesize.go
@@ -88,6 +88,12 @@ func HypothesizeHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.C
 		if req.Params.Task != nil {
 			ctx = context.WithoutCancel(ctx)
 		}
+		// See the identical guard in ReviewHandler (knomit#122). This tool
+		// shares parseEffortAndScope and therefore the same silent-drop
+		// exposure: an unrecognised scope key runs the pass whole-corpus.
+		if err := rejectUnknownArguments(req, hypothesizeTool()); err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
 		b := repos.BindingFromContext(ctx)
 		if !b.WriteOK() {
 			return mcpgo.NewToolResultError(fmt.Sprintf(

--- a/internal/mcp/review.go
+++ b/internal/mcp/review.go
@@ -53,6 +53,15 @@ func ReviewHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 		if req.Params.Task != nil {
 			ctx = context.WithoutCancel(ctx)
 		}
+		// FIRST, before the binding gate and before any argument is read
+		// (knomit#122). A malformed call is malformed wherever it is pointed,
+		// and the harm this prevents is a call that RUNS: an unrecognised
+		// scope key made every session whole-corpus, and an unscoped
+		// completion advances the watermark. Rejecting after StartSession
+		// would be too late by exactly the write that matters.
+		if err := rejectUnknownArguments(req, reviewTool()); err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
 		b := repos.BindingFromContext(ctx)
 		if !b.WriteOK() {
 			return mcpgo.NewToolResultError(fmt.Sprintf(

--- a/internal/mcp/unknown_args_test.go
+++ b/internal/mcp/unknown_args_test.go
@@ -1,0 +1,215 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// newReviewTestRepoWithStore mirrors newLearnTestRepo but also returns the
+// store, so a test can read pipeline state (the watermark) directly rather
+// than inferring whether a session ran from the shape of a response.
+func newReviewTestRepoWithStore(t *testing.T) (*repos.RepoInstance, *store.Service) {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:         "test",
+		UID:          nextTestRepoUID(),
+		AgentBranch:  "agent/test",
+		Svc:          svc,
+		Ontology:     fact.CodeOntology(),
+		OntologyRoot: "kb",
+	})
+	return ri, svc
+}
+
+// knomit#122. An MCP tool call is a JSON object with no arity check, so a
+// caller can invent a parameter and the server runs a DIFFERENT, VALID, SILENT
+// operation. That is what happened on knomit-kb (#121): every scoped
+// knomit_review call after a context compaction carried
+//
+//	{"effort": "medium", "scope": "{\"entities\": [\"installAndRestart\"]}"}
+//
+// — a `scope` key, which does not exist on knomit_review, holding stringified
+// JSON. The key was never read, so the calls ran as WHOLE-CORPUS incremental
+// passes, and an unscoped completion ADVANCES THE WATERMARK. One malformed
+// call converted a populated corpus into permanent sub-millisecond done:true
+// walls, with hundreds of facts unreachable except via a full scan.
+//
+// The order of the fix matters and is asserted here: unknown keys are rejected
+// FIRST. Type-validating the KNOWN keys — the original proposal — would not
+// have caught this, because the failing key is never read at all.
+const (
+	// The verbatim shape of the failing call, from the operator's transcript.
+	badScopeKey   = "scope"
+	badScopeValue = `{"entities": ["installAndRestart"]}`
+)
+
+// The exact #121 payload must be refused by knomit_review, and the refusal
+// must name the offending key — a caller that invented a parameter needs to be
+// told which one, or it re-sends the same call.
+func TestReviewHandler_RejectsUnknownArgumentKey(t *testing.T) {
+	ri := newLearnTestRepo(t, fact.CodeOntology())
+	onAgent := repos.WithBranch(repos.WithRepoInstance(context.Background(), ri), "agent/test")
+
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"effort":    "medium",
+		badScopeKey: badScopeValue,
+	}
+	result, err := ReviewHandler()(onAgent, req)
+	require.NoError(t, err)
+	require.True(t, result.IsError,
+		"an unrecognised argument key must be an error, not a silent whole-corpus pass")
+
+	text := resultText(t, result)
+	require.Contains(t, text, badScopeKey, "the error names the offending key")
+	require.Contains(t, text, "entities",
+		"the error lists the valid keys, so the caller can correct itself")
+}
+
+// The assertion that actually encodes #122's severity: the malformed call must
+// not RUN. Returning an error is not enough on its own — a guard placed after
+// StartSession would still return an error, and would still have done the
+// damage. The damage has a name and a durable instrument: an unscoped session's
+// completion advances the review watermark, which is what converted knomit-kb
+// into permanent done:true walls.
+//
+// So this test reads the watermark, and it proves the instrument can move by
+// moving it: a valid unscoped call on the same repo advances it. Without that
+// second half the check would pass on a repo where the watermark never advances
+// for unrelated reasons.
+func TestReviewHandler_UnknownArgumentKeyDoesNotAdvanceWatermark(t *testing.T) {
+	ri, svc := newReviewTestRepoWithStore(t)
+	onAgent := repos.WithBranch(repos.WithRepoInstance(context.Background(), ri), "agent/test")
+	ctx := context.Background()
+
+	before, err := svc.Pipeline().GetPipelineWatermark(ctx, "review", "agent/test")
+	require.NoError(t, err)
+
+	var bad mcpgo.CallToolRequest
+	bad.Params.Arguments = map[string]any{"effort": "medium", badScopeKey: badScopeValue}
+	result, err := ReviewHandler()(onAgent, bad)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+
+	after, err := svc.Pipeline().GetPipelineWatermark(ctx, "review", "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, before, after,
+		"a rejected call must not have run a session — the watermark moved, "+
+			"which is exactly the harm #122 describes")
+
+	// The instrument works: a VALID unscoped call does advance it. Without
+	// this, an always-frozen watermark would make the check above vacuous.
+	var good mcpgo.CallToolRequest
+	good.Params.Arguments = map[string]any{"effort": "medium"}
+	result, err = ReviewHandler()(onAgent, good)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "control call must run: %s", resultText(t, result))
+
+	moved, err := svc.Pipeline().GetPipelineWatermark(ctx, "review", "agent/test")
+	require.NoError(t, err)
+	require.NotEqual(t, before, moved,
+		"control: an accepted unscoped call DOES advance the watermark, so the "+
+			"assertion above is capable of failing")
+}
+
+// Same for knomit_hypothesize: it shares parseEffortAndScope and the same
+// silent-drop exposure.
+func TestHypothesizeHandler_RejectsUnknownArgumentKey(t *testing.T) {
+	ri := newLearnTestRepo(t, fact.CodeOntology())
+	onAgent := repos.WithBranch(repos.WithRepoInstance(context.Background(), ri), "agent/test")
+
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"effort":    "medium",
+		badScopeKey: badScopeValue,
+	}
+	result, err := HypothesizeHandler()(onAgent, req)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "unrecognised key must be refused")
+	require.Contains(t, resultText(t, result), badScopeKey)
+}
+
+// The working form must keep working. This is the control that stops the fix
+// from being "reject everything": the operator's correct call — the one whose
+// sibling transcripts kept working through the same window — still runs.
+func TestReviewHandler_AcceptsDeclaredArgumentKeys(t *testing.T) {
+	ri := newLearnTestRepo(t, fact.CodeOntology())
+	onAgent := repos.WithBranch(repos.WithRepoInstance(context.Background(), ri), "agent/test")
+
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"effort":   "medium",
+		"entities": []any{"installAndRestart"},
+	}
+	result, err := ReviewHandler()(onAgent, req)
+	require.NoError(t, err)
+	require.False(t, result.IsError,
+		"the correct call form must still run: %s", resultText(t, result))
+}
+
+// Transport metadata is not a caller mistake. MCP clients attach `_meta` and
+// other underscore-prefixed keys of their own accord; rejecting those would
+// break working clients to catch a bug they do not have.
+func TestReviewHandler_AllowsUnderscorePrefixedKeys(t *testing.T) {
+	ri := newLearnTestRepo(t, fact.CodeOntology())
+	onAgent := repos.WithBranch(repos.WithRepoInstance(context.Background(), ri), "agent/test")
+
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"effort": "medium",
+		"_meta":  map[string]any{"progressToken": "abc"},
+	}
+	result, err := ReviewHandler()(onAgent, req)
+	require.NoError(t, err)
+	require.False(t, result.IsError,
+		"underscore-prefixed transport metadata must pass: %s", resultText(t, result))
+}
+
+// The allowlist is DERIVED FROM THE TOOL SCHEMA, never hand-maintained beside
+// it. A hand-written list is a second declaration of the same thing, and the
+// two drift the first time a parameter is added — at which point the new
+// parameter is rejected as unknown and the tool is broken by its own guard.
+//
+// This test drives the helper with every key each tool declares, so adding a
+// parameter to the schema cannot break it and removing the derivation would
+// fail it.
+func TestRejectUnknownArguments_AcceptsEveryDeclaredKey(t *testing.T) {
+	for _, tool := range []mcpgo.Tool{reviewTool(), hypothesizeTool()} {
+		t.Run(tool.Name, func(t *testing.T) {
+			require.NotEmpty(t, tool.InputSchema.Properties,
+				"a tool with no declared properties would make this check vacuous")
+
+			args := map[string]any{}
+			for key := range tool.InputSchema.Properties {
+				args[key] = "x"
+			}
+			var req mcpgo.CallToolRequest
+			req.Params.Arguments = args
+
+			require.NoError(t, rejectUnknownArguments(req, tool),
+				"every key the tool declares must be accepted")
+		})
+	}
+}
+
+// A call carrying no arguments at all is the documented way to start a
+// session, and must not be caught by the guard.
+func TestRejectUnknownArguments_AcceptsEmptyArguments(t *testing.T) {
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{}
+	require.NoError(t, rejectUnknownArguments(req, reviewTool()))
+}

--- a/internal/mcp/unknown_args_test.go
+++ b/internal/mcp/unknown_args_test.go
@@ -126,6 +126,87 @@ func TestReviewHandler_UnknownArgumentKeyDoesNotAdvanceWatermark(t *testing.T) {
 			"assertion above is capable of failing")
 }
 
+// The hypothesize analogue of the watermark test above, and it exists because
+// its absence was caught in review (PR #126, HIGH-2).
+//
+// TestHypothesizeHandler_RejectsUnknownArgumentKey below asserts only IsError,
+// which cannot see WHERE the guard runs: with the guard moved after the engine
+// it still returns an error, and the whole internal/mcp package stays green.
+// Verified by running exactly that sabotage.
+//
+// The harm is not hypothetical and not smaller than review's. NewHypothesizer
+// drives the SAME Pipeline.StartSession; an empty seed pool reaches
+// completeSession, and an unscoped completion advances the HYPOTHESIZE
+// watermark for that branch. Same walling mechanism, same corpus, different
+// watermark key.
+func TestHypothesizeHandler_UnknownArgumentKeyDoesNotAdvanceWatermark(t *testing.T) {
+	ri, svc := newReviewTestRepoWithStore(t)
+	onAgent := repos.WithBranch(repos.WithRepoInstance(context.Background(), ri), "agent/test")
+	ctx := context.Background()
+
+	before, err := svc.Pipeline().GetPipelineWatermark(ctx, "hypothesize", "agent/test")
+	require.NoError(t, err)
+
+	var bad mcpgo.CallToolRequest
+	bad.Params.Arguments = map[string]any{"effort": "medium", badScopeKey: badScopeValue}
+	result, err := HypothesizeHandler()(onAgent, bad)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+
+	after, err := svc.Pipeline().GetPipelineWatermark(ctx, "hypothesize", "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, before, after,
+		"a rejected call must not have run a session — the hypothesize watermark "+
+			"moved, which walls this tool exactly as #121 walled review")
+
+	// Control: a VALID unscoped call DOES advance it, so the assertion above is
+	// capable of failing.
+	var good mcpgo.CallToolRequest
+	good.Params.Arguments = map[string]any{"effort": "medium"}
+	result, err = HypothesizeHandler()(onAgent, good)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "control call must run: %s", resultText(t, result))
+
+	moved, err := svc.Pipeline().GetPipelineWatermark(ctx, "hypothesize", "agent/test")
+	require.NoError(t, err)
+	require.NotEqual(t, before, moved,
+		"control: an accepted unscoped call DOES advance the hypothesize watermark")
+}
+
+// The handler must pass its OWN tool's schema to the guard. Handing it the
+// sibling tool's schema compiles, passes every test that existed at review
+// time, and makes knomit_review reject `page`, `item_id` and
+// `completion_token` — the entire paging protocol (PR #126, MEDIUM-1).
+//
+// AcceptsEveryDeclaredKey cannot see this: it hands the helper a tool and then
+// checks that tool's own keys, so the pairing is correct by construction. That
+// is the test-calls-the-helper disguise again — this test drives the HANDLER.
+func TestReviewHandler_AcceptsPagingArgumentKeys(t *testing.T) {
+	ri := newLearnTestRepo(t, fact.CodeOntology())
+	onAgent := repos.WithBranch(repos.WithRepoInstance(context.Background(), ri), "agent/test")
+
+	// The paging protocol's three keys, which exist on knomit_review and NOT on
+	// knomit_hypothesize. session_id is present so the call is a continue —
+	// what matters is that the guard does not reject these keys.
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"session_id":       "no-such-session",
+		"page":             float64(2),
+		"item_id":          float64(7),
+		"completion_token": "tok",
+	}
+	result, err := ReviewHandler()(onAgent, req)
+	require.NoError(t, err)
+
+	// The call fails on the session, not on the arguments. Asserting the
+	// MESSAGE is the point: "IsError" is true either way, and this test exists
+	// precisely because a coarser assertion could not tell the two apart.
+	text := resultText(t, result)
+	require.NotContains(t, text, "unknown argument",
+		"the paging keys belong to knomit_review and must pass its guard — "+
+			"handing the guard the wrong tool's schema breaks paging silently")
+}
+
 // Same for knomit_hypothesize: it shares parseEffortAndScope and the same
 // silent-drop exposure.
 func TestHypothesizeHandler_RejectsUnknownArgumentKey(t *testing.T) {
@@ -206,10 +287,60 @@ func TestRejectUnknownArguments_AcceptsEveryDeclaredKey(t *testing.T) {
 	}
 }
 
-// A call carrying no arguments at all is the documented way to start a
-// session, and must not be caught by the guard.
-func TestRejectUnknownArguments_AcceptsEmptyArguments(t *testing.T) {
+// Two shapes mean "no arguments", and BOTH must pass: an empty object, and
+// Arguments left nil entirely. The nil path is the one the guard's own
+// early-return handles, and it was previously untested — an omission caught in
+// review (PR #126, LOW-2). Calling with no arguments is the documented way to
+// start a session, so a guard that rejected either shape would break the
+// tool's primary entry point.
+func TestRejectUnknownArguments_AcceptsBothNoArgumentShapes(t *testing.T) {
+	t.Run("empty object", func(t *testing.T) {
+		var req mcpgo.CallToolRequest
+		req.Params.Arguments = map[string]any{}
+		require.NoError(t, rejectUnknownArguments(req, reviewTool()))
+	})
+
+	t.Run("nil arguments", func(t *testing.T) {
+		var req mcpgo.CallToolRequest // Params.Arguments left nil
+		require.NoError(t, rejectUnknownArguments(req, reviewTool()),
+			"a call with no arguments at all starts a session and must pass")
+	})
+}
+
+// PR #126, MEDIUM-2. `arguments` that is present but NOT a JSON object
+// bypassed the guard completely: GetArguments type-asserts to map[string]any
+// and yields nil for anything else, the guard early-returned nil, and the call
+// RAN — unscoped, advancing the watermark. That is #121's exact consequence
+// reached by a second route, and the route is wire-reachable: mcp-go
+// unmarshals `arguments` into a bare `any` and performs no schema validation
+// on the server path.
+//
+// The guard's comment claimed "the ordinary per-argument accessors handle it".
+// They do not: they silently default, which is the whole failure mode.
+//
+// Ruled consistent with the hard-error decision on unknown keys — same class,
+// same silent-unscoped consequence.
+func TestReviewHandler_RejectsNonObjectArguments(t *testing.T) {
+	ri, svc := newReviewTestRepoWithStore(t)
+	onAgent := repos.WithBranch(repos.WithRepoInstance(context.Background(), ri), "agent/test")
+	ctx := context.Background()
+
+	before, err := svc.Pipeline().GetPipelineWatermark(ctx, "review", "agent/test")
+	require.NoError(t, err)
+
+	// The #121 payload, delivered as a JSON STRING rather than an object.
 	var req mcpgo.CallToolRequest
-	req.Params.Arguments = map[string]any{}
-	require.NoError(t, rejectUnknownArguments(req, reviewTool()))
+	req.Params.Arguments = `{"effort": "medium", "scope": "{\"entities\": [\"x\"]}"}`
+
+	result, err := ReviewHandler()(onAgent, req)
+	require.NoError(t, err)
+	require.True(t, result.IsError,
+		"arguments that are not a JSON object must be rejected, not silently "+
+			"treated as no arguments at all")
+
+	after, err := svc.Pipeline().GetPipelineWatermark(ctx, "review", "agent/test")
+	require.NoError(t, err)
+	require.Equal(t, before, after,
+		"the rejected call must not have run — this is #121's consequence "+
+			"reached by a second route")
 }

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -414,9 +414,6 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 
 // ── seed scan ─────────────────────────────────────────────────────────────
 
-// dirtyFacts returns the session's seed facts: everything changed since this
-// tool's watermark, or the whole (strategy-filtered) corpus on a full scan.
-//
 // seedScan describes HOW a seed pool was produced: which of the two scan paths
 // ran, what the watermark was at the time, and whether a scope was active.
 //
@@ -444,6 +441,9 @@ const (
 	seedScanIncremental = "incremental"
 )
 
+// dirtyFacts returns the session's seed facts: everything changed since this
+// tool's watermark, or the whole (strategy-filtered) corpus on a full scan.
+//
 // First run (no watermark): uses the search index to retrieve facts without
 // reading every file from git.
 // Incremental (has watermark): uses DiffFiles to read only changed paths.

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -152,11 +152,16 @@ func (p *Pipeline) StartSession(ctx context.Context) (*PipelineResult, error) {
 	}
 
 	t := time.Now()
-	seeds, err := p.dirtyFacts(ctx, branch, d.Facts, d.Search, d.Pipeline)
+	seeds, scan, err := p.dirtyFacts(ctx, branch, d.Facts, d.Search, d.Pipeline)
 	if err != nil {
 		return nil, wrapf(tool, err, "dirty facts")
 	}
+	// scoped/path/watermark ride this line because seeds+elapsed alone cannot
+	// tell a finished corpus from a call whose scope was silently dropped
+	// (knomit#122). With them, #121's week of forensics is one grep.
 	log.Info().Str("tool", tool).Str("session", sess.ID).Int("seeds", len(seeds)).
+		Bool("scoped", scan.Scoped).Str("scan_path", scan.Path).
+		Str("watermark", scan.Watermark).
 		Dur("elapsed", time.Since(t)).Msg("pipeline: seed scan")
 
 	// An empty seed pool completes the session immediately — which still runs
@@ -412,6 +417,33 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 // dirtyFacts returns the session's seed facts: everything changed since this
 // tool's watermark, or the whole (strategy-filtered) corpus on a full scan.
 //
+// seedScan describes HOW a seed pool was produced: which of the two scan paths
+// ran, what the watermark was at the time, and whether a scope was active.
+//
+// It exists because the seed-scan log line carried only `seeds` and `elapsed`,
+// and those two numbers cannot distinguish "this corpus is finished" from "this
+// call lost its scope and diffed HEAD against HEAD" (knomit#122). Recovering
+// the difference after the fact took: reading a DB column for the scoped flag,
+// inferring the path from wall-clock timing, and solving for the watermark by
+// counting commit-log entries against candidate cutoffs until one matched the
+// seed count. All three values are known here, at the moment the decision is
+// made, and none of them was being written down.
+//
+// Reported for both paths, including the watermark on a scoped run where it did
+// NOT gate the scan: its value is the diagnostic — a watermark sitting at HEAD
+// is what makes every later unscoped call a no-op — not whether this particular
+// call consulted it.
+type seedScan struct {
+	Path      string // seedScanFull or seedScanIncremental
+	Watermark string // empty on a first run; the hash diffed against otherwise
+	Scoped    bool
+}
+
+const (
+	seedScanFull        = "full"
+	seedScanIncremental = "incremental"
+)
+
 // First run (no watermark): uses the search index to retrieve facts without
 // reading every file from git.
 // Incremental (has watermark): uses DiffFiles to read only changed paths.
@@ -422,13 +454,16 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 // load-bearing: discovery seeding excludes origin=discovered facts, and
 // dropping Origin here previously let a discovered fact seed its own
 // discovery.
-func (p *Pipeline) dirtyFacts(ctx context.Context, branch string, gs store.FactIndex, idx SearchQuery, pipelineIdx store.PipelineIndex) ([]fact.Fact, error) {
+func (p *Pipeline) dirtyFacts(ctx context.Context, branch string, gs store.FactIndex, idx SearchQuery, pipelineIdx store.PipelineIndex) ([]fact.Fact, seedScan, error) {
 	tool := p.strategy.Tool()
 
 	watermark, err := pipelineIdx.GetPipelineWatermark(ctx, tool, branch)
 	if err != nil {
-		return nil, fmt.Errorf("get watermark: %w", err)
+		return nil, seedScan{}, fmt.Errorf("get watermark: %w", err)
 	}
+	// Recorded before the branch below, so the two agree by construction: the
+	// same expression that CHOOSES the path is the one that names it.
+	scan := seedScan{Watermark: watermark, Scoped: !p.scope.IsEmpty()}
 
 	// Full-scan path, taken when EITHER:
 	//   - no watermark → first run, all facts are dirty; or
@@ -442,6 +477,7 @@ func (p *Pipeline) dirtyFacts(ctx context.Context, branch string, gs store.FactI
 	//     scoped is exempt from both
 	//     (decisions/architecture/synthesize/scope-filter).
 	if watermark == "" || !p.scope.IsEmpty() {
+		scan.Path = seedScanFull
 		// Scope is applied in Go via p.scope.Matches, NOT pushed into
 		// SearchOptions: store.Search ANDs its domain+entity clauses
 		// (intersection) and canonicalises domains, whereas the filter is
@@ -450,7 +486,7 @@ func (p *Pipeline) dirtyFacts(ctx context.Context, branch string, gs store.FactI
 		// the same scope yields the same seed pool regardless of watermark.
 		results, err := idx.Search(ctx, branch, p.strategy.SeedQuery())
 		if err != nil {
-			return nil, fmt.Errorf("search all: %w", err)
+			return nil, scan, fmt.Errorf("search all: %w", err)
 		}
 		seeds := make([]fact.Fact, 0, len(results))
 		for _, sr := range results {
@@ -463,13 +499,14 @@ func (p *Pipeline) dirtyFacts(ctx context.Context, branch string, gs store.FactI
 			}
 			seeds = append(seeds, f)
 		}
-		return seeds, nil
+		return seeds, scan, nil
 	}
 
 	// Incremental: only changed facts since watermark.
+	scan.Path = seedScanIncremental
 	added, modified, _, err := gs.DiffFiles(ctx, branch, watermark)
 	if err != nil {
-		return nil, fmt.Errorf("diff files: %w", err)
+		return nil, scan, fmt.Errorf("diff files: %w", err)
 	}
 
 	var seeds []fact.Fact
@@ -493,7 +530,7 @@ func (p *Pipeline) dirtyFacts(ctx context.Context, branch string, gs store.FactI
 		}
 		seeds = append(seeds, f)
 	}
-	return seeds, nil
+	return seeds, scan, nil
 }
 
 // factFromSearchResult projects a search hit into a fact.Fact so the full-scan

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -262,7 +262,7 @@ func (r *Reviewer) storeIndices() (store.FactIndex, SearchQuery, store.PipelineI
 // whole epistemic corpus on a full scan), projected onto the prompt-facing
 // shape the review path works in.
 func (r *Reviewer) dirtyFacts(ctx context.Context, branch string, gs store.FactIndex, idx SearchQuery, pipelineIdx store.PipelineIndex) ([]factForLLM, error) {
-	seeds, err := r.p.dirtyFacts(ctx, branch, gs, idx, pipelineIdx)
+	seeds, _, err := r.p.dirtyFacts(ctx, branch, gs, idx, pipelineIdx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/synthesize/seed_scan_fields_test.go
+++ b/internal/synthesize/seed_scan_fields_test.go
@@ -1,0 +1,87 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// knomit#122 fix (b). The seed-scan log line carried `seeds` and `elapsed` and
+// nothing else, so when knomit-kb walled (#121) the three facts that actually
+// explained it — was the call scoped, which path did the scan take, and what
+// was the watermark — had to be reconstructed: the scoped flag from a DB
+// column, the path from wall-clock timing (sub-millisecond ⇒ empty diff,
+// 15–172 ms ⇒ full scan), and the watermark by counting commit-log entries
+// against candidate cutoffs until one matched the seed count exactly.
+//
+// All three are known inside dirtyFacts at the moment it decides. These tests
+// pin them to the decision rather than to the log format, so the values stay
+// correct even if the line is later reworded.
+func TestSeedScan_ReportsPathScopeAndWatermark(t *testing.T) {
+	ctx := context.Background()
+	branch := "agent/test"
+
+	// No watermark: the first run is a full scan by definition, and there is no
+	// watermark to report.
+	t.Run("first run is a full scan with no watermark", func(t *testing.T) {
+		r, svc := newPhaseTestReviewer(t)
+		writeKindFact(t, svc, branch, "kb/technology/a.md", fact.Epistemic, fact.Observation)
+
+		gs, idx, pipelineIdx, _ := r.storeIndices()
+		_, scan, err := r.p.dirtyFacts(ctx, branch, gs, idx, pipelineIdx)
+		require.NoError(t, err)
+
+		require.Equal(t, seedScanFull, scan.Path)
+		require.False(t, scan.Scoped)
+		require.Empty(t, scan.Watermark, "there is no watermark on a first run")
+	})
+
+	// A watermark and no scope: the incremental path, and the watermark it
+	// diffed against is reported. This is the combination that produced #121's
+	// walls, and the hash is what would have named it.
+	t.Run("watermark without scope takes the incremental path", func(t *testing.T) {
+		r, svc := newPhaseTestReviewer(t)
+		writeKindFact(t, svc, branch, "kb/technology/base.md", fact.Epistemic, fact.Observation)
+		head, err := svc.Branches().HeadCommit(ctx, branch)
+		require.NoError(t, err)
+		require.NoError(t, svc.Pipeline().SetPipelineWatermark(ctx, "review", branch, head))
+		writeKindFact(t, svc, branch, "kb/technology/b.md", fact.Epistemic, fact.Observation)
+
+		gs, idx, pipelineIdx, _ := r.storeIndices()
+		_, scan, err := r.p.dirtyFacts(ctx, branch, gs, idx, pipelineIdx)
+		require.NoError(t, err)
+
+		require.Equal(t, seedScanIncremental, scan.Path)
+		require.False(t, scan.Scoped)
+		require.Equal(t, head, scan.Watermark,
+			"the incremental path reports the watermark it diffed against")
+	})
+
+	// A scope forces the full scan even WITH a watermark (the scoped exemption).
+	// Reporting both the scope flag and the path is what makes the exemption
+	// visible in the log instead of inferable from timing: #121's diagnosis
+	// turned on exactly this pair disagreeing with the operator's belief.
+	t.Run("scope forces a full scan even with a watermark", func(t *testing.T) {
+		r, svc := newPhaseTestReviewer(t)
+		writeKindFact(t, svc, branch, "kb/technology/base.md", fact.Epistemic, fact.Observation)
+		head, err := svc.Branches().HeadCommit(ctx, branch)
+		require.NoError(t, err)
+		require.NoError(t, svc.Pipeline().SetPipelineWatermark(ctx, "review", branch, head))
+
+		r.p.scope = ScopeFilter{Domain: []string{"technology"}}
+
+		gs, idx, pipelineIdx, _ := r.storeIndices()
+		_, scan, err := r.p.dirtyFacts(ctx, branch, gs, idx, pipelineIdx)
+		require.NoError(t, err)
+
+		require.Equal(t, seedScanFull, scan.Path,
+			"a scoped run is exempt from the watermark on the read side")
+		require.True(t, scan.Scoped)
+		require.Equal(t, head, scan.Watermark,
+			"the watermark is reported even when it did not gate the scan — "+
+				"its VALUE is the diagnostic, not whether it was used")
+	})
+}

--- a/internal/synthesize/seed_scan_log_test.go
+++ b/internal/synthesize/seed_scan_log_test.go
@@ -1,0 +1,113 @@
+package synthesize
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// PR #126, HIGH-1 + MEDIUM-3. Fix (b)'s deliverable is the LOG LINE, and the
+// line had no coverage at all: seed_scan_fields_test.go pins the seedScan
+// struct, but nothing pinned what StartSession actually emits.
+//
+// Two distinct gaps, both closed here.
+//
+// HIGH-1 — the label VALUES were pinned by nothing. Every assertion compared
+// scan.Path against the constants seedScanFull/seedScanIncremental, so
+// swapping the constants' values ("full" ⇄ "incremental") was invisible BY
+// CONSTRUCTION and left the suite fully green. The log could then mislabel
+// which path ran — the exact diagnostic #121 needed — with no test failing.
+//
+// So the assertions below name "full" and "incremental" as STRING LITERALS at
+// the assertion site. Reaching them through the constants would re-create the
+// same non-assertion in a new shape: a test that reaches the thing under test
+// through the thing under test pins nothing.
+//
+// MEDIUM-3 — the three field BINDINGS were pinned by nothing either. Swapping
+// or inverting them at the log call left the suite green, so the line could
+// report the wrong scoped flag or the watermark under the wrong key.
+//
+// Asserting field NAMES as well as values is deliberate: an operator greps for
+// these names, and #121's diagnosis was reconstructed by arithmetic precisely
+// because they did not exist.
+func TestSeedScanLogLine_CarriesScopedPathAndWatermark(t *testing.T) {
+	ctx := context.Background()
+	const branch = "agent/test"
+
+	t.Run("unscoped incremental run", func(t *testing.T) {
+		r, svc := newPhaseTestReviewer(t)
+		writeKindFact(t, svc, branch, "kb/technology/base.md", fact.Epistemic, fact.Observation)
+		head, err := svc.Branches().HeadCommit(ctx, branch)
+		require.NoError(t, err)
+		require.NoError(t, svc.Pipeline().SetPipelineWatermark(ctx, "review", branch, head))
+		writeKindFact(t, svc, branch, "kb/technology/b.md", fact.Epistemic, fact.Observation)
+
+		line := captureSeedScanLine(t, func() { _, _ = r.StartSession(ctx) })
+
+		require.Equal(t, "incremental", line["scan_path"],
+			`the literal is asserted here on purpose: comparing against `+
+				`seedScanIncremental would pass even with the constants' values swapped`)
+		require.Equal(t, false, line["scoped"])
+		require.Equal(t, head, line["watermark"])
+	})
+
+	t.Run("scoped run is a full scan", func(t *testing.T) {
+		r, svc := newPhaseTestReviewer(t)
+		writeKindFact(t, svc, branch, "kb/technology/base.md", fact.Epistemic, fact.Observation)
+		head, err := svc.Branches().HeadCommit(ctx, branch)
+		require.NoError(t, err)
+		require.NoError(t, svc.Pipeline().SetPipelineWatermark(ctx, "review", branch, head))
+		r.p.scope = ScopeFilter{Domain: []string{"technology"}}
+
+		line := captureSeedScanLine(t, func() { _, _ = r.StartSession(ctx) })
+
+		require.Equal(t, "full", line["scan_path"],
+			"literal, for the same reason as above")
+		require.Equal(t, true, line["scoped"],
+			"the scoped flag is the field that told #121's forensics which calls "+
+				"had lost their scope")
+		require.Equal(t, head, line["watermark"],
+			"reported on the scoped path too: its VALUE is the diagnostic, not "+
+				"whether this call consulted it")
+	})
+}
+
+// captureSeedScanLine runs fn with the global logger redirected, and returns
+// the decoded "pipeline: seed scan" line.
+//
+// It asserts the line was emitted at all: a capture helper that returned an
+// empty map when nothing was logged would make every assertion above vacuous —
+// which is the failure mode this whole test exists to close.
+func captureSeedScanLine(t *testing.T, fn func()) map[string]any {
+	t.Helper()
+
+	var buf bytes.Buffer
+	prev := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.InfoLevel)
+	t.Cleanup(func() { log.Logger = prev })
+
+	fn()
+
+	for _, raw := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			continue
+		}
+		if entry["message"] == "pipeline: seed scan" {
+			return entry
+		}
+	}
+	t.Fatal("no 'pipeline: seed scan' line was logged — every assertion on it " +
+		"would otherwise be vacuous")
+	return nil
+}


### PR DESCRIPTION
Closes #122. Base of the bug-fix campaign's stacked PRs — everything else stacks on this branch.

## The bug

An MCP tool call is a JSON object with **no arity check**, so a caller can invent a parameter and the server runs a *different, valid, silent* operation. On knomit-kb every `knomit_review` call after a context compaction carried:

```json
{"effort": "medium", "scope": "{\"entities\": [\"installAndRestart\"]}"}
```

A `scope` key — which `knomit_review` does not have — holding stringified JSON. It was never read, so the calls ran as whole-corpus **incremental** passes. An unscoped completion **advances the review watermark**, so one malformed call converted a populated corpus into permanent sub-millisecond `done:true` walls, with ~288 facts unreachable except via a full scan (#121).

This is a class, not one bug.

## (a) Unknown argument keys are an error

Rejected with a message naming the offending keys *and* the valid set — a caller that invented a parameter cannot correct itself from "invalid arguments", and the one that produced #121 would simply have re-sent the same call.

**Order matters and is asserted.** The original proposal was to type-check the *known* keys. That would not have caught this bug at all: the failing key is never read. Reject-unknown comes first; type validation of known keys is a second, narrower guard for later.

**The allowlist is derived from the tool's own `InputSchema.Properties`**, never listed beside it. A hand-maintained list is a second declaration of the same thing, and its failure mode is the guard rejecting the tool's own newly-added parameter. A test drives every declared key of both tools so the derivation cannot be quietly replaced.

`_`-prefixed keys (`_meta`) are allowlisted — transport metadata is not a caller mistake. Scoped to `knomit_review` and `knomit_hypothesize`, the two tools with measured evidence; the server-wide class is recorded on the issue rather than widened here.

**Placement:** before the binding gate and before any argument is read. A malformed call is malformed wherever it is pointed, and the harm prevented is a call that **runs** — rejecting after `StartSession` would be too late by exactly the write that matters.

## (b) The seed-scan log line says what it did

It carried `seeds` and `elapsed`, which cannot distinguish a finished corpus from a call whose scope was dropped. It now also carries `scoped`, `scan_path` (full vs incremental) and the `watermark` hash.

All three were known inside `dirtyFacts` at the moment it decided, and none was written down. Recovering them after the fact took a DB column, wall-clock inference (sub-millisecond ⇒ empty diff; 15–172 ms ⇒ full scan), and solving for the watermark by counting commit-log entries against candidate cutoffs until one matched the seed count exactly.

`dirtyFacts` now returns a `seedScan`, so the values are pinned to the **decision** rather than to the log format. The watermark is reported on the scoped path too, where it did not gate the scan: its *value* is the diagnostic — a watermark sitting at HEAD is what makes every later unscoped call a no-op — not whether this call consulted it.

## (c) Deferred, deliberately

The health line on the `len(seeds)==0` return is **not** here. It merges into #115 and ships with the planning-gate change, per the forensic report's own framing that it "closes #115's user-visible half". Split apart, each half is broken: the gate fix without the line leaves the completion ambiguity #115 measured; the line without the gate fix leaves backfill starved on a hydrated corpus.

## Review round 1 — findings closed

Checkpoint-1 review (review-pr-1) confirmed the headline watermark test load-bearing repo-wide, the schema derivation by probe, and MN5/MN13 independently. Seven findings; all closed in commit `1bb0abe2`:

- **HIGH-2** — the flagged sabotage was **uncaught on `knomit_hypothesize`**: moving that guard after the engine left `internal/mcp` fully green, because its test asserted only `IsError`. Same `Pipeline.StartSession`, same walling mechanism, different watermark key. Added the hypothesize analogue with its control call.
- **HIGH-1 / MEDIUM-3** — fix (b)'s deliverable, the **log line**, had zero coverage: the constants' values and the three field bindings were each pinned by nothing. Added a zerolog-capture test asserting field names **and** values, with the path values as string literals at the assertion site.
- **MEDIUM-1** — the handler could be handed the **wrong tool's schema** and nothing noticed, which would make `knomit_review` reject the entire paging protocol. Added a handler-level test.
- **MEDIUM-2** — non-object `arguments` **bypassed the guard entirely and still advanced the watermark**; reproduced end-to-end with the #121 payload as a JSON string. Now a hard error. The comment claiming the accessors handled it was wrong and is replaced.
- **LOW-1 / LOW-2** — `dirtyFacts`' doc summary restored above its func; the no-arguments test retargeted to cover the previously untested nil path.

### Known residue in the MEDIUM-2 fix — recorded, not built (ruled)

A **typed nil map** (`map[string]any(nil)`) as `arguments` trips the new reject branch and produces a self-contradicting message: *"expected a JSON object, got map[string]interface {}"*. `GetArguments`' type assertion succeeds and yields a nil map, so the `args == nil` branch is taken, while `GetRawArguments()` is a non-nil interface holding a nil map — so the raw check fires.

**Not wire-reachable:** JSON `null` unmarshals into `any` as an untyped nil, not a typed nil map, so no client can produce this shape. It is reachable only by a Go caller constructing the request directly.

Left unfixed deliberately, on a checkpoint the reviewer has closed — adding code here would re-open a verified commit for a defect no caller can reach. The one-line fix is named so it is not rediscovered: **treat a nil map as no-arguments before the raw check**. It rides the next commit that touches `args.go` for other reasons.

## ⚠️ Reviewer: check this hardest

**Asserting that the call returns an error proves nothing about WHEN the guard runs.** A guard placed after `StartSession` still returns an error — and still does the damage.

`TestReviewHandler_UnknownArgumentKeyDoesNotAdvanceWatermark` is the only test that catches that. It reads the **watermark** rather than the response, and includes a control call proving the watermark can actually move (otherwise it would pass vacuously on a repo where the watermark never advances). Under the sabotage that moves the guard after the session, **every other test in this PR still passed**.

## Sabotage evidence

Each guard was deliberately broken and observed failing.

> **Table corrected after checkpoint-1 review.** One row was imprecise about what it sabotaged; see the note beneath. Each row now names the sabotage exactly enough to reproduce.

| sabotage | caught by |
|---|---|
| `rejectUnknownArguments` returns `nil` always | both handler rejection tests — witnessed at RED, before implementing |
| **review guard moved after `StartSession`, still returning the error** | **two** tests, both asserting the watermark: `TestReviewHandler_UnknownArgumentKeyDoesNotAdvanceWatermark` and `TestReviewHandler_RejectsNonObjectArguments`. (At `55add786` this was repo-wide unique to the first — reviewer-confirmed across all 49 packages. The MEDIUM-2 fix in `1bb0abe2` added the second catch; re-derived at that commit.) |
| **hypothesize guard moved after the engine, still returning the error** | **only** `TestHypothesizeHandler_UnknownArgumentKeyDoesNotAdvanceWatermark` |
| `ReviewHandler` passes `hypothesizeTool()` instead of `reviewTool()` | **only** `TestReviewHandler_AcceptsPagingArgumentKeys` |
| underscore allowlist removed | `TestReviewHandler_AllowsUnderscorePrefixedKeys` |
| schema derivation replaced by a hand-written list | `TestRejectUnknownArguments_AcceptsEveryDeclaredKey` — names the drifted keys (`completion_token`, `item_id`, `page`) |
| non-object `arguments` accepted (guard early-returns nil) | **only** `TestReviewHandler_RejectsNonObjectArguments` — watermark moves |
| the constants' VALUES swapped (`seedScanFull = "incremental"`, vice versa) | **only** `TestSeedScanLogLine_CarriesScopedPathAndWatermark` — both subtests |
| the three log field bindings inverted/swapped at the call | **only** `TestSeedScanLogLine_CarriesScopedPathAndWatermark` — both subtests |
| which constant each scan branch ASSIGNS swapped, + `Scoped` hardcoded false | all three `TestSeedScan_ReportsPathScopeAndWatermark` subtests |

**Correction, recorded rather than quietly amended.** The last row previously read "scan path labels swapped + `Scoped` hardcoded false". "Labels swapped" was ambiguous. As *executed* it swapped which constant each branch **assigns**, and that does redden all three subtests — re-run and confirmed. Read the other way — swapping the constants' **values** — it reddened nothing, because every assertion compared against the constants rather than the literals.

The row was not wrong about what was run; it was imprecise about what was run, and the reviewer's reading found a real uncovered gap that the executed sabotage could not have. Both sabotages are now listed separately, and the value-swap is covered by the new log-line test.

## Attestations

- **MN5** — `internal/synthesize/review_effort_normal_test.go` is byte-identical. Verified two ways: `git diff --name-only dev -- <path>` is empty, and `TestConformance_BridgeFilesUntouched` passes with a non-empty diff (so it is not passing vacuously).
- **MN13** — no numeric constant added. The two new constants are path labels (`"full"`, `"incremental"`), not thresholds and not corpus properties.
- Full suite: 49 packages ok. `go vet` clean. `gofmt` clean.

## Operational trap for anyone testing against a live corpus

HEAD has moved off the frozen watermark, so an unscoped probe now returns a small non-zero result — **the recent commits, not the backlog draining**. The motif-less epistemic facts still sit behind the watermark, reachable only via a scoped call or a deliberate watermark reset. "Unscoped works now" reads a different phenomenon than the wall did.
