### PR TITLE
fix(synthesize): plan level-triggered work on an empty dirty set, and say why an empty return is empty (#115, #122c)

### DIFF
--- a/internal/synthesize/level_triggered_planning_test.go
+++ b/internal/synthesize/level_triggered_planning_test.go
@@ -114,8 +114,21 @@ func TestStartSession_EmptyDirtySetAtNormalEffortStillCompletes(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, targets, "precondition: same corpus, backfill pool non-empty")
 
-	// 1. The predicate itself, directly. This is the assertion that fails the
-	// moment the effort gate leaves HasLevelTriggeredWork, wherever it goes.
+	// 1. The predicate itself, directly.
+	//
+	// KEPT DELIBERATELY, and not redundant with assertion 2. Review flagged it
+	// as the test-calls-the-helper disguise and over-specified — a
+	// behaviour-equivalent refactor moving the gate into planLevelTriggered
+	// would fail it. That refactor is not behaviour-equivalent as far as this
+	// package is concerned: levelTriggeredStrategy's doc comment states that
+	// THE IMPLEMENTATION OWNS ITS OWN GATING and that review's must return
+	// false below EffortMedium. This assertion pins that interface contract,
+	// which exists so a future strategy author knows where gating belongs;
+	// assertion 2 pins the wiring. They fail for different reasons.
+	//
+	// If it ever does fail spuriously, the fix is to move the contract, not to
+	// delete the assertion — assertion 2 would still pass with the gate in the
+	// wrong place for the next strategy that copies this one.
 	d := r.p.deps()
 	has, err := reviewStrategy{}.HasLevelTriggeredWork(ctx, d, branch)
 	require.NoError(t, err)
@@ -124,16 +137,53 @@ func TestStartSession_EmptyDirtySetAtNormalEffortStillCompletes(t *testing.T) {
 			"corpus: backfill fires on every fact there, which is the corpus MN5's "+
 			"test uses (invariants/synthesize/motif/effort-amendment)")
 
-	// 2. The path actually taken. The early-exit path is the one that appends
-	// the empty-seed health line; the plan path never does. So the presence of
-	// that line is proof the session completed WITHOUT planning — which
-	// `res.Done` alone cannot tell you, since both paths end done.
+	// 2. The path actually taken — asserted by CONTENT, not by non-emptiness.
+	//
+	// An earlier version asserted only `require.NotEmpty(res.Health)`, which
+	// is INERT: under the effort-gate sabotage the Plan path populates Health
+	// with the restatement/abstraction block, so Health is non-empty on both
+	// paths and the assertion could never fail (PR #128, MEDIUM-1). Only the
+	// early-exit path emits this sentence.
 	res, err := r.StartSession(ctx)
 	require.NoError(t, err)
 	require.True(t, res.Done)
-	require.NotEmpty(t, res.Health,
+	require.Contains(t, strings.Join(res.Health, "\n"), "review found nothing",
 		"the session must complete via the early-exit path, not by planning "+
 			"an empty queue and completing at the end of it")
+}
+
+// emptySeedHealth's THIRD branch — a first-run full scan (no watermark, no
+// scope) that matched no eligible facts — was untested (PR #128, LOW-2).
+//
+// Driven directly rather than through StartSession because the situation is
+// awkward to stage end-to-end and the branch is pure: it maps a seedScan onto
+// a sentence. What matters is that all three cases are distinguishable and
+// that this one blames neither the watermark nor a scope, because on a first
+// run neither is the reason.
+func TestEmptySeedHealth_DistinguishesAllThreeCases(t *testing.T) {
+	scoped := strings.Join(emptySeedHealth(seedScan{Scoped: true, Path: seedScanFull}), "\n")
+	require.Contains(t, scoped, "scope")
+	require.NotContains(t, scoped, "watermark")
+
+	incremental := strings.Join(emptySeedHealth(
+		seedScan{Path: seedScanIncremental, Watermark: "abcdef1234567890"}), "\n")
+	require.Contains(t, incremental, "watermark")
+	require.Contains(t, incremental, "abcdef12", "the hash is carried, abbreviated")
+
+	// First run: no watermark to blame, no scope to widen.
+	firstRun := strings.Join(emptySeedHealth(seedScan{Path: seedScanFull}), "\n")
+	require.NotEmpty(t, firstRun, "the third case must say something too")
+	require.NotContains(t, firstRun, "watermark",
+		"there is no watermark on a first run — naming one sends the reader to "+
+			"a mechanism that was not involved")
+	require.NotContains(t, firstRun, "scope",
+		"an unscoped run must not blame a scope")
+
+	// All three sentences differ: an operator must be able to tell which case
+	// they are in from the line alone, which is the whole point of #122(c).
+	require.NotEqual(t, scoped, incremental)
+	require.NotEqual(t, scoped, firstRun)
+	require.NotEqual(t, incremental, firstRun)
 }
 
 // knomit#122 fix (c), merged here because it is #115's user-visible half. An
@@ -170,20 +220,36 @@ func TestStartSession_EmptyReturnSaysWhyItIsEmpty(t *testing.T) {
 	// Case 2: a scope that matches nothing. Same done:true shape, different
 	// cause, and the operator needs to tell them apart — this is the pair the
 	// #115 comment measured as ambiguous exactly when it mattered.
-	t.Run("scope matched no facts", func(t *testing.T) {
-		r, _, _ := newQuietCorpusReviewer(t, EffortNormal)
-		r.p.scope = ScopeFilter{Entities: []string{"nothing-has-this-entity"}}
+	//
+	// PARAMETERIZED OVER BOTH EFFORTS, and that is the point of this subtest's
+	// current shape (PR #128, MEDIUM-2). At EffortNormal the effort gate
+	// suppresses the level-triggered path, so the scoped sentence appeared to
+	// be covered while being unreachable at the efforts that actually run
+	// vocabulary work. Measured before the fix: EffortMedium with a scope
+	// matching nothing returned done=false and planned backfill over facts
+	// ALL OUTSIDE the named scope, with no scoped sentence anywhere.
+	//
+	// A scoped session must never silently widen into a corpus-wide one. That
+	// is the #122 family's own rule, and this fix had broken it in the course
+	// of fixing a sibling case.
+	for _, effort := range []Effort{EffortNormal, EffortMedium} {
+		t.Run("scope matched no facts at effort "+string(effort), func(t *testing.T) {
+			r, _, _ := newQuietCorpusReviewer(t, effort)
+			r.p.scope = ScopeFilter{Entities: []string{"nothing-has-this-entity"}}
 
-		res, err := r.StartSession(ctx)
-		require.NoError(t, err)
-		require.True(t, res.Done)
+			res, err := r.StartSession(ctx)
+			require.NoError(t, err)
+			require.True(t, res.Done,
+				"a scope matching no facts must COMPLETE, never become a "+
+					"corpus-wide session over facts outside the scope")
 
-		health := strings.Join(res.Health, "\n")
-		require.NotEmpty(t, res.Health)
-		require.Contains(t, health, "scope",
-			"a scoped empty return must say the SCOPE matched nothing, not blame the watermark")
-		require.NotContains(t, health, "watermark",
-			"a scoped run is exempt from the watermark on both halves — "+
-				"naming it here would send the reader to the wrong mechanism")
-	})
+			health := strings.Join(res.Health, "\n")
+			require.NotEmpty(t, res.Health)
+			require.Contains(t, health, "scope",
+				"a scoped empty return must say the SCOPE matched nothing, not blame the watermark")
+			require.NotContains(t, health, "watermark",
+				"a scoped run is exempt from the watermark on both halves — "+
+					"naming it here would send the reader to the wrong mechanism")
+		})
+	}
 }

--- a/internal/synthesize/level_triggered_planning_test.go
+++ b/internal/synthesize/level_triggered_planning_test.go
@@ -1,0 +1,189 @@
+package synthesize
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// knomit#115. StartSession returns before the strategy plans when the
+// watermark-diffed seed pool is empty — and an unscoped session's completion
+// advances the watermark past the session's OWN writes. Composed: after one
+// full-scan session on a quiet corpus, every subsequent unscoped session
+// returns done:true forever.
+//
+// But motif backfill's pool (LiveFactsWithoutMotifs) is corpus-wide and
+// watermark-independent BY DESIGN. It is a LEVEL-triggered pass — the corpus
+// state IS the trigger — and it was being starved by a gate that only looks at
+// recent commits. The consequence beyond a bulk run: a corpus hydrated from a
+// remote (facts present, no new commits) never backfills at all.
+//
+// newQuietCorpusReviewer builds exactly that situation: facts exist, none carry
+// motifs, and the watermark already sits at HEAD so the dirty set is empty.
+func newQuietCorpusReviewer(t *testing.T, effort Effort) (*Reviewer, *store.Service, string) {
+	t.Helper()
+	const branch = "agent/test"
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+
+	// Several epistemic facts, none carrying a motif — the backfill pool.
+	for _, p := range []string{"kb/technology/a.md", "kb/technology/b.md", "kb/technology/c.md"} {
+		writeKindFact(t, svc, branch, p, fact.Epistemic, fact.Observation)
+	}
+
+	// The watermark at HEAD is what makes the dirty set empty. This is the
+	// state an unscoped session leaves behind on a quiet corpus, and the state
+	// a freshly-hydrated remote clone starts in.
+	head, err := svc.Branches().HeadCommit(ctx, branch)
+	require.NoError(t, err)
+	require.NoError(t, svc.Pipeline().SetPipelineWatermark(ctx, "review", branch, head))
+
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:         "test",
+		AgentBranch:  branch,
+		Svc:          svc,
+		OntologyRoot: "kb",
+	})
+	return NewReviewerWithOptions(ri, nil, effort, ScopeFilter{}), svc, branch
+}
+
+// The fix: an empty dirty set must not hide level-triggered work. At an effort
+// that maintains vocabulary, a corpus with un-motifed facts has work to do, and
+// the session must plan it rather than reporting success at having done
+// nothing.
+func TestStartSession_EmptyDirtySetStillPlansLevelTriggeredWork(t *testing.T) {
+	r, svc, branch := newQuietCorpusReviewer(t, EffortMedium)
+	ctx := context.Background()
+
+	// Precondition: the dirty set really is empty, so this test is exercising
+	// the early-exit path and not merely a corpus that happened to have seeds.
+	gs, idx, pipelineIdx, _ := r.storeIndices()
+	seeds, scan, err := r.p.dirtyFacts(ctx, branch, gs, idx, pipelineIdx)
+	require.NoError(t, err)
+	require.Empty(t, seeds, "precondition: the watermark-diffed seed pool is empty")
+	require.Equal(t, seedScanIncremental, scan.Path)
+
+	// Precondition: there IS level-triggered work — facts without motifs.
+	targets, err := svc.Motifs().LiveFactsWithoutMotifs(ctx, branch, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, targets, "precondition: the backfill pool is non-empty")
+
+	res, err := r.StartSession(ctx)
+	require.NoError(t, err)
+	require.False(t, res.Done,
+		"a corpus with pending level-triggered work must not report done — "+
+			"LiveFactsWithoutMotifs is watermark-independent by design, and the "+
+			"corpus state IS the trigger")
+}
+
+// MN5's guarantee, protected explicitly. The effort gate still governs: at
+// normal effort the vocabulary passes do not run, so there is no
+// level-triggered work to rescue and the session completes exactly as before.
+//
+// This is the trap in this fix, and it is not hypothetical. Backfill fires on
+// any authored fact LACKING a motif — which is every fact on a motif-free
+// corpus, precisely the corpus MN5's test uses. A level-triggered check placed
+// OUTSIDE the effort gate would make a normal-effort session start planning
+// backfill work, changing what EffortNormal produces
+// (invariants/synthesize/motif/effort-amendment).
+// Asserting only `res.Done` here would NOT catch the bug this test is for.
+// Plan gates the vocabulary passes a second time, so a level-triggered check
+// with its effort gate removed still ends with a completed session at normal
+// effort — done:true either way. (Measured: under exactly that sabotage this
+// test passed while the health-line test failed.) So the assertions below name
+// the two things that actually differ.
+func TestStartSession_EmptyDirtySetAtNormalEffortStillCompletes(t *testing.T) {
+	r, svc, branch := newQuietCorpusReviewer(t, EffortNormal)
+	ctx := context.Background()
+
+	// Same corpus as the test above: the backfill pool is non-empty. The ONLY
+	// difference is the effort dial.
+	targets, err := svc.Motifs().LiveFactsWithoutMotifs(ctx, branch, 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, targets, "precondition: same corpus, backfill pool non-empty")
+
+	// 1. The predicate itself, directly. This is the assertion that fails the
+	// moment the effort gate leaves HasLevelTriggeredWork, wherever it goes.
+	d := r.p.deps()
+	has, err := reviewStrategy{}.HasLevelTriggeredWork(ctx, d, branch)
+	require.NoError(t, err)
+	require.False(t, has,
+		"EffortNormal must report no level-triggered work even on a motif-free "+
+			"corpus: backfill fires on every fact there, which is the corpus MN5's "+
+			"test uses (invariants/synthesize/motif/effort-amendment)")
+
+	// 2. The path actually taken. The early-exit path is the one that appends
+	// the empty-seed health line; the plan path never does. So the presence of
+	// that line is proof the session completed WITHOUT planning — which
+	// `res.Done` alone cannot tell you, since both paths end done.
+	res, err := r.StartSession(ctx)
+	require.NoError(t, err)
+	require.True(t, res.Done)
+	require.NotEmpty(t, res.Health,
+		"the session must complete via the early-exit path, not by planning "+
+			"an empty queue and completing at the end of it")
+}
+
+// knomit#122 fix (c), merged here because it is #115's user-visible half. An
+// empty return said nothing: done:true, no health block, indistinguishable
+// from a finished corpus. That ambiguity is exactly what made #121's wall read
+// as completion for hours.
+//
+// Two distinct empty cases must be distinguishable in the response itself.
+func TestStartSession_EmptyReturnSaysWhyItIsEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	// Case 1: watermark at HEAD, nothing changed. The line must name the
+	// watermark and the remedy, because the facts behind it are reachable only
+	// via a scope or a watermark reset.
+	t.Run("nothing changed since the watermark", func(t *testing.T) {
+		r, svc, branch := newQuietCorpusReviewer(t, EffortNormal)
+		head, err := svc.Branches().HeadCommit(ctx, branch)
+		require.NoError(t, err)
+
+		res, err := r.StartSession(ctx)
+		require.NoError(t, err)
+		require.True(t, res.Done)
+
+		health := strings.Join(res.Health, "\n")
+		require.NotEmpty(t, res.Health,
+			"an empty return with no health block cannot be told from a finished corpus")
+		require.Contains(t, health, "watermark",
+			"the line names the mechanism that made the pool empty")
+		require.Contains(t, health, head[:8],
+			"the line carries the watermark hash — the value that had to be "+
+				"reconstructed by arithmetic in #121")
+	})
+
+	// Case 2: a scope that matches nothing. Same done:true shape, different
+	// cause, and the operator needs to tell them apart — this is the pair the
+	// #115 comment measured as ambiguous exactly when it mattered.
+	t.Run("scope matched no facts", func(t *testing.T) {
+		r, _, _ := newQuietCorpusReviewer(t, EffortNormal)
+		r.p.scope = ScopeFilter{Entities: []string{"nothing-has-this-entity"}}
+
+		res, err := r.StartSession(ctx)
+		require.NoError(t, err)
+		require.True(t, res.Done)
+
+		health := strings.Join(res.Health, "\n")
+		require.NotEmpty(t, res.Health)
+		require.Contains(t, health, "scope",
+			"a scoped empty return must say the SCOPE matched nothing, not blame the watermark")
+		require.NotContains(t, health, "watermark",
+			"a scoped run is exempt from the watermark on both halves — "+
+				"naming it here would send the reader to the wrong mechanism")
+	})
+}

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -164,10 +164,27 @@ func (p *Pipeline) StartSession(ctx context.Context) (*PipelineResult, error) {
 		Str("watermark", scan.Watermark).
 		Dur("elapsed", time.Since(t)).Msg("pipeline: seed scan")
 
-	// An empty seed pool completes the session immediately — which still runs
-	// the watermark advance, so an unscoped no-op run records that it saw HEAD.
+	// An empty seed pool USED TO complete the session immediately — which still
+	// runs the watermark advance, so an unscoped no-op run records that it saw
+	// HEAD. Composed with that advance, one full-scan session on a quiet corpus
+	// made every later unscoped session return done:true forever (knomit#115).
+	//
+	// The seed scan is EDGE-triggered: it asks what changed. A strategy may own
+	// a LEVEL-triggered pass that asks what the corpus is missing, and that
+	// question has an answer even when nothing changed. Ask before giving up.
 	if len(seeds) == 0 {
-		return p.completeSession(ctx, sess)
+		if !p.planLevelTriggered(ctx, d, branch) {
+			res, cerr := p.completeSession(ctx, sess)
+			if cerr != nil {
+				return nil, cerr
+			}
+			// #122(c): an empty return that says nothing cannot be told from a
+			// finished corpus, which is how #121's wall read as completion.
+			res.Health = append(res.Health, emptySeedHealth(scan)...)
+			return res, nil
+		}
+		log.Info().Str("tool", tool).Str("session", sess.ID).
+			Msg("pipeline: dirty set empty but level-triggered work is pending; planning anyway")
 	}
 
 	if err := p.strategy.Plan(ctx, d, sess, seeds); err != nil {
@@ -413,6 +430,69 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 }
 
 // ── seed scan ─────────────────────────────────────────────────────────────
+
+// planLevelTriggered asks the strategy whether the corpus's own state gives it
+// work the empty dirty set would otherwise hide (knomit#115).
+//
+// Degrades to false in both failure modes — a strategy that does not implement
+// levelTriggeredStrategy, and one whose check errors — so the behaviour when
+// this cannot answer is exactly the behaviour before it existed. An error here
+// must not fail a session that was about to complete successfully.
+func (p *Pipeline) planLevelTriggered(ctx context.Context, d Deps, branch string) bool {
+	lt, ok := p.strategy.(levelTriggeredStrategy)
+	if !ok {
+		return false
+	}
+	has, err := lt.HasLevelTriggeredWork(ctx, d, branch)
+	if err != nil {
+		log.Warn().Err(err).Str("tool", p.strategy.Tool()).
+			Msg("pipeline: level-triggered check failed; completing as before")
+		return false
+	}
+	return has
+}
+
+// emptySeedHealth explains an empty seed pool to the agent that asked for one
+// (knomit#122 fix c, closing knomit#115's user-visible half).
+//
+// The empty return was `done: true` with no health block at all —
+// indistinguishable from a finished corpus. That ambiguity is not cosmetic: on
+// knomit-kb it read as completion while ~288 facts sat unreachable behind a
+// watermark, and telling the two apart took a forensic pass over checkpointed
+// database copies.
+//
+// The two cases get DIFFERENT sentences because they have different remedies,
+// and naming the wrong mechanism is worse than naming none. A scoped run is
+// exempt from the watermark on both halves, so a scoped empty pool is never a
+// watermark effect and this must not say it is.
+func emptySeedHealth(scan seedScan) []string {
+	if scan.Scoped {
+		return []string{
+			"review found nothing: this session's scope matched no facts. " +
+				"Widen the scope, or drop it for a whole-corpus pass.",
+		}
+	}
+	if scan.Path == seedScanIncremental {
+		return []string{
+			fmt.Sprintf("review found nothing: nothing has changed since the review "+
+				"watermark (%s). Facts older than the watermark are reachable only "+
+				"through a scoped call or a watermark reset — this is NOT a "+
+				"statement that the corpus is finished.", shortHash(scan.Watermark)),
+		}
+	}
+	return []string{
+		"review found nothing: a whole-corpus scan matched no eligible facts.",
+	}
+}
+
+// shortHash abbreviates a commit hash for a health line, leaving anything that
+// is not a full hash alone.
+func shortHash(h string) string {
+	if len(h) <= 8 {
+		return h
+	}
+	return h[:8]
+}
 
 // seedScan describes HOW a seed pool was produced: which of the two scan paths
 // ran, what the watermark was at the time, and whether a scope was active.

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -173,7 +173,7 @@ func (p *Pipeline) StartSession(ctx context.Context) (*PipelineResult, error) {
 	// a LEVEL-triggered pass that asks what the corpus is missing, and that
 	// question has an answer even when nothing changed. Ask before giving up.
 	if len(seeds) == 0 {
-		if !p.planLevelTriggered(ctx, d, branch) {
+		if !p.planLevelTriggered(ctx, d, branch, scan) {
 			res, cerr := p.completeSession(ctx, sess)
 			if cerr != nil {
 				return nil, cerr
@@ -438,7 +438,26 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 // levelTriggeredStrategy, and one whose check errors — so the behaviour when
 // this cannot answer is exactly the behaviour before it existed. An error here
 // must not fail a session that was about to complete successfully.
-func (p *Pipeline) planLevelTriggered(ctx context.Context, d Deps, branch string) bool {
+func (p *Pipeline) planLevelTriggered(ctx context.Context, d Deps, branch string, scan seedScan) bool {
+	// A SCOPED session never plans level-triggered work (knomit#128 review,
+	// MEDIUM-2). The level-triggered pools are corpus-wide by construction —
+	// LiveFactsWithoutMotifs does not know what scope the caller named — so
+	// consulting them on a scoped run turns a scope that matched nothing into
+	// a whole-corpus session that rewrites facts the operator never asked
+	// about. Measured before this guard: EffortMedium plus a scope matching no
+	// facts planned backfill over three facts, all outside the scope, and
+	// printed no scoped sentence at all.
+	//
+	// This is the #122 family's own rule — a scope must never silently widen —
+	// applied to the fix that closed a sibling case. A scoped run with an empty
+	// pool is FINISHED for that scope, and says so via emptySeedHealth.
+	//
+	// The level-triggered pass is not lost: it is reached by any unscoped
+	// session, which is the shape that legitimately speaks for the whole
+	// corpus.
+	if scan.Scoped {
+		return false
+	}
 	lt, ok := p.strategy.(levelTriggeredStrategy)
 	if !ok {
 		return false

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -63,6 +63,35 @@ func (reviewStrategy) AcceptSeed(f fact.Fact) bool {
 	return f.Kind == fact.Epistemic
 }
 
+// HasLevelTriggeredWork reports whether the motif vocabulary has work the
+// dirty-set gate would otherwise hide (knomit#115). Review's backfill pool is
+// corpus-wide and watermark-independent, so "nothing changed recently" is not
+// an answer to "does this corpus have un-motifed facts".
+//
+// THE EFFORT GATE IS CHECKED FIRST, AND THAT ORDER IS LOAD-BEARING. Backfill
+// fires on any authored fact lacking a motif — every fact on a motif-free
+// corpus, which is exactly the corpus MN5's review_effort_normal_test.go uses.
+// Answering true at EffortNormal would make a normal-effort session start
+// planning backfill work on that corpus, changing what EffortNormal PRODUCES
+// rather than merely what it costs. That is the guarantee MN5 exists to hold
+// (invariants/synthesize/motif/effort-amendment), and it is the one way this
+// fix could break it.
+//
+// Limit 1: this is an existence check, not a census. Nothing here needs to know
+// HOW MANY facts lack motifs — planMotifBackfillWork re-reads the pool under
+// its own budget — and asking for one keeps the empty-seed path cheap, which is
+// the only thing that path was ever good at.
+func (reviewStrategy) HasLevelTriggeredWork(ctx context.Context, d Deps, branch string) (bool, error) {
+	if !d.Effort.MaintainsVocabulary() {
+		return false, nil
+	}
+	targets, err := d.Motifs.LiveFactsWithoutMotifs(ctx, branch, 1)
+	if err != nil {
+		return false, wrapf(reviewTool, err, "level-triggered check: backfill pool")
+	}
+	return len(targets) > 0, nil
+}
+
 // Plan builds the review work queue over a non-empty seed pool: cluster, dedup,
 // then enqueue prune items per surviving multi-fact cluster, distill items over
 // the (chunked) seed pool, and — at effort >= medium — discover items per

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -106,6 +106,41 @@ type pagedStrategy interface {
 	RenderPayload(item *store.PipelineWorkItem) (string, error)
 }
 
+// levelTriggeredStrategy is the optional half of Strategy for tools that own a
+// pass whose trigger is CORPUS STATE rather than recent change.
+//
+// The engine's seed scan is edge-triggered: it diffs against a watermark and
+// asks "what changed?". Some passes are level-triggered and ask "what is the
+// corpus missing?" — review's motif backfill reads LiveFactsWithoutMotifs,
+// which is corpus-wide and watermark-independent by design. Composing the two
+// starved the second: an empty dirty set completed the session before the
+// strategy ever planned, so on a quiet corpus the level-triggered pass could
+// never run, and a corpus hydrated from a remote (facts present, no new
+// commits) never backfilled at all (knomit#115).
+//
+// Optional rather than part of Strategy for the same reason as pagedStrategy:
+// hypothesize has no level-triggered pass, and widening the required interface
+// would force a meaningless implementation on every tool. The engine
+// type-asserts; a strategy that does not implement this is simply never asked,
+// and keeps the old behaviour exactly.
+type levelTriggeredStrategy interface {
+	// HasLevelTriggeredWork reports whether the corpus's own state gives this
+	// strategy work to do, independent of what changed recently.
+	//
+	// It is consulted ONLY when the dirty seed pool is empty — the one moment
+	// the edge-triggered gate would otherwise hide the answer. An error is
+	// logged and treated as "no", so a strategy that cannot answer degrades to
+	// the previous behaviour rather than failing the session.
+	//
+	// The implementation owns its own gating. Review's, in particular, must
+	// return false below EffortMedium: backfill fires on any authored fact
+	// lacking a motif, which is every fact on a motif-free corpus — precisely
+	// the corpus MN5's test uses — so rescuing it at normal effort would change
+	// what EffortNormal PRODUCES
+	// (invariants/synthesize/motif/effort-amendment).
+	HasLevelTriggeredWork(ctx context.Context, d Deps, branch string) (bool, error)
+}
+
 // WorkItemView is a strategy's rendering of one work item: what the agent is
 // shown and what shape its answer must take. The engine wraps it with the
 // item id and payload (see PipelineItem) — a strategy never has to remember to


### PR DESCRIPTION
Closes #115. Also closes #122's fix (c) — see "Why (c) is here" below.

**Stacked on #126** (`fix/mcp-reject-unknown-args`). Review that one first; this PR targets it, so its diff shows only this fix.

## The bug

`StartSession` returned before the strategy planned whenever the watermark-diffed seed pool was empty — and an unscoped session's completion **advances the watermark past the session's own writes**. Composed: after one full-scan session on a quiet corpus, every subsequent unscoped session returned `done: true` with no items, forever. A corpus hydrated from a remote (facts present, no new commits) never backfilled at all.

The mismatch underneath it:

- The seed scan is **edge-triggered**. It diffs a watermark and asks *what changed?*
- Motif backfill is **level-triggered**. `LiveFactsWithoutMotifs` is corpus-wide and watermark-independent *by design*, and asks *what is the corpus missing?*

"Nothing changed recently" is not an answer to the second question. The gate was treating it as one.

## The fix

A new optional strategy interface, `levelTriggeredStrategy`, following the `pagedStrategy` precedent already in this file: the engine type-asserts, and a strategy that does not implement it keeps the old behaviour exactly. `hypothesize` has no level-triggered pass and is untouched.

It is consulted **only** when the dirty pool is empty — the one moment the edge-triggered gate would otherwise hide the answer. An error is logged and treated as "no", so a strategy that cannot answer degrades to the previous behaviour rather than failing a session that was about to complete successfully.

## ⚠️ Reviewer: the whole risk of this fix is one gate's position

**The effort check is inside `HasLevelTriggeredWork`, and it has to be.**

Backfill fires on any authored fact *lacking* a motif — which is **every fact on a motif-free corpus**, precisely the corpus MN5's `review_effort_normal_test.go` uses. A level-triggered check placed outside the effort gate would make a normal-effort session start planning backfill work on that corpus, changing what `EffortNormal` **produces** rather than merely what it costs. That is the guarantee MN5 exists to hold (`invariants/synthesize/motif/effort-amendment` — verified current: both its blob refs are byte-identical at HEAD).

**The test for that nearly did not work, and the near-miss is worth knowing.**

Asserting only `res.Done` at normal effort does **not** catch a misplaced effort gate. `Plan` gates the vocabulary passes a second time, so with the effort check removed the session *still* ends completed at normal effort — `done: true` either way. Measured under exactly that sabotage: the control test passed, while a different test failed for unrelated reasons.

The control now asserts two things that actually differ:
1. `HasLevelTriggeredWork` returns false at `EffortNormal` — the predicate directly, so it fails wherever the gate moves to.
2. The empty return carries the empty-seed health line — which **only the early-exit path appends**, proving the session completed without planning. `res.Done` cannot tell you that, since both paths end done.

## Why (c) is here

The forensic report for #121 framed the `len(seeds)==0` health line as closing "#115's user-visible half", and it is right. Split across two PRs, each half ships broken: the gate fix without the line leaves the completion ambiguity #115's own comment measured (once backfill is dry, a scoped session with nothing pending returns the *same* shape as a scope matching zero facts — ambiguous exactly when an operator needs to tell "wrong scope" from "finished"); the line without the gate fix leaves the level-triggered pass starved.

The empty return previously said **nothing** — `done: true`, no health block, indistinguishable from a finished corpus. That ambiguity is how #121's wall read as completion while ~288 facts sat unreachable behind a watermark.

The two empty cases now get **different sentences**, because they have different remedies and naming the wrong mechanism is worse than naming none:

- **Watermark case** — carries the hash, and says explicitly that this is *not* a statement that the corpus is finished. The hash is the value that had to be reconstructed by counting commit-log entries against candidate cutoffs in #121; it reuses the `seedScan` added in #126.
- **Scoped case** — says the scope matched no facts, and deliberately never mentions the watermark. A scoped run is exempt from the watermark on *both* halves, so its empty pool is never a watermark effect.

## Review round — findings closed

Checkpoint-2 (review-pr-2) confirmed the production fix correct and every sabotage row reproducing. Three findings, closed in commit `83b7060b`:

- **MEDIUM-2 (behaviour)** — `planLevelTriggered` never consulted `scan.Scoped`, and the level-triggered pools are corpus-wide by construction. Measured: EffortMedium + a scope matching nothing returned `done=false` and planned backfill over three facts **all outside the named scope**, with no scoped sentence. A scope matching nothing silently became a whole-corpus session — the #122 family's own rule broken by the fix that closed a sibling case. Now skipped on scoped scans; the scoped subtest is parameterized over EffortNormal **and** EffortMedium, since it read as covered only at the effort where the gate hid it.
- **MEDIUM-1** — the control test's second assertion was inert (`NotEmpty(res.Health)` is non-empty on both paths, because the Plan path fills Health with the restatement block). Replaced with a `Contains` on content only the early-exit path emits. Verified in both directions: each assertion now catches the effort-gate sabotage alone, for different reasons.
- **LOW-2 / LOW-4** — `emptySeedHealth`'s third branch (first-run full scan) now tested, including that all three sentences differ; MN13 attestation corrected below.

## Cost of this change, stated plainly

The empty-seed path widened from *return immediately* to **running the entire review `Plan`** — `ScopedCluster`, `dedupCluster`, the corpus-wide restatement KNN refresh, and all three motif passes — on every quiet session at effort ≥ medium.

That is the intended trade (a quiet corpus that never backfills is the bug), but it is a real per-session cost that did not exist before, and it lands exactly on the sessions that used to be cheapest. Scoped sessions are now exempt (MEDIUM-2), which removes the sharpest edge.

One consequence worth naming since it is invisible from the diff: `Plan` is entered with `clusters=nil` on this path, so the restatement shortlist's cluster co-membership exclusion admits everything — correct, because there are no clusters to have already co-presented a pair, but not obvious.

## Deliberately not included

A count of facts unreachable behind the watermark, which #122's fix (c) suggests. Getting it requires a corpus-wide scan — the one thing the empty path is good at avoiding — so it would make the fast path slow to print a number. Flagged for the designer rather than paid for silently. Note the count matters less after this fix: the facts in #121's case were facts *without motifs*, so that corpus now plans backfill instead of returning empty at all.

## Sabotage evidence

> Rows name the exact edit and the exact assertion that reddens, so each is reproducible without interpretation.

| sabotage | caught by |
|---|---|
| effort gate deleted from `HasLevelTriggeredWork` | `EmptyDirtySetAtNormalEffortStillCompletes` — **both** assertions independently: the predicate call, and the `Contains "review found nothing"`. Verified by neutering each in turn. The `res.Done`-only version passed. |
| `planLevelTriggered` returns false unconditionally | `EmptyDirtySetStillPlansLevelTriggeredWork` |
| **`scan.Scoped` guard removed from `planLevelTriggered`** | `EmptyReturnSaysWhyItIsEmpty/scope_matched_no_facts_at_effort_medium` — fails on `require.True(res.Done)`; the EffortNormal case stays green, which is why the subtest is parameterized |
| scoped branch deleted from `emptySeedHealth` (falls through to the watermark line) | `EmptyReturnSaysWhyItIsEmpty/scope_matched_no_facts_*` — on the `Contains "scope"` clause. **Correction:** an earlier version of this table implied the `NotContains "watermark"` clause catches it; it does not, `Contains "scope"` does. |
| health lines removed entirely | both `EmptyReturnSaysWhyItIsEmpty` subtests (witnessed at RED) |
| `emptySeedHealth` returns one sentence for all three cases | `EmptySeedHealth_DistinguishesAllThreeCases` |

## Attestations

- **MN5** — `internal/synthesize/review_effort_normal_test.go` byte-identical to `dev`. Verified by diff and by `TestConformance_BridgeFilesUntouched`.
- **MN13** (corrected per review LOW-4) — **two** production literals, not one: `LiveFactsWithoutMotifs(..., 1)` (an existence-check limit — nothing reads the count) and `shortHash`'s `8` (display width for an abbreviated commit hash). Neither is a threshold and neither encodes a corpus property; the conclusion is unchanged, the original count was wrong.
- Full suite: 49 packages ok. `go vet` clean. `gofmt` clean.
