### PR TITLE
fix(synthesize): the bridging-inactive line is scope-local, and says so (#119)

### DIFF
--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -1154,6 +1154,11 @@ type motifActivation struct {
 	// because one heavily-shared motif and three df-2 motifs are different
 	// situations with the same cluster count.
 	Pairs int
+	// Seeds is how many seed facts the decision was made over. Reported
+	// because this whole struct describes ONE SESSION'S POOL, and without the
+	// count the health line cannot say so — which is precisely how its earlier
+	// wording came to make a claim about the corpus (knomit#119).
+	Seeds int
 }
 
 // motifActive decides whether this corpus has enough recurring vocabulary for
@@ -1166,6 +1171,7 @@ func motifActive(seeds []factForLLM, resolve motifResolver) motifActivation {
 		Active:      clusters >= motifActivationFloor,
 		DF2Clusters: clusters,
 		Pairs:       pairs,
+		Seeds:       len(seeds),
 	}
 }
 
@@ -1335,12 +1341,32 @@ func motifBridgeHealthLines(h motifEnumHealth, near, far int) []string {
 				"(no candidates — this is NOT a statement about the corpus)", h.Failure)}
 	}
 	if h.Activation.Evaluated && !h.Activation.Active {
+		// SCOPE-LOCAL BY CONSTRUCTION (knomit#119). Every number here is
+		// computed over THIS SESSION'S SEED POOL (see motifActive), so the
+		// sentence may not generalise past it.
+		//
+		// It used to. The retired wording claimed "the corpus has too little
+		// repeated vocabulary ... it activates itself as recurrence
+		// accumulates" — both halves false on a scoped session. It was
+		// measured printing on a corpus roughly 4x past the floor, in the same
+		// health block as a corpus-wide line reporting 16 recurring motifs;
+		// and the second half additionally invited an operator to WAIT for an
+		// activation a narrow scope never reaches. One operator lost ~50
+		// sessions to it, re-deriving the confusion from scratch.
+		//
+		// The mechanics were never wrong; only the sentence was. Hence wording
+		// plus the pool size rather than a corpus-wide recount: computing this
+		// corpus-wide would add a per-session query to buy a claim a
+		// corpus-shaped session never needs, because at that shape the gate
+		// passes and this line does not print at all.
 		return []string{fmt.Sprintf(
-			"motif bridging inactive: %d recurring motif(s) (%d bridgeable pair(s)), below the "+
-				"%d-motif validity floor — the corpus has too little repeated vocabulary for a "+
-				"shared-motif pair to mean anything yet. Recomputed every session; it activates "+
-				"itself as recurrence accumulates.",
-			h.Activation.DF2Clusters, h.Activation.Pairs, motifActivationFloor)}
+			"motif bridging inactive for THIS SESSION's pool: %d recurring motif(s) "+
+				"(%d bridgeable pair(s)) among the %d seed fact(s) evaluated, below the "+
+				"%d-motif floor. Scope-local: a narrow scope reports inactive on a "+
+				"knowledge base that is far past the floor, so this is NOT a statement "+
+				"about the whole base. Recomputed per session from the pool in hand.",
+			h.Activation.DF2Clusters, h.Activation.Pairs, h.Activation.Seeds,
+			motifActivationFloor)}
 	}
 	if h.Candidates == 0 && len(h.OverCeilingNames) == 0 {
 		return nil

--- a/internal/synthesize/bridge_motif_scope_local_test.go
+++ b/internal/synthesize/bridge_motif_scope_local_test.go
@@ -1,0 +1,123 @@
+package synthesize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// knomit#119. The activation counter is computed over THIS SESSION'S SEED POOL
+// — correct mechanics — but the sentence beside it claimed something about the
+// corpus:
+//
+//	"the corpus has too little repeated vocabulary for a shared-motif pair to
+//	 mean anything yet"
+//
+// On a scoped session that is false, and measurably so: it printed on a corpus
+// roughly 4x past the activation floor, in the same health block as a
+// corpus-wide vocabulary line reporting 43 clusters and 16 recurring.
+//
+// It is the sharpest member of its family because the other members require a
+// reader to misread a number. This line performed the misreading itself, in
+// English, adjacent to the line that contradicted it — and since scoped
+// sessions are the standard operating mode, it printed routinely.
+//
+// The severity is not hypothetical. An operator with ~50 sessions of exposure
+// re-derived the confusion from scratch and escalated a structural-
+// unreachability concern for a corpus that had already had bridging enumerate
+// live. A false sentence printed every session eventually colonises any reader.
+func TestMotifBridgeHealthLines_InactiveLineIsScopeLocal(t *testing.T) {
+	lines := strings.Join(motifBridgeHealthLines(motifEnumHealth{
+		Activation: motifActivation{
+			Evaluated:   true,
+			Active:      false,
+			DF2Clusters: 0,
+			Pairs:       0,
+			Seeds:       2,
+		},
+	}, 0, 0), "\n")
+
+	require.Contains(t, lines, "motif bridging inactive",
+		"the line still fires — the mechanics were never the defect")
+
+	// THE FIX. The claim must be about the pool the number was computed over.
+	require.Contains(t, lines, "2",
+		"the line names how many seed facts the decision was made over — "+
+			"without that a reader cannot tell a 2-fact scope from the corpus")
+
+	// THE DEFECT, stated as its own assertion so it cannot come back by
+	// rewording. Any sentence generalising from this session's pool to the
+	// corpus is the bug, whatever words carry it.
+	lower := strings.ToLower(lines)
+	require.NotContains(t, lower, "the corpus has too little",
+		"the retired claim, verbatim")
+	require.NotContains(t, lower, "the corpus",
+		"this line may not make ANY claim about the corpus: it is computed over "+
+			"one session's seed pool, and on a scoped session the corpus can be "+
+			"far past the floor while this pool is not")
+}
+
+// The second half of #119's severity, and a separate assertion because it is a
+// separate misreading. The retired sentence ended:
+//
+//	"Recomputed every session; it activates itself as recurrence accumulates."
+//
+// which the operator read as "keep going and it will switch on" — a promise
+// about the future of a corpus, made by a line that only ever measured one
+// session's pool. On a scoped session the pool does not accumulate anything;
+// the next narrow scope reports inactive again.
+func TestMotifBridgeHealthLines_InactiveLinePromisesNoFutureActivation(t *testing.T) {
+	lines := strings.ToLower(strings.Join(motifBridgeHealthLines(motifEnumHealth{
+		Activation: motifActivation{Evaluated: true, Active: false, DF2Clusters: 1, Seeds: 3},
+	}, 0, 0), "\n"))
+
+	require.NotContains(t, lines, "activates itself",
+		"the retired promise, verbatim — it invited an operator to wait for an "+
+			"activation that a narrow scope will never reach")
+	require.NotContains(t, lines, "accumulates",
+		"nothing accumulates across sessions here: the count is recomputed from "+
+			"the pool in hand, and a scoped pool is a fresh pool each time")
+}
+
+// The seed count has to be REAL, not a field someone can forget to populate.
+// motifActive is where the decision is made and where the pool is in hand, so
+// that is where the count must come from — a Seeds field left at zero would
+// make the line say "among 0 seed facts" on a pool that had plenty.
+func TestMotifActive_RecordsThePoolItDecidedOver(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"lone-shape"}},
+		{File: "kb/b/2.md", Motifs: []string{"lone-shape"}},
+		{File: "kb/c/3.md", Motifs: []string{"other-shape"}},
+	}
+	act := motifActive(seeds, identityResolver)
+
+	require.True(t, act.Evaluated)
+	require.Equal(t, len(seeds), act.Seeds,
+		"the activation decision must carry the size of the pool it was made "+
+			"over, or the health line cannot say what it measured")
+}
+
+// End-to-end through buildMotifBridges, so the field is populated on the path
+// that actually produces the health block — not only when motifActive is
+// called directly. This is the wiring half: a Seeds field that only the unit
+// test ever sets would leave the shipped line saying "among 0 seed facts".
+func TestBuildMotifBridges_BelowFloorLineCarriesTheSeedCount(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/a/1.md", Motifs: []string{"lone-shape"}, Entities: []string{"Alpha"}},
+		{File: "kb/b/2.md", Motifs: []string{"lone-shape"}, Entities: []string{"Beta"}},
+	}
+	clusters, labels := oneCommunityEach(seeds)
+
+	_, _, health, err := buildMotifBridges(context.Background(), &pairwiseIndex{}, "main",
+		seeds, clusters, EffortHigh, motifQualityConfig(), identityResolver, labels, constPairCos(0.1))
+	require.NoError(t, err)
+	require.False(t, health.Activation.Active, "precondition: below the floor")
+
+	require.Equal(t, len(seeds), health.Activation.Seeds,
+		"the seed count must survive the real enumeration path, not just a "+
+			"direct motifActive call")
+	require.Contains(t, strings.Join(motifBridgeHealthLines(health, 0, 0), "\n"), "2",
+		"and reach the rendered line")
+}


