### PR TITLE
fix(synthesize): UUID-normalize prune-merge output paths (#107a)

### DIFF
--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -168,6 +168,25 @@ func ApplyPruneDecisions(ctx context.Context,
 			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("merge: skipping hypothesis-type output %s — prune-merge cannot create hypotheses", mf.Path)})
 			continue
 		}
+		// Replace the LLM-generated filename with a UUID, as distill does
+		// below and as discovery does in discovery.go (knomit#107a). This was
+		// the only one of validateOutputPath's four callers that did not, and
+		// validateOutputPath checks the ontology root and private paths and
+		// NOTHING ELSE — there is no collision check on this path. So an
+		// LLM-supplied merged.path naming a fact that already existed
+		// overwrote it whole: body, refs, motifs, origin, gone with no warning.
+		//
+		// The corpus's own convention note recorded this as a hazard rather
+		// than a design — "Do not assume a prune-merge output path is
+		// collision-proof by UUID" — which is what a reader had to know in
+		// order not to be bitten by it. Now they do not.
+		//
+		// NORMALIZE rather than reject (designer ruling). Rejecting the merge
+		// on collision would silently undo a consolidation the judge asked
+		// for, which is the argument the DropInvalidMotifs comment makes a few
+		// lines below; the LLM's DIRECTORY choice is still honoured, only the
+		// filename is replaced.
+		mf.Path = normalizeFactPath(mf.Path)
 		// TRANSFER: pooled from the facts being subsumed, not from mf.Sources.
 		// The merged fact REPLACES its sources and they are deleted immediately
 		// below, so trusting the count the model happened to emit discards the

--- a/internal/synthesize/decision_merge_path_collision_test.go
+++ b/internal/synthesize/decision_merge_path_collision_test.go
@@ -84,6 +84,11 @@ func TestApplyPruneDecisions_MergeDoesNotOverwriteAnExistingFact(t *testing.T) {
 // keeps those tests asserting what they were written to assert (sources
 // pooling, hypothesis exclusion, unreadable-source warnings) rather than
 // accidentally re-asserting a filename.
+// It FAILS on a miss rather than returning "" (PR #131, LOW-5). Call sites in
+// sources_pooling_test.go feed the result straight into readSources, so an
+// empty path surfaced as a confusing ReadFact error about a path that is
+// obviously wrong, instead of the true diagnosis: the merge wrote nothing.
+// A helper that cannot find what it was asked for should say which.
 func mergedFactPath(t *testing.T, svc *store.Service, branch, title string) string {
 	t.Helper()
 	facts, err := svc.Search().Search(context.Background(), branch, store.SearchOptions{Limit: 1000})
@@ -93,6 +98,9 @@ func mergedFactPath(t *testing.T, svc *store.Service, branch, title string) stri
 			return f.Path
 		}
 	}
+	require.FailNow(t, "no merged fact found",
+		"no live fact titled %q on %s — the merge wrote nothing, which is a "+
+			"different failure from the path being wrong", title, branch)
 	return ""
 }
 

