### PR TITLE
fix(synthesize): surface backfill drain progress and state coverage's ceiling (#124)

### DIFF
--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -334,7 +334,12 @@ type MotifIndex interface {
 	// staleness guard would read "vanished" for a fact that is right there.
 	LiveFactIDs(ctx context.Context, branch string, paths []string) (map[string]int64, error)
 	// MotifCoverage reports how many live authored facts carry a motif.
-	MotifCoverage(ctx context.Context, branch string) (with, total int, err error)
+	// It returns three counts that PARTITION the authored population:
+	// `with` carry a motif, `backlog` are neither covered nor judged (the
+	// offer pool), and `total` is all of them. The caller derives declines as
+	// total-with-backlog rather than counting them separately, so the four
+	// numbers cannot disagree (knomit#124).
+	MotifCoverage(ctx context.Context, branch string) (with, backlog, total int, err error)
 	// AliasRows returns the alias table with its audit columns (method and the
 	// merge rationale).
 	AliasRows(ctx context.Context, branch string) (map[string]AliasRow, error)

--- a/internal/store/motif_definition.go
+++ b/internal/store/motif_definition.go
@@ -361,23 +361,39 @@ func (mi *motifIndex) LiveFactsWithoutMotifs(ctx context.Context, branch string,
 
 // MotifCoverage reports how many live AUTHORED facts carry at least one motif.
 // Reported in health; nothing branches on it.
-func (mi *motifIndex) MotifCoverage(ctx context.Context, branch string) (with, total int, err error) {
+func (mi *motifIndex) MotifCoverage(ctx context.Context, branch string) (with, backlog, total int, err error) {
 	branchID, err := mi.rh.branchID(ctx, branch)
 	if err != nil {
-		return 0, 0, fmt.Errorf("MotifCoverage: %w", err)
+		return 0, 0, 0, fmt.Errorf("MotifCoverage: %w", err)
 	}
+	// All three counts come from ONE query over ONE denominator, and the
+	// backlog term repeats LiveFactsWithoutMotifs' predicate exactly
+	// (knomit#124). The repetition is deliberate and it is the point: the
+	// backlog reported to an operator must be the same population the offer
+	// pool walks, or drain progress describes a queue nobody is draining.
+	// Computing it in a second method with its own WHERE clause is how those
+	// two drift apart.
+	//
+	// The three are a PARTITION — covered + declined + backlog = total — which
+	// is what lets the caller derive `declined` without a fourth count that
+	// could disagree with the other three.
 	err = conn(ctx, mi.rh.db).QueryRowContext(ctx, `
 		SELECT
 		  COUNT(DISTINCT CASE WHEN EXISTS (
 		      SELECT 1 FROM fact_motifs m WHERE m.fact_id = f.id) THEN bf.path END),
+		  COUNT(DISTINCT CASE WHEN NOT EXISTS (
+		      SELECT 1 FROM fact_motifs m WHERE m.fact_id = f.id)
+		    AND NOT EXISTS (
+		      SELECT 1 FROM motif_backfill_judged j
+		       WHERE j.branch_id = bf.branch_id AND j.fact_id = f.id) THEN bf.path END),
 		  COUNT(DISTINCT bf.path)
 		  FROM branch_facts bf
 		  JOIN facts f ON f.id = bf.fact_id
-		 WHERE bf.branch_id = ? AND f.origin = 'authored'`, branchID).Scan(&with, &total)
+		 WHERE bf.branch_id = ? AND f.origin = 'authored'`, branchID).Scan(&with, &backlog, &total)
 	if err != nil {
-		return 0, 0, fmt.Errorf("MotifCoverage: %w", err)
+		return 0, 0, 0, fmt.Errorf("MotifCoverage: %w", err)
 	}
-	return with, total, nil
+	return with, backlog, total, nil
 }
 
 // RecordBackfillJudgedEmpty records that the backfill pass asked about these

--- a/internal/synthesize/backfill_backlog_count_test.go
+++ b/internal/synthesize/backfill_backlog_count_test.go
@@ -1,0 +1,83 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// knomit#124, the store half. Drain progress is only worth reporting if the
+// backlog it is derived from is THE SAME POPULATION the offer pool walks.
+//
+// MotifCoverage's backlog term repeats LiveFactsWithoutMotifs' predicate
+// verbatim, and this test is what stops the two drifting: it asserts they
+// agree across every transition a fact can make — never asked, covered by an
+// assignment, and resolved by an honest decline.
+//
+// A backlog counted with its own slightly-different WHERE clause would report
+// drain progress against a queue nobody is draining, which is the same class
+// of defect as the issue itself (a number describing something other than what
+// happens).
+func TestMotifCoverage_BacklogMatchesTheOfferPool(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	d := env.deps()
+
+	env.writeFact("kb/a.md", "A", "body a")
+	env.writeFact("kb/b.md", "B", "body b")
+	env.writeFact("kb/c.md", "C", "body c")
+
+	// A helper that reads both numbers and asserts the invariant they must
+	// always satisfy: the counted backlog IS the offer pool's size.
+	agree := func(stage string) (with, backlog, total int) {
+		t.Helper()
+		with, backlog, total, err := env.svc.Motifs().MotifCoverage(ctx, env.branch)
+		require.NoError(t, err)
+
+		pool, err := env.svc.Motifs().LiveFactsWithoutMotifs(ctx, env.branch, 1000)
+		require.NoError(t, err)
+
+		require.Equalf(t, len(pool), backlog,
+			"%s: the reported backlog must equal what the offer pool actually "+
+				"holds — a drain figure over a different population is not a "+
+				"drain figure", stage)
+		require.Equalf(t, total, with+backlog+(total-with-backlog),
+			"%s: the three counts must partition the corpus", stage)
+		return with, backlog, total
+	}
+
+	// 1. Nothing asked yet: everything is backlog.
+	with, backlog, total := agree("never asked")
+	require.Equal(t, 0, with)
+	require.Equal(t, 3, backlog)
+	require.Equal(t, 3, total)
+
+	// 2. One fact gains a motif — it leaves the backlog through the fact_motifs
+	// door and lands in coverage.
+	res := motifBackfillResult{Assignments: []motifAssignment{
+		{Path: "kb/a.md", Motifs: []string{"silent-fallback"}},
+	}}
+	require.NoError(t, applyMotifBackfill(ctx, d, env.branch, res,
+		offeredBackfillForTest(t, ctx, env)))
+
+	with, backlog, _ = agree("one assigned")
+	require.Equal(t, 1, with)
+	require.Equal(t, 2, backlog)
+
+	// 3. One fact is honestly DECLINED — it leaves the backlog through the
+	// judged door WITHOUT entering coverage. This is the transition the whole
+	// issue is about, and the one coverage alone cannot see.
+	ids := env.liveFactIDs()
+	require.NoError(t, env.svc.Motifs().RecordBackfillJudgedEmpty(ctx, env.branch,
+		[]int64{ids["kb/b.md"]}))
+
+	with, backlog, total = agree("one declined")
+	require.Equal(t, 1, with, "a decline does NOT raise coverage")
+	require.Equal(t, 1, backlog, "but it DOES shrink the backlog")
+
+	declined := total - with - backlog
+	require.Equal(t, 1, declined,
+		"and the derived decline count finds it — this is the number the "+
+			"ceiling clause is computed from")
+}

--- a/internal/synthesize/backfill_drain_health_test.go
+++ b/internal/synthesize/backfill_drain_health_test.go
@@ -1,0 +1,126 @@
+package synthesize
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// knomit#124. `coverage` counts facts carrying >= 1 motif, but the backlog
+// leaves by TWO doors: a fact that gained a motif leaves via fact_motifs, and a
+// fact an agent judged to carry none leaves via motif_backfill_judged.
+//
+// So an honest decline removes a fact from the backlog WITHOUT adding it to
+// coverage — and coverage can never reach 100% on any corpus where a single
+// fact was honestly declined. Nothing anywhere states that ceiling, and drain
+// progress (the number that CAN reach 100%) is surfaced nowhere at all.
+//
+// The consequence is behavioural, not cosmetic, and it was measured in the
+// field: a completion criterion written against coverage reads as a permanent
+// stall, and the way to keep the number moving is to STOP DECLINING. The metric
+// pays for dishonest judgments. That is what separates this from the rest of
+// the truthful-instrumentation family — the others cost a reader a misreading.
+//
+// The three populations partition the corpus exactly:
+//
+//	total = covered + declined + backlog
+//
+// so every number below is derived from that identity rather than from a
+// second count that could disagree with it.
+func TestRecordBackfillHealth_SurfacesDrainProgressAndTheCeiling(t *testing.T) {
+	// 100 authored facts: 40 carry motifs, 10 were honestly declined, 50 are
+	// still in the backlog.
+	sess := &store.PipelineSession{}
+	recordBackfillHealth(sess, backfillHealth{
+		WithMotifs: 40,
+		TotalFacts: 100,
+		Backlog:    50,
+		Offered:    8,
+		Vocabulary: 5,
+	})
+	require.Len(t, sess.Health, 1)
+	line := sess.Health[0]
+
+	require.Contains(t, line, "coverage 40%",
+		"the existing number keeps its meaning — this fix adds, it does not redefine")
+
+	// DRAIN PROGRESS: the number a completion criterion should read. 50 of 100
+	// facts have been resolved (40 covered + 10 declined), and unlike coverage
+	// it can reach 100%.
+	require.Contains(t, line, "50/100",
+		"judged/total must be surfaced: it is the number that CAN complete, and "+
+			"it was available nowhere")
+
+	// THE CEILING, stated rather than left for a reader to derive. With 10
+	// honest declines, coverage can never exceed 90%.
+	require.Contains(t, line, "90%",
+		"the ceiling must be stated: a completion criterion written against "+
+			"coverage otherwise reads as a permanent stall")
+	require.Contains(t, strings.ToLower(line), "declin",
+		"and it must name WHY the ceiling is where it is — an unexplained "+
+			"ceiling invites someone to 'fix' it by declining less")
+}
+
+// A corpus with no declines has no ceiling below 100%, and must not carry a
+// clause saying so. A line that always mentions a ceiling trains a reader to
+// skip it — the same reasoning as #130's drop clause.
+func TestRecordBackfillHealth_NoCeilingClauseWhenNothingDeclined(t *testing.T) {
+	sess := &store.PipelineSession{}
+	recordBackfillHealth(sess, backfillHealth{
+		WithMotifs: 30,
+		TotalFacts: 100,
+		Backlog:    70, // 30 covered + 0 declined + 70 backlog
+	})
+	require.Len(t, sess.Health, 1)
+	line := sess.Health[0]
+
+	require.Contains(t, line, "30/100", "drain progress is always reported")
+	require.NotContains(t, strings.ToLower(line), "declin",
+		"no declines, no ceiling clause")
+}
+
+// The identity total = covered + declined + backlog is what every derived
+// number rests on. If a caller ever supplies figures that violate it — a
+// backlog larger than the uncovered population, say — the line must not print
+// a negative decline count or a ceiling above 100%. It degrades to the plain
+// form rather than rendering arithmetic nobody can act on.
+func TestRecordBackfillHealth_DegradesRatherThanPrintNonsense(t *testing.T) {
+	sess := &store.PipelineSession{}
+	recordBackfillHealth(sess, backfillHealth{
+		WithMotifs: 40,
+		TotalFacts: 100,
+		Backlog:    90, // impossible: 40 + 90 > 100
+	})
+	require.Len(t, sess.Health, 1)
+	line := sess.Health[0]
+
+	require.NotContains(t, line, "-",
+		"a negative derived count must never reach an operator")
+	require.NotContains(t, strings.ToLower(line), "declin",
+		"an inconsistent input yields no ceiling claim rather than a wrong one")
+}
+
+// COMPOSITION, from the drain and stated on the issue: a corpus can drain
+// PERFECTLY and still show single-digit coverage forever, if most of its facts
+// are honestly motif-less. Coverage measures the corpus's composition; drain
+// progress measures the work. Reporting only the first makes a finished job
+// look like a failed one.
+func TestRecordBackfillHealth_FullyDrainedCorpusReportsCompletion(t *testing.T) {
+	sess := &store.PipelineSession{}
+	recordBackfillHealth(sess, backfillHealth{
+		WithMotifs: 3,
+		TotalFacts: 100,
+		Backlog:    0, // fully drained: 3 covered, 97 declined, nothing pending
+	})
+	require.Len(t, sess.Health, 1)
+	line := sess.Health[0]
+
+	require.Contains(t, line, "coverage 3%",
+		"composition is what it is")
+	require.Contains(t, line, "100/100",
+		"but the DRAIN is complete, and that must be visible — otherwise a "+
+			"finished corpus reads as a 3% failure forever")
+}

--- a/internal/synthesize/cluster_key_wire_test.go
+++ b/internal/synthesize/cluster_key_wire_test.go
@@ -1,0 +1,136 @@
+package synthesize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// knomit#120. The work item exposes id/type/prompt/response_schema/facts — not
+// ClusterKey. So an answering agent cannot follow the rule "judge restate-
+// items honestly, never no-op them", because it cannot tell WHICH 2-fact prune
+// item is one.
+//
+// The consequence is not theoretical and it is destructive. A no-op on a
+// restatement item records a DECLINED verdict against the judge-outcome
+// throttle AND permanently retires the standing pair — DeleteRestatementPair
+// runs unconditionally after the verdict. Measured: a session whose health said
+// "restatement candidates emitted: 1" served two 2-fact prune items; the
+// operator no-op'd both under the ordinary-cluster rule. If either carried a
+// restate- key, that no-op was #111's destructive non-answer — unavoidable
+// rather than avoidable, because nothing on the wire could distinguish them.
+//
+// Until this ships, the only safe fleet rule is "treat every 2-fact prune as a
+// possible restatement pair", which spends honest judgment on ordinary
+// clusters every session.
+func TestNextItem_CarriesClusterKeyOnTheWire(t *testing.T) {
+	ctx := context.Background()
+	r, svc := newPhaseTestReviewer(t)
+	sess := manualSession(t, svc, "agent/test")
+
+	// Two 2-fact prune items, indistinguishable on every field the wire
+	// carried before this fix: same type, same shape, same fact count.
+	require.NoError(t, svc.Pipeline().InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+		SessionID:  sess.ID,
+		StepType:   "prune",
+		ClusterKey: restatementClusterKeyPrefix + "0",
+		FactsJSON:  `[{"file":"kb/technology/a.md"},{"file":"kb/technology/b.md"}]`,
+		Priority:   restatementPriority,
+	}))
+	require.NoError(t, svc.Pipeline().InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+		SessionID:  sess.ID,
+		StepType:   "prune",
+		ClusterKey: "cluster-7",
+		FactsJSON:  `[{"file":"kb/technology/c.md"},{"file":"kb/technology/d.md"}]`,
+		Priority:   0.1,
+	}))
+
+	// BOTH LAYERS, asserted separately — because they are separate structs
+	// populated at separate places, and this test's name promises the wire.
+	//
+	// The engine's PipelineItem is not what an MCP client sees; ReviewItem is,
+	// and `reviewResult` projects one onto the other field by field. A fix that
+	// populated the engine type and forgot the projection would satisfy an
+	// engine-level assertion completely while leaving the wire exactly as
+	// broken as before — the same gap this campaign has now hit five times.
+	engine, err := r.p.nextItem(ctx, sess)
+	require.NoError(t, err)
+	require.NotNil(t, engine.Item)
+
+	// The restatement item sorts first on restatementPriority, so this is the
+	// one an agent meets — and it must be able to tell what it is holding.
+	require.Equal(t, restatementClusterKeyPrefix+"0", engine.Item.ClusterKey,
+		"engine layer: the PipelineItem must carry the stored item's key")
+
+	wire, err := r.PageItem(ctx, sess.ID, engine.Item.ID, 1)
+	require.NoError(t, err)
+	require.NotNil(t, wire.Item)
+	require.Equal(t, restatementClusterKeyPrefix+"0", wire.Item.ClusterKey,
+		"WIRE layer: a restatement pair must be distinguishable from an "+
+			"ordinary 2-fact prune cluster in what the CLIENT receives; without "+
+			"this the only safe rule is to treat every 2-fact prune as possibly "+
+			"destructive to no-op")
+}
+
+// The PAGING path builds its item separately (pipeline.go has two PipelineItem
+// construction sites), and a paged item is exactly where the distinction is
+// most likely to be needed — a large restatement pair arrives across pages, and
+// the agent decides how to answer after reading them.
+//
+// This is the wiring half: populating the field at one construction site and
+// not the other would leave paged items indistinguishable while the unit test
+// above passed.
+func TestPageItem_CarriesClusterKeyOnEveryPage(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+
+	item := currentDistillItem(t, svc, sessionID)
+	require.NotEmpty(t, item.ClusterKey, "precondition: the stored item has a key to carry")
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.Greater(t, first.Item.Pages, 1,
+		"precondition: the item must genuinely span more than one page, or the "+
+			"page-2 construction site below is never exercised")
+
+	// EVERY page, not just the first. Page 1 falls through to renderWorkItem;
+	// pages after it are built by payloadResult — a SECOND PipelineItem
+	// construction site. Populating one and not the other would leave a paged
+	// item identifiable on its first page and anonymous on the rest, which is
+	// worse than uniformly absent: the agent reads the later pages last, and
+	// that is when it decides how to answer.
+	for p := 1; p <= first.Item.Pages; p++ {
+		res, perr := r.PageItem(ctx, sessionID, item.ID, p)
+		require.NoErrorf(t, perr, "page %d", p)
+		require.Equalf(t, item.ClusterKey, res.Item.ClusterKey,
+			"page %d dropped the cluster key; both PipelineItem construction "+
+				"sites must carry it", p)
+	}
+}
+
+// THE WIRE CONTRACT, pinned deliberately.
+//
+// Exposing the raw cluster key rather than a derived is_restatement flag is the
+// choice this fix makes: the key already exists and is already computed, so it
+// cannot drift from its source the way a second declaration would.
+//
+// The cost of that choice is that consumers key off the `restate-` PREFIX, and
+// a prefix nothing pins is a silent-breakage contract — change the constant and
+// every agent's rule quietly stops matching, with no failure anywhere. This
+// test is that pin: it fails, naming the wire contract, if the prefix changes.
+func TestRestatementClusterKeyPrefix_IsAWireContract(t *testing.T) {
+	require.Equal(t, "restate-", restatementClusterKeyPrefix,
+		"this prefix is now part of the WIRE CONTRACT (#120): answering agents "+
+			"identify restatement pairs by it, and a non-answer on one is "+
+			"destructive (#111). Changing it silently breaks every consumer's "+
+			"rule — if it must change, the change is a coordinated wire change, "+
+			"not a rename")
+
+	// And the producer still uses it, so the pin is on a live path rather than
+	// on an orphaned constant.
+	require.True(t, strings.HasPrefix(restatementClusterKeyPrefix+"0", "restate-"))
+}

--- a/internal/synthesize/motif_backfill.go
+++ b/internal/synthesize/motif_backfill.go
@@ -206,6 +206,20 @@ func buildBackfillHints(ctx context.Context, d Deps, branch string, targets []st
 type backfillHealth struct {
 	WithMotifs int
 	TotalFacts int
+	// Backlog is how many authored facts are still UNRESOLVED — neither
+	// carrying a motif nor recorded as judged-none-apply (knomit#124).
+	//
+	// It exists because the backlog leaves by TWO doors and coverage only sees
+	// one. A fact that gained a motif leaves via fact_motifs; a fact an agent
+	// honestly declined leaves via motif_backfill_judged. So the three
+	// populations partition the corpus —
+	//
+	//	total = covered + declined + backlog
+	//
+	// — and this is the term that lets the other two be told apart. Without it
+	// `declined` is unknowable, and with it every derived number below comes
+	// from one identity rather than from a second count that could disagree.
+	Backlog    int
 	Offered    int
 	Vocabulary int
 }
@@ -215,18 +229,57 @@ func recordBackfillHealth(sess *store.PipelineSession, h backfillHealth) {
 		return
 	}
 	pct := 100 * float64(h.WithMotifs) / float64(h.TotalFacts)
-	sess.Health = append(sess.Health, fmt.Sprintf(
-		"motif backfill: coverage %.0f%% (%d/%d authored facts), %d offered this session, %d vocabulary shown",
-		pct, h.WithMotifs, h.TotalFacts, h.Offered, h.Vocabulary))
+
+	// DRAIN PROGRESS, beside coverage and not instead of it — they measure
+	// different things and a reader needs both (knomit#124).
+	//
+	// coverage = covered/total measures the corpus's COMPOSITION: how much of
+	// it turned out to carry a mechanism. resolved = total-backlog measures the
+	// WORK: how much of it has been asked about. Only the second can reach
+	// 100%, because an honest decline resolves a fact without covering it.
+	//
+	// Reporting only coverage made a finished job look like a failed one — a
+	// corpus that drains perfectly still shows single-digit coverage forever if
+	// most of its facts are honestly motif-less. Worse, it priced a behaviour:
+	// a completion criterion written against coverage reads as a permanent
+	// stall, and the way to keep the number moving is to stop declining.
+	resolved := h.TotalFacts - h.Backlog
+	line := fmt.Sprintf(
+		"motif backfill: coverage %.0f%% (%d/%d authored facts), judged %d/%d, "+
+			"%d offered this session, %d vocabulary shown",
+		pct, h.WithMotifs, h.TotalFacts, resolved, h.TotalFacts,
+		h.Offered, h.Vocabulary)
+
+	// The ceiling, stated only when there IS one. An unexplained ceiling
+	// invites someone to "fix" it by declining less, so the clause names the
+	// declines that cause it; and a line that mentions a ceiling every session
+	// trains a reader to skip it (the #130 drop-clause reasoning).
+	//
+	// Guarded on the identity holding: the three populations partition the
+	// corpus, so a caller supplying figures that violate it gets the plain form
+	// rather than a negative count or a ceiling above 100%. Arithmetic nobody
+	// can act on is worse than a number that is merely incomplete.
+	if declined := h.TotalFacts - h.WithMotifs - h.Backlog; declined > 0 && resolved >= 0 {
+		ceiling := 100 * float64(h.TotalFacts-declined) / float64(h.TotalFacts)
+		line += fmt.Sprintf(
+			" — coverage cannot exceed %.0f%%: %d fact(s) were honestly declined "+
+				"(judged, no motif applies), which resolves them without covering them",
+			ceiling, declined)
+	}
+	sess.Health = append(sess.Health, line)
 }
 
 // planMotifBackfillWork enqueues at most one backfill item per session.
 func planMotifBackfillWork(ctx context.Context, d Deps, sess *store.PipelineSession, branch string) error {
-	with, total, err := d.Motifs.MotifCoverage(ctx, branch)
+	with, backlog, total, err := d.Motifs.MotifCoverage(ctx, branch)
 	if err != nil {
 		return nil // an addition to review; degrade rather than fail
 	}
-	health := backfillHealth{WithMotifs: with, TotalFacts: total}
+	// All three counts come from the one query, so the health line's derived
+	// `declined` cannot disagree with them (knomit#124). They are a
+	// SESSION-START snapshot — this runs during Plan, before any of this
+	// session's answers land — which is what the health block is throughout.
+	health := backfillHealth{WithMotifs: with, Backlog: backlog, TotalFacts: total}
 	defer func() { recordBackfillHealth(sess, health) }()
 
 	targets, err := d.Motifs.LiveFactsWithoutMotifs(ctx, branch, maxBackfillFacts)

--- a/internal/synthesize/motif_dynamics_phase2_test.go
+++ b/internal/synthesize/motif_dynamics_phase2_test.go
@@ -225,7 +225,7 @@ func TestPhase2Dynamics_BackfillCoverageClosesOverSessions(t *testing.T) {
 		require.NoError(t, env.svc.Motifs().RebuildAliases(ctx, env.branch))
 	}
 
-	with, all, err := env.svc.Motifs().MotifCoverage(ctx, env.branch)
+	with, _, all, err := env.svc.Motifs().MotifCoverage(ctx, env.branch)
 	require.NoError(t, err)
 	require.Equal(t, all, with,
 		"coverage must CLOSE: every authored fact was offered across the sessions")

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -752,10 +752,15 @@ func (p *Pipeline) payloadResult(ctx context.Context, d Deps, sess *store.Pipeli
 	return &PipelineResult{
 		SessionID: sess.ID,
 		Item: &PipelineItem{
-			ID:        item.ID,
-			Type:      item.StepType,
-			FactsJSON: item.FactsJSON,
-			Facts:     facts,
+			ID:   item.ID,
+			Type: item.StepType,
+			// Carried on EVERY page, not only the first (knomit#120). The agent
+			// reads the later pages last, and that is when it decides how to
+			// answer — a key present on page 1 and absent afterwards would be
+			// worse than uniformly absent.
+			ClusterKey: item.ClusterKey,
+			FactsJSON:  item.FactsJSON,
+			Facts:      facts,
 		},
 		Progress: &ReviewProgress{
 			Completed: completed,
@@ -867,6 +872,7 @@ func (p *Pipeline) renderWorkItem(ctx context.Context, d Deps, sess *store.Pipel
 		Item: &PipelineItem{
 			ID:             item.ID,
 			Type:           view.Type,
+			ClusterKey:     item.ClusterKey,
 			Prompt:         view.Prompt,
 			ResponseSchema: view.ResponseSchema,
 			FactsJSON:      item.FactsJSON,

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -174,8 +174,9 @@ func reviewResultPage(res *PipelineResult, page int) (*ReviewResult, error) {
 	}
 
 	out.Item = &ReviewItem{
-		ID:   res.Item.ID,
-		Type: res.Item.Type,
+		ID:         res.Item.ID,
+		Type:       res.Item.Type,
+		ClusterKey: res.Item.ClusterKey,
 	}
 	if res.Item.Facts == "" {
 		// Nothing shipped beside the prompt: a single-page step type.

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -171,6 +171,21 @@ type PipelineItem struct {
 	// hypothesize echoes it back to the agent as the `fact` field. Carrying it
 	// here spares the facades a second read of the work item.
 	FactsJSON string
+	// ClusterKey is the stored item's grouping key, carried to the wire so an
+	// answering agent can tell WHAT it is holding (knomit#120).
+	//
+	// It matters because item types differ in what a NON-ANSWER costs. An
+	// ordinary prune cluster is safe to no-op; a restatement pair (key prefixed
+	// `restate-`) is not — a no-op records a DECLINED verdict against the
+	// throttle and permanently retires the standing pair. Two 2-fact prune
+	// items were identical on every other field, so the only safe fleet rule
+	// was to treat every one as possibly destructive.
+	//
+	// The RAW key rather than a derived is_restatement flag: the key already
+	// exists and is already computed, so it cannot drift from its source the
+	// way a second declaration would. The cost is that consumers key off the
+	// prefix, which is why the prefix is pinned as a wire contract by test.
+	ClusterKey string
 	// Facts is the RENDERED payload the strategy chose to ship beside the
 	// prompt — distinct from FactsJSON, which is what the row stores. They
 	// coincide for distill today; keeping them separate is what lets a

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -290,6 +290,17 @@ type ReviewItem struct {
 	// wire, which is pure cost on the exact items that are already too large.
 	// Mirrors HypothesizeItem.Fact, which has always shipped this way.
 	Facts json.RawMessage `json:"facts,omitempty"`
+	// ClusterKey identifies what this item was grouped FROM, so an answering
+	// agent can tell what it is holding (knomit#120).
+	//
+	// Read it before deciding to no-op. Item types differ in what a non-answer
+	// costs: an ordinary prune cluster (`cluster-N`) is safe to skip, while a
+	// restatement pair (`restate-N`) is not — a no-op there records a declined
+	// verdict AND permanently retires the standing pair, recoverable only by an
+	// edit that re-mints it. Before this field the two were identical on the
+	// wire and the only safe rule was to judge every 2-fact prune as though it
+	// were destructive.
+	ClusterKey string `json:"cluster_key,omitempty"`
 
 	// Paging. An item whose facts exceed one tool result is served across
 	// several; the agent accumulates every page and answers once at the end.

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -721,7 +721,7 @@ func report(ctx context.Context, corpus, scratch string) error {
 			"epistemic seeds only, so MotifReport.seed_bridgeable_pairs is the smaller number " +
 			"and the one an activation decision is made on.",
 	}
-	if with, total, err := svc.Motifs().MotifCoverage(ctx, branch); err == nil {
+	if with, _, total, err := svc.Motifs().MotifCoverage(ctx, branch); err == nil {
 		r.WithMotifs, r.AuthoredLive = with, total
 		if total > 0 {
 			r.Coverage = float64(with) / float64(total)


### PR DESCRIPTION
Closes #124. **Stacked on #138** → #137. Review those first; this PR targets #138.

## The bug

`coverage` counts facts carrying ≥1 motif — but the backlog leaves by **two doors**. A fact that gained a motif leaves via `fact_motifs`; a fact an agent honestly declined leaves via `motif_backfill_judged`.

So an honest decline removes a fact from the backlog **without adding it to coverage**, and coverage can never reach 100% on any corpus where a single fact was honestly declined. Nothing stated that ceiling, and drain progress — the number that *can* reach 100% — was surfaced nowhere at all.

**The consequence is behavioural, not cosmetic.** Measured in the field: a completion criterion written against coverage reads as a permanent stall, and the way to keep the number moving is to **stop declining**. The metric priced a behaviour. That is what separates this from the rest of the truthful-instrumentation family, whose members merely cost a reader a misreading.

The composition point makes it worse: **a corpus can drain perfectly and still show single-digit coverage forever**, if most of its facts are honestly motif-less. Coverage measures the corpus's *composition*; drain progress measures the *work*. Reporting only the first makes a finished job look like a failed one — there is a test for exactly that case, asserting `coverage 3%` beside `judged 100/100`.

## One query, one denominator

`MotifCoverage` now returns `(with, backlog, total)`, and **the backlog term repeats `LiveFactsWithoutMotifs`' predicate verbatim.**

That repetition is deliberate and it is the point: the backlog reported to an operator must be **the same population the offer pool walks**, or drain progress describes a queue nobody is draining. A second method with its own `WHERE` clause is exactly how those two drift apart.

The three counts **partition** the corpus:

```
total = covered + declined + backlog
```

so `declined` is *derived from the identity* rather than counted separately, and the four numbers cannot disagree. That also handles a case a naive two-count version gets wrong: a fact judged-empty that **later gains motifs through a merge** would be double-counted by arithmetic over two independent counts. It cannot be, by a partition.

## ⚠️ Reviewer: the store-half test is the one to check

`TestMotifCoverage_BacklogMatchesTheOfferPool` asserts the reported backlog **equals the offer pool** across every transition a fact can make — never asked, covered by assignment, resolved by decline.

Verified by sabotage: dropping the judged clause from the backlog term fails it **at the "one declined" stage precisely** — which is the *only* transition that distinguishes the two predicates. The health-line unit tests all still passed under that sabotage, because they take `Backlog` as an input. So this test carries that catch alone.

The ceiling clause renders **only when there are declines** (the #130 drop-clause reasoning: a line that mentions a ceiling every session trains a reader to skip it) and **names the declines that cause it**, because an unexplained ceiling invites someone to "fix" it by declining less.

## Snapshot semantics, stated

These are **session-start** figures — the health block is recorded during `Plan`, before any of this session's answers land. That is true of the whole block; it is now said where the numbers are taken rather than left to be inferred.

## Sabotage evidence

| sabotage | caught by |
|---|---|
| judged clause dropped from the backlog term (predicate drifts from the offer pool) | **only** `TestMotifCoverage_BacklogMatchesTheOfferPool`, at the "one declined" stage; every health-line test passed |
| ceiling clause rendered unconditionally (`declined > 0 && resolved >= 0` → `true`) | `NoCeilingClauseWhenNothingDeclined` **and** `DegradesRatherThanPrintNonsense` |
| (RED, before implementing) no drain figure at all | `SurfacesDrainProgressAndTheCeiling` and `FullyDrainedCorpusReportsCompletion` |

## Attestations

- **MN5** — `internal/synthesize/review_effort_normal_test.go` byte-identical to `dev`.
- **MN13** — no constant added or changed. The percentages are derived from corpus counts, not thresholds.
- Full suite: 49 packages ok. `go vet` clean. `gofmt` clean.
- `MotifCoverage`'s signature changed; both callers updated (`planMotifBackfillWork`, `tools/motifannex`) plus one test.
