### PR TITLE
fix(synthesize): carry the work item's cluster key to the wire (#120)

### DIFF
--- a/internal/synthesize/cluster_key_wire_test.go
+++ b/internal/synthesize/cluster_key_wire_test.go
@@ -1,0 +1,136 @@
+package synthesize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// knomit#120. The work item exposes id/type/prompt/response_schema/facts — not
+// ClusterKey. So an answering agent cannot follow the rule "judge restate-
+// items honestly, never no-op them", because it cannot tell WHICH 2-fact prune
+// item is one.
+//
+// The consequence is not theoretical and it is destructive. A no-op on a
+// restatement item records a DECLINED verdict against the judge-outcome
+// throttle AND permanently retires the standing pair — DeleteRestatementPair
+// runs unconditionally after the verdict. Measured: a session whose health said
+// "restatement candidates emitted: 1" served two 2-fact prune items; the
+// operator no-op'd both under the ordinary-cluster rule. If either carried a
+// restate- key, that no-op was #111's destructive non-answer — unavoidable
+// rather than avoidable, because nothing on the wire could distinguish them.
+//
+// Until this ships, the only safe fleet rule is "treat every 2-fact prune as a
+// possible restatement pair", which spends honest judgment on ordinary
+// clusters every session.
+func TestNextItem_CarriesClusterKeyOnTheWire(t *testing.T) {
+	ctx := context.Background()
+	r, svc := newPhaseTestReviewer(t)
+	sess := manualSession(t, svc, "agent/test")
+
+	// Two 2-fact prune items, indistinguishable on every field the wire
+	// carried before this fix: same type, same shape, same fact count.
+	require.NoError(t, svc.Pipeline().InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+		SessionID:  sess.ID,
+		StepType:   "prune",
+		ClusterKey: restatementClusterKeyPrefix + "0",
+		FactsJSON:  `[{"file":"kb/technology/a.md"},{"file":"kb/technology/b.md"}]`,
+		Priority:   restatementPriority,
+	}))
+	require.NoError(t, svc.Pipeline().InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+		SessionID:  sess.ID,
+		StepType:   "prune",
+		ClusterKey: "cluster-7",
+		FactsJSON:  `[{"file":"kb/technology/c.md"},{"file":"kb/technology/d.md"}]`,
+		Priority:   0.1,
+	}))
+
+	// BOTH LAYERS, asserted separately — because they are separate structs
+	// populated at separate places, and this test's name promises the wire.
+	//
+	// The engine's PipelineItem is not what an MCP client sees; ReviewItem is,
+	// and `reviewResult` projects one onto the other field by field. A fix that
+	// populated the engine type and forgot the projection would satisfy an
+	// engine-level assertion completely while leaving the wire exactly as
+	// broken as before — the same gap this campaign has now hit five times.
+	engine, err := r.p.nextItem(ctx, sess)
+	require.NoError(t, err)
+	require.NotNil(t, engine.Item)
+
+	// The restatement item sorts first on restatementPriority, so this is the
+	// one an agent meets — and it must be able to tell what it is holding.
+	require.Equal(t, restatementClusterKeyPrefix+"0", engine.Item.ClusterKey,
+		"engine layer: the PipelineItem must carry the stored item's key")
+
+	wire, err := r.PageItem(ctx, sess.ID, engine.Item.ID, 1)
+	require.NoError(t, err)
+	require.NotNil(t, wire.Item)
+	require.Equal(t, restatementClusterKeyPrefix+"0", wire.Item.ClusterKey,
+		"WIRE layer: a restatement pair must be distinguishable from an "+
+			"ordinary 2-fact prune cluster in what the CLIENT receives; without "+
+			"this the only safe rule is to treat every 2-fact prune as possibly "+
+			"destructive to no-op")
+}
+
+// The PAGING path builds its item separately (pipeline.go has two PipelineItem
+// construction sites), and a paged item is exactly where the distinction is
+// most likely to be needed — a large restatement pair arrives across pages, and
+// the agent decides how to answer after reading them.
+//
+// This is the wiring half: populating the field at one construction site and
+// not the other would leave paged items indistinguishable while the unit test
+// above passed.
+func TestPageItem_CarriesClusterKeyOnEveryPage(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+
+	item := currentDistillItem(t, svc, sessionID)
+	require.NotEmpty(t, item.ClusterKey, "precondition: the stored item has a key to carry")
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.Greater(t, first.Item.Pages, 1,
+		"precondition: the item must genuinely span more than one page, or the "+
+			"page-2 construction site below is never exercised")
+
+	// EVERY page, not just the first. Page 1 falls through to renderWorkItem;
+	// pages after it are built by payloadResult — a SECOND PipelineItem
+	// construction site. Populating one and not the other would leave a paged
+	// item identifiable on its first page and anonymous on the rest, which is
+	// worse than uniformly absent: the agent reads the later pages last, and
+	// that is when it decides how to answer.
+	for p := 1; p <= first.Item.Pages; p++ {
+		res, perr := r.PageItem(ctx, sessionID, item.ID, p)
+		require.NoErrorf(t, perr, "page %d", p)
+		require.Equalf(t, item.ClusterKey, res.Item.ClusterKey,
+			"page %d dropped the cluster key; both PipelineItem construction "+
+				"sites must carry it", p)
+	}
+}
+
+// THE WIRE CONTRACT, pinned deliberately.
+//
+// Exposing the raw cluster key rather than a derived is_restatement flag is the
+// choice this fix makes: the key already exists and is already computed, so it
+// cannot drift from its source the way a second declaration would.
+//
+// The cost of that choice is that consumers key off the `restate-` PREFIX, and
+// a prefix nothing pins is a silent-breakage contract — change the constant and
+// every agent's rule quietly stops matching, with no failure anywhere. This
+// test is that pin: it fails, naming the wire contract, if the prefix changes.
+func TestRestatementClusterKeyPrefix_IsAWireContract(t *testing.T) {
+	require.Equal(t, "restate-", restatementClusterKeyPrefix,
+		"this prefix is now part of the WIRE CONTRACT (#120): answering agents "+
+			"identify restatement pairs by it, and a non-answer on one is "+
+			"destructive (#111). Changing it silently breaks every consumer's "+
+			"rule — if it must change, the change is a coordinated wire change, "+
+			"not a rename")
+
+	// And the producer still uses it, so the pin is on a live path rather than
+	// on an orphaned constant.
+	require.True(t, strings.HasPrefix(restatementClusterKeyPrefix+"0", "restate-"))
+}

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -752,10 +752,15 @@ func (p *Pipeline) payloadResult(ctx context.Context, d Deps, sess *store.Pipeli
 	return &PipelineResult{
 		SessionID: sess.ID,
 		Item: &PipelineItem{
-			ID:        item.ID,
-			Type:      item.StepType,
-			FactsJSON: item.FactsJSON,
-			Facts:     facts,
+			ID:   item.ID,
+			Type: item.StepType,
+			// Carried on EVERY page, not only the first (knomit#120). The agent
+			// reads the later pages last, and that is when it decides how to
+			// answer — a key present on page 1 and absent afterwards would be
+			// worse than uniformly absent.
+			ClusterKey: item.ClusterKey,
+			FactsJSON:  item.FactsJSON,
+			Facts:      facts,
 		},
 		Progress: &ReviewProgress{
 			Completed: completed,
@@ -867,6 +872,7 @@ func (p *Pipeline) renderWorkItem(ctx context.Context, d Deps, sess *store.Pipel
 		Item: &PipelineItem{
 			ID:             item.ID,
 			Type:           view.Type,
+			ClusterKey:     item.ClusterKey,
 			Prompt:         view.Prompt,
 			ResponseSchema: view.ResponseSchema,
 			FactsJSON:      item.FactsJSON,

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -174,8 +174,9 @@ func reviewResultPage(res *PipelineResult, page int) (*ReviewResult, error) {
 	}
 
 	out.Item = &ReviewItem{
-		ID:   res.Item.ID,
-		Type: res.Item.Type,
+		ID:         res.Item.ID,
+		Type:       res.Item.Type,
+		ClusterKey: res.Item.ClusterKey,
 	}
 	if res.Item.Facts == "" {
 		// Nothing shipped beside the prompt: a single-page step type.

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -171,6 +171,21 @@ type PipelineItem struct {
 	// hypothesize echoes it back to the agent as the `fact` field. Carrying it
 	// here spares the facades a second read of the work item.
 	FactsJSON string
+	// ClusterKey is the stored item's grouping key, carried to the wire so an
+	// answering agent can tell WHAT it is holding (knomit#120).
+	//
+	// It matters because item types differ in what a NON-ANSWER costs. An
+	// ordinary prune cluster is safe to no-op; a restatement pair (key prefixed
+	// `restate-`) is not — a no-op records a DECLINED verdict against the
+	// throttle and permanently retires the standing pair. Two 2-fact prune
+	// items were identical on every other field, so the only safe fleet rule
+	// was to treat every one as possibly destructive.
+	//
+	// The RAW key rather than a derived is_restatement flag: the key already
+	// exists and is already computed, so it cannot drift from its source the
+	// way a second declaration would. The cost is that consumers key off the
+	// prefix, which is why the prefix is pinned as a wire contract by test.
+	ClusterKey string
 	// Facts is the RENDERED payload the strategy chose to ship beside the
 	// prompt — distinct from FactsJSON, which is what the row stores. They
 	// coincide for distill today; keeping them separate is what lets a

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -290,6 +290,17 @@ type ReviewItem struct {
 	// wire, which is pure cost on the exact items that are already too large.
 	// Mirrors HypothesizeItem.Fact, which has always shipped this way.
 	Facts json.RawMessage `json:"facts,omitempty"`
+	// ClusterKey identifies what this item was grouped FROM, so an answering
+	// agent can tell what it is holding (knomit#120).
+	//
+	// Read it before deciding to no-op. Item types differ in what a non-answer
+	// costs: an ordinary prune cluster (`cluster-N`) is safe to skip, while a
+	// restatement pair (`restate-N`) is not — a no-op there records a declined
+	// verdict AND permanently retires the standing pair, recoverable only by an
+	// edit that re-mints it. Before this field the two were identical on the
+	// wire and the only safe rule was to judge every 2-fact prune as though it
+	// were destructive.
+	ClusterKey string `json:"cluster_key,omitempty"`
 
 	// Paging. An item whose facts exceed one tool result is served across
 	// several; the agent accumulates every page and answers once at the end.


### PR DESCRIPTION
Closes #120. **Stacked on #137** (`fix/bridging-line-scope-local`). Review that first; this PR targets it, so its diff shows only this fix.

Also unblocks **#111** — a defer verb an agent cannot aim is not a fix.

## The bug

The work item exposed `id`/`type`/`prompt`/`response_schema`/`facts` — not `ClusterKey`. So an answering agent could not follow the rule *"judge `restate-` items honestly, never no-op them"*, because nothing on the wire told it which 2-fact prune item was one.

**That is destructive, not merely inconvenient.** A no-op on a restatement item records a DECLINED verdict against the judge-outcome throttle **and permanently retires the standing pair** — `DeleteRestatementPair` runs unconditionally after the verdict, recoverable only by an edit that re-mints it.

Measured: a session whose health read `restatement candidates emitted: 1` served two 2-fact prune items, and the operator no-op'd both under the ordinary-cluster rule. Whichever carried the `restate-` key, that no-op was #111's destructive non-answer — **unavoidable rather than avoidable**.

Until now the only safe fleet rule was "treat every 2-fact prune as a possible restatement pair", spending honest judgment on ordinary clusters every session.

## The design choice, and its cost

**The raw key, not a derived `is_restatement` flag.** The key already exists and is already computed, so it cannot drift from its source the way a second declaration would — the same reasoning as #126's schema-derived allowlist. It is also general: it identifies provenance for *every* item type, which #135's cross-pipeline collision work will want.

**The cost is real and is paid for explicitly.** Consumers now key off the `restate-` **prefix**, and a prefix nothing pins is a silent-breakage contract: change the constant and every agent's rule stops matching, with no failure anywhere. So the prefix is pinned by a test that names it as a wire contract and states what changing it costs — *"if it must change, the change is a coordinated wire change, not a rename."*

## ⚠️ Reviewer: two things to check hardest

**1. Both `PipelineItem` construction sites.** `pipeline.go` builds one in `renderWorkItem` and another in `payloadResult` (pages after the first). Populating one would leave a paged item identifiable on page 1 and anonymous afterwards — **worse than uniformly absent**, because the agent reads the later pages last, and that is when it decides how to answer. The paging test walks every page of a genuinely multi-page item and names the page that dropped the key.

**2. The engine/wire split — I got this wrong first and the sabotage caught it.**

The first test was named `...CarriesClusterKeyOnTheWire` and asserted on `PipelineItem` — the **engine** type. `ReviewItem` is what an MCP client receives, and `reviewResult` projects one onto the other field by field. **A fix that populated the engine type and forgot the projection would have satisfied that assertion completely while leaving the wire exactly as broken.**

The test now asserts **both layers, separately labelled**. Verify that the wire-layer assertion genuinely goes through `reviewResult` rather than re-reading the engine struct — that is the whole point of it.

## Sabotage evidence

Three sabotages, three distinct catches — the sites are independent and each is named by the failure.

| sabotage | caught by |
|---|---|
| `ClusterKey` dropped from **`payloadResult`** (page-2 site) | **only** `TestPageItem_CarriesClusterKeyOnEveryPage`, failing with *"page 2 dropped the cluster key"*; the `nextItem` test still passed |
| `ClusterKey` dropped from **`renderWorkItem`** (page-1 / normal site) | both tests — `nextItem` on the engine assertion, paging on *"page 1 dropped..."* |
| `ClusterKey` dropped from **`reviewResult`** (the MCP projection) | **only the WIRE-layer assertion**, by name; the engine-layer assertion in the same test passed |

That third row is the one worth reading twice: engine and wire are separate populations, and only a separately-labelled assertion distinguishes them.

## Attestations

- **MN5** — `internal/synthesize/review_effort_normal_test.go` byte-identical to `dev`.
- **MN13** — no constant added or changed. `restatementClusterKeyPrefix` is *pinned* at its existing value, not introduced.
- Full suite: 49 packages ok. `go vet` clean. `gofmt` clean.