### PR DESCRIPTION
Closes #119. **Base of the P2 stack** — the truthful-instrumentation family. Everything else in P2 stacks on this branch.

## The bug

The activation counter is computed over **this session's seed pool** — correct mechanics, never the defect. The sentence beside it claimed something about the corpus:

> the corpus has too little repeated vocabulary for a shared-motif pair to mean anything yet. Recomputed every session; it activates itself as recurrence accumulates.

On a scoped session, **both halves are false**. Measured printing on a corpus roughly 4x past the activation floor, in the *same health block* as a corpus-wide vocabulary line reporting 43 clusters and 16 recurring — a contradiction four lines apart.

Scope-locality was established three independent ways: the adjacent-line contradiction (on two corpora), the fleet's kind-checked eligibility measurements, and the line's own presence/absence flipping with pool shape — broad sessions print `motif bridges: N candidates` instead and never emit this line at all.

**This is the sharpest member of its family.** The other members require a reader to misread a number. This line performed the misreading itself, in English, adjacent to the line that contradicted it. And since scoped sessions are the standard operating mode, it printed routinely.

## The second half was independently harmful

*"It activates itself as recurrence accumulates"* reads as **"keep going and it will switch on"** — a promise about a corpus's future, made by a line that only ever measured one session's pool. A narrow scope accumulates nothing; the next narrow scope reports inactive again.

