### PR TITLE
fix(synthesize): the vocabulary line labels both df populations (#116)

### DIFF
--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -334,7 +334,12 @@ type MotifIndex interface {
 	// staleness guard would read "vanished" for a fact that is right there.
 	LiveFactIDs(ctx context.Context, branch string, paths []string) (map[string]int64, error)
 	// MotifCoverage reports how many live authored facts carry a motif.
-	MotifCoverage(ctx context.Context, branch string) (with, total int, err error)
+	// It returns three counts that PARTITION the authored population:
+	// `with` carry a motif, `backlog` are neither covered nor judged (the
+	// offer pool), and `total` is all of them. The caller derives declines as
+	// total-with-backlog rather than counting them separately, so the four
+	// numbers cannot disagree (knomit#124).
+	MotifCoverage(ctx context.Context, branch string) (with, backlog, total int, err error)
 	// AliasRows returns the alias table with its audit columns (method and the
 	// merge rationale).
 	AliasRows(ctx context.Context, branch string) (map[string]AliasRow, error)

--- a/internal/store/motif_definition.go
+++ b/internal/store/motif_definition.go
@@ -211,6 +211,23 @@ type MotifVocabularyHealth struct {
 	// links; one where every cluster has exactly two carriers has high
 	// recurrence and modest links. Both numbers are needed to tell those apart.
 	Links int
+	// EpistemicRecurring is how many clusters have df >= 2 counting EPISTEMIC
+	// carriers only — the population the activation floor actually reads
+	// (knomit#116).
+	//
+	// Reported beside Recurring because the two diverge, badly, and nothing
+	// said so. Recurring's "authored facts only" qualifier filters ORIGIN, not
+	// KIND, so a reader takes it as naming the population when it names a
+	// different axis entirely. Measured divergence up to 5.0x — one motif read
+	// raw df 5 / epistemic df 1, all five carriers in one folder — and one
+	// corpus printed "3 recur" four lines above "0 recurring motif(s) … below
+	// the floor", in the same health block.
+	//
+	// Mint quality and activation contribution are INDEPENDENT axes: a name can
+	// be among the healthiest in a vocabulary by span and contribute nothing to
+	// activation, because all its carriers are pragmatic. The floor is right not
+	// to count them; the line was wrong to imply it had.
+	EpistemicRecurring int
 }
 
 // RecurrenceRate is the fraction of clusters carried by more than one fact.
@@ -256,9 +273,20 @@ func (mi *motifIndex) VocabularyHealth(ctx context.Context, branch string) (Moti
 	// report one cluster where the point readers see several singletons. The two
 	// queries agree because they compute the same thing, not because they were
 	// written on the same day.
+	// Both df counts come from ONE row per cluster, so the raw and epistemic
+	// figures can never describe different cluster sets (knomit#116). A second
+	// query with its own GROUP BY would be free to disagree with this one about
+	// which clusters exist, and the whole point of reporting them side by side
+	// is that they are the same clusters counted over different carriers.
+	//
+	// The epistemic predicate is `f.kind = 'epistemic'` — the same one
+	// AcceptSeed and epistemicLiveJoin apply, which is what makes this number
+	// the one the activation floor reads rather than merely a similar one.
 	key := motifClusterKeyExpr("m.motif")
 	rows, err := conn(ctx, mi.rh.db).QueryContext(ctx, `
-		SELECT `+key+`, COUNT(DISTINCT bf.path)
+		SELECT `+key+`,
+		       COUNT(DISTINCT bf.path),
+		       COUNT(DISTINCT CASE WHEN f.kind = 'epistemic' THEN bf.path END)
 		  FROM branch_facts bf
 		  JOIN facts f ON f.id = bf.fact_id
 		  JOIN fact_motifs m ON m.fact_id = bf.fact_id
@@ -271,14 +299,17 @@ func (mi *motifIndex) VocabularyHealth(ctx context.Context, branch string) (Moti
 	defer rows.Close()
 	for rows.Next() {
 		var key string
-		var df int
-		if err := rows.Scan(&key, &df); err != nil {
+		var df, epistemicDF int
+		if err := rows.Scan(&key, &df, &epistemicDF); err != nil {
 			return h, fmt.Errorf("VocabularyHealth: scan: %w", err)
 		}
 		h.Clusters++
 		h.Mints++ // one mint per cluster, by whichever fact first used it
 		if df >= 2 {
 			h.Recurring++
+		}
+		if epistemicDF >= 2 {
+			h.EpistemicRecurring++
 		}
 		h.Links += df - 1 // every use after the first
 	}

--- a/internal/store/motif_definition.go
+++ b/internal/store/motif_definition.go
@@ -361,23 +361,39 @@ func (mi *motifIndex) LiveFactsWithoutMotifs(ctx context.Context, branch string,
 
 // MotifCoverage reports how many live AUTHORED facts carry at least one motif.
 // Reported in health; nothing branches on it.
-func (mi *motifIndex) MotifCoverage(ctx context.Context, branch string) (with, total int, err error) {
+func (mi *motifIndex) MotifCoverage(ctx context.Context, branch string) (with, backlog, total int, err error) {
 	branchID, err := mi.rh.branchID(ctx, branch)
 	if err != nil {
-		return 0, 0, fmt.Errorf("MotifCoverage: %w", err)
+		return 0, 0, 0, fmt.Errorf("MotifCoverage: %w", err)
 	}
+	// All three counts come from ONE query over ONE denominator, and the
+	// backlog term repeats LiveFactsWithoutMotifs' predicate exactly
+	// (knomit#124). The repetition is deliberate and it is the point: the
+	// backlog reported to an operator must be the same population the offer
+	// pool walks, or drain progress describes a queue nobody is draining.
+	// Computing it in a second method with its own WHERE clause is how those
+	// two drift apart.
+	//
+	// The three are a PARTITION — covered + declined + backlog = total — which
+	// is what lets the caller derive `declined` without a fourth count that
+	// could disagree with the other three.
 	err = conn(ctx, mi.rh.db).QueryRowContext(ctx, `
 		SELECT
 		  COUNT(DISTINCT CASE WHEN EXISTS (
 		      SELECT 1 FROM fact_motifs m WHERE m.fact_id = f.id) THEN bf.path END),
+		  COUNT(DISTINCT CASE WHEN NOT EXISTS (
+		      SELECT 1 FROM fact_motifs m WHERE m.fact_id = f.id)
+		    AND NOT EXISTS (
+		      SELECT 1 FROM motif_backfill_judged j
+		       WHERE j.branch_id = bf.branch_id AND j.fact_id = f.id) THEN bf.path END),
 		  COUNT(DISTINCT bf.path)
 		  FROM branch_facts bf
 		  JOIN facts f ON f.id = bf.fact_id
-		 WHERE bf.branch_id = ? AND f.origin = 'authored'`, branchID).Scan(&with, &total)
+		 WHERE bf.branch_id = ? AND f.origin = 'authored'`, branchID).Scan(&with, &backlog, &total)
 	if err != nil {
-		return 0, 0, fmt.Errorf("MotifCoverage: %w", err)
+		return 0, 0, 0, fmt.Errorf("MotifCoverage: %w", err)
 	}
-	return with, total, nil
+	return with, backlog, total, nil
 }
 
 // RecordBackfillJudgedEmpty records that the backfill pass asked about these

--- a/internal/synthesize/backfill_backlog_count_test.go
+++ b/internal/synthesize/backfill_backlog_count_test.go
@@ -1,0 +1,83 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// knomit#124, the store half. Drain progress is only worth reporting if the
+// backlog it is derived from is THE SAME POPULATION the offer pool walks.
+//
+// MotifCoverage's backlog term repeats LiveFactsWithoutMotifs' predicate
+// verbatim, and this test is what stops the two drifting: it asserts they
+// agree across every transition a fact can make — never asked, covered by an
+// assignment, and resolved by an honest decline.
+//
+// A backlog counted with its own slightly-different WHERE clause would report
+// drain progress against a queue nobody is draining, which is the same class
+// of defect as the issue itself (a number describing something other than what
+// happens).
+func TestMotifCoverage_BacklogMatchesTheOfferPool(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	d := env.deps()
+
+	env.writeFact("kb/a.md", "A", "body a")
+	env.writeFact("kb/b.md", "B", "body b")
+	env.writeFact("kb/c.md", "C", "body c")
+
+	// A helper that reads both numbers and asserts the invariant they must
+	// always satisfy: the counted backlog IS the offer pool's size.
+	agree := func(stage string) (with, backlog, total int) {
+		t.Helper()
+		with, backlog, total, err := env.svc.Motifs().MotifCoverage(ctx, env.branch)
+		require.NoError(t, err)
+
+		pool, err := env.svc.Motifs().LiveFactsWithoutMotifs(ctx, env.branch, 1000)
+		require.NoError(t, err)
+
+		require.Equalf(t, len(pool), backlog,
+			"%s: the reported backlog must equal what the offer pool actually "+
+				"holds — a drain figure over a different population is not a "+
+				"drain figure", stage)
+		require.Equalf(t, total, with+backlog+(total-with-backlog),
+			"%s: the three counts must partition the corpus", stage)
+		return with, backlog, total
+	}
+
+	// 1. Nothing asked yet: everything is backlog.
+	with, backlog, total := agree("never asked")
+	require.Equal(t, 0, with)
+	require.Equal(t, 3, backlog)
+	require.Equal(t, 3, total)
+
+	// 2. One fact gains a motif — it leaves the backlog through the fact_motifs
+	// door and lands in coverage.
+	res := motifBackfillResult{Assignments: []motifAssignment{
+		{Path: "kb/a.md", Motifs: []string{"silent-fallback"}},
+	}}
+	require.NoError(t, applyMotifBackfill(ctx, d, env.branch, res,
+		offeredBackfillForTest(t, ctx, env)))
+
+	with, backlog, _ = agree("one assigned")
+	require.Equal(t, 1, with)
+	require.Equal(t, 2, backlog)
+
+	// 3. One fact is honestly DECLINED — it leaves the backlog through the
+	// judged door WITHOUT entering coverage. This is the transition the whole
+	// issue is about, and the one coverage alone cannot see.
+	ids := env.liveFactIDs()
+	require.NoError(t, env.svc.Motifs().RecordBackfillJudgedEmpty(ctx, env.branch,
+		[]int64{ids["kb/b.md"]}))
+
+	with, backlog, total = agree("one declined")
+	require.Equal(t, 1, with, "a decline does NOT raise coverage")
+	require.Equal(t, 1, backlog, "but it DOES shrink the backlog")
+
+	declined := total - with - backlog
+	require.Equal(t, 1, declined,
+		"and the derived decline count finds it — this is the number the "+
+			"ceiling clause is computed from")
+}

--- a/internal/synthesize/backfill_drain_health_test.go
+++ b/internal/synthesize/backfill_drain_health_test.go
@@ -1,0 +1,126 @@
+package synthesize
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// knomit#124. `coverage` counts facts carrying >= 1 motif, but the backlog
+// leaves by TWO doors: a fact that gained a motif leaves via fact_motifs, and a
+// fact an agent judged to carry none leaves via motif_backfill_judged.
+//
+// So an honest decline removes a fact from the backlog WITHOUT adding it to
+// coverage — and coverage can never reach 100% on any corpus where a single
+// fact was honestly declined. Nothing anywhere states that ceiling, and drain
+// progress (the number that CAN reach 100%) is surfaced nowhere at all.
+//
+// The consequence is behavioural, not cosmetic, and it was measured in the
+// field: a completion criterion written against coverage reads as a permanent
+// stall, and the way to keep the number moving is to STOP DECLINING. The metric
+// pays for dishonest judgments. That is what separates this from the rest of
+// the truthful-instrumentation family — the others cost a reader a misreading.
+//
+// The three populations partition the corpus exactly:
+//
+//	total = covered + declined + backlog
+//
+// so every number below is derived from that identity rather than from a
+// second count that could disagree with it.
+func TestRecordBackfillHealth_SurfacesDrainProgressAndTheCeiling(t *testing.T) {
+	// 100 authored facts: 40 carry motifs, 10 were honestly declined, 50 are
+	// still in the backlog.
+	sess := &store.PipelineSession{}
+	recordBackfillHealth(sess, backfillHealth{
+		WithMotifs: 40,
+		TotalFacts: 100,
+		Backlog:    50,
+		Offered:    8,
+		Vocabulary: 5,
+	})
+	require.Len(t, sess.Health, 1)
+	line := sess.Health[0]
+
+	require.Contains(t, line, "coverage 40%",
+		"the existing number keeps its meaning — this fix adds, it does not redefine")
+
+	// DRAIN PROGRESS: the number a completion criterion should read. 50 of 100
+	// facts have been resolved (40 covered + 10 declined), and unlike coverage
+	// it can reach 100%.
+	require.Contains(t, line, "50/100",
+		"judged/total must be surfaced: it is the number that CAN complete, and "+
+			"it was available nowhere")
+
+	// THE CEILING, stated rather than left for a reader to derive. With 10
+	// honest declines, coverage can never exceed 90%.
+	require.Contains(t, line, "90%",
+		"the ceiling must be stated: a completion criterion written against "+
+			"coverage otherwise reads as a permanent stall")
+	require.Contains(t, strings.ToLower(line), "declin",
+		"and it must name WHY the ceiling is where it is — an unexplained "+
+			"ceiling invites someone to 'fix' it by declining less")
+}
+
+// A corpus with no declines has no ceiling below 100%, and must not carry a
+// clause saying so. A line that always mentions a ceiling trains a reader to
+// skip it — the same reasoning as #130's drop clause.
+func TestRecordBackfillHealth_NoCeilingClauseWhenNothingDeclined(t *testing.T) {
+	sess := &store.PipelineSession{}
+	recordBackfillHealth(sess, backfillHealth{
+		WithMotifs: 30,
+		TotalFacts: 100,
+		Backlog:    70, // 30 covered + 0 declined + 70 backlog
+	})
+	require.Len(t, sess.Health, 1)
+	line := sess.Health[0]
+
+	require.Contains(t, line, "30/100", "drain progress is always reported")
+	require.NotContains(t, strings.ToLower(line), "declin",
+		"no declines, no ceiling clause")
+}
+
+// The identity total = covered + declined + backlog is what every derived
+// number rests on. If a caller ever supplies figures that violate it — a
+// backlog larger than the uncovered population, say — the line must not print
+// a negative decline count or a ceiling above 100%. It degrades to the plain
+// form rather than rendering arithmetic nobody can act on.
+func TestRecordBackfillHealth_DegradesRatherThanPrintNonsense(t *testing.T) {
+	sess := &store.PipelineSession{}
+	recordBackfillHealth(sess, backfillHealth{
+		WithMotifs: 40,
+		TotalFacts: 100,
+		Backlog:    90, // impossible: 40 + 90 > 100
+	})
+	require.Len(t, sess.Health, 1)
+	line := sess.Health[0]
+
+	require.NotContains(t, line, "-",
+		"a negative derived count must never reach an operator")
+	require.NotContains(t, strings.ToLower(line), "declin",
+		"an inconsistent input yields no ceiling claim rather than a wrong one")
+}
+
+// COMPOSITION, from the drain and stated on the issue: a corpus can drain
+// PERFECTLY and still show single-digit coverage forever, if most of its facts
+// are honestly motif-less. Coverage measures the corpus's composition; drain
+// progress measures the work. Reporting only the first makes a finished job
+// look like a failed one.
+func TestRecordBackfillHealth_FullyDrainedCorpusReportsCompletion(t *testing.T) {
+	sess := &store.PipelineSession{}
+	recordBackfillHealth(sess, backfillHealth{
+		WithMotifs: 3,
+		TotalFacts: 100,
+		Backlog:    0, // fully drained: 3 covered, 97 declined, nothing pending
+	})
+	require.Len(t, sess.Health, 1)
+	line := sess.Health[0]
+
+	require.Contains(t, line, "coverage 3%",
+		"composition is what it is")
+	require.Contains(t, line, "100/100",
+		"but the DRAIN is complete, and that must be visible — otherwise a "+
+			"finished corpus reads as a 3% failure forever")
+}

--- a/internal/synthesize/cluster_key_wire_test.go
+++ b/internal/synthesize/cluster_key_wire_test.go
@@ -1,0 +1,136 @@
+package synthesize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// knomit#120. The work item exposes id/type/prompt/response_schema/facts — not
+// ClusterKey. So an answering agent cannot follow the rule "judge restate-
+// items honestly, never no-op them", because it cannot tell WHICH 2-fact prune
+// item is one.
+//
+// The consequence is not theoretical and it is destructive. A no-op on a
+// restatement item records a DECLINED verdict against the judge-outcome
+// throttle AND permanently retires the standing pair — DeleteRestatementPair
+// runs unconditionally after the verdict. Measured: a session whose health said
+// "restatement candidates emitted: 1" served two 2-fact prune items; the
+// operator no-op'd both under the ordinary-cluster rule. If either carried a
+// restate- key, that no-op was #111's destructive non-answer — unavoidable
+// rather than avoidable, because nothing on the wire could distinguish them.
+//
+// Until this ships, the only safe fleet rule is "treat every 2-fact prune as a
+// possible restatement pair", which spends honest judgment on ordinary
+// clusters every session.
+func TestNextItem_CarriesClusterKeyOnTheWire(t *testing.T) {
+	ctx := context.Background()
+	r, svc := newPhaseTestReviewer(t)
+	sess := manualSession(t, svc, "agent/test")
+
+	// Two 2-fact prune items, indistinguishable on every field the wire
+	// carried before this fix: same type, same shape, same fact count.
+	require.NoError(t, svc.Pipeline().InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+		SessionID:  sess.ID,
+		StepType:   "prune",
+		ClusterKey: restatementClusterKeyPrefix + "0",
+		FactsJSON:  `[{"file":"kb/technology/a.md"},{"file":"kb/technology/b.md"}]`,
+		Priority:   restatementPriority,
+	}))
+	require.NoError(t, svc.Pipeline().InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+		SessionID:  sess.ID,
+		StepType:   "prune",
+		ClusterKey: "cluster-7",
+		FactsJSON:  `[{"file":"kb/technology/c.md"},{"file":"kb/technology/d.md"}]`,
+		Priority:   0.1,
+	}))
+
+	// BOTH LAYERS, asserted separately — because they are separate structs
+	// populated at separate places, and this test's name promises the wire.
+	//
+	// The engine's PipelineItem is not what an MCP client sees; ReviewItem is,
+	// and `reviewResult` projects one onto the other field by field. A fix that
+	// populated the engine type and forgot the projection would satisfy an
+	// engine-level assertion completely while leaving the wire exactly as
+	// broken as before — the same gap this campaign has now hit five times.
+	engine, err := r.p.nextItem(ctx, sess)
+	require.NoError(t, err)
+	require.NotNil(t, engine.Item)
+
+	// The restatement item sorts first on restatementPriority, so this is the
+	// one an agent meets — and it must be able to tell what it is holding.
+	require.Equal(t, restatementClusterKeyPrefix+"0", engine.Item.ClusterKey,
+		"engine layer: the PipelineItem must carry the stored item's key")
+
+	wire, err := r.PageItem(ctx, sess.ID, engine.Item.ID, 1)
+	require.NoError(t, err)
+	require.NotNil(t, wire.Item)
+	require.Equal(t, restatementClusterKeyPrefix+"0", wire.Item.ClusterKey,
+		"WIRE layer: a restatement pair must be distinguishable from an "+
+			"ordinary 2-fact prune cluster in what the CLIENT receives; without "+
+			"this the only safe rule is to treat every 2-fact prune as possibly "+
+			"destructive to no-op")
+}
+
+// The PAGING path builds its item separately (pipeline.go has two PipelineItem
+// construction sites), and a paged item is exactly where the distinction is
+// most likely to be needed — a large restatement pair arrives across pages, and
+// the agent decides how to answer after reading them.
+//
+// This is the wiring half: populating the field at one construction site and
+// not the other would leave paged items indistinguishable while the unit test
+// above passed.
+func TestPageItem_CarriesClusterKeyOnEveryPage(t *testing.T) {
+	r, svc, sessionID := pagingCorpus(t, 60, 3*1024)
+	ctx := context.Background()
+
+	item := currentDistillItem(t, svc, sessionID)
+	require.NotEmpty(t, item.ClusterKey, "precondition: the stored item has a key to carry")
+
+	first, err := r.PageItem(ctx, sessionID, item.ID, 1)
+	require.NoError(t, err)
+	require.Greater(t, first.Item.Pages, 1,
+		"precondition: the item must genuinely span more than one page, or the "+
+			"page-2 construction site below is never exercised")
+
+	// EVERY page, not just the first. Page 1 falls through to renderWorkItem;
+	// pages after it are built by payloadResult — a SECOND PipelineItem
+	// construction site. Populating one and not the other would leave a paged
+	// item identifiable on its first page and anonymous on the rest, which is
+	// worse than uniformly absent: the agent reads the later pages last, and
+	// that is when it decides how to answer.
+	for p := 1; p <= first.Item.Pages; p++ {
+		res, perr := r.PageItem(ctx, sessionID, item.ID, p)
+		require.NoErrorf(t, perr, "page %d", p)
+		require.Equalf(t, item.ClusterKey, res.Item.ClusterKey,
+			"page %d dropped the cluster key; both PipelineItem construction "+
+				"sites must carry it", p)
+	}
+}
+
+// THE WIRE CONTRACT, pinned deliberately.
+//
+// Exposing the raw cluster key rather than a derived is_restatement flag is the
+// choice this fix makes: the key already exists and is already computed, so it
+// cannot drift from its source the way a second declaration would.
+//
+// The cost of that choice is that consumers key off the `restate-` PREFIX, and
+// a prefix nothing pins is a silent-breakage contract — change the constant and
+// every agent's rule quietly stops matching, with no failure anywhere. This
+// test is that pin: it fails, naming the wire contract, if the prefix changes.
+func TestRestatementClusterKeyPrefix_IsAWireContract(t *testing.T) {
+	require.Equal(t, "restate-", restatementClusterKeyPrefix,
+		"this prefix is now part of the WIRE CONTRACT (#120): answering agents "+
+			"identify restatement pairs by it, and a non-answer on one is "+
+			"destructive (#111). Changing it silently breaks every consumer's "+
+			"rule — if it must change, the change is a coordinated wire change, "+
+			"not a rename")
+
+	// And the producer still uses it, so the pin is on a live path rather than
+	// on an orphaned constant.
+	require.True(t, strings.HasPrefix(restatementClusterKeyPrefix+"0", "restate-"))
+}

