### PR TITLE
fix(synthesize): restatement emission counts what was SERVED, and names what was dropped (#117a)

### DIFF
--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -412,6 +412,7 @@ type restatementHealth struct {
 	TailP999       float64
 	OperatingPoint float64 // title-cos of the last selected pair, in THIS repo
 	Emitted        int
+	Dropped        int
 	ResolutionRate float64
 	ThrottleState  string
 	// MotifWidened counts pairs admitted ONLY because their facts share a
@@ -677,16 +678,27 @@ func pairTouchesScope(ctx context.Context, d Deps, branch string, p store.Restat
 // and needs no prompt, schema, or apply-path change. The judge that already
 // knows how to merge under a fidelity contract gets to apply it to pairs it
 // previously never saw.
-func enqueueRestatementItems(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, pairs []store.RestatementPair) error {
+//
+// Returns what actually reached the judge, and what did not (knomit#117a). The
+// count and the insert were separated by a `continue`, so a candidate whose
+// pair could not be loaded evaporated between them: no item, no health line, no
+// warning. Measured on core as `restatement candidates emitted: 8` beside ZERO
+// restate- items in a fully-drained 48-item queue. The number was not wrong
+// about what it counted — it counted SELECTION and was read as SERVICE, and
+// nothing in the output could tell the two apart.
+func enqueueRestatementItems(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, pairs []store.RestatementPair) (served, dropped int, err error) {
 	for i, p := range pairs {
 		facts := make([]factForLLM, 0, 2)
 		for _, path := range []string{p.APath, p.BPath} {
 			f, err := d.Search.GetByPath(ctx, branch, path)
 			if err != nil {
-				return wrapf(reviewTool, err, "shortlist: read %s", path)
+				return served, dropped, wrapf(reviewTool, err, "shortlist: read %s", path)
 			}
 			if f == nil {
-				break // raced a retraction; drop the pair rather than half-ship it
+				// Raced a retraction, or the pair names a path that no longer
+				// resolves — drop rather than half-ship. Dropping is still
+				// right; doing it silently was not.
+				break
 			}
 			facts = append(facts, factForLLM{
 				File:       f.Path,
@@ -701,11 +713,20 @@ func enqueueRestatementItems(ctx context.Context, d Deps, sess *store.PipelineSe
 			})
 		}
 		if len(facts) != 2 {
+			dropped++
+			// WARN, not Debug: this is a computed candidate the corpus paid a
+			// KNN query for, and it is being discarded. The pair is NOT
+			// retired — no verdict is recorded — so it stays standing and can
+			// be re-selected once its half resolves again. That makes a
+			// persistent drop a LOOP rather than a loss, which is worth
+			// seeing in a log.
+			log.Warn().Str("session", sess.ID).Str("a", p.APath).Str("b", p.BPath).
+				Msg("review: restatement candidate dropped — a half did not resolve")
 			continue
 		}
 		factsJSON, err := json.Marshal(facts)
 		if err != nil {
-			return wrapf(reviewTool, err, "shortlist: marshal pair %d", i)
+			return served, dropped, wrapf(reviewTool, err, "shortlist: marshal pair %d", i)
 		}
 		if err := d.Pipeline.InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
 			SessionID:  sess.ID,
@@ -714,10 +735,25 @@ func enqueueRestatementItems(ctx context.Context, d Deps, sess *store.PipelineSe
 			FactsJSON:  string(factsJSON),
 			Priority:   restatementPriority,
 		}); err != nil {
-			return wrapf(reviewTool, err, "shortlist: insert item %d", i)
+			return served, dropped, wrapf(reviewTool, err, "shortlist: insert item %d", i)
 		}
+		served++
 	}
-	return nil
+	return served, dropped, nil
+}
+
+// applyEmissionOutcome corrects the health block from what SELECTION chose to
+// what enqueue actually served (knomit#117a).
+//
+// It exists as its own function because the two numbers are produced in
+// different places — selectRestatementCandidates sets Emitted, and the drop
+// happens later, at enqueue — so without an explicit hand-off the health line
+// keeps reporting selection while the queue reflects service. That gap is the
+// whole bug, and a fix that only changed enqueue's return value would leave the
+// number an operator READS exactly as wrong as before.
+func applyEmissionOutcome(h *restatementHealth, served, dropped int) {
+	h.Emitted = served
+	h.Dropped = dropped
 }
 
 // planRestatementShortlist runs the whole phase-0 sequence for one session:
@@ -777,9 +813,13 @@ func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineS
 	selectHealth.Coverage = health.Coverage
 	health = selectHealth
 
-	if err := enqueueRestatementItems(ctx, d, sess, branch, pairs); err != nil {
+	served, dropped, err := enqueueRestatementItems(ctx, d, sess, branch, pairs)
+	if err != nil {
 		return err
 	}
+	// Emitted was recorded by selection; only enqueue knows what survived to
+	// the queue. Reconcile before the deferred recordRestatementHealth fires.
+	applyEmissionOutcome(&health, served, dropped)
 	return nil
 }
 
@@ -806,7 +846,7 @@ func healthLines(h restatementHealth) []string {
 		fmt.Sprintf("standing restatement pairs: %d (title-cos p99 %.3f, p99.9 %.3f)",
 			h.StandingPairs, h.TailP99, h.TailP999),
 		fmt.Sprintf("operating point: title-cos %.3f (this corpus, this session)", h.OperatingPoint),
-		fmt.Sprintf("restatement candidates emitted: %d", h.Emitted),
+		emittedLine(h),
 		fmt.Sprintf("shortlist throttle: %s%s (trailing resolution-rate %.0f%% over last %d judged)",
 			h.ThrottleState, probeSuffix(h), h.ResolutionRate*100, throttleWindow),
 		// The motif signal's actual contribution, not its existence (designer
@@ -814,6 +854,21 @@ func healthLines(h restatementHealth) []string {
 		// a line that only ever said "enabled" could not support that claim.
 		motifSignalLine(h),
 	}
+}
+
+// emittedLine reports what actually reached the judge, and names any candidate
+// that did not (knomit#117a).
+//
+// The drop clause appears ONLY when something dropped. A block that mentions
+// drops every session trains a reader to skip the line, which is how the
+// original silence would come back wearing a number.
+func emittedLine(h restatementHealth) string {
+	if h.Dropped == 0 {
+		return fmt.Sprintf("restatement candidates emitted: %d", h.Emitted)
+	}
+	return fmt.Sprintf("restatement candidates emitted: %d (%d selected but dropped "+
+		"unserved — a half no longer resolves; the pair stays standing and will "+
+		"be re-offered)", h.Emitted, h.Dropped)
 }
 
 // motifSignalLine reports what the §7 motif widener contributed this session.

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -814,12 +814,20 @@ func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineS
 	health = selectHealth
 
 	served, dropped, err := enqueueRestatementItems(ctx, d, sess, branch, pairs)
+	// Reconcile on BOTH paths, before the early return (PR #130, LOW-1).
+	// Emitted was recorded by selection; only enqueue knows what survived to
+	// the queue. An enqueue that fails PART WAY through has already inserted
+	// some items, and returning without reconciling leaves the deferred
+	// recordRestatementHealth reporting selection's count over a partial
+	// queue — this issue's own bug, re-opened on the error path.
+	//
+	// Unobservable today (StartSession discards the result on error), which is
+	// exactly why it is worth closing now rather than when something starts
+	// reading it.
+	applyEmissionOutcome(&health, served, dropped)
 	if err != nil {
 		return err
 	}
-	// Emitted was recorded by selection; only enqueue knows what survived to
-	// the queue. Reconcile before the deferred recordRestatementHealth fires.
-	applyEmissionOutcome(&health, served, dropped)
 	return nil
 }
 

--- a/internal/synthesize/restatement_emission_honesty_test.go
+++ b/internal/synthesize/restatement_emission_honesty_test.go
@@ -97,25 +97,44 @@ func TestRestatementHealth_EmittedIsServedAndDropsAreNamed(t *testing.T) {
 // printed equals the number of restate- items in the queue.
 func TestPlanRestatementShortlist_HealthEmittedMatchesTheQueue(t *testing.T) {
 	ctx := context.Background()
-	// 200 facts: shortlistBudget is corpus-scaled (5 per 1000), so a small env
-	// gets a budget of ZERO and selects nothing — the test would then pass
-	// vacuously with 0 emitted and 0 queued.
-	env := newRestatementEnv(t, 200)
+
+	// CORPUS SIZE IS LOAD-BEARING, AND SO IS THE PAIR COUNT. Re-derived from
+	// shortlistPerMille (5 per 1000, capped at maxShortlistItems):
+	//
+	//     200 facts → budget 1      400 facts → budget 2
+	//
+	// An earlier version of this test used 200 and injected ONE unservable
+	// pair. That fixed BUDGET vacuity — a smaller env budgets zero and selects
+	// nothing — but left SERVICE vacuity untouched: the single unservable pair
+	// consumed the only slot, so served was structurally 0 and the central
+	// assertion below compared 0 against 0. Proof: hardcoding `h.Emitted = 0`
+	// passed the entire package (PR #130, HIGH-1).
+	//
+	// 400 buys two slots, and two top-ranked pairs fill them: one unservable
+	// (so a drop is exercised) and one servable (so the served count is
+	// NON-ZERO and the equality means something).
+	env := newRestatementEnv(t, 400)
 	env.seedShortlist()
 	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
 	require.NoError(t, err)
 
-	// A standing pair naming a path that does not resolve, ranked at the top of
-	// the distribution so selection cannot help but pick it. This is core's
-	// situation: a computed candidate whose half is gone by the time the queue
-	// is built.
+	// Both ranked above anything the corpus produced on its own, so selection
+	// cannot help but pick them. The unservable one is core's situation: a
+	// computed candidate whose half is gone by the time the queue is built.
 	ids := env.factIDs()
 	require.NoError(t, env.svc.Abstraction().ReplaceRestatementPairs(ctx, env.branch, nil,
-		[]store.RestatementPair{{
-			APath: "kb/f0.md", BPath: "kb/gone.md",
-			AFactID: ids["kb/f0.md"], BFactID: 999999,
-			TitleCos: 0.999,
-		}}, nil))
+		[]store.RestatementPair{
+			{
+				APath: "kb/f0.md", BPath: "kb/gone.md",
+				AFactID: ids["kb/f0.md"], BFactID: 999999,
+				TitleCos: 0.999,
+			},
+			{
+				APath: "kb/f1.md", BPath: "kb/f2.md",
+				AFactID: ids["kb/f1.md"], BFactID: ids["kb/f2.md"],
+				TitleCos: 0.998,
+			},
+		}, nil))
 
 	require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
 
@@ -135,6 +154,15 @@ func TestPlanRestatementShortlist_HealthEmittedMatchesTheQueue(t *testing.T) {
 			restate++
 		}
 	}
+
+	// NON-VACUITY PRECONDITION, asserted rather than assumed. Without it the
+	// equality below holds trivially whenever nothing is served, which is
+	// exactly how this test passed while `h.Emitted = 0` was hardcoded. A
+	// fixture chosen to make a test discriminate has to be checked, or the
+	// test silently stops discriminating when the fixture drifts.
+	require.Greater(t, restate, 0,
+		"non-vacuity: at least one candidate must actually be SERVED, or the "+
+			"served-equals-queued assertion below compares 0 against 0")
 
 	require.Contains(t, emitted, "emitted: "+itoa(restate),
 		"the emitted number must equal the restate- items actually queued; "+

--- a/internal/synthesize/restatement_emission_honesty_test.go
+++ b/internal/synthesize/restatement_emission_honesty_test.go
@@ -1,0 +1,146 @@
+package synthesize
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// knomit#117(a). The emission loop counted candidates and THEN inserted them,
+// with `if len(facts) != 2 { continue }` between the two — so any candidate
+// whose pair failed to load was dropped with no health line, no warning, and no
+// trace anywhere. Measured on core: `restatement candidates emitted: 8`, and
+// ZERO restate- items in a fully-drained 48-item queue.
+//
+// The number was not wrong about what it counted. It counted SELECTION and was
+// read as SERVICE, and nothing in the output could tell the two apart.
+//
+// A pair naming a path that does not resolve is the exact failure: GetByPath
+// returns nil, the loop breaks with one fact, and the candidate evaporates.
+func TestEnqueueRestatementItems_DropsAreCountedAndReported(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 3)
+	d := env.deps()
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	require.NoError(t, err)
+
+	ids := env.factIDs()
+	pairs := []store.RestatementPair{
+		// Servable: both halves resolve.
+		{AFactID: ids["kb/f0.md"], BFactID: ids["kb/f1.md"], APath: "kb/f0.md", BPath: "kb/f1.md"},
+		// Not servable: kb/gone.md does not exist. This is the silent drop.
+		{AFactID: ids["kb/f2.md"], BFactID: 999999, APath: "kb/f2.md", BPath: "kb/gone.md"},
+	}
+
+	served, dropped, err := enqueueRestatementItems(ctx, d, sess, env.branch, pairs)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, served,
+		"served counts what actually reached the judge, not what was selected")
+	require.Equal(t, 1, dropped,
+		"the unservable candidate must be COUNTED, not silently skipped")
+
+	// And the queue agrees with the number: exactly one restate- item exists.
+	items := env.workItems(sess.ID)
+	var restate int
+	for _, it := range items {
+		if strings.HasPrefix(it.ClusterKey, restatementClusterKeyPrefix) {
+			restate++
+		}
+	}
+	require.Equal(t, served, restate,
+		"the served count and the queue must not be able to disagree — "+
+			"8-counted/0-served is exactly the bug")
+}
+
+// The health block is where an operator reads this, so the count it prints must
+// be the SERVED count. A drop that changes no visible number is the same bug
+// wearing a return value.
+func TestRestatementHealth_EmittedIsServedAndDropsAreNamed(t *testing.T) {
+	t.Run("drops are stated", func(t *testing.T) {
+		lines := strings.Join(healthLines(restatementHealth{Emitted: 1, Dropped: 2}), "\n")
+		require.Contains(t, lines, "restatement candidates emitted: 1",
+			"the emitted number is what reached the judge")
+		require.Contains(t, lines, "2",
+			"the dropped count appears somewhere in the block")
+		require.Contains(t, strings.ToLower(lines), "drop",
+			"a drop must be NAMED, not left for a reader to infer from arithmetic")
+	})
+
+	// The common case must not gain a noise line. A health block that always
+	// mentions drops trains a reader to skip the line that matters.
+	t.Run("no drop line when nothing dropped", func(t *testing.T) {
+		lines := strings.Join(healthLines(restatementHealth{Emitted: 3, Dropped: 0}), "\n")
+		require.Contains(t, lines, "restatement candidates emitted: 3")
+		require.NotContains(t, strings.ToLower(lines), "drop",
+			"no drop line when there were no drops")
+	})
+}
+
+// THE WIRING, THROUGH THE REAL PATH — and this test exists in this form
+// because an earlier version of it did not work.
+//
+// health.Emitted is assigned by SELECTION (selectRestatementCandidates); the
+// drop happens later, at ENQUEUE. So a fix that corrects enqueue's return value
+// but never feeds it back leaves the number an operator reads exactly as wrong
+// as before. The first draft of this test called applyEmissionOutcome itself —
+// which asserts that the helper works, not that anything CALLS it. Under a
+// sabotage that deleted the call site, it passed.
+//
+// So: drive planRestatementShortlist, and read the health block it actually
+// produced. The invariant asserted is the one that failed on core — the number
+// printed equals the number of restate- items in the queue.
+func TestPlanRestatementShortlist_HealthEmittedMatchesTheQueue(t *testing.T) {
+	ctx := context.Background()
+	// 200 facts: shortlistBudget is corpus-scaled (5 per 1000), so a small env
+	// gets a budget of ZERO and selects nothing — the test would then pass
+	// vacuously with 0 emitted and 0 queued.
+	env := newRestatementEnv(t, 200)
+	env.seedShortlist()
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	require.NoError(t, err)
+
+	// A standing pair naming a path that does not resolve, ranked at the top of
+	// the distribution so selection cannot help but pick it. This is core's
+	// situation: a computed candidate whose half is gone by the time the queue
+	// is built.
+	ids := env.factIDs()
+	require.NoError(t, env.svc.Abstraction().ReplaceRestatementPairs(ctx, env.branch, nil,
+		[]store.RestatementPair{{
+			APath: "kb/f0.md", BPath: "kb/gone.md",
+			AFactID: ids["kb/f0.md"], BFactID: 999999,
+			TitleCos: 0.999,
+		}}, nil))
+
+	require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
+
+	// What the operator reads.
+	var emitted string
+	for _, line := range sess.Health {
+		if strings.HasPrefix(line, "restatement candidates emitted:") {
+			emitted = line
+		}
+	}
+	require.NotEmpty(t, emitted, "the health block must carry the emitted line")
+
+	// What is actually in the queue.
+	var restate int
+	for _, it := range env.workItems(sess.ID) {
+		if strings.HasPrefix(it.ClusterKey, restatementClusterKeyPrefix) {
+			restate++
+		}
+	}
+
+	require.Contains(t, emitted, "emitted: "+itoa(restate),
+		"the emitted number must equal the restate- items actually queued; "+
+			"core printed 8 beside a queue containing 0")
+	require.Contains(t, strings.ToLower(emitted), "drop",
+		"and the unservable candidate must be named, not absorbed into arithmetic")
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }


### PR DESCRIPTION
Addresses **#117 part (a)** only. Part (b) — the throttle-state lies — is P2 truthful-instrumentation and is deliberately not here.

**Stacked on #128** (`fix/level-triggered-planning-gate`), which is stacked on #126. Review those first; this PR targets #128, so its diff shows only this fix.

## The bug

The emission loop counted candidates and *then* inserted them, with

```go
if len(facts) != 2 { continue }
```

between the two. Any candidate whose pair failed to load evaporated in that gap: no work item, no health line, no warning, no trace anywhere.

Measured on core's first-ever review session: `restatement candidates emitted: 8`, beside **zero** `restate-` items in a fully-drained 48-item queue.

The number was not wrong about what it counted. **It counted SELECTION and was read as SERVICE**, and nothing in the output could tell the two apart.

## The fix

`enqueueRestatementItems` returns `(served, dropped)`. `applyEmissionOutcome` reconciles the health block after the queue is built.

The hand-off is explicit and named because the two numbers are produced in different places — selection sets `Emitted`, the drop happens later at enqueue. That distance is the whole bug, and an implicit hand-off would leave it available to re-open.

The health line gains a drop clause **only when something dropped**. A block that mentions drops every session trains a reader to skip the line, which is how the original silence would come back wearing a number.

The clause says the pair *stays standing and will be re-offered*, because that is true and it changes what an operator should do: no verdict is recorded on a drop, so the pair is not retired. **A persistent drop is a loop, not a loss** — and a `Warn` log carries both paths for whoever has to break it.

Dropping an unservable pair is still correct; a half-shipped pair would be worse. Doing it silently was the defect.

## ⚠️ Reviewer: the wiring test is the one to check

**This is the second instance of the campaign's standing path-vs-state trap, in a new disguise.**

The first draft of the wiring test called `applyEmissionOutcome` itself. That asserts *the helper works* — not that anything **calls** it. Under a sabotage that deleted the call site, **it passed.**

Rewritten to drive `planRestatementShortlist` and assert the invariant that actually failed on core: **the number printed equals the number of `restate-` items in the queue.** Under the same sabotage it now fails with `"emitted: 1" does not contain "emitted: 0"` — core's 8-versus-0 in miniature.

Two details in that test that are load-bearing, not incidental:

- It uses a **400-fact** corpus and **two** injected pairs. `shortlistBudget` is corpus-scaled at 5 per 1000 (capped at 8): 200 facts → 1 slot, 400 → 2. One slot is not enough — the unservable pair consumes it and `served` is structurally 0. Trimming either the corpus or the second pair silently disarms this test, which is what review caught.
- Both pairs are injected at the top of the distribution (`0.999` / `0.998`) so selection cannot help but pick them. Otherwise the drop never occurs and the assertion is untested.
- The `require.Greater(t, restate, 0)` precondition is not decoration: it is what makes the drift above **fail** instead of passing quietly.

## Adjacent defect found, NOT fixed — needs a designer ruling

**The probe-slot accounting has the same selected-versus-served confusion.**

`selectRestatementCandidates` consumes a defunded corpus's periodic probe when `len(out) > 0`, and the comment there states the intent exactly:

> The probe is spent only if it actually put something in front of the judge.

But `out` is the **selected** set. A probe whose candidates are all dropped at enqueue buys another full interval of silence for nothing — the same bug, one level up, and the code comment is already the specification it violates.

Not fixed here because the remedy (moving probe consumption after enqueue) changes **throttle recovery timing**, and that interacts with #117(b)'s throttle work in P2. Flagged rather than folded in.

## Review round — findings closed

Checkpoint-2 (review-pr-2), closed in commit `216eab73`:

- **HIGH-1 — the wiring test was SERVICE-vacuous.** The 200-fact corpus fixed *budget* vacuity but not *service* vacuity: `shortlistBudget(200)` is **one** slot, the single unservable pair consumed it, so `served` was structurally 0 and the central assertion compared 0 against 0. Proof, re-run here: hardcoding `h.Emitted = 0` — a health block reporting "emitted: 0" forever — **passed the entire package**.

  Fixed with a 400-fact env (budget 2, re-derived from `shortlistPerMille` rather than copied) and **two** top-ranked pairs, one unservable and one servable, plus an explicit non-vacuity precondition:

  ```go
  require.Greater(t, restate, 0, "non-vacuity: at least one candidate must be SERVED")
  ```

  A fixture chosen to make a test discriminate stops discriminating the moment it drifts, and nothing says so — unless the test asserts it.

- **LOW-1 — the enqueue error path re-opened the bug.** On error the function returned before `applyEmissionOutcome`, leaving the deferred health recorder to report *selection's* count over a *partially* enqueued queue. Reconciliation now runs on both paths. Unobservable today (StartSession discards the result on error); fixed anyway, because the whole issue is a count describing something other than what happened.

## Sabotage evidence

| sabotage | caught by |
|---|---|
| a dropped candidate counted as served again | `TestEnqueueRestatementItems_DropsAreCountedAndReported` |
| `applyEmissionOutcome` call site deleted (enqueue counts honestly, health never learns) | `TestPlanRestatementShortlist_HealthEmittedMatchesTheQueue` — **only after rewriting**; the direct-call version passed |
| drop clause never rendered | `TestRestatementHealth_.../drops_are_stated` **and** the wiring test |
| (RED, before implementing) no counting at all | all three |
| **`h.Emitted` hardcoded to 0** (health reports "emitted: 0" forever) | `TestPlanRestatementShortlist_HealthEmittedMatchesTheQueue` — **only after the 400-fact fix**; at 200 facts it passed the entire package |

## Attestations

- **MN5** — `internal/synthesize/review_effort_normal_test.go` byte-identical to `dev`.
- **MN13** — no constant added or changed. `shortlistPerMille` and `maxShortlistItems` are untouched; the 400 in the test is a fixture sized *from* `shortlistPerMille`, with the derivation shown in the test so a reader can check it rather than trust it.
- Full suite: 49 packages ok. `go vet` clean. `gofmt` clean.