One operator lost roughly fifty sessions to it, re-deriving the confusion from scratch and escalating a structural-unreachability concern for a corpus that had *already* had bridging enumerate live.

## The fix

`motifActivation` gains `Seeds`, populated in `motifActive` — where the decision is made and the pool is already in hand. The line now names the pool it measured, states scope-locality explicitly, and promises nothing about the future.

**Wording, not a recount.** The issue offered both options. Computing this corpus-wide would add a per-session query to buy a claim a corpus-shaped session never needs — at that shape the gate passes and this line does not print. The thread's third confirmation (presence/absence flipping with pool shape) is what decides it.

## ⚠️ Reviewer: the two retired sentences are asserted as ABSENT, separately

Each retired claim has its own assertion, distinct from the assertion that the seed count is present. That separation is load-bearing, and I verified it rather than assuming it:

**Sabotage: restore the false wording while KEEPING the seed count.** The count assertion passes; both content assertions fail. So they catch different regressions — a fix that added the count but left the corpus claim would be caught, which is exactly the half-fix most likely to be attempted.

The `NotContains "the corpus"` assertion is deliberately broader than the verbatim retired string: **this line may not make any claim about the corpus, whatever words carry it.** A reworded generalisation is the same bug.

## Sabotage evidence

| sabotage | caught by |
|---|---|
| `Seeds` left unpopulated in `motifActive` (`Seeds: 0`) | `TestMotifActive_RecordsThePoolItDecidedOver` **and** `TestBuildMotifBridges_BelowFloorLineCarriesTheSeedCount` — the second is the wiring half, proving the field survives the real enumeration path and not just a direct call |
| false wording restored **with the seed count kept** | **only** the two content assertions in `InactiveLineIsScopeLocal` / `InactiveLinePromisesNoFutureActivation`; the count assertion passed |

## Attestations

- **MN5** — `internal/synthesize/review_effort_normal_test.go` byte-identical to `dev`.
- **MN13** — no constant added or changed. `motifActivationFloor` untouched; this is wording plus `len()` of a slice already in hand.
- Full suite: 49 packages ok. `go vet` clean. `gofmt` clean.
- The two pre-existing bridging-inactive tests (`BelowFloorCorpusIsEvaluatedAndSpeaks`, the motif-free short-circuit test) still pass unmodified — the `motif bridging inactive` prefix is deliberately preserved so they keep asserting what they were written to assert.