--- a/internal/synthesize/decision_merge_path_collision_test.go
+++ b/internal/synthesize/decision_merge_path_collision_test.go
@@ -1,0 +1,151 @@
+package synthesize
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// knomit#107a. prune's merge was the ONLY one of validateOutputPath's four
+// callers that never ran normalizeFactPath — distill does it at decision.go's
+// distill loop, discovery does it in discovery.go. validateOutputPath checks
+// the ontology root and private paths, and nothing else: there is no collision
+// check anywhere on that path.
+//
+// So an LLM-supplied merged.path naming a fact that already exists overwrote it
+// WHOLE — body, refs, motifs, origin — with no warning and no trace. The
+// corpus's own convention note recorded the hazard rather than defending it:
+// "Merge path-uniqueness therefore depends on the LLM emitting a distinct path
+// and on downstream dedup — NOT on UUID replacement. Do not assume a
+// prune-merge output path is collision-proof by UUID."
+//
+// Designer ruling: NORMALIZE, matching the three sibling paths, with UUID
+// filenames on merged facts accepted as the visible change.
+func TestApplyPruneDecisions_MergeDoesNotOverwriteAnExistingFact(t *testing.T) {
+	ctx := context.Background()
+	const branch = "agent/test"
+	const victim = "kb/technology/victim.md"
+
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+
+	// A live fact the merge is about to be aimed at. Its body is the tell: if
+	// the merge overwrites it, this string is gone.
+	const victimBody = "PRECIOUS-ORIGINAL-CONTENT"
+	_, err = svc.Facts().WriteFact(ctx, branch, victim,
+		"---\ntype: observation\n---\n# Victim\n\n"+victimBody, "seed victim", "test")
+	require.NoError(t, err)
+
+	// The two facts the merge legitimately subsumes.
+	for _, p := range []string{"kb/technology/a.md", "kb/technology/b.md"} {
+		_, err = svc.Facts().WriteFact(ctx, branch, p,
+			"---\ntype: observation\n---\n# Src\n\nsource body", "seed "+p, "test")
+		require.NoError(t, err)
+	}
+
+	// The LLM names the victim's path as its merge output. Nothing in the
+	// prompt stops it, and nothing downstream checked.
+	merges := []MergeEntry{{
+		Paths: []string{"kb/technology/a.md", "kb/technology/b.md"},
+		Merged: mergedFact{
+			Path:  victim,
+			Title: "Merged",
+			Body:  "merged body",
+			Type:  "observation",
+		},
+	}}
+
+	_, err = ApplyPruneDecisions(ctx, svc.Facts(), svc.Search(), nil, merges,
+		"review-test", func(ProgressEvent) {}, branch, bareRefFixture, "kb")
+	require.NoError(t, err)
+
+	// THE ASSERTION. The victim must still be there, unchanged.
+	got, err := svc.Facts().ReadFact(ctx, branch, victim, nil)
+	require.NoError(t, err, "the pre-existing fact must still exist")
+	require.Contains(t, got.Content, victimBody,
+		"the merge overwrote a live fact whole — body, refs, motifs and origin "+
+			"replaced by an LLM-chosen path collision")
+}
+
+// mergedFactPath finds the fact a prune-merge wrote, by title.
+//
+// Tests used to look the merged fact up at the literal path the fixture put in
+// merged.Path. Since knomit#107a that path's FILENAME is replaced by a UUID —
+// the same normalization distill and discovery have always applied — so a
+// literal lookup finds nothing. The title is the stable handle, and using it
+// keeps those tests asserting what they were written to assert (sources
+// pooling, hypothesis exclusion, unreadable-source warnings) rather than
+// accidentally re-asserting a filename.
+func mergedFactPath(t *testing.T, svc *store.Service, branch, title string) string {
+	t.Helper()
+	facts, err := svc.Search().Search(context.Background(), branch, store.SearchOptions{Limit: 1000})
+	require.NoError(t, err)
+	for _, f := range facts {
+		if f.Title == title {
+			return f.Path
+		}
+	}
+	return ""
+}
+
+// The merge must still WRITE something: normalizing must not be mistaken for
+// rejecting. A fix that made the collision impossible by dropping the merge
+// would silently undo a consolidation the judge asked for — which is the
+// argument decision.go's DropInvalidMotifs comment makes twenty lines away,
+// and the reason #107b (refuse-if-lossy) is a separate, undecided question.
+func TestApplyPruneDecisions_MergeStillWritesUnderANormalizedPath(t *testing.T) {
+	ctx := context.Background()
+	const branch = "agent/test"
+
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, branch))
+
+	for _, p := range []string{"kb/technology/a.md", "kb/technology/b.md"} {
+		_, err = svc.Facts().WriteFact(ctx, branch, p,
+			"---\ntype: observation\n---\n# Src\n\nsource body", "seed "+p, "test")
+		require.NoError(t, err)
+	}
+
+	merges := []MergeEntry{{
+		Paths: []string{"kb/technology/a.md", "kb/technology/b.md"},
+		Merged: mergedFact{
+			Path:  "kb/technology/human-chosen-name.md",
+			Title: "Merged",
+			Body:  "MERGED-BODY-MARKER",
+			Type:  "observation",
+		},
+	}}
+
+	stats, err := ApplyPruneDecisions(ctx, svc.Facts(), svc.Search(), nil, merges,
+		"review-test", func(ProgressEvent) {}, branch, bareRefFixture, "kb")
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Merged, "the merge must still commit")
+
+	// It landed under a UUID filename in the directory the LLM chose — the
+	// same shape distill has always produced.
+	facts, err := svc.Search().Search(ctx, branch, store.SearchOptions{Limit: 100})
+	require.NoError(t, err)
+
+	var mergedPath string
+	for _, f := range facts {
+		if strings.Contains(f.Body, "MERGED-BODY-MARKER") {
+			mergedPath = f.Path
+		}
+	}
+	require.NotEmpty(t, mergedPath, "the merged fact must be on the branch")
+	require.True(t, strings.HasPrefix(mergedPath, "kb/technology/"),
+		"the LLM's DIRECTORY choice is kept; only the filename is replaced")
+	require.NotContains(t, mergedPath, "human-chosen-name",
+		"the LLM-emitted filename is replaced by a UUID, as on the distill path")
+}