--- a/internal/synthesize/motif_backfill.go
+++ b/internal/synthesize/motif_backfill.go
@@ -206,6 +206,20 @@ func buildBackfillHints(ctx context.Context, d Deps, branch string, targets []st
 type backfillHealth struct {
 	WithMotifs int
 	TotalFacts int
+	// Backlog is how many authored facts are still UNRESOLVED — neither
+	// carrying a motif nor recorded as judged-none-apply (knomit#124).
+	//
+	// It exists because the backlog leaves by TWO doors and coverage only sees
+	// one. A fact that gained a motif leaves via fact_motifs; a fact an agent
+	// honestly declined leaves via motif_backfill_judged. So the three
+	// populations partition the corpus —
+	//
+	//	total = covered + declined + backlog
+	//
+	// — and this is the term that lets the other two be told apart. Without it
+	// `declined` is unknowable, and with it every derived number below comes
+	// from one identity rather than from a second count that could disagree.
+	Backlog    int
 	Offered    int
 	Vocabulary int
 }
@@ -215,18 +229,57 @@ func recordBackfillHealth(sess *store.PipelineSession, h backfillHealth) {
 		return
 	}
 	pct := 100 * float64(h.WithMotifs) / float64(h.TotalFacts)
-	sess.Health = append(sess.Health, fmt.Sprintf(
-		"motif backfill: coverage %.0f%% (%d/%d authored facts), %d offered this session, %d vocabulary shown",
-		pct, h.WithMotifs, h.TotalFacts, h.Offered, h.Vocabulary))
+
+	// DRAIN PROGRESS, beside coverage and not instead of it — they measure
+	// different things and a reader needs both (knomit#124).
+	//
+	// coverage = covered/total measures the corpus's COMPOSITION: how much of
+	// it turned out to carry a mechanism. resolved = total-backlog measures the
+	// WORK: how much of it has been asked about. Only the second can reach
+	// 100%, because an honest decline resolves a fact without covering it.
+	//
+	// Reporting only coverage made a finished job look like a failed one — a
+	// corpus that drains perfectly still shows single-digit coverage forever if
+	// most of its facts are honestly motif-less. Worse, it priced a behaviour:
+	// a completion criterion written against coverage reads as a permanent
+	// stall, and the way to keep the number moving is to stop declining.
+	resolved := h.TotalFacts - h.Backlog
+	line := fmt.Sprintf(
+		"motif backfill: coverage %.0f%% (%d/%d authored facts), judged %d/%d, "+
+			"%d offered this session, %d vocabulary shown",
+		pct, h.WithMotifs, h.TotalFacts, resolved, h.TotalFacts,
+		h.Offered, h.Vocabulary)
+
+	// The ceiling, stated only when there IS one. An unexplained ceiling
+	// invites someone to "fix" it by declining less, so the clause names the
+	// declines that cause it; and a line that mentions a ceiling every session
+	// trains a reader to skip it (the #130 drop-clause reasoning).
+	//
+	// Guarded on the identity holding: the three populations partition the
+	// corpus, so a caller supplying figures that violate it gets the plain form
+	// rather than a negative count or a ceiling above 100%. Arithmetic nobody
+	// can act on is worse than a number that is merely incomplete.
+	if declined := h.TotalFacts - h.WithMotifs - h.Backlog; declined > 0 && resolved >= 0 {
+		ceiling := 100 * float64(h.TotalFacts-declined) / float64(h.TotalFacts)
+		line += fmt.Sprintf(
+			" — coverage cannot exceed %.0f%%: %d fact(s) were honestly declined "+
+				"(judged, no motif applies), which resolves them without covering them",
+			ceiling, declined)
+	}
+	sess.Health = append(sess.Health, line)
 }
 
 // planMotifBackfillWork enqueues at most one backfill item per session.
 func planMotifBackfillWork(ctx context.Context, d Deps, sess *store.PipelineSession, branch string) error {
-	with, total, err := d.Motifs.MotifCoverage(ctx, branch)
+	with, backlog, total, err := d.Motifs.MotifCoverage(ctx, branch)
 	if err != nil {
 		return nil // an addition to review; degrade rather than fail
 	}
-	health := backfillHealth{WithMotifs: with, TotalFacts: total}
+	// All three counts come from the one query, so the health line's derived
+	// `declined` cannot disagree with them (knomit#124). They are a
+	// SESSION-START snapshot — this runs during Plan, before any of this
+	// session's answers land — which is what the health block is throughout.
+	health := backfillHealth{WithMotifs: with, Backlog: backlog, TotalFacts: total}
 	defer func() { recordBackfillHealth(sess, health) }()
 
 	targets, err := d.Motifs.LiveFactsWithoutMotifs(ctx, branch, maxBackfillFacts)

--- a/internal/synthesize/motif_define.go
+++ b/internal/synthesize/motif_define.go
@@ -186,10 +186,36 @@ func motifVocabularyHealthLines(h store.MotifVocabularyHealth) []string {
 	if h.Clusters == 0 {
 		return nil
 	}
-	return []string{fmt.Sprintf(
-		"motif vocabulary: %d clusters, recurrence %.0f%% (%d recur), mint-to-link %.2f (%d mints / %d links), authored facts only",
-		h.Clusters, 100*h.RecurrenceRate(), h.Recurring,
-		h.MintToLinkRatio(), h.Mints, h.Links)}
+	// BOTH POPULATIONS, BOTH LABELLED (knomit#116). The raw figure counts every
+	// authored carrier; the activation floor reads only EPISTEMIC ones, and the
+	// two diverge by up to 5x on measured corpora. The old line's "authored
+	// facts only" qualifier filters ORIGIN, not KIND — a reader takes it as
+	// naming the population, and it names a different axis.
+	//
+	// Labelling, not redefinition: raw recurrence keeps its meaning, because it
+	// is the honest answer to "is this vocabulary being reused at all". The
+	// epistemic count answers a different question — "how close is bridging to
+	// activating" — and only that one was ever unavailable.
+	return []string{
+		fmt.Sprintf(
+			"motif vocabulary: %d clusters, recurrence %.0f%% (%d recur over authored "+
+				"carriers; %d recur over EPISTEMIC carriers — the population the "+
+				"activation floor reads), mint-to-link %.2f (%d mints / %d links)",
+			h.Clusters, 100*h.RecurrenceRate(), h.Recurring, h.EpistemicRecurring,
+			h.MintToLinkRatio(), h.Mints, h.Links),
+
+		// ONE SENTENCE, ITS OWN LINE, REMOVED BY #127's FIX. df counts
+		// CARRIERS, and duplicate records of one event inflate it — measured
+		// live at df 4 resting on one event. Labelling the population correctly
+		// does not make the count correct, so this says so rather than shipping
+		// a more precise wrong number.
+		//
+		// Deliberately self-contained and last: #127's PR deletes this line, and
+		// nothing above depends on its presence or its position.
+		"motif vocabulary caveat: df counts CARRIERS, not distinct claims — " +
+			"duplicate records of one event inflate every figure above (#127); " +
+			"treat them as upper bounds until that lands.",
+	}
 }
 
 // motifDefineHealth reports what the pass did. Nothing branches on it.

--- a/internal/synthesize/motif_dynamics_phase2_test.go
+++ b/internal/synthesize/motif_dynamics_phase2_test.go
@@ -225,7 +225,7 @@ func TestPhase2Dynamics_BackfillCoverageClosesOverSessions(t *testing.T) {
 		require.NoError(t, env.svc.Motifs().RebuildAliases(ctx, env.branch))
 	}
 
-	with, all, err := env.svc.Motifs().MotifCoverage(ctx, env.branch)
+	with, _, all, err := env.svc.Motifs().MotifCoverage(ctx, env.branch)
 	require.NoError(t, err)
 	require.Equal(t, all, with,
 		"coverage must CLOSE: every authored fact was offered across the sessions")

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -752,10 +752,15 @@ func (p *Pipeline) payloadResult(ctx context.Context, d Deps, sess *store.Pipeli
 	return &PipelineResult{
 		SessionID: sess.ID,
 		Item: &PipelineItem{
-			ID:        item.ID,
-			Type:      item.StepType,
-			FactsJSON: item.FactsJSON,
-			Facts:     facts,
+			ID:   item.ID,
+			Type: item.StepType,
+			// Carried on EVERY page, not only the first (knomit#120). The agent
+			// reads the later pages last, and that is when it decides how to
+			// answer — a key present on page 1 and absent afterwards would be
+			// worse than uniformly absent.
+			ClusterKey: item.ClusterKey,
+			FactsJSON:  item.FactsJSON,
+			Facts:      facts,
 		},
 		Progress: &ReviewProgress{
 			Completed: completed,
@@ -867,6 +872,7 @@ func (p *Pipeline) renderWorkItem(ctx context.Context, d Deps, sess *store.Pipel
 		Item: &PipelineItem{
 			ID:             item.ID,
 			Type:           view.Type,
+			ClusterKey:     item.ClusterKey,
 			Prompt:         view.Prompt,
 			ResponseSchema: view.ResponseSchema,
 			FactsJSON:      item.FactsJSON,

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -174,8 +174,9 @@ func reviewResultPage(res *PipelineResult, page int) (*ReviewResult, error) {
 	}
 
 	out.Item = &ReviewItem{
-		ID:   res.Item.ID,
-		Type: res.Item.Type,
+		ID:         res.Item.ID,
+		Type:       res.Item.Type,
+		ClusterKey: res.Item.ClusterKey,
 	}
 	if res.Item.Facts == "" {
 		// Nothing shipped beside the prompt: a single-page step type.

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -171,6 +171,21 @@ type PipelineItem struct {
 	// hypothesize echoes it back to the agent as the `fact` field. Carrying it
 	// here spares the facades a second read of the work item.
 	FactsJSON string
+	// ClusterKey is the stored item's grouping key, carried to the wire so an
+	// answering agent can tell WHAT it is holding (knomit#120).
+	//
+	// It matters because item types differ in what a NON-ANSWER costs. An
+	// ordinary prune cluster is safe to no-op; a restatement pair (key prefixed
+	// `restate-`) is not — a no-op records a DECLINED verdict against the
+	// throttle and permanently retires the standing pair. Two 2-fact prune
+	// items were identical on every other field, so the only safe fleet rule
+	// was to treat every one as possibly destructive.
+	//
+	// The RAW key rather than a derived is_restatement flag: the key already
+	// exists and is already computed, so it cannot drift from its source the
+	// way a second declaration would. The cost is that consumers key off the
+	// prefix, which is why the prefix is pinned as a wire contract by test.
+	ClusterKey string
 	// Facts is the RENDERED payload the strategy chose to ship beside the
 	// prompt — distinct from FactsJSON, which is what the row stores. They
 	// coincide for distill today; keeping them separate is what lets a

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -290,6 +290,17 @@ type ReviewItem struct {
 	// wire, which is pure cost on the exact items that are already too large.
 	// Mirrors HypothesizeItem.Fact, which has always shipped this way.
 	Facts json.RawMessage `json:"facts,omitempty"`
+	// ClusterKey identifies what this item was grouped FROM, so an answering
+	// agent can tell what it is holding (knomit#120).
+	//
+	// Read it before deciding to no-op. Item types differ in what a non-answer
+	// costs: an ordinary prune cluster (`cluster-N`) is safe to skip, while a
+	// restatement pair (`restate-N`) is not — a no-op there records a declined
+	// verdict AND permanently retires the standing pair, recoverable only by an
+	// edit that re-mints it. Before this field the two were identical on the
+	// wire and the only safe rule was to judge every 2-fact prune as though it
+	// were destructive.
+	ClusterKey string `json:"cluster_key,omitempty"`
 
 	// Paging. An item whose facts exceed one tool result is served across
 	// several; the agent accumulates every page and answers once at the end.

--- a/internal/synthesize/vocabulary_epistemic_df_test.go
+++ b/internal/synthesize/vocabulary_epistemic_df_test.go
@@ -1,0 +1,83 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// knomit#116, the store half. Reporting an epistemic recurrence figure is only
+// worth doing if it is THE NUMBER THE ACTIVATION FLOOR READS — a similar-looking
+// count computed over a slightly different population would be the original
+// defect with an extra column.
+//
+// This reproduces the field's sharpest exhibit in miniature: a motif whose
+// carriers are mostly PRAGMATIC. Raw df counts them all; the epistemic df sees
+// only the epistemic ones; and the gap between the two numbers is exactly what
+// an operator was reading as activation progress.
+//
+// `wrong-deciding-variable` was the worst measured case — raw df 5, epistemic
+// df 1, all five carriers in one folder, four pragmatic heuristics and one
+// observation. The path told the topic; it never told the kind.
+func TestVocabularyHealth_EpistemicRecurringCountsOnlyEpistemicCarriers(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+
+	// One motif on three carriers: two PRAGMATIC, one EPISTEMIC.
+	// Raw df = 3 (recurring). Epistemic df = 1 (NOT recurring).
+	writeKindFactWithMotifs(t, env, "kb/decisions/a.md", fact.Pragmatic, fact.Policy,
+		[]string{"wrong-deciding-variable"})
+	writeKindFactWithMotifs(t, env, "kb/decisions/b.md", fact.Pragmatic, fact.Heuristic,
+		[]string{"wrong-deciding-variable"})
+	writeKindFactWithMotifs(t, env, "kb/decisions/c.md", fact.Epistemic, fact.Observation,
+		[]string{"wrong-deciding-variable"})
+
+	// A second motif carried by two EPISTEMIC facts: recurring on BOTH counts,
+	// so the test distinguishes "epistemic count works" from "epistemic count
+	// is always lower".
+	writeKindFactWithMotifs(t, env, "kb/gotchas/d.md", fact.Epistemic, fact.Observation,
+		[]string{"genuinely-recurring"})
+	writeKindFactWithMotifs(t, env, "kb/gotchas/e.md", fact.Epistemic, fact.Observation,
+		[]string{"genuinely-recurring"})
+
+	require.NoError(t, env.svc.Motifs().RebuildAliases(ctx, env.branch))
+
+	h, err := env.svc.Motifs().VocabularyHealth(ctx, env.branch)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, h.Clusters, "precondition: two distinct motifs")
+	require.Equal(t, 2, h.Recurring,
+		"RAW: both motifs have >= 2 authored carriers, so both count as recurring")
+	require.Equal(t, 1, h.EpistemicRecurring,
+		"EPISTEMIC: only the second motif has >= 2 epistemic carriers — the "+
+			"pragmatic-carried one contributes nothing to activation, and that "+
+			"gap is precisely what a reader was mistaking for progress")
+}
+
+// writeKindFactWithMotifs writes a fact of a chosen KIND carrying motifs.
+//
+// The kind is the point: the existing motif helper writes observations only,
+// and this test is entirely about the epistemic/pragmatic split that the
+// vocabulary line was blind to.
+func writeKindFactWithMotifs(t *testing.T, env *restatementEnv, path string, kind fact.Kind, typ fact.Type, motifs []string) {
+	t.Helper()
+	f := fact.NewFact(path)
+	f.Title = "T " + path
+	f.Body = "body for " + path
+	f.Kind = kind
+	f.Type = typ
+	f.Domain = []string{"alpha"}
+	f.Entities = []string{"Widget"}
+	f.Refs = []string{}
+	f.Confidence = 0.7
+	f.Sources = 1
+	f.Motifs = motifs
+	rendered, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = env.svc.Facts().WriteFact(context.Background(), env.branch, f.Path(),
+		rendered, "write "+path, "test")
+	require.NoError(t, err)
+}

--- a/internal/synthesize/vocabulary_line_labels_test.go
+++ b/internal/synthesize/vocabulary_line_labels_test.go
@@ -1,0 +1,95 @@
+package synthesize
+
+import (
+	"strings"
+	"testing"
+
+	"knomit/internal/store"
+
+	"github.com/stretchr/testify/require"
+)
+
+// knomit#116. The vocabulary health line counts RAW df, and its "authored facts
+// only" qualifier filters ORIGIN, not KIND — which is the whole misdirection: a
+// reader takes the qualifier as naming the population, and it names a different
+// axis.
+//
+// The activation floor counts df >= 2 in the post-AcceptSeed EPISTEMIC pool.
+// So the number in the health block and the number the activation decision
+// reads are computed over different populations, and nothing labelled either.
+//
+// Measured divergence, four corpora: up to 5.0x. The sharpest single exhibit is
+// `wrong-deciding-variable` — raw df 5, epistemic df 1, with all five carriers
+// under kb/decisions/, four pragmatic heuristics and one observation in one
+// folder. And knomit-io-kb printed both numbers in ONE block, four lines apart:
+// "22 clusters, recurrence 14% (3 recur)" beside "0 recurring motif(s) … below
+// the 3-motif validity floor".
+//
+// The fix is labelling, not a redefinition: raw df keeps its meaning, and the
+// number the floor actually reads is reported beside it.
+func TestMotifVocabularyHealthLines_ReportsBothPopulations(t *testing.T) {
+	line := strings.Join(motifVocabularyHealthLines(store.MotifVocabularyHealth{
+		Clusters:           22,
+		Recurring:          3,
+		EpistemicRecurring: 0,
+		Mints:              22,
+		Links:              4,
+	}), "\n")
+
+	require.Contains(t, line, "3 recur",
+		"raw recurrence keeps its meaning — this fix adds a number, it does not "+
+			"redefine one")
+	require.Contains(t, line, "0",
+		"and the epistemic count, which is what the activation floor reads")
+
+	// BOTH must be LABELLED. An unlabelled second number is the original defect
+	// with more digits: the reader still cannot tell which population either
+	// figure describes.
+	lower := strings.ToLower(line)
+	require.Contains(t, lower, "epistemic",
+		"the activation-relevant population must be named; 'authored facts only' "+
+			"filters ORIGIN, not KIND, and reading it as the population is the bug")
+	require.Contains(t, lower, "authored",
+		"and the raw population stays named too")
+}
+
+// The df CAVEAT (#127 cross-link). df counts CARRIERS, and duplicate records of
+// one event inflate it — measured live: `test-becomes-the-incident` read df 4
+// resting on ONE event, its three genuinely independent carriers still
+// unassigned in the pool.
+//
+// So labelling the population correctly does not make the count correct. A
+// reader who acts on the corrected line is still acting on an upper bound, and
+// this fix must say so rather than shipping a more precise wrong number.
+//
+// THE CAVEAT IS ONE SENTENCE, ON ITS OWN LINE. #127's PR removes it when the
+// merge + df recount lands, and that removal should be a deletion rather than a
+// rewrite — so nothing else in the block may depend on its presence or its
+// position.
+func TestMotifVocabularyHealthLines_CarriesTheDfCaveatAsOneRemovableLine(t *testing.T) {
+	lines := motifVocabularyHealthLines(store.MotifVocabularyHealth{
+		Clusters: 22, Recurring: 3, EpistemicRecurring: 1, Mints: 22, Links: 4,
+	})
+	require.Len(t, lines, 2,
+		"the caveat is its OWN line, so #127 deletes a line rather than editing one")
+
+	caveat := lines[1]
+	require.Contains(t, strings.ToLower(caveat), "carrier",
+		"the caveat names what df actually counts")
+	require.Contains(t, caveat, "#127",
+		"and cites the issue whose fix removes it, so a reader can check whether "+
+			"it is still true")
+
+	// The metrics line must stand alone without it: removing the caveat leaves
+	// a complete, correct line rather than a dangling clause.
+	require.NotContains(t, lines[0], "#127",
+		"the metrics line carries no reference to the caveat — deleting line 2 "+
+			"must leave line 1 untouched and self-contained")
+}
+
+// An empty vocabulary says nothing at all, caveat included. A corpus with no
+// motifs has no df to be inflated, and a lone caveat with no metrics beside it
+// would send a reader looking for a number that was never printed.
+func TestMotifVocabularyHealthLines_SilentOnAnEmptyVocabulary(t *testing.T) {
+	require.Empty(t, motifVocabularyHealthLines(store.MotifVocabularyHealth{}))
+}

--- a/tools/motifannex/main.go
+++ b/tools/motifannex/main.go
@@ -721,7 +721,7 @@ func report(ctx context.Context, corpus, scratch string) error {
 			"epistemic seeds only, so MotifReport.seed_bridgeable_pairs is the smaller number " +
 			"and the one an activation decision is made on.",
 	}
-	if with, total, err := svc.Motifs().MotifCoverage(ctx, branch); err == nil {
+	if with, _, total, err := svc.Motifs().MotifCoverage(ctx, branch); err == nil {
 		r.WithMotifs, r.AuthoredLive = with, total
 		if total > 0 {
 			r.Coverage = float64(with) / float64(total)


### PR DESCRIPTION
Closes #116(i). **Stacked on #139** → #138 → #137. Review those first; this PR targets #139.

The other half of the original issue — backfill coverage's ceiling — shipped separately as #124 (PR #139).

## The bug

The vocabulary health line counts **raw df**, and its `authored facts only` qualifier filters **ORIGIN, not KIND**. That is the whole misdirection: a reader takes the qualifier as naming the population, and it names a different axis.

The activation floor counts `df >= 2` in the post-`AcceptSeed` **epistemic** pool. So the number in the health block and the number the activation decision reads were computed over different populations, and nothing labelled either.

Measured divergence across four corpora, **up to 5.0x**. Sharpest single exhibit: `wrong-deciding-variable` — raw df 5, epistemic df 1, with **all five carriers under `kb/decisions/`** (four pragmatic heuristics, one observation; one folder, one cluster). And knomit-io-kb printed both numbers in **one health block, four lines apart**:

```
motif vocabulary: 22 clusters, recurrence 14% (3 recur) … authored facts only
motif bridging inactive: 0 recurring motif(s) … below the 3-motif validity floor
```

## The fix: labelling, not redefinition

Raw recurrence **keeps its meaning** — it is the honest answer to *"is this vocabulary being reused at all"*. The epistemic count answers a different question — *"how close is bridging to activating"* — and only that one was ever unavailable.

Mint quality and activation contribution are **independent axes**. A name can be among the healthiest in a vocabulary by span and contribute nothing to activation, because all its carriers are pragmatic. The floor is right not to count them; the line was wrong to imply it had.

**Both counts come from one row per cluster.** A second query with its own `GROUP BY` would be free to disagree with the first about which clusters exist, and the entire point of printing the two side by side is that they are *the same clusters counted over different carriers*. The epistemic predicate is `f.kind = 'epistemic'` — the same one `AcceptSeed` and `epistemicLiveJoin` apply — which is what makes this the number the floor reads rather than merely a similar one.

## Not shipped: the path heuristic

The thread proposed predicting the gap from carrier **paths**. It is dead: `decisions/` was refuted and then shown corpus-dependent (6/7 epistemic on one corpus, 3/3 pragmatic on another), `principles/` was counter-exampled, and only `conventions/ ≈ pragmatic` survived three corpora.

Closing form: **the path tells you the TOPIC, never the KIND** — which is exactly what this fix measures instead of guessing.

## ⚠️ Reviewer: the caveat's removal contract

The df caveat (#127 cross-link, designer-approved) ships here because **labelling the population correctly does not make the count correct**. df counts *carriers*, and duplicate records of one event inflate it — measured live at df 4 resting on ONE event. Without the caveat this fix would ship a *more precise wrong number*.

**#127's PR must be able to DELETE it, not rewrite around it.** So:

- it is **one sentence**, on **its own line**, **last**;
- the metrics line carries **no reference** to it and is complete without it.

That contract is asserted, not just intended: `TestMotifVocabularyHealthLines_CarriesTheDfCaveatAsOneRemovableLine` fails if the caveat is folded into the metrics line — which is the tempting shape, and the one that would turn #127's deletion into a rewrite. Verified by sabotage.

## Sabotage evidence

| sabotage | caught by |
|---|---|
| epistemic filter dropped from the query (`CASE WHEN f.kind…` → plain count) | **only** `TestVocabularyHealth_EpistemicRecurringCountsOnlyEpistemicCarriers`; every line-level test passed, because they take the value as input |
| caveat folded into the metrics line instead of its own | `...CarriesTheDfCaveatAsOneRemovableLine`, on the *"deleting line 2 must leave line 1 self-contained"* assertion |
| (RED, before implementing) no epistemic figure, no caveat line | `ReportsBothPopulations` and `...AsOneRemovableLine` |

The first row is the #120/#124 layer lesson again: **unit tests over a struct cannot see a defect in what populates it.** The store-half test carries that catch alone.

The store fixture is built to distinguish *"the epistemic count works"* from *"the epistemic count is always lower"* — one motif on 2 pragmatic + 1 epistemic carriers (raw recurring, epistemic **not**), and a second on 2 epistemic carriers (recurring on **both** counts).

## Attestations

- **MN5** — `internal/synthesize/review_effort_normal_test.go` byte-identical to `dev`.
- **MN13** — no constant added or changed. `motifActivationFloor` untouched; the `df >= 2` threshold is the pre-existing definition of "recurring", applied to a second population rather than introduced.
- Full suite: 49 packages ok. `go vet` clean. `gofmt` clean.