--- a/internal/synthesize/decision_prune_hypothesis_guard_test.go
+++ b/internal/synthesize/decision_prune_hypothesis_guard_test.go
@@ -124,7 +124,11 @@ func TestApplyPruneDecisions_AcceptsSynthesisMerge(t *testing.T) {
 	require.Equal(t, 1, stats.Merged, "synthesis-type merge must commit")
 	require.Empty(t, warns, "no warns expected for valid synthesis merge; got: %v", warns)
 
-	got, err := svc.Search().GetByPath(context.Background(), "agent/test", "kb/synth/merged.md")
+	// The filename is UUID-normalized since #107a, so the merged fact is found
+	// by title rather than by the path the fixture supplied.
+	mergedPath := mergedFactPath(t, svc, "agent/test", "Merged synthesis")
+	require.NotEmpty(t, mergedPath, "valid merge must have written a fact")
+	got, err := svc.Search().GetByPath(context.Background(), "agent/test", mergedPath)
 	require.NoError(t, err)
 	require.NotNil(t, got, "valid merge must have written a fact")
 	require.Equal(t, "Merged synthesis", got.Title)

--- a/internal/synthesize/sources_pooling_test.go
+++ b/internal/synthesize/sources_pooling_test.go
@@ -258,7 +258,7 @@ func TestApplyPruneDecisions_MergePoolsSubsumedSources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, stats.Merged)
 
-	require.Equal(t, 8, readSources(t, svc, branch, "kb/technology/merged.md"),
+	require.Equal(t, 8, readSources(t, svc, branch, mergedFactPath(t, svc, branch, "M")),
 		"a merge deletes its inputs, so their corroborations must transfer to the survivor")
 
 	// And they really are gone, which is what makes the transfer mandatory.
@@ -286,7 +286,7 @@ func TestApplyPruneDecisions_MergeExcludesHypothesisSources(t *testing.T) {
 		"test", func(ProgressEvent) {}, branch, bareRefFixture, "kb")
 	require.NoError(t, err)
 
-	require.Equal(t, 2, readSources(t, svc, branch, "kb/technology/merged.md"),
+	require.Equal(t, 2, readSources(t, svc, branch, mergedFactPath(t, svc, branch, "M")),
 		"a hypothesis is a conjecture; its count must not pool into the merged fact")
 }
 
@@ -308,7 +308,7 @@ func TestApplyPruneDecisions_MergeWarnsWhenSourcesUnreadable(t *testing.T) {
 	_, err := ApplyPruneDecisions(ctx, svc.Facts(), svc.Search(), nil, merges, "test", onProgress, branch, bareRefFixture, "kb")
 	require.NoError(t, err)
 
-	require.Equal(t, 1, readSources(t, svc, branch, "kb/technology/merged.md"),
+	require.Equal(t, 1, readSources(t, svc, branch, mergedFactPath(t, svc, branch, "M")),
 		"the floor still applies — 0 would make the fact invisible to every downstream weight")
 	require.NotEmpty(t, *warns, "a merge that could read none of its sources must say so")
 	require.Contains(t, (*warns)[0], "could be read",
@@ -426,7 +426,7 @@ func TestApplyPruneDecisions_MergeOverHypothesesDoesNotWarnUnreadable(t *testing
 	_, err := ApplyPruneDecisions(ctx, svc.Facts(), svc.Search(), nil, merges, "test", onProgress, branch, bareRefFixture, "kb")
 	require.NoError(t, err)
 
-	require.Equal(t, 1, readSources(t, svc, branch, "kb/technology/merged.md"),
+	require.Equal(t, 1, readSources(t, svc, branch, mergedFactPath(t, svc, branch, "M")),
 		"conjecture pools nothing, so the merged fact rests on the floor")
 	for _, w := range *warns {
 		require.NotContains(t, w, "could be read",


### PR DESCRIPTION
Addresses **#107 part (a)** — the path-collision half. Part (b), the refuse-if-lossy guard, is parked at P2-with-design and is **not** here; its options come to the designer when reached.

**Top of the P1 stack.** Stacked on #130 → #128 → #126. Review those first; this PR targets #130.

## The bug

prune's merge was the only one of `validateOutputPath`'s four callers that never ran `normalizeFactPath` — distill does, discovery does, reflect has no filename to choose. And `validateOutputPath` checks the ontology root and private paths and **nothing else**: there is no collision check anywhere on that path.

So an LLM-supplied `merged.path` naming a fact that already existed **overwrote it whole** — body, refs, motifs, origin — with no warning and no trace. Composed with the parse-time origin reattribution #107 describes, that is two distinct ways prune's merge can silently destroy provenance.

The corpus's own convention note had recorded this for months, as a *hazard* rather than a design:

> Merge path-uniqueness therefore depends on the LLM emitting a distinct path and on downstream dedup — NOT on UUID replacement. **Do not assume a prune-merge output path is collision-proof by UUID.**

That is a warning a reader had to already be holding in order not to be bitten by it. Now they don't have to.

## The fix

`mf.Path = normalizeFactPath(mf.Path)`, in the same position distill uses.

**NORMALIZE, not reject** (designer ruling). Rejecting the merge on collision would silently undo a consolidation the judge asked for — which is the argument `decision.go`'s own `DropInvalidMotifs` comment makes a few lines below, and the tension #107b owns. The LLM's **directory** choice is still honoured; only the filename is replaced.

Nothing downstream depended on the LLM-chosen path: `ApplyPruneDecisions` returns stats only — no `written` slice, unlike distill — so the path is used solely for the write, the progress event and the commit message.

## ⚠️ Reviewer: the two new tests are a PAIR, and the second one is the load-bearing one

- **`MergeDoesNotOverwriteAnExistingFact`** pins that a pre-existing fact survives.
- **`MergeStillWritesUnderANormalizedPath`** pins **NORMALIZE over REJECT.**

Verified by sabotage: implementing the rejected alternative (collision-check, then skip the merge) leaves the **first test passing** and fails only the second.

Without that second test, a future "fix" could satisfy this issue by dropping merges on collision, pass the obvious regression test, and quietly reintroduce the exact failure mode `DropInvalidMotifs` exists to prevent — a judge's decision discarded silently.

## Five existing tests changed — updated, not weakened

They looked the merged fact up at the literal fixture path (`kb/synth/merged.md`, `kb/technology/merged.md`), which no longer exists once the filename is a UUID. They now find it **by title** via a shared helper.

Each still asserts exactly what it was written to assert — sources pooling, hypothesis-source exclusion, unreadable-source warnings — and **none of them was ever about the filename**. The helper carries that reasoning in its doc comment so the next reader does not mistake it for a workaround.

## Follow-up owed on merge, deliberately not done here

The convention fact `kb/conventions/synthesize/normalize-fact-path-uuid/b4b46263.md` becomes **stale the moment this lands on `dev`** — its entire "WHAT THIS DOES NOT MEAN" section describes behaviour this PR removes.

Not updated now, because the corpus should not describe unmerged code. Flagged so it is not lost: it needs a `/knomit-update` when this merges.

## Review round — one finding, closed

Checkpoint-2 (review-pr-2) confirmed the production fix correct, the NORMALIZE-over-REJECT pin **load-bearing** (implementing the rejected alternative passes the victim test and fails only `MergeStillWritesUnderANormalizedPath`), the drift from #107b **pure** (one executable statement added, `DropInvalidMotifs` untouched), and the five changed tests still asserting their originals.

**LOW-5**, closed in commit `8feedec9`: `mergedFactPath` returned `""` on a miss, and the `sources_pooling_test.go` call sites feed the result straight into `readSources` — so a miss surfaced as a confusing `ReadFact` error about an obviously wrong path instead of the true diagnosis, *the merge wrote nothing*. It now fails with that sentence. Diagnostic only; no assertion changed.

## Sabotage evidence

| sabotage | caught by |
|---|---|
| `normalizeFactPath` call removed | both new tests |
| **reject-on-collision instead of normalize** (the ruled-against alternative) | **only** `MergeStillWritesUnderANormalizedPath` — the victim test passed |
| (RED, before implementing) no normalization at all | victim test failed showing the live data loss: the victim's body replaced by the merged fact's |

## Attestations

- **MN5** — `internal/synthesize/review_effort_normal_test.go` byte-identical to `dev`.
- **MN13** — no constant added. `normalizeFactPath`'s 8-char UUID width is pre-existing and unchanged.
- Full suite: 49 packages ok. `go vet` clean. `gofmt` clean.
