### PR TITLE
fix(synthesize): duplicates reach dedup — cross-cluster fall-through, in-flight refresh, structural detection (#127)

### DIFF
--- a/internal/store/abstraction.go
+++ b/internal/store/abstraction.go
@@ -262,6 +262,47 @@ func (ax *abstractionIndex) TopTitleNeighbours(ctx context.Context, branch strin
 // dedupCluster does (conventions/synthesize/scoped-cluster-queryby-path): every
 // one of these facts is already indexed, and ONNX inference to recompute a
 // vector we already hold is pure waste.
+// TitleVectorsByFactID returns STORED title-axis vectors, keyed by fact id.
+//
+// Symmetric with BodyVectorsByFactID, and for the same reason: the structural
+// detection pass finds pairs that no KNN returned, so it has no similarity
+// score in hand and must read the two vectors it already has rather than
+// re-embed anything.
+func (ax *abstractionIndex) TitleVectorsByFactID(ctx context.Context, ids []int64) (map[int64][]float32, error) {
+	out := make(map[int64][]float32, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	for _, chunk := range chunkIDs(ids) {
+		placeholders, args := idPlaceholders(chunk)
+		rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+			`SELECT rowid, embedding FROM fact_titles_vec WHERE rowid IN (`+placeholders+`)`, args...)
+		if err != nil {
+			return nil, fmt.Errorf("abstraction: title vectors: %w", err)
+		}
+		for rows.Next() {
+			var id int64
+			var blob []byte
+			if err := rows.Scan(&id, &blob); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("abstraction: scan title vector: %w", err)
+			}
+			vec, err := bytesToFloat32Slice(blob)
+			if err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("abstraction: decode title vector %d: %w", id, err)
+			}
+			out[id] = vec
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("abstraction: title vectors: %w", err)
+		}
+		rows.Close()
+	}
+	return out, nil
+}
+
 func (ax *abstractionIndex) BodyVectorsByFactID(ctx context.Context, ids []int64) (map[int64][]float32, error) {
 	out := make(map[int64][]float32, len(ids))
 	if len(ids) == 0 {
@@ -496,11 +537,15 @@ func (ax *abstractionIndex) ReplaceRestatementPairs(ctx context.Context, branch 
 		}
 	}
 	for _, p := range add {
+		kind := p.MatchKind
+		if kind == "" {
+			kind = MatchTitleKNN
+		}
 		if _, err := db.ExecContext(ctx,
 			`INSERT OR REPLACE INTO restatement_pairs
-			     (branch_id, a_path, b_path, a_fact_id, b_fact_id, title_cos)
-			 VALUES (?, ?, ?, ?, ?, ?)`,
-			branchID, p.APath, p.BPath, p.AFactID, p.BFactID, p.TitleCos); err != nil {
+			     (branch_id, a_path, b_path, a_fact_id, b_fact_id, title_cos, match_kind)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			branchID, p.APath, p.BPath, p.AFactID, p.BFactID, p.TitleCos, kind); err != nil {
 			return fmt.Errorf("abstraction: insert pair %s|%s: %w", p.APath, p.BPath, err)
 		}
 	}
@@ -527,7 +572,7 @@ func (ax *abstractionIndex) RestatementPairsByRank(ctx context.Context, branch s
 		return nil, nil
 	}
 	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
-		`SELECT p.a_path, p.b_path, p.a_fact_id, p.b_fact_id, p.title_cos
+		`SELECT p.a_path, p.b_path, p.a_fact_id, p.b_fact_id, p.title_cos, p.match_kind
 		   FROM restatement_pairs p
 		   JOIN branches b ON b.id = p.branch_id
 		  WHERE b.name = ?
@@ -537,14 +582,69 @@ func (ax *abstractionIndex) RestatementPairsByRank(ctx context.Context, branch s
 		return nil, fmt.Errorf("abstraction: rank pairs: %w", err)
 	}
 	defer rows.Close()
+	return scanRestatementPairs(rows)
+}
 
+// RestatementPairsByMatchKind ranks WITHIN one detection route.
+//
+// The cosine ordering is kept inside the population rather than dropped: it
+// still orders structural matches sensibly against each other, it just no
+// longer decides whether they are reachable at all.
+func (ax *abstractionIndex) RestatementPairsByMatchKind(ctx context.Context, branch string, kinds []string, limit int) ([]RestatementPair, error) {
+	if limit <= 0 || len(kinds) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(kinds)), ",")
+	args := make([]any, 0, len(kinds)+2)
+	args = append(args, branch)
+	for _, k := range kinds {
+		args = append(args, k)
+	}
+	args = append(args, limit)
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT p.a_path, p.b_path, p.a_fact_id, p.b_fact_id, p.title_cos, p.match_kind
+		   FROM restatement_pairs p
+		   JOIN branches b ON b.id = p.branch_id
+		  WHERE b.name = ? AND p.match_kind IN (`+placeholders+`)
+		  ORDER BY p.title_cos DESC, p.a_path ASC, p.b_path ASC
+		  LIMIT ?`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: rank pairs by match kind: %w", err)
+	}
+	defer rows.Close()
+	return scanRestatementPairs(rows)
+}
+
+func scanRestatementPairs(rows *sql.Rows) ([]RestatementPair, error) {
 	var out []RestatementPair
 	for rows.Next() {
 		var p RestatementPair
-		if err := rows.Scan(&p.APath, &p.BPath, &p.AFactID, &p.BFactID, &p.TitleCos); err != nil {
+		if err := rows.Scan(&p.APath, &p.BPath, &p.AFactID, &p.BFactID, &p.TitleCos, &p.MatchKind); err != nil {
 			return nil, fmt.Errorf("abstraction: scan pair: %w", err)
 		}
 		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// LiveEpistemicFactTitles is the structural detection pass's input: what each
+// live fact SAYS IT IS, rather than where it sits in the vector space.
+func (ax *abstractionIndex) LiveEpistemicFactTitles(ctx context.Context, branch string) (map[int64]LiveFactTitle, error) {
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT f.id, f.path, f.title`+epistemicLiveJoin, branch)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: live fact titles: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[int64]LiveFactTitle{}
+	for rows.Next() {
+		var id int64
+		var t LiveFactTitle
+		if err := rows.Scan(&id, &t.Path, &t.Title); err != nil {
+			return nil, fmt.Errorf("abstraction: scan live fact title: %w", err)
+		}
+		out[id] = t
 	}
 	return out, rows.Err()
 }
@@ -564,6 +664,13 @@ func (ax *abstractionIndex) RestatementPairStats(ctx context.Context, branch str
 	}
 	if st.Count == 0 {
 		return st, nil
+	}
+	if err := conn(ctx, ax.rh.db).QueryRowContext(ctx,
+		`SELECT COUNT(*)
+		   FROM restatement_pairs p
+		   JOIN branches b ON b.id = p.branch_id
+		  WHERE b.name = ? AND p.match_kind <> ?`, branch, MatchTitleKNN).Scan(&st.Structural); err != nil {
+		return st, fmt.Errorf("abstraction: structural pair count: %w", err)
 	}
 	var err error
 	if st.P99, err = ax.pairQuantile(ctx, branch, st.Count, 0.99); err != nil {

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -211,6 +211,20 @@ type PipelineIndex interface {
 	// engine's running totals have to live.
 	AddPipelineSessionStats(ctx context.Context, id string, s PipelineSessionStats) error
 	PipelineWorkItemStats(ctx context.Context, sessionID string) (completed, remaining int, err error)
+	// PendingPipelineWorkItems returns this session's UNANSWERED items, in
+	// queue order. It exists for the mid-session refresh: an item's payload is
+	// materialised when the session is planned, so a merge applied later in the
+	// same session leaves every still-queued item describing a corpus that no
+	// longer exists.
+	PendingPipelineWorkItems(ctx context.Context, sessionID string) ([]PipelineWorkItem, error)
+	// UpdatePipelineWorkItemFacts rewrites an unanswered item's payload. The
+	// response IS NULL guard is the same CAS the claim protocol uses: an item
+	// answered between the read and the rewrite must not be edited underneath
+	// the answer that is already being applied.
+	UpdatePipelineWorkItemFacts(ctx context.Context, id int64, factsJSON string) (updated bool, err error)
+	// DeletePipelineWorkItem removes an unanswered item, for the case where a
+	// refresh leaves it with too little left to judge. Same CAS guard.
+	DeletePipelineWorkItem(ctx context.Context, id int64) (deleted bool, err error)
 	GetPipelineWatermark(ctx context.Context, tool, branch string) (string, error)
 	SetPipelineWatermark(ctx context.Context, tool, branch, hash string) error
 }

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -391,6 +391,19 @@ type AbstractionIndex interface {
 	// dropFactIDs are removed, add is inserted, and coveredNow is recorded as
 	// covered.
 	ReplaceRestatementPairs(ctx context.Context, branch string, dropFactIDs []int64, add []RestatementPair, coveredNow []int64) error
+	// RestatementPairsByMatchKind returns the top `limit` pairs found by one of
+	// the named match kinds, ranked by title cosine WITHIN that population.
+	// Structurally matched pairs are near-certain duplicates whatever their
+	// titles score, so they cannot be reached through the cosine ranking that
+	// serves the title-KNN population.
+	RestatementPairsByMatchKind(ctx context.Context, branch string, kinds []string, limit int) ([]RestatementPair, error)
+	// TitleVectorsByFactID returns STORED title-axis vectors, keyed by fact id.
+	// Symmetric with BodyVectorsByFactID; nothing is re-embedded.
+	TitleVectorsByFactID(ctx context.Context, ids []int64) (map[int64][]float32, error)
+	// LiveEpistemicFactTitles is LiveEpistemicFacts with the title, for the
+	// structural detection pass — which matches on what a fact SAYS IT IS
+	// rather than on where it sits in the vector space.
+	LiveEpistemicFactTitles(ctx context.Context, branch string) (map[int64]LiveFactTitle, error)
 	// RestatementPairsByRank returns the top `limit` pairs by title cosine.
 	RestatementPairsByRank(ctx context.Context, branch string, limit int) ([]RestatementPair, error)
 	// RestatementPairStats describes the standing population. Observability
@@ -450,7 +463,26 @@ type RestatementPair struct {
 	AFactID  int64
 	BFactID  int64
 	TitleCos float64
+	// MatchKind records HOW the pair was found. Selection reads it because the
+	// two routes want different treatment: a title-KNN pair is ranked by its
+	// cosine, while a structurally matched pair is a near-certain duplicate
+	// whatever its cosine happens to be. Empty on construction means
+	// MatchTitleKNN; the store normalises.
+	MatchKind string
 }
+
+// Restatement pair match kinds — how a standing pair was found.
+const (
+	// MatchTitleKNN: the two facts are top-K title neighbours of each other.
+	MatchTitleKNN = "title-knn"
+	// MatchPathIdentity: their paths normalise to one identity — the same
+	// segment set, or one path's segments a subset of the other's, after
+	// casefolding, stemming, and ignoring a UUID filename.
+	MatchPathIdentity = "path-identity"
+	// MatchRareToken: they share a token that is rare in THIS corpus's own
+	// token distribution — an identifier, in practice.
+	MatchRareToken = "rare-token"
+)
 
 // RestatementPairStats describes the standing pair population for health
 // output: how many pairs stand, and where the top of the distribution sits.
@@ -458,6 +490,15 @@ type RestatementPairStats struct {
 	Count int
 	P99   float64
 	P999  float64
+	// Structural counts the pairs found by something other than title
+	// proximity. Observability: reported, read by no branch.
+	Structural int
+}
+
+// LiveFactTitle is one live fact's path and title, keyed by fact id.
+type LiveFactTitle struct {
+	Path  string
+	Title string
 }
 
 // Embedder computes vector embeddings. Roles differ because retrieval models

--- a/internal/store/migrate/repo/000023_restatement_match_kind.down.sql
+++ b/internal/store/migrate/repo/000023_restatement_match_kind.down.sql
@@ -1,0 +1,19 @@
+-- Symmetric rebuild back to the 000018 shape, and idempotent for the same
+-- reason the up is: a cache with nothing to preserve.
+DROP TABLE IF EXISTS restatement_pairs;
+
+CREATE TABLE restatement_pairs (
+    branch_id  INTEGER NOT NULL REFERENCES branches(id),
+    a_path     TEXT NOT NULL,
+    b_path     TEXT NOT NULL,
+    a_fact_id  INTEGER NOT NULL,
+    b_fact_id  INTEGER NOT NULL,
+    title_cos  REAL NOT NULL,
+    PRIMARY KEY (branch_id, a_path, b_path)
+);
+CREATE INDEX restatement_pairs_rank
+    ON restatement_pairs(branch_id, title_cos DESC);
+CREATE INDEX restatement_pairs_a ON restatement_pairs(branch_id, a_fact_id);
+CREATE INDEX restatement_pairs_b ON restatement_pairs(branch_id, b_fact_id);
+
+DELETE FROM restatement_cache_state;

--- a/internal/store/migrate/repo/000023_restatement_match_kind.up.sql
+++ b/internal/store/migrate/repo/000023_restatement_match_kind.up.sql
@@ -1,0 +1,52 @@
+-- How a standing restatement pair was FOUND, so selection can tell the two
+-- detection routes apart (#127).
+--
+-- The shortlist has ranked candidates by title cosine alone since it existed.
+-- That is the right ranking for a pair discovered BY title cosine, and the
+-- wrong one for a pair discovered structurally — two facts that share a
+-- normalised path identity, or a token that is rare in this corpus, are
+-- near-certain duplicates whatever their titles happen to score. Ranking those
+-- by cosine would leave them standing in the cache and never selected: real
+-- detection that never reaches the judge, which is the exact failure this issue
+-- is about.
+--
+-- REBUILT, not ALTERed. Two reasons, and the second is the binding one:
+--
+--  1. restatement_pairs is derived index state — a cache the shortlist refresh
+--     rebuilds from git — so there is nothing here to preserve. Every existing
+--     row was found by the title KNN and predates structural detection
+--     entirely, so a full re-detection is what we want on the next session
+--     regardless.
+--  2. `ALTER TABLE ... ADD COLUMN` is NOT idempotent, and this schema's
+--     recovery path re-runs a migration to find out whether an interrupted
+--     body committed. That budget is already spent by 000019's ADD COLUMN; a
+--     second one fails the re-run outright. DROP+CREATE re-runs cleanly, which
+--     is the 000017 precedent (a rebuild, for its own reasons).
+--
+-- The cache STATE goes with the pairs, and leaving it would be the bug the
+-- ReplaceRestatementPairs comment warns about: the state rows are what says
+-- "already covered", so a cache that lost its pairs but kept its state would
+-- never rebuild them.
+--
+-- No GraphSchemaVersion bump, for the reason 000018/000019 skipped it: there is
+-- no derived state elsewhere that a rebuild would leave stale.
+DROP TABLE IF EXISTS restatement_pairs;
+
+CREATE TABLE restatement_pairs (
+    branch_id  INTEGER NOT NULL REFERENCES branches(id),
+    a_path     TEXT NOT NULL,
+    b_path     TEXT NOT NULL,
+    a_fact_id  INTEGER NOT NULL,
+    b_fact_id  INTEGER NOT NULL,
+    title_cos  REAL NOT NULL,
+    match_kind TEXT NOT NULL DEFAULT 'title-knn',
+    PRIMARY KEY (branch_id, a_path, b_path)
+);
+CREATE INDEX restatement_pairs_rank
+    ON restatement_pairs(branch_id, title_cos DESC);
+CREATE INDEX restatement_pairs_a ON restatement_pairs(branch_id, a_fact_id);
+CREATE INDEX restatement_pairs_b ON restatement_pairs(branch_id, b_fact_id);
+CREATE INDEX restatement_pairs_match
+    ON restatement_pairs(branch_id, match_kind, title_cos DESC);
+
+DELETE FROM restatement_cache_state;

--- a/internal/store/pipeline_index.go
+++ b/internal/store/pipeline_index.go
@@ -375,3 +375,68 @@ func (pi *pipelineIndex) PipelineWorkItemStats(ctx context.Context, sessionID st
 	}
 	return completed, remaining, nil
 }
+
+// PendingPipelineWorkItems returns this session's unanswered items in queue
+// order — the same ordering NextPipelineWorkItem serves, so a caller iterating
+// them sees the queue as the agent will.
+func (pi *pipelineIndex) PendingPipelineWorkItems(ctx context.Context, sessionID string) ([]PipelineWorkItem, error) {
+	rows, err := pi.sessionDB.QueryContext(ctx,
+		`SELECT id, session_id, step_type, cluster_key, facts_json, response, priority, depth, created_at
+		 FROM pipeline_work_items
+		 WHERE session_id = ? AND response IS NULL
+		 ORDER BY priority DESC, id ASC`, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("PendingPipelineWorkItems: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []PipelineWorkItem
+	for rows.Next() {
+		var item PipelineWorkItem
+		if err := rows.Scan(&item.ID, &item.SessionID, &item.StepType, &item.ClusterKey,
+			&item.FactsJSON, &item.Response, &item.Priority, &item.Depth, &item.CreatedAt); err != nil {
+			return nil, fmt.Errorf("PendingPipelineWorkItems scan: %w", err)
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("PendingPipelineWorkItems rows: %w", err)
+	}
+	return out, nil
+}
+
+// UpdatePipelineWorkItemFacts rewrites an unanswered item's payload.
+//
+// The `response IS NULL` guard is the claim protocol's CAS, used here in the
+// other direction: the claim stops two callers applying one answer, and this
+// stops a payload edit landing on an item whose answer is already being
+// applied. updated=false means the item was claimed first — a benign no-op,
+// exactly as a lost claim is.
+func (pi *pipelineIndex) UpdatePipelineWorkItemFacts(ctx context.Context, id int64, factsJSON string) (bool, error) {
+	res, err := pi.sessionDB.ExecContext(ctx,
+		`UPDATE pipeline_work_items SET facts_json = ? WHERE id = ? AND response IS NULL`,
+		factsJSON, id)
+	if err != nil {
+		return false, fmt.Errorf("UpdatePipelineWorkItemFacts: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("UpdatePipelineWorkItemFacts rows: %w", err)
+	}
+	return n > 0, nil
+}
+
+// DeletePipelineWorkItem removes an unanswered item. Same CAS guard as the
+// payload rewrite above, for the same reason.
+func (pi *pipelineIndex) DeletePipelineWorkItem(ctx context.Context, id int64) (bool, error) {
+	res, err := pi.sessionDB.ExecContext(ctx,
+		`DELETE FROM pipeline_work_items WHERE id = ? AND response IS NULL`, id)
+	if err != nil {
+		return false, fmt.Errorf("DeletePipelineWorkItem: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("DeletePipelineWorkItem rows: %w", err)
+	}
+	return n > 0, nil
+}

--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -85,6 +85,13 @@ type ReviewStats struct {
 	// and a path list there would be a wire-shape change for an internal
 	// hand-off.
 	Retired []string `json:"-"`
+	// Rewritten is every path this apply CHANGED IN PLACE — a confidence
+	// update, today. Same contract as Retired: only writes that succeeded, and
+	// for the same consumer. A queued item carries a SNAPSHOT of each fact's
+	// fields, so an in-place rewrite leaves later items showing the old
+	// confidence; measured live, facts set to 0.5/0.7/0.8 still read
+	// 0.9/0.9/0.95 at items queued before the update.
+	Rewritten []string `json:"-"`
 }
 
 // ApplyPruneDecisions applies prune decisions (retract/update) and merges to the git store.
@@ -111,6 +118,10 @@ func ApplyPruneDecisions(ctx context.Context,
 	// Track deleted paths to avoid double-deletion when a path appears in
 	// both "retract" decisions and merge source lists.
 	deletedPaths := make(map[string]bool)
+	// Paths changed in place rather than removed. Separate from deletedPaths
+	// because the two mean opposite things to a queued work item: one member
+	// must be dropped, the other re-read.
+	rewrittenPaths := make(map[string]bool)
 	// mergeGate is the one gate the merge outputs below go through, built once
 	// for the whole call.
 	mergeGate := refs.New(localRepoID, refs.FromFactQuery(idx, agentBranch))
@@ -161,6 +172,7 @@ func ApplyPruneDecisions(ctx context.Context,
 			}
 			onProgress(ProgressEvent{Phase: "detail-update", Message: fmt.Sprintf("update %.2f %s", d.Confidence, d.Path)})
 			stats.Updated++
+			rewrittenPaths[d.Path] = true
 		}
 	}
 
@@ -290,6 +302,18 @@ func ApplyPruneDecisions(ctx context.Context,
 	}
 	sort.Strings(stats.Retired)
 
+	// A path that was updated and then subsumed by a merge in the same apply is
+	// RETIRED, not rewritten: it is gone, and asking a later item to re-read it
+	// would find nothing.
+	stats.Rewritten = make([]string, 0, len(rewrittenPaths))
+	for p := range rewrittenPaths {
+		if deletedPaths[p] {
+			continue
+		}
+		stats.Rewritten = append(stats.Rewritten, p)
+	}
+	sort.Strings(stats.Rewritten)
+
 	return stats, nil
 }
 
@@ -397,7 +421,9 @@ func ApplyDistillDecisions(ctx context.Context,
 		}
 		onProgress(ProgressEvent{Phase: "detail-distill-retract", Message: "retract " + path})
 		stats.Pruned++
+		stats.Retired = append(stats.Retired, path)
 	}
+	sort.Strings(stats.Retired)
 
 	return stats, written, nil
 }

--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"knomit/internal/fact"
@@ -73,6 +74,17 @@ type ReviewStats struct {
 	Merged      int
 	Updated     int
 	Synthesized int
+	// Retired is every path this apply actually removed from the corpus —
+	// retracted facts and merge sources alike, and only those whose delete
+	// SUCCEEDED. It is the input to the mid-session refresh of already-queued
+	// work items (see inflight.go), which is why it reports what happened
+	// rather than what was asked for: an item stripped of a fact that is still
+	// live would be a second bug wearing the first one's fix.
+	//
+	// Not serialised. ReviewStats is embedded in ReviewResult as `summary`,
+	// and a path list there would be a wire-shape change for an internal
+	// hand-off.
+	Retired []string `json:"-"`
 }
 
 // ApplyPruneDecisions applies prune decisions (retract/update) and merges to the git store.
@@ -111,11 +123,17 @@ func ApplyPruneDecisions(ctx context.Context,
 			// no-op
 		case "retract":
 			msg := fmt.Sprintf("synthesize-%s: retract %s", recipeName, d.Path)
-			deletedPaths[d.Path] = true
 			if _, err := gs.DeleteFact(ctx, agentBranch, d.Path, msg); err != nil {
 				onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("retract %s: %v", d.Path, err)})
 				continue
 			}
+			// Recorded AFTER the delete succeeded. The merge loop below already
+			// does this; the retract branch used to mark the path deleted first,
+			// which made a FAILED retract look identical to a completed one —
+			// harmless while deletedPaths only suppressed double-deletion, and
+			// not harmless now that the same set says which facts left the
+			// corpus.
+			deletedPaths[d.Path] = true
 			onProgress(ProgressEvent{Phase: "detail-retract", Message: "retract " + d.Path})
 			stats.Pruned++
 
@@ -263,6 +281,14 @@ func ApplyPruneDecisions(ctx context.Context,
 		onProgress(ProgressEvent{Phase: "detail-merge", Message: "merge " + merged.Path()})
 		stats.Merged++
 	}
+
+	// Sorted so the retired set is a deterministic function of what happened,
+	// not of Go's map iteration order.
+	stats.Retired = make([]string, 0, len(deletedPaths))
+	for p := range deletedPaths {
+		stats.Retired = append(stats.Retired, p)
+	}
+	sort.Strings(stats.Retired)
 
 	return stats, nil
 }

--- a/internal/synthesize/identity.go
+++ b/internal/synthesize/identity.go
@@ -158,6 +158,16 @@ func buildIdentityIndex(titles map[int64]store.LiveFactTitle) *identityIndex {
 // Returns 0 for a corpus with no shared tokens, which makes every rarity test
 // false: with no distribution to read, nothing is known to be rare, and
 // inventing a fallback number is exactly the forbidden constant.
+//
+// KNOWN BLIND SPOT (review LOW-1, accepted): on a corpus where more than half
+// of all matchable token-occurrences sit on df==2 tokens, this returns 2, and
+// the caller's `df < cut && df >= 2` band is then empty — both structural
+// routes find nothing. That is graceful (no worse than having no structural
+// detection at all) and needs an atypical distribution: real corpora repeat
+// their freeform path prefixes, and those are high-df tokens that pull the
+// median up. Recorded rather than fixed, because every fix for it is a floor
+// or a fallback — i.e. a corpus-property constant (MN13) — and the failure is
+// silence rather than a wrong merge.
 func factWeightedMedianDF(perFact map[int64][]string, df map[string]int) int {
 	var occurrences []int
 	for _, toks := range perFact {

--- a/internal/synthesize/identity.go
+++ b/internal/synthesize/identity.go
@@ -1,0 +1,360 @@
+// Package synthesize — structural duplicate detection (#127).
+//
+// The title-KNN shortlist finds pairs that are CLOSE IN THE VECTOR SPACE. The
+// duplicates that survive longest are the ones it cannot reach: two records of
+// one event, filed under two freeform categories, whose titles are paraphrases
+// rather than neighbours. Measured on the live core corpus, six confirmed
+// duplicate pairs each had a partner ~24 unrelated facts closer to it by title
+// cosine than nothing — and the whole point is that similarity is not the only
+// evidence a corpus carries about identity.
+//
+// This file adds the other evidence, in two shapes:
+//
+//   - PATH IDENTITY. Two paths that normalise to one identity — the same
+//     tokens in a different order (devops/gitlab vs gitlab/devops), or one
+//     path's tokens a subset of the other's (vulnerabilities/cisco vs
+//     vulnerabilities/networking/cisco). Casefolding, hyphen splitting and
+//     singular/plural collapse come from textnorm; a UUID filename is dropped,
+//     because a generated name is not something two facts can agree about,
+//     while a slug filename is content and stays.
+//
+//   - RARE IDENTIFIER TOKENS. Two facts that share a token which is
+//     identifier-SHAPED (it carries a digit) and rare in THIS corpus. A CVE
+//     id, a ticket number, a version. The shape test is lexical and says
+//     nothing about any corpus; the rarity test is read entirely off this
+//     repo's own distribution, per the corpus-property-constants principle —
+//     there is no rarity number here to configure, and a literal `CVE-\d+`
+//     pattern would be exactly the forbidden thing, a corpus property wearing
+//     a regex.
+//
+// Detection only. The pairs join the standing shortlist and are judged and
+// merged by the machinery that already exists.
+package synthesize
+
+import (
+	"path"
+	"sort"
+	"strings"
+
+	"knomit/internal/store"
+	"knomit/internal/textnorm"
+)
+
+// maxStructuralPairs is a RESOURCE BUDGET on one refresh's writes: the most
+// structurally matched pairs a single session will mint.
+//
+// Not a claim about how many duplicates a corpus contains (MN13) — it bounds
+// what one pass may cost when a corpus's token distribution turns out to be
+// degenerate, in the same class as shortlistOverfetch. Pairs beyond it are not
+// lost, only deferred: the next session's refresh re-derives from the same
+// corpus and mints the ones that are still missing.
+const maxStructuralPairs = 500
+
+// identityIndex is the corpus's own structural evidence, derived once per
+// refresh.
+type identityIndex struct {
+	// pathTokens is every fact's full normalised path token set, for the
+	// subset test.
+	pathTokens map[int64]map[string]struct{}
+	// discriminating maps a fact to the tokens that are more specific than
+	// this corpus's typical path token — the ones a match may rest on.
+	discriminating map[int64][]string
+	// identifiers maps a fact to its rare identifier-shaped tokens.
+	identifiers map[int64][]string
+	// byToken is the inverted index over both discriminating sets, so a
+	// candidate scan never has to compare every fact with every other.
+	byToken map[string][]int64
+}
+
+// buildIdentityIndex derives the structural evidence for a whole corpus.
+//
+// Both rarity cuts are the corpus's own FACT-WEIGHTED MEDIAN document
+// frequency: the df of the token a randomly chosen occurrence carries. That is
+// the right centre for this question and the distinct-token median is not — a
+// corpus's token vocabulary is dominated by its hapax tail, so a median over
+// DISTINCT tokens lands at one or two and would reject `cisco` (df 12) as
+// insufficiently rare while accepting nothing useful. Weighting by occurrence
+// asks "is this token more specific than what a path segment usually is?",
+// which is the question, and it is answered entirely by the corpus.
+func buildIdentityIndex(titles map[int64]store.LiveFactTitle) *identityIndex {
+	ix := &identityIndex{
+		pathTokens:     make(map[int64]map[string]struct{}, len(titles)),
+		discriminating: make(map[int64][]string, len(titles)),
+		identifiers:    make(map[int64][]string, len(titles)),
+		byToken:        map[string][]int64{},
+	}
+	if len(titles) == 0 {
+		return ix
+	}
+
+	pathDF := map[string]int{}
+	idDF := map[string]int{}
+	rawPath := make(map[int64][]string, len(titles))
+	rawID := make(map[int64][]string, len(titles))
+
+	for id, t := range titles {
+		pt := pathTokensOf(t.Path)
+		rawPath[id] = pt
+		set := make(map[string]struct{}, len(pt))
+		for _, tok := range pt {
+			set[tok] = struct{}{}
+			pathDF[tok]++
+		}
+		ix.pathTokens[id] = set
+
+		idt := identifierTokens(t.Path, t.Title)
+		rawID[id] = idt
+		for _, tok := range idt {
+			idDF[tok]++
+		}
+	}
+
+	pathCut := factWeightedMedianDF(rawPath, pathDF)
+	idCut := factWeightedMedianDF(rawID, idDF)
+
+	for id := range titles {
+		for _, tok := range rawPath[id] {
+			// Strictly below the typical token, and carried by someone else:
+			// a hapax can match nothing, so indexing it is pure cost.
+			if pathDF[tok] < pathCut && pathDF[tok] >= 2 {
+				ix.discriminating[id] = append(ix.discriminating[id], tok)
+				ix.byToken[tok] = append(ix.byToken[tok], id)
+			}
+		}
+		for _, tok := range rawID[id] {
+			if idDF[tok] < idCut && idDF[tok] >= 2 {
+				ix.identifiers[id] = append(ix.identifiers[id], tok)
+				ix.byToken[tok] = append(ix.byToken[tok], id)
+			}
+		}
+	}
+	for tok := range ix.byToken {
+		slice := ix.byToken[tok]
+		sort.Slice(slice, func(i, j int) bool { return slice[i] < slice[j] })
+		ix.byToken[tok] = slice
+	}
+	return ix
+}
+
+// factWeightedMedianDF is the df of the token a randomly chosen OCCURRENCE
+// carries, over the tokens that could match anything at all — the corpus's own
+// answer to "how specific is a shared token, typically".
+//
+// Two choices here, and both were wrong in an earlier version:
+//
+// WEIGHTED BY OCCURRENCE, not over distinct tokens. A corpus's vocabulary is
+// dominated by its hapax tail, so a median over DISTINCT tokens lands at one or
+// two and would reject `cisco` (df 12 on the live corpus) as insufficiently
+// rare while accepting nothing useful.
+//
+// OVER df >= 2 ONLY. A token carried by exactly one fact can never pair with
+// anything, so counting its occurrences measures a population the question is
+// not about — and there are a great many of them (every generated filename,
+// every one-off number). Including them dragged the median to 1, at which point
+// `< median` is unsatisfiable and the whole rare-token route silently found
+// nothing. That is the shape of failure this issue is about, so it gets a test:
+// TestStructural_RareIdentifierToken fails outright if this filter is dropped.
+//
+// Returns 0 for a corpus with no shared tokens, which makes every rarity test
+// false: with no distribution to read, nothing is known to be rare, and
+// inventing a fallback number is exactly the forbidden constant.
+func factWeightedMedianDF(perFact map[int64][]string, df map[string]int) int {
+	var occurrences []int
+	for _, toks := range perFact {
+		for _, t := range toks {
+			if df[t] < 2 {
+				continue
+			}
+			occurrences = append(occurrences, df[t])
+		}
+	}
+	if len(occurrences) == 0 {
+		return 0
+	}
+	sort.Ints(occurrences)
+	return occurrences[len(occurrences)/2]
+}
+
+// pathTokensOf normalises one fact path into match tokens.
+//
+// The extension goes, and a UUID FILENAME goes with it: the uuid is minted per
+// fact (conventions/synthesize/normalize-fact-path-uuid), so it is by
+// construction something no two facts can share, and keeping it would only add
+// a token that is guaranteed not to match. A SLUG filename stays — an author
+// who named the file said something about the fact, and that is content.
+func pathTokensOf(p string) []string {
+	p = strings.TrimSuffix(p, path.Ext(p))
+	if isGeneratedName(path.Base(p)) {
+		p = path.Dir(p)
+	}
+	return textnorm.Tokens(textnorm.Canonicalize(p))
+}
+
+// isGeneratedName reports whether a filename is a minted uuid rather than an
+// authored slug: all hex, and long enough not to be a word.
+func isGeneratedName(base string) bool {
+	if len(base) < 8 {
+		return false
+	}
+	for _, r := range base {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+// identifierTokens returns the identifier-SHAPED tokens of a fact's path and
+// title: tokens carrying at least one digit.
+//
+// The shape test is the generalisation of "extract the CVE key" that carries no
+// claim about this corpus. A CVE id, a ticket number, a build number and a
+// version all pass it; ordinary prose does not. Which of them is rare enough to
+// match on is decided afterwards, by the corpus.
+func identifierTokens(p, title string) []string {
+	toks := textnorm.Tokens(textnorm.Canonicalize(strings.TrimSuffix(p, path.Ext(p)) + " " + title))
+	out := make([]string, 0, 4)
+	for _, t := range toks {
+		if hasDigit(t) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func hasDigit(s string) bool {
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+// structuralMatch is one detected pair, before it is scored and stored.
+type structuralMatch struct {
+	a, b int64
+	kind string
+}
+
+// structuralCandidates finds the pairs the title axis cannot reach.
+//
+// Only pairs TOUCHING the rescanned set are returned, mirroring the title KNN's
+// own delta discipline: a pair between two facts that neither changed nor were
+// requeued was already minted by the session that first saw them.
+func (ix *identityIndex) structuralCandidates(requeue []int64) []structuralMatch {
+	inRequeue := make(map[int64]struct{}, len(requeue))
+	for _, id := range requeue {
+		inRequeue[id] = struct{}{}
+	}
+
+	seen := map[[2]int64]string{}
+	var out []structuralMatch
+	// Deterministic: requeue is already sorted by the caller, and each token's
+	// posting list is sorted, so the same corpus yields the same pairs in the
+	// same order however Go iterates its maps.
+	for _, id := range requeue {
+		for _, tok := range append(append([]string{}, ix.discriminating[id]...), ix.identifiers[id]...) {
+			for _, other := range ix.byToken[tok] {
+				if other == id {
+					continue
+				}
+				// Both sides in the requeue would emit the pair twice; the
+				// lower id owns it.
+				if _, alsoRescanned := inRequeue[other]; alsoRescanned && other < id {
+					continue
+				}
+				key := [2]int64{min64(id, other), max64(id, other)}
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				kind, ok := ix.classify(id, other)
+				if !ok {
+					continue
+				}
+				seen[key] = kind
+				out = append(out, structuralMatch{a: key[0], b: key[1], kind: kind})
+				if len(out) >= maxStructuralPairs {
+					return out
+				}
+			}
+		}
+	}
+	return out
+}
+
+// classify decides WHY two facts match, preferring the stronger evidence.
+//
+// Path identity first: two paths that normalise to one identity are making a
+// claim about the same subject with the corpus's own filing as the witness. A
+// shared rare identifier is the weaker, wider net.
+func (ix *identityIndex) classify(a, b int64) (string, bool) {
+	if ix.pathIdentity(a, b) {
+		return store.MatchPathIdentity, true
+	}
+	if sharesToken(ix.identifiers[a], ix.identifiers[b]) {
+		return store.MatchRareToken, true
+	}
+	return "", false
+}
+
+// pathIdentity holds when one path's token set contains the other's — equality
+// included — and the containment rests on something specific.
+//
+// Equality is the segment-INVERSION case (devops/gitlab vs gitlab/devops
+// normalise to one set). Proper containment is the prefix-EXTENSION case
+// (vulnerabilities/cisco inside vulnerabilities/networking/cisco). Both are
+// required to share at least one discriminating token, or every fact filed
+// under the corpus's common prefix would match every other.
+func (ix *identityIndex) pathIdentity(a, b int64) bool {
+	sa, sb := ix.pathTokens[a], ix.pathTokens[b]
+	if len(sa) == 0 || len(sb) == 0 {
+		return false
+	}
+	if !tokenSubsetOf(sa, sb) && !tokenSubsetOf(sb, sa) {
+		return false
+	}
+	return sharesToken(ix.discriminating[a], ix.discriminating[b])
+}
+
+func tokenSubsetOf(small, large map[string]struct{}) bool {
+	if len(small) > len(large) {
+		return false
+	}
+	for t := range small {
+		if _, ok := large[t]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func sharesToken(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, t := range a {
+		set[t] = struct{}{}
+	}
+	for _, t := range b {
+		if _, ok := set[t]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/synthesize/identity_test.go
+++ b/internal/synthesize/identity_test.go
@@ -1,0 +1,325 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// structuralEnv builds a corpus with a realistic token distribution plus ONE
+// designated duplicate pair, so a test can say which route found it.
+//
+// The filler matters: both rarity cuts are read off the corpus's own
+// distribution, so a corpus with no distribution has nothing rare in it. Every
+// filler fact carries a common year token and a unique widget number, which is
+// what an ordinary corpus's identifier vocabulary looks like.
+//
+// 404 facts, because shortlistBudget is corpus-scaled at 5 per 1000 and the
+// reservation this commit adds only exists at budget >= 2. A 200-fact corpus
+// budgets 1 and the reservation test would pass vacuously.
+const structuralFiller = 404
+
+func structuralEnv(t *testing.T, pair [2]struct{ Path, Title string }) *restatementEnv {
+	t.Helper()
+	env := newRestatementEnv(t, 0)
+	for i := range structuralFiller {
+		env.writeFact(
+			fmt.Sprintf("kb/technology/filler/topic%d/%08x.md", i, i+1),
+			fmt.Sprintf("Filler note 2026 about widget %d", 1000+i),
+			"an unrelated body")
+	}
+	for _, f := range pair {
+		env.writeFact(f.Path, f.Title, "a body about the event")
+	}
+	return env
+}
+
+func namedFact(path, title string) struct{ Path, Title string } {
+	return struct{ Path, Title string }{path, title}
+}
+
+// pairKindIn returns the stored match kind for a pair, or "" if it never stood.
+func pairKindIn(t *testing.T, env *restatementEnv, a, b string) string {
+	t.Helper()
+	pairs, err := env.svc.Abstraction().RestatementPairsByRank(context.Background(), env.branch, 100_000)
+	require.NoError(t, err)
+	for _, p := range pairs {
+		if (p.APath == a && p.BPath == b) || (p.APath == b && p.BPath == a) {
+			return p.MatchKind
+		}
+	}
+	return ""
+}
+
+// TestStructural_PathPrefixExtension — vulnerabilities/cisco and
+// vulnerabilities/networking/cisco are one subject filed at two depths. One
+// token set contains the other, and the containment rests on `cisco` rather
+// than on the prefix every security fact shares.
+//
+// Measured pair: 1e8287a2 / bfbb31b8, verified identical by body comparison
+// (the same nine CVEs), title cosine 0.917 — and absent from a 14,768-row
+// standing cache.
+func TestStructural_PathPrefixExtension(t *testing.T) {
+	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
+	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "Cisco patches nine flaws across Crosswork and Secure Workload"),
+		namedFact(b, "Nine Cisco advisories cover Crosswork and Secure Workload"),
+	})
+	env.seedShortlist()
+	require.Equal(t, store.MatchPathIdentity, pairKindIn(t, env, a, b),
+		"one path's tokens inside the other's is one subject filed at two depths")
+}
+
+// TestStructural_PathSegmentInversion — devops/gitlab and gitlab/devops are the
+// same filing decision made in two orders. Freeform categories produce this
+// whenever the same event is ingested twice.
+func TestStructural_PathSegmentInversion(t *testing.T) {
+	a := "kb/technology/devops/gitlab/aaaaaaa1.md"
+	b := "kb/technology/gitlab/devops/bbbbbbb2.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "GitLab directive flaw exploited within days"),
+		namedFact(b, "Attackers reach GitLab through a directive flaw"),
+	})
+	env.seedShortlist()
+	require.Equal(t, store.MatchPathIdentity, pairKindIn(t, env, a, b),
+		"the same segments in a different order are the same identity")
+}
+
+// TestStructural_PluralFold — vulnerabilities/gitlab against
+// vulnerability/gitlab. The singular/plural collapse arrives from textnorm
+// rather than from anything invented here, which is why it is asserted rather
+// than reimplemented.
+//
+// CASE is deliberately not exercised through a path: WriteFact lowercases fact
+// paths, so a mixed-case path never reaches the corpus and a test that wrote
+// one would be asserting against a path the store does not hold. (The first
+// draft of this test did exactly that and passed nothing — the fact simply was
+// not there under the name it looked for.) Case folding still matters for
+// TITLES, which is where identifierTokens reads it, and
+// TestStructural_RareIdentifierToken covers that path.
+func TestStructural_PluralFold(t *testing.T) {
+	a := "kb/technology/security/vulnerabilities/gitlab/aaaaaaa3.md"
+	b := "kb/technology/security/vulnerability/gitlab/bbbbbbb4.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "GitLab honeypot traffic climbs after disclosure"),
+		namedFact(b, "Honeypots record GitLab exploitation attempts"),
+	})
+	env.seedShortlist()
+	require.Equal(t, store.MatchPathIdentity, pairKindIn(t, env, a, b),
+		"plural is spelling, not identity")
+}
+
+// TestStructural_SlugVersusUUIDFilename — a generated uuid filename is minted
+// per fact and can therefore never match anything, so it is dropped before the
+// paths are compared. An authored slug is content and stays.
+func TestStructural_SlugVersusUUIDFilename(t *testing.T) {
+	a := "kb/technology/security/vulnerabilities/gitlab/check-point-advisory.md"
+	b := "kb/technology/security/vulnerabilities/gitlab/aaaaaaa5.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "GitLab advisory reaches customers late"),
+		namedFact(b, "Late customer notification on the GitLab advisory"),
+	})
+	env.seedShortlist()
+	require.Equal(t, store.MatchPathIdentity, pairKindIn(t, env, a, b),
+		"a uuid filename must not block a match its directory already makes")
+}
+
+// TestStructural_RareIdentifierToken — the generalisation of "extract the CVE
+// key". The two facts sit in different category sub-trees, so no path rule
+// reaches them; what they share is an identifier-SHAPED token that is rare in
+// this corpus.
+//
+// Measured pair: check-point-smartconsole-cve-2026-16232 / 23d98f38, same CVE,
+// same CVSS, body cosine 0.930, absent from the standing cache.
+func TestStructural_RareIdentifierToken(t *testing.T) {
+	a := "kb/technology/security/vulnerabilities/network-security/check-point-smartconsole.md"
+	b := "kb/technology/security/vulnerabilities/network-appliances/aaaaaaa6.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "SmartConsole authentication bypass CVE-2026-16232 under active exploitation"),
+		namedFact(b, "Check Point flaw CVE-2026-16232 exploited against a handful of customers"),
+	})
+	env.seedShortlist()
+	require.Equal(t, store.MatchRareToken, pairKindIn(t, env, a, b),
+		"a shared rare identifier is evidence of identity that no path rule reaches")
+}
+
+// TestStructural_CommonIdentifierTokenIsNotEvidence is the other half, and it
+// is what makes the rarity test mean something.
+//
+// Both facts carry `2026`, which every filler fact also carries. A rule with a
+// hard-coded pattern — `CVE-\d+`, or "any number" — would pair them; the rule
+// here asks the corpus how specific the token is, and the corpus says it is
+// the least specific token it has.
+func TestStructural_CommonIdentifierTokenIsNotEvidence(t *testing.T) {
+	a := "kb/technology/hardware/storage/aaaaaaa7.md"
+	b := "kb/technology/policy/procurement/aaaaaaa8.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "Storage shipments fell in 2026"),
+		namedFact(b, "Procurement rules changed in 2026"),
+	})
+	env.seedShortlist()
+	require.Equal(t, "", pairKindIn(t, env, a, b),
+		"a token the whole corpus carries says nothing about identity")
+}
+
+// TestStructural_SharedGenericPrefixIsNotIdentity — every security fact's path
+// contains the same top segments. Containment alone would therefore pair a
+// corpus with itself; the match has to rest on a token more specific than the
+// corpus's typical one.
+func TestStructural_SharedGenericPrefixIsNotIdentity(t *testing.T) {
+	a := "kb/technology/filler/aaaaaaa9.md"
+	b := "kb/technology/filler/topic3/bbbbbbbc.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "One note about a widget"),
+		namedFact(b, "Another note about a different widget"),
+	})
+	env.seedShortlist()
+	require.Equal(t, "", pairKindIn(t, env, a, b),
+		"the prefix the whole corpus shares is not an identity claim")
+}
+
+// TestStructural_ReachesTheJudge is the wiring half, and the point of the
+// commit: detection that never reaches the judge is this issue's own failure
+// mode arriving one layer later.
+//
+// The two facts' titles are far apart on the axis — that is why the KNN never
+// paired them — so they cannot be selected through the cosine ranking. Only the
+// reserved structural slot gets them judged.
+func TestStructural_ReachesTheJudge(t *testing.T) {
+	ctx := context.Background()
+	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
+	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "Cisco patches nine flaws across Crosswork and Secure Workload"),
+		namedFact(b, "Nine Cisco advisories cover Crosswork and Secure Workload"),
+	})
+
+	d := env.deps()
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	require.NoError(t, err)
+	require.NoError(t, planRestatementShortlist(ctx, d, sess, env.branch, nil))
+
+	// The fixture must actually budget more than one slot, or the reservation
+	// under test does not exist.
+	require.GreaterOrEqual(t, shortlistBudget(structuralFiller+2), 2,
+		"fixture must fund a budget of at least two, or the reservation cannot fire")
+
+	require.True(t, shortlistQueueHoldsPair(t, env, sess.ID, a, b),
+		"a structurally matched pair must be offered to the judge, not merely detected")
+}
+
+// TestStructural_ReservationSurvivesAFullOrdinaryBand — the reservation is only
+// meaningful when the ordinary band could have taken every slot. A widener that
+// fires only on underfill is decorative (the designer's Q10 ruling on the motif
+// signal, which this reservation copies).
+func TestStructural_ReservationSurvivesAFullOrdinaryBand(t *testing.T) {
+	ctx := context.Background()
+	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
+	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "Cisco patches nine flaws across Crosswork and Secure Workload"),
+		namedFact(b, "Nine Cisco advisories cover Crosswork and Secure Workload"),
+	})
+	env.seedShortlist()
+
+	d := env.deps()
+	budget := shortlistBudget(structuralFiller + 2)
+	ordinary, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, budget*shortlistOverfetch)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(ordinary), budget,
+		"fixture must supply enough title-ranked pairs to fill the budget alone, "+
+			"or the reservation is not being tested")
+
+	pairs, h, err := selectRestatementCandidates(ctx, d, env.branch, nil, structuralFiller+2)
+	require.NoError(t, err)
+	require.Equal(t, 1, h.StructuralOffered,
+		"the reserved slot must be spent even when the ordinary band could have filled the budget")
+	require.True(t, containsPair(pairs, a, b))
+	require.Len(t, pairs, budget, "the reservation reallocates a slot, it does not add one")
+}
+
+// TestStructural_NoTitleVectorIsDroppedNotScored — the ranking column means
+// "title cosine". A structural pair whose vectors are not both stored is
+// dropped rather than given a placeholder, because a placeholder there is a
+// number no measurement produced. The pair is not lost: the axis backfill fills
+// in over sessions and a later refresh mints it.
+//
+// The fixture needs a PARTIALLY filled axis, and getting there is the whole
+// difficulty. An empty axis does not exercise this at all — with no fact on the
+// axis the refresh has nothing to rescan and returns before any pair is built,
+// so a test written that way passes without ever reaching the code it names.
+// (It was written that way first, and the sabotage that invents a score walked
+// straight through it.) So: one twin is written first and lands in the single
+// batch the budget affords, the other is written last and does not.
+func TestStructural_NoTitleVectorIsDroppedNotScored(t *testing.T) {
+	ctx := context.Background()
+	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
+	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
+
+	emb := &restatementEmbedder{perBatchDelay: 40 * time.Millisecond}
+	env := newRestatementEnvWith(t, 0, emb)
+	env.writeFact(a, "Cisco patches nine flaws across Crosswork and Secure Workload", "body")
+	for i := range titleBackfillBatch * 2 {
+		env.writeFact(fmt.Sprintf("kb/technology/filler/topic%d/%08x.md", i, i+1),
+			fmt.Sprintf("Filler note 2026 about widget %d", 1000+i), "an unrelated body")
+	}
+	env.writeFact(b, "Nine Cisco advisories cover Crosswork and Secure Workload", "body")
+
+	// One batch fits in the budget; the rest of the corpus does not.
+	d := env.deps()
+	have, total, err := ensureTitleVectors(ctx, d, env.branch, time.Millisecond)
+	require.NoError(t, err)
+	require.Greater(t, have, 0, "fixture needs SOME facts on the axis")
+	require.Less(t, have, total,
+		"fixture needs a PARTIAL axis, or the drop under test is never reached")
+
+	onAxis, err := env.svc.Abstraction().LiveEpistemicFactsOnAxis(ctx, env.branch)
+	require.NoError(t, err)
+	byPath := map[string]bool{}
+	for _, p := range onAxis {
+		byPath[p] = true
+	}
+	require.True(t, byPath[a], "fixture: the first twin must be on the axis")
+	require.False(t, byPath[b], "fixture: the second twin must NOT be on the axis")
+
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
+	require.NoError(t, err)
+	require.Equal(t, "", pairKindIn(t, env, a, b),
+		"a pair that cannot be scored on the title axis must not be stored with an invented score")
+
+	// ...and once the axis closes, the same corpus yields the pair.
+	env.seedShortlist()
+	require.Equal(t, store.MatchPathIdentity, pairKindIn(t, env, a, b),
+		"the pair is deferred by a missing vector, never discarded")
+}
+
+// TestStructural_ContainmentWithoutSpecificityIsNotPathIdentity pins what
+// classify MEANS, as opposed to what the inverted index happens to reach.
+//
+// These two facts are reached through their shared rare identifier, and their
+// path token sets are in a containment relation — but the containment rests
+// only on the prefix the whole corpus shares, so it is not an identity claim
+// and the pair must be reported as what it actually is.
+//
+// This is the only test that reaches pathIdentity with a pair the index did not
+// select FOR its path tokens; without it, dropping the specificity requirement
+// inside pathIdentity changes nothing any test observes, because the index
+// enforces the same rule on the way in.
+func TestStructural_ContainmentWithoutSpecificityIsNotPathIdentity(t *testing.T) {
+	a := "kb/technology/filler/aaaaaab1.md"
+	b := "kb/technology/filler/deeper/aaaaaab2.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "One report on CVE-2026-77777"),
+		namedFact(b, "A second report on CVE-2026-77777"),
+	})
+	env.seedShortlist()
+	require.Equal(t, store.MatchRareToken, pairKindIn(t, env, a, b),
+		"containment on the corpus's shared prefix is not a path identity — "+
+			"the shared identifier is what found this pair, and the record must say so")
+}

--- a/internal/synthesize/inflight.go
+++ b/internal/synthesize/inflight.go
@@ -1,0 +1,236 @@
+// Package synthesize — mid-session refresh of already-queued work items.
+//
+// A session's work items are MATERIALISED when the session is planned: each
+// item's payload is a snapshot of the facts it was about, marshalled into
+// facts_json and handed to the prompt verbatim at render time. That is fine
+// while the corpus holds still, and a review session is precisely the thing
+// that stops it holding still — a merge applied to one item retires facts that
+// later items are still carrying.
+//
+// Corpus-level retirement itself WORKS: the merged fact is written and every
+// source is deleted, so a session that starts afterwards never sees the
+// originals. The gap is only intra-session: items materialised before the merge
+// are never re-checked against it, so the same session goes on to re-offer a
+// fact that no longer exists — spending a judge slot, or one of the eight
+// backfill slots, on a corpus state that is already gone.
+//
+// This file closes that gap. It takes the set of paths an apply RETIRED and
+// brings the still-queued items back into agreement with the corpus.
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+
+	"knomit/internal/store"
+)
+
+// minJudgeableMembers is the smallest payload a consolidation judge can act on.
+//
+// A STRUCTURAL floor, not a corpus property (MN13): a prune item asks "should
+// these facts be merged", and that question is unanswerable about one fact.
+// The same floor already governs planning — Plan filters to clusters with more
+// than one member, and enqueueRestatementItems drops a pair it can only half
+// ship.
+const minJudgeableMembers = 2
+
+// minBridgeMembers is the same kind of structural floor for a bridge: a
+// discover item asks what two or more independent facts jointly entail, and
+// enumerateBridgeCandidates will not emit a set below it.
+const minBridgeMembers = 2
+
+// refreshInFlightItems reconciles this session's UNANSWERED work items with a
+// set of paths that have just been retired from the corpus.
+//
+// Composability note: this takes the retired set as a whole, AFTER the apply
+// that produced it has finished, rather than hooking each individual delete.
+// That is deliberate — it works unchanged whether the merge writes and deletes
+// sequentially or lands both halves in one atomic batch commit.
+//
+// Per-item failures warn and skip that item (conventions/synthesize/write-paths/
+// failure-isolation): a payload that cannot be decoded is one stale item, and
+// losing the whole refresh over it would strand every other item too.
+func refreshInFlightItems(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, retired []string) error {
+	if len(retired) == 0 || sess == nil {
+		return nil
+	}
+	gone := make(map[string]struct{}, len(retired))
+	for _, p := range retired {
+		gone[p] = struct{}{}
+	}
+
+	items, err := d.Pipeline.PendingPipelineWorkItems(ctx, sess.ID)
+	if err != nil {
+		return wrapf(reviewTool, err, "in-flight refresh: read pending items")
+	}
+
+	var updated, dropped int
+	for _, item := range items {
+		action, payload, aerr := refreshedPayload(ctx, d, branch, item, gone)
+		if aerr != nil {
+			log.Warn().Err(aerr).Int64("item", item.ID).Str("step", item.StepType).
+				Msg("review: in-flight refresh could not read an item's payload; leaving it as planned")
+			continue
+		}
+		switch action {
+		case refreshUnchanged:
+			continue
+		case refreshRewrite:
+			ok, uerr := d.Pipeline.UpdatePipelineWorkItemFacts(ctx, item.ID, payload)
+			if uerr != nil {
+				log.Warn().Err(uerr).Int64("item", item.ID).Msg("review: in-flight refresh: rewrite failed")
+				continue
+			}
+			if ok {
+				updated++
+			}
+		case refreshDelete:
+			ok, derr := d.Pipeline.DeletePipelineWorkItem(ctx, item.ID)
+			if derr != nil {
+				log.Warn().Err(derr).Int64("item", item.ID).Msg("review: in-flight refresh: delete failed")
+				continue
+			}
+			if ok {
+				dropped++
+			}
+		}
+	}
+
+	if updated > 0 || dropped > 0 {
+		log.Info().Str("session", sess.ID).Int("retired", len(retired)).
+			Int("items_rewritten", updated).Int("items_dropped", dropped).
+			Msg("review: in-flight work items refreshed after a mid-session retirement")
+		// Reported, not merely logged: an item that silently vanishes from the
+		// queue is indistinguishable from one that was never planned.
+		d.OnProgress(ProgressEvent{Phase: "detail-refresh", Message: fmt.Sprintf(
+			"in-flight refresh: %d fact(s) retired mid-session — %d queued item(s) rewritten, %d dropped",
+			len(retired), updated, dropped)})
+	}
+	return nil
+}
+
+// refreshAction is what a refresh decided about one item.
+type refreshAction int
+
+const (
+	refreshUnchanged refreshAction = iota
+	refreshRewrite
+	refreshDelete
+)
+
+// refreshedPayload decides what to do with one queued item, and returns its
+// rewritten payload when the answer is "rewrite".
+//
+// Step types with no fact payload — reflect, and the two motif VOCABULARY
+// passes, which name motifs rather than facts — fall through unchanged. That
+// is not an oversight to be tidied later: a pass whose payload cannot name a
+// retired fact has nothing to reconcile.
+func refreshedPayload(ctx context.Context, d Deps, branch string, item store.PipelineWorkItem, gone map[string]struct{}) (refreshAction, string, error) {
+	switch item.StepType {
+	case "prune":
+		// Cluster prunes and shortlist pairs share this shape, and share the
+		// floor: both ask whether these facts consolidate.
+		return refreshFactList(item.FactsJSON, gone, minJudgeableMembers)
+
+	case "distill":
+		// Distill synthesizes UPWARD from what it is shown rather than
+		// reconciling members against each other, so one surviving fact is
+		// still a question worth asking. Only an empty payload is vacuous.
+		return refreshFactList(item.FactsJSON, gone, 1)
+
+	case "discover":
+		var payload DiscoverWorkPayload
+		if err := json.Unmarshal([]byte(item.FactsJSON), &payload); err != nil {
+			return refreshUnchanged, "", fmt.Errorf("decode discover payload: %w", err)
+		}
+		kept, removed := withoutRetired(payload.Bridge.Members, gone)
+		if removed == 0 {
+			return refreshUnchanged, "", nil
+		}
+		if len(kept) < minBridgeMembers {
+			return refreshDelete, "", nil
+		}
+		payload.Bridge.Members = kept
+		blob, err := json.Marshal(payload)
+		if err != nil {
+			return refreshUnchanged, "", fmt.Errorf("re-marshal discover payload: %w", err)
+		}
+		return refreshRewrite, string(blob), nil
+
+	case motifBackfillStepType:
+		// Backfill is RE-MATERIALISED rather than filtered. Its payload is a
+		// budget — the oldest maxBackfillFacts facts still lacking a motif —
+		// so merely dropping a retired entry would leave the session offering
+		// seven where it had eight. Re-deriving hands the freed slot to a fact
+		// that still exists, which is the whole point of the sequence: a
+		// confirmed duplicate must not cost backfill budget.
+		if !backfillPayloadNames(item.FactsJSON, gone) {
+			return refreshUnchanged, "", nil
+		}
+		payload, err := backfillPayloadFor(ctx, d, branch)
+		if err != nil {
+			return refreshUnchanged, "", err
+		}
+		if len(payload.Facts) == 0 {
+			return refreshDelete, "", nil
+		}
+		blob, err := json.Marshal(payload)
+		if err != nil {
+			return refreshUnchanged, "", fmt.Errorf("re-marshal backfill payload: %w", err)
+		}
+		return refreshRewrite, string(blob), nil
+	}
+	return refreshUnchanged, "", nil
+}
+
+// refreshFactList reconciles a plain []factForLLM payload against the retired
+// set, deleting the item when too little is left to judge.
+func refreshFactList(factsJSON string, gone map[string]struct{}, floor int) (refreshAction, string, error) {
+	var facts []factForLLM
+	if err := json.Unmarshal([]byte(factsJSON), &facts); err != nil {
+		return refreshUnchanged, "", fmt.Errorf("decode fact list payload: %w", err)
+	}
+	kept, removed := withoutRetired(facts, gone)
+	if removed == 0 {
+		return refreshUnchanged, "", nil
+	}
+	if len(kept) < floor {
+		return refreshDelete, "", nil
+	}
+	blob, err := json.Marshal(kept)
+	if err != nil {
+		return refreshUnchanged, "", fmt.Errorf("re-marshal fact list payload: %w", err)
+	}
+	return refreshRewrite, string(blob), nil
+}
+
+// withoutRetired returns the members that survive, and how many were removed.
+func withoutRetired(facts []factForLLM, gone map[string]struct{}) ([]factForLLM, int) {
+	kept := make([]factForLLM, 0, len(facts))
+	for _, f := range facts {
+		if _, dead := gone[f.File]; dead {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept, len(facts) - len(kept)
+}
+
+// backfillPayloadNames reports whether a backfill payload offers any of the
+// retired paths. Checked before re-deriving, so an untouched backfill item is
+// left exactly as planned rather than silently re-rolled on every merge.
+func backfillPayloadNames(factsJSON string, gone map[string]struct{}) bool {
+	var payload backfillPayload
+	if err := json.Unmarshal([]byte(factsJSON), &payload); err != nil {
+		return false
+	}
+	for _, f := range payload.Facts {
+		if _, dead := gone[f.Path]; dead {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/synthesize/inflight.go
+++ b/internal/synthesize/inflight.go
@@ -14,8 +14,15 @@
 // fact that no longer exists — spending a judge slot, or one of the eight
 // backfill slots, on a corpus state that is already gone.
 //
-// This file closes that gap. It takes the set of paths an apply RETIRED and
-// brings the still-queued items back into agreement with the corpus.
+// This file closes that gap. It takes the paths an apply MUTATED — retired, or
+// changed in place — and brings the still-queued items back into agreement with
+// the corpus.
+//
+// It runs over EVERY unanswered item in the session, not just items of the
+// vehicle that did the mutating. Staleness is cross-vehicle by nature: a prune
+// merge retires facts that a distill item queued in the same session is still
+// carrying, and measured live, that happens as often as the within-vehicle
+// case.
 package synthesize
 
 import (
@@ -53,13 +60,22 @@ const minBridgeMembers = 2
 // Per-item failures warn and skip that item (conventions/synthesize/write-paths/
 // failure-isolation): a payload that cannot be decoded is one stale item, and
 // losing the whole refresh over it would strand every other item too.
-func refreshInFlightItems(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, retired []string) error {
-	if len(retired) == 0 || sess == nil {
+func refreshInFlightItems(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, stats *ReviewStats) error {
+	if sess == nil || stats == nil {
 		return nil
 	}
-	gone := make(map[string]struct{}, len(retired))
-	for _, p := range retired {
-		gone[p] = struct{}{}
+	if len(stats.Retired) == 0 && len(stats.Rewritten) == 0 {
+		return nil
+	}
+	m := mutation{
+		gone:    make(map[string]struct{}, len(stats.Retired)),
+		changed: make(map[string]struct{}, len(stats.Rewritten)),
+	}
+	for _, p := range stats.Retired {
+		m.gone[p] = struct{}{}
+	}
+	for _, p := range stats.Rewritten {
+		m.changed[p] = struct{}{}
 	}
 
 	items, err := d.Pipeline.PendingPipelineWorkItems(ctx, sess.ID)
@@ -69,7 +85,7 @@ func refreshInFlightItems(ctx context.Context, d Deps, sess *store.PipelineSessi
 
 	var updated, dropped int
 	for _, item := range items {
-		action, payload, aerr := refreshedPayload(ctx, d, branch, item, gone)
+		action, payload, aerr := refreshedPayload(ctx, d, branch, item, m)
 		if aerr != nil {
 			log.Warn().Err(aerr).Int64("item", item.ID).Str("step", item.StepType).
 				Msg("review: in-flight refresh could not read an item's payload; leaving it as planned")
@@ -100,16 +116,35 @@ func refreshInFlightItems(ctx context.Context, d Deps, sess *store.PipelineSessi
 	}
 
 	if updated > 0 || dropped > 0 {
-		log.Info().Str("session", sess.ID).Int("retired", len(retired)).
+		log.Info().Str("session", sess.ID).
+			Int("retired", len(stats.Retired)).Int("rewritten", len(stats.Rewritten)).
 			Int("items_rewritten", updated).Int("items_dropped", dropped).
 			Msg("review: in-flight work items refreshed after a mid-session retirement")
 		// Reported, not merely logged: an item that silently vanishes from the
 		// queue is indistinguishable from one that was never planned.
 		d.OnProgress(ProgressEvent{Phase: "detail-refresh", Message: fmt.Sprintf(
-			"in-flight refresh: %d fact(s) retired mid-session — %d queued item(s) rewritten, %d dropped",
-			len(retired), updated, dropped)})
+			"in-flight refresh: %d fact(s) retired and %d changed mid-session — "+
+				"%d queued item(s) rewritten, %d dropped",
+			len(stats.Retired), len(stats.Rewritten), updated, dropped)})
 	}
 	return nil
+}
+
+// mutation is what one apply did to the corpus, in the two shapes a queued
+// item cares about: members that must be DROPPED, and members that must be
+// RE-READ because their stored fields moved underneath the snapshot.
+type mutation struct {
+	gone    map[string]struct{}
+	changed map[string]struct{}
+}
+
+// touches reports whether a path was mutated at all.
+func (m mutation) touches(path string) bool {
+	if _, ok := m.gone[path]; ok {
+		return true
+	}
+	_, ok := m.changed[path]
+	return ok
 }
 
 // refreshAction is what a refresh decided about one item.
@@ -128,26 +163,26 @@ const (
 // passes, which name motifs rather than facts — fall through unchanged. That
 // is not an oversight to be tidied later: a pass whose payload cannot name a
 // retired fact has nothing to reconcile.
-func refreshedPayload(ctx context.Context, d Deps, branch string, item store.PipelineWorkItem, gone map[string]struct{}) (refreshAction, string, error) {
+func refreshedPayload(ctx context.Context, d Deps, branch string, item store.PipelineWorkItem, m mutation) (refreshAction, string, error) {
 	switch item.StepType {
 	case "prune":
 		// Cluster prunes and shortlist pairs share this shape, and share the
 		// floor: both ask whether these facts consolidate.
-		return refreshFactList(item.FactsJSON, gone, minJudgeableMembers)
+		return refreshFactList(ctx, d, branch, item.FactsJSON, m, minJudgeableMembers)
 
 	case "distill":
 		// Distill synthesizes UPWARD from what it is shown rather than
 		// reconciling members against each other, so one surviving fact is
 		// still a question worth asking. Only an empty payload is vacuous.
-		return refreshFactList(item.FactsJSON, gone, 1)
+		return refreshFactList(ctx, d, branch, item.FactsJSON, m, 1)
 
 	case "discover":
 		var payload DiscoverWorkPayload
 		if err := json.Unmarshal([]byte(item.FactsJSON), &payload); err != nil {
 			return refreshUnchanged, "", fmt.Errorf("decode discover payload: %w", err)
 		}
-		kept, removed := withoutRetired(payload.Bridge.Members, gone)
-		if removed == 0 {
+		kept, dropped, rewritten := reconcileMembers(ctx, d, branch, payload.Bridge.Members, m)
+		if dropped == 0 && rewritten == 0 {
 			return refreshUnchanged, "", nil
 		}
 		if len(kept) < minBridgeMembers {
@@ -167,7 +202,7 @@ func refreshedPayload(ctx context.Context, d Deps, branch string, item store.Pip
 		// seven where it had eight. Re-deriving hands the freed slot to a fact
 		// that still exists, which is the whole point of the sequence: a
 		// confirmed duplicate must not cost backfill budget.
-		if !backfillPayloadNames(item.FactsJSON, gone) {
+		if !backfillPayloadNames(item.FactsJSON, m) {
 			return refreshUnchanged, "", nil
 		}
 		payload, err := backfillPayloadFor(ctx, d, branch)
@@ -186,15 +221,15 @@ func refreshedPayload(ctx context.Context, d Deps, branch string, item store.Pip
 	return refreshUnchanged, "", nil
 }
 
-// refreshFactList reconciles a plain []factForLLM payload against the retired
-// set, deleting the item when too little is left to judge.
-func refreshFactList(factsJSON string, gone map[string]struct{}, floor int) (refreshAction, string, error) {
+// refreshFactList reconciles a plain []factForLLM payload against one apply's
+// mutations, deleting the item when too little is left to judge.
+func refreshFactList(ctx context.Context, d Deps, branch, factsJSON string, m mutation, floor int) (refreshAction, string, error) {
 	var facts []factForLLM
 	if err := json.Unmarshal([]byte(factsJSON), &facts); err != nil {
 		return refreshUnchanged, "", fmt.Errorf("decode fact list payload: %w", err)
 	}
-	kept, removed := withoutRetired(facts, gone)
-	if removed == 0 {
+	kept, dropped, rewritten := reconcileMembers(ctx, d, branch, facts, m)
+	if dropped == 0 && rewritten == 0 {
 		return refreshUnchanged, "", nil
 	}
 	if len(kept) < floor {
@@ -207,28 +242,74 @@ func refreshFactList(factsJSON string, gone map[string]struct{}, floor int) (ref
 	return refreshRewrite, string(blob), nil
 }
 
-// withoutRetired returns the members that survive, and how many were removed.
-func withoutRetired(facts []factForLLM, gone map[string]struct{}) ([]factForLLM, int) {
-	kept := make([]factForLLM, 0, len(facts))
+// reconcileMembers drops retired members and RE-READS changed ones, returning
+// the survivors plus how many were dropped and how many were re-read.
+//
+// Re-read rather than patched: the queued member is a snapshot of the fields a
+// prompt shows, and an apply that rewrote the fact may have moved more than the
+// one field it was asked about. Reading the live record is the only version of
+// this that cannot drift from what a freshly planned item would have carried.
+//
+// A changed member that can no longer be read is left exactly as it was. That
+// is the conservative direction: showing a stale snapshot costs one imprecise
+// judgement, while dropping a member the corpus may still hold silently
+// shrinks the question.
+func reconcileMembers(ctx context.Context, d Deps, branch string, facts []factForLLM, m mutation) (kept []factForLLM, dropped, rewritten int) {
+	kept = make([]factForLLM, 0, len(facts))
 	for _, f := range facts {
-		if _, dead := gone[f.File]; dead {
+		if _, dead := m.gone[f.File]; dead {
+			dropped++
 			continue
+		}
+		if _, moved := m.changed[f.File]; moved {
+			if fresh, ok := liveMember(ctx, d, branch, f); ok {
+				kept = append(kept, fresh)
+				rewritten++
+				continue
+			}
 		}
 		kept = append(kept, f)
 	}
-	return kept, len(facts) - len(kept)
+	return kept, dropped, rewritten
 }
 
-// backfillPayloadNames reports whether a backfill payload offers any of the
-// retired paths. Checked before re-deriving, so an untouched backfill item is
-// left exactly as planned rather than silently re-rolled on every merge.
-func backfillPayloadNames(factsJSON string, gone map[string]struct{}) bool {
+// liveMember re-reads one member from the index, in the same field mapping the
+// planner uses (enqueueRestatementItems). Motifs are carried too: a member's
+// motifs steer the distill enrichment line and the bridge specificity score.
+func liveMember(ctx context.Context, d Deps, branch string, stale factForLLM) (factForLLM, bool) {
+	rec, err := d.Search.GetByPath(ctx, branch, stale.File)
+	if err != nil || rec == nil {
+		return stale, false
+	}
+	return factForLLM{
+		File:       rec.Path,
+		Title:      rec.Title,
+		Body:       rec.Body,
+		Type:       rec.Type,
+		Domain:     rec.Domain,
+		Entities:   rec.Entities,
+		Motifs:     rec.Motifs,
+		Confidence: rec.Confidence,
+		Sources:    rec.Sources,
+		Origin:     rec.Origin,
+	}, true
+}
+
+// backfillPayloadNames reports whether a backfill payload offers any mutated
+// path. Checked before re-deriving, so an untouched backfill item is left
+// exactly as planned rather than silently re-rolled on every mutation.
+//
+// A CHANGED path counts, not only a retired one: the payload binds each offer
+// to the fact id it was planned against, and applyMotifBackfill refuses to
+// write against any other version — so an updated fact would otherwise sit in
+// the payload as a slot that is guaranteed to be skipped.
+func backfillPayloadNames(factsJSON string, m mutation) bool {
 	var payload backfillPayload
 	if err := json.Unmarshal([]byte(factsJSON), &payload); err != nil {
 		return false
 	}
 	for _, f := range payload.Facts {
-		if _, dead := gone[f.Path]; dead {
+		if m.touches(f.Path) {
 			return true
 		}
 	}

--- a/internal/synthesize/inflight_test.go
+++ b/internal/synthesize/inflight_test.go
@@ -445,3 +445,59 @@ func TestApplyPrune_RewrittenExcludesPathsTheSameApplyRetired(t *testing.T) {
 		"a path this apply retired must not also be reported as rewritten — "+
 			"there is nothing left to re-read")
 }
+
+// TestInFlightRefresh_ReinforcementRefreshesQueuedSnapshots — the third
+// vehicle. Measured live this session: a merged pair came back in a DISTILL
+// item and in a DISCOVER item, so all three work-item types re-serve stale
+// facts.
+//
+// Discover has no retire path of its own — it WRITES new facts and REINFORCES
+// existing ones, and nothing in applyDiscoverStep deletes anything. Its
+// contribution to in-session staleness is therefore the mutated-but-live half:
+// a reinforced fact gains a source and a ref, and every queued item is still
+// carrying the count from before.
+func TestInFlightRefresh_ReinforcementRefreshesQueuedSnapshots(t *testing.T) {
+	env := newInflightEnv(t)
+	env.writeFact("kb/other-x.md", "X", "x")
+	// The reinforced fact is re-rendered through SerializeFact by the
+	// reinforce path, which refuses any fact whose stored bytes would not
+	// round-trip. Write it the way a real writer does, or the gate rejects it
+	// and the test measures a rejection rather than a refresh.
+	env.writeFactWithMotifsConf(dupAPath, "SmartConsole bypass", "one recording", nil, 0.7)
+
+	queuedID := env.queue("prune", "cluster-1", members(dupAPath, "kb/other-x.md"), 3)
+	before := sourcesOf(env.factsOf(queuedID), dupAPath)
+	require.GreaterOrEqual(t, before, 0, "the queued item must carry the fact under test")
+
+	discoverID := env.queue("discover", "discover-fwd-0", DiscoverWorkPayload{
+		Direction: DiscoverForward,
+		Bridge: BridgeSeedSet{
+			Token:   "SmartConsole",
+			Members: members(dupBPath, "kb/other-x.md"),
+		},
+	}, -1)
+	// Refs must cite EVERY seed, and the reinforced fact must not be one of
+	// them — a fact is not an independent derivation of itself.
+	env.applyResponse(discoverID, fmt.Sprintf(
+		`{"proposals":[],"reinforcements":[{"path":%q,"reason":"the seeds independently re-derive this",
+		  "refs":[%q,%q]}]}`, dupAPath, dupBPath, "kb/other-x.md"))
+
+	live, err := env.svc.Search().GetByPath(context.Background(), env.branch, dupAPath)
+	require.NoError(t, err)
+	require.NotNil(t, live)
+	require.Greater(t, live.Sources, before,
+		"fixture: the reinforcement must actually have landed, or this proves nothing")
+
+	after := sourcesOf(env.factsOf(queuedID), dupAPath)
+	require.Equal(t, live.Sources, after,
+		"a reinforced fact's queued snapshot must show the sources the corpus now holds")
+}
+
+func sourcesOf(facts []factForLLM, path string) int {
+	for _, f := range facts {
+		if f.File == path {
+			return f.Sources
+		}
+	}
+	return -1
+}

--- a/internal/synthesize/inflight_test.go
+++ b/internal/synthesize/inflight_test.go
@@ -1,0 +1,283 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// The in-flight refresh tests drive reviewStrategy.Apply — the production call
+// site — rather than refreshInFlightItems directly. A test that calls the
+// helper asserts the helper works, not that anything calls it; S5 in the
+// commit-1 table is the same lesson from the other side.
+
+// inflightEnv is a corpus with a duplicate pair plus enough motif-less filler
+// that the backfill budget can be observed refilling.
+type inflightEnv struct {
+	*restatementEnv
+	sess *store.PipelineSession
+}
+
+const (
+	dupAPath   = "kb/technology/security/vulnerabilities/network-security/dup-a.md"
+	dupBPath   = "kb/technology/security/vulnerabilities/network-appliances/dup-b.md"
+	mergedPath = "kb/technology/security/vulnerabilities/network-security/merged.md"
+)
+
+func newInflightEnv(t *testing.T) *inflightEnv {
+	t.Helper()
+	// maxBackfillFacts + 4 filler facts, so the payload is over-subscribed and
+	// a freed slot has a real candidate to go to. Asserted below rather than
+	// assumed.
+	env := newRestatementEnv(t, maxBackfillFacts+4)
+	env.writeFact(dupAPath, "SmartConsole bypass", "one recording of the event")
+	env.writeFact(dupBPath, "SmartConsole bypass, again", "the same event, second category")
+	sess, err := env.svc.Pipeline().CreatePipelineSession(context.Background(), reviewTool, env.branch)
+	require.NoError(t, err)
+	return &inflightEnv{restatementEnv: env, sess: sess}
+}
+
+// queue inserts a work item exactly as Plan would, and returns its id.
+func (e *inflightEnv) queue(stepType, clusterKey string, payload any, priority float64) int64 {
+	e.t.Helper()
+	blob, err := json.Marshal(payload)
+	require.NoError(e.t, err)
+	require.NoError(e.t, e.svc.Pipeline().InsertPipelineWorkItem(context.Background(), store.PipelineWorkItem{
+		SessionID: e.sess.ID, StepType: stepType, ClusterKey: clusterKey,
+		FactsJSON: string(blob), Priority: priority,
+	}))
+	// The highest id is the row just inserted. Deliberately NOT "the last item
+	// in the pending list": that list is in QUEUE order (priority DESC, id
+	// ASC), so the newest row is rarely last.
+	var newest int64
+	for _, it := range e.pending() {
+		if it.ID > newest {
+			newest = it.ID
+		}
+	}
+	return newest
+}
+
+func (e *inflightEnv) pending() []store.PipelineWorkItem {
+	e.t.Helper()
+	items, err := e.svc.Pipeline().PendingPipelineWorkItems(context.Background(), e.sess.ID)
+	require.NoError(e.t, err)
+	return items
+}
+
+func (e *inflightEnv) itemByID(id int64) *store.PipelineWorkItem {
+	e.t.Helper()
+	for _, it := range e.pending() {
+		if it.ID == id {
+			return &it
+		}
+	}
+	return nil
+}
+
+func members(paths ...string) []factForLLM {
+	out := make([]factForLLM, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, factForLLM{File: p, Title: p, Body: "b", Type: "observation"})
+	}
+	return out
+}
+
+// mergeResponse is the judge's answer merging dup-a and dup-b into one fact.
+func mergeResponse() string {
+	return fmt.Sprintf(`{"decisions":[],"merges":[{"paths":[%q,%q],"merged":{
+		"path":%q,"title":"SmartConsole bypass","body":"Both recordings, unioned.",
+		"type":"observation","domain":["security"],"confidence":0.9,"sources":2,
+		"entities":["SmartConsole"],"refs":[]}}]}`, dupAPath, dupBPath, mergedPath)
+}
+
+// applyMerge answers the given prune item with the merge, through Decode+Apply.
+func (e *inflightEnv) applyMerge(itemID int64) {
+	e.t.Helper()
+	ctx := context.Background()
+	item := e.itemByID(itemID)
+	require.NotNil(e.t, item, "the item to answer must still be queued")
+	dec, _, err := reviewStrategy{}.Decode(item, mergeResponse())
+	require.NoError(e.t, err)
+	claimed, err := e.svc.Pipeline().AnswerPipelineWorkItem(ctx, item.ID, mergeResponse())
+	require.NoError(e.t, err)
+	require.True(e.t, claimed)
+	require.NoError(e.t, reviewStrategy{}.Apply(ctx, e.deps(), e.sess, item, dec))
+	// The merge must actually have happened, or every assertion below is about
+	// a session in which nothing was retired.
+	gone, err := e.svc.Facts().FactExists(ctx, e.branch, dupBPath)
+	require.NoError(e.t, err)
+	require.False(e.t, gone, "the merge must have retired the loser, or this fixture proves nothing")
+}
+
+// TestInFlightRefresh_MergeFreesTheBackfillBudget is #127's (a): a confirmed
+// duplicate must not go on costing one of the session's backfill slots.
+//
+// The backfill payload is materialised during Plan, so a merge applied later in
+// the SAME session cannot reach it — the retired fact keeps its slot and the
+// session offers seven live facts where it budgeted eight.
+func TestInFlightRefresh_MergeFreesTheBackfillBudget(t *testing.T) {
+	ctx := context.Background()
+	env := newInflightEnv(t)
+
+	// The payload as Plan would build it, then forced to offer the duplicate —
+	// which is what Plan does anyway when the duplicate is among the oldest
+	// motif-less facts.
+	planned, err := backfillPayloadFor(ctx, env.deps(), env.branch)
+	require.NoError(t, err)
+	require.Len(t, planned.Facts, maxBackfillFacts,
+		"fixture must over-subscribe the budget, or a freed slot has nowhere to go")
+	planned.Facts[0] = backfillItem{Path: dupBPath, FactID: env.liveFactIDs()[dupBPath]}
+	backfillID := env.queue(motifBackfillStepType, "motif-backfill", planned, motifBackfillPriority)
+
+	pruneID := env.queue("prune", "cluster-0", members(dupAPath, dupBPath), 2)
+	env.applyMerge(pruneID)
+
+	refreshed := env.itemByID(backfillID)
+	require.NotNil(t, refreshed, "the backfill item must survive — it still has live facts to offer")
+	var got backfillPayload
+	require.NoError(t, json.Unmarshal([]byte(refreshed.FactsJSON), &got))
+
+	for _, f := range got.Facts {
+		require.NotEqual(t, dupBPath, f.Path, "a retired fact must not still be offered for backfill")
+		require.NotEqual(t, dupAPath, f.Path, "a retired fact must not still be offered for backfill")
+	}
+	require.Len(t, got.Facts, maxBackfillFacts,
+		"the freed slot must go to a live fact — filtering alone would leave the session "+
+			"offering fewer facts than its budget")
+}
+
+// TestInFlightRefresh_QueuedPruneItemLosesTheMergedFact — a still-queued
+// consolidation item stops naming a fact the session has already retired,
+// while keeping the members it can still judge.
+func TestInFlightRefresh_QueuedPruneItemLosesTheMergedFact(t *testing.T) {
+	env := newInflightEnv(t)
+	env.writeFact("kb/other-x.md", "X", "x")
+	env.writeFact("kb/other-y.md", "Y", "y")
+
+	pruneID := env.queue("prune", "cluster-0", members(dupAPath, dupBPath), 2)
+	queuedID := env.queue("prune", "cluster-1", members(dupBPath, "kb/other-x.md", "kb/other-y.md"), 3)
+
+	env.applyMerge(pruneID)
+
+	still := env.itemByID(queuedID)
+	require.NotNil(t, still, "two live members remain — the item is still judgeable")
+	var facts []factForLLM
+	require.NoError(t, json.Unmarshal([]byte(still.FactsJSON), &facts))
+	require.Len(t, facts, 2)
+	for _, f := range facts {
+		require.NotEqual(t, dupBPath, f.File, "a retired fact must not be re-offered to the judge")
+	}
+}
+
+// TestInFlightRefresh_ItemBelowTheJudgeableFloorIsDropped pins the FLOOR, not
+// merely emptiness: one surviving member is not a consolidation question, and
+// an item reduced to one would spend a judge slot asking whether a single fact
+// should be merged with itself.
+func TestInFlightRefresh_ItemBelowTheJudgeableFloorIsDropped(t *testing.T) {
+	env := newInflightEnv(t)
+	env.writeFact("kb/other-x.md", "X", "x")
+
+	pruneID := env.queue("prune", "cluster-0", members(dupAPath, dupBPath), 2)
+	queuedID := env.queue("prune", "cluster-1", members(dupBPath, "kb/other-x.md"), 3)
+
+	env.applyMerge(pruneID)
+
+	require.Nil(t, env.itemByID(queuedID),
+		"an item left with fewer than two members has nothing to judge and must leave the queue")
+}
+
+// TestInFlightRefresh_UntouchedItemsKeepTheirExactPayload is the guard against
+// the opposite failure: a refresh that re-rolled every queued item on every
+// merge would churn payloads the agent may already be holding, and would make
+// the backfill item a different offer each time anything merged anywhere.
+func TestInFlightRefresh_UntouchedItemsKeepTheirExactPayload(t *testing.T) {
+	ctx := context.Background()
+	env := newInflightEnv(t)
+	env.writeFact("kb/other-x.md", "X", "x")
+	env.writeFact("kb/other-y.md", "Y", "y")
+
+	planned, err := backfillPayloadFor(ctx, env.deps(), env.branch)
+	require.NoError(t, err)
+	// Strip both duplicates from the offer so this payload names nothing that
+	// the merge below retires, and then cut it SHORT.
+	//
+	// The short cut is what makes this test discriminate. A payload equal to
+	// what a re-derivation would produce cannot tell "left alone" from
+	// "re-derived and coincidentally identical" — the first draft of this test
+	// had exactly that hole and passed under the sabotage it exists to catch.
+	var clean []backfillItem
+	for _, f := range planned.Facts {
+		if f.Path != dupAPath && f.Path != dupBPath {
+			clean = append(clean, f)
+		}
+	}
+	require.Greater(t, len(clean), 3, "fixture needs room to be cut short")
+	planned.Facts = clean[:3]
+	backfillID := env.queue(motifBackfillStepType, "motif-backfill", planned, motifBackfillPriority)
+
+	// Assert the fixture is DISTINGUISHABLE: a re-derivation right now would
+	// return a different offer, so an unchanged payload below is evidence.
+	wouldBe, err := backfillPayloadFor(ctx, env.deps(), env.branch)
+	require.NoError(t, err)
+	require.NotEqual(t, len(planned.Facts), len(wouldBe.Facts),
+		"a re-derived payload must differ from the queued one, or this test cannot fail")
+	untouchedID := env.queue("prune", "cluster-1", members("kb/other-x.md", "kb/other-y.md"), 3)
+
+	beforeBackfill := env.itemByID(backfillID).FactsJSON
+	beforeUntouched := env.itemByID(untouchedID).FactsJSON
+
+	pruneID := env.queue("prune", "cluster-0", members(dupAPath, dupBPath), 2)
+	env.applyMerge(pruneID)
+
+	require.Equal(t, beforeBackfill, env.itemByID(backfillID).FactsJSON,
+		"a backfill payload naming no retired fact must not be re-derived")
+	require.Equal(t, beforeUntouched, env.itemByID(untouchedID).FactsJSON,
+		"an item naming no retired fact must be left exactly as planned")
+}
+
+// failingDelete wraps a FactIndex and refuses to delete one path, so a test can
+// drive the case where the corpus did NOT actually lose the fact.
+type failingDelete struct {
+	store.FactIndex
+	refuse string
+}
+
+func (f failingDelete) DeleteFact(ctx context.Context, branch, path, message string) (string, error) {
+	if path == f.refuse {
+		return "", fmt.Errorf("simulated delete failure for %s", path)
+	}
+	return f.FactIndex.DeleteFact(ctx, branch, path, message)
+}
+
+// TestApplyPrune_RetiredNamesOnlyFactsThatActuallyLeft — ReviewStats.Retired
+// drives a refresh that STRIPS facts from queued items, so a path reported as
+// retired when its delete failed would remove a live fact from the judge's
+// view. The retract branch used to mark the path deleted before attempting the
+// delete, which made a failed retract indistinguishable from a completed one.
+func TestApplyPrune_RetiredNamesOnlyFactsThatActuallyLeft(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	env.writeFact("kb/keep-me.md", "Keeps", "survives a failed delete")
+	env.writeFact("kb/goes.md", "Goes", "deleted for real")
+
+	d := env.deps()
+	gs := failingDelete{FactIndex: env.svc.Facts(), refuse: "kb/keep-me.md"}
+	stats, err := ApplyPruneDecisions(ctx, gs, env.svc.Search(),
+		[]PruneDecision{{Path: "kb/keep-me.md", Action: "retract"}, {Path: "kb/goes.md", Action: "retract"}},
+		nil, reviewTool, d.OnProgress, env.branch, "", "kb")
+	require.NoError(t, err)
+
+	require.NotContains(t, stats.Retired, "kb/keep-me.md",
+		"a fact whose delete FAILED is still live and must not be reported as retired")
+	require.Contains(t, stats.Retired, "kb/goes.md")
+
+	exists, err := env.svc.Facts().FactExists(ctx, env.branch, "kb/keep-me.md")
+	require.NoError(t, err)
+	require.True(t, exists, "the fixture must leave the refused fact live, or this test proves nothing")
+}

--- a/internal/synthesize/inflight_test.go
+++ b/internal/synthesize/inflight_test.go
@@ -281,3 +281,167 @@ func TestApplyPrune_RetiredNamesOnlyFactsThatActuallyLeft(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exists, "the fixture must leave the refused fact live, or this test proves nothing")
 }
+
+// applyResponse answers a queued item through Decode+Apply, the production
+// path, and asserts the claim was won.
+func (e *inflightEnv) applyResponse(itemID int64, response string) {
+	e.t.Helper()
+	ctx := context.Background()
+	item := e.itemByID(itemID)
+	require.NotNil(e.t, item, "the item to answer must still be queued")
+	dec, _, err := reviewStrategy{}.Decode(item, response)
+	require.NoError(e.t, err)
+	claimed, err := e.svc.Pipeline().AnswerPipelineWorkItem(ctx, item.ID, response)
+	require.NoError(e.t, err)
+	require.True(e.t, claimed)
+	require.NoError(e.t, reviewStrategy{}.Apply(ctx, e.deps(), e.sess, item, dec))
+}
+
+func (e *inflightEnv) factsOf(itemID int64) []factForLLM {
+	e.t.Helper()
+	item := e.itemByID(itemID)
+	require.NotNil(e.t, item)
+	var facts []factForLLM
+	require.NoError(e.t, json.Unmarshal([]byte(item.FactsJSON), &facts))
+	return facts
+}
+
+func confidenceOf(facts []factForLLM, path string) (float64, bool) {
+	for _, f := range facts {
+		if f.File == path {
+			return f.Confidence, true
+		}
+	}
+	return 0, false
+}
+
+// TestInFlightRefresh_UpdateRefreshesQueuedSnapshots — an item's payload is a
+// SNAPSHOT of each fact's fields, so a confidence rewritten mid-session leaves
+// every later item showing the old number. Measured live: facts set to
+// 0.5/0.7/0.8 still read 0.9/0.9/0.95 at items queued before the update.
+//
+// Staleness here is not retirement — the fact is still live and still belongs
+// in the item. The member has to be RE-READ, not dropped.
+func TestInFlightRefresh_UpdateRefreshesQueuedSnapshots(t *testing.T) {
+	env := newInflightEnv(t)
+	env.writeFact("kb/other-x.md", "X", "x")
+
+	judgedID := env.queue("prune", "cluster-0", members(dupAPath, dupBPath), 2)
+	queuedID := env.queue("prune", "cluster-1", members(dupAPath, "kb/other-x.md"), 3)
+
+	before, ok := confidenceOf(env.factsOf(queuedID), dupAPath)
+	require.True(t, ok)
+
+	env.applyResponse(judgedID, fmt.Sprintf(
+		`{"decisions":[{"path":%q,"action":"update","confidence":0.31}],"merges":[]}`, dupAPath))
+
+	after, ok := confidenceOf(env.factsOf(queuedID), dupAPath)
+	require.True(t, ok, "an UPDATED fact is still live and must stay in the item")
+	require.NotEqual(t, before, after, "the queued snapshot must not keep the pre-update value")
+	require.InDelta(t, 0.31, after, 0.001,
+		"the queued item must show the confidence the corpus now holds")
+}
+
+// TestInFlightRefresh_ClearsAcrossVehicles — the queue a merge leaves stale is
+// not its own. Measured live: a distill was offered over facts merged twenty
+// minutes earlier, and 23 clusters this session reached prune AND distill.
+func TestInFlightRefresh_ClearsAcrossVehicles(t *testing.T) {
+	env := newInflightEnv(t)
+	env.writeFact("kb/other-x.md", "X", "x")
+	env.writeFact("kb/other-y.md", "Y", "y")
+
+	distillID := env.queue("distill", "group-0",
+		members(dupBPath, "kb/other-x.md", "kb/other-y.md"), 0)
+	discoverID := env.queue("discover", "discover-fwd-0", DiscoverWorkPayload{
+		Direction: DiscoverForward,
+		Bridge: BridgeSeedSet{
+			Token:   "SmartConsole",
+			Members: members(dupBPath, "kb/other-x.md", "kb/other-y.md"),
+		},
+	}, -1)
+
+	pruneID := env.queue("prune", "cluster-0", members(dupAPath, dupBPath), 2)
+	env.applyMerge(pruneID)
+
+	for _, f := range env.factsOf(distillID) {
+		require.NotEqual(t, dupBPath, f.File,
+			"a merged-away fact must not still be offered to distill")
+	}
+
+	item := env.itemByID(discoverID)
+	require.NotNil(t, item)
+	var payload DiscoverWorkPayload
+	require.NoError(t, json.Unmarshal([]byte(item.FactsJSON), &payload))
+	require.Len(t, payload.Bridge.Members, 2)
+	for _, f := range payload.Bridge.Members {
+		require.NotEqual(t, dupBPath, f.File,
+			"a merged-away fact must not still count as a bridge member")
+	}
+}
+
+// TestInFlightRefresh_DistillRetractClearsOtherQueues is the mirror: distill
+// retires facts through its own retract list, and the items left holding them
+// belong to other vehicles.
+func TestInFlightRefresh_DistillRetractClearsOtherQueues(t *testing.T) {
+	env := newInflightEnv(t)
+	env.writeFact("kb/other-x.md", "X", "x")
+	env.writeFact("kb/other-y.md", "Y", "y")
+
+	queuedID := env.queue("prune", "cluster-1",
+		members(dupBPath, "kb/other-x.md", "kb/other-y.md"), 3)
+	distillID := env.queue("distill", "group-0", members(dupAPath, dupBPath), 0)
+
+	env.applyResponse(distillID, fmt.Sprintf(
+		`{"synthesize":[{"path":"kb/technology/security/vulnerabilities/network-security/distilled.md",
+		"title":"One event","body":"Synthesized from both recordings.","type":"synthesis",
+		"domain":["security"],"confidence":0.8,"entities":["SmartConsole"],"refs":[]}],
+		"retract":[%q]}`, dupBPath))
+
+	gone, err := env.svc.Facts().FactExists(context.Background(), env.branch, dupBPath)
+	require.NoError(t, err)
+	require.False(t, gone, "the distill must have retracted the fact, or this test proves nothing")
+
+	still := env.itemByID(queuedID)
+	require.NotNil(t, still)
+	for _, f := range env.factsOf(queuedID) {
+		require.NotEqual(t, dupBPath, f.File,
+			"a fact distill retracted must not still be offered to prune")
+	}
+}
+
+// TestApplyPrune_RewrittenExcludesPathsTheSameApplyRetired — Retired and
+// Rewritten mean opposite things to a queued item: drop this member, versus
+// re-read it. One judge response can do BOTH to a path (raise its confidence,
+// then subsume it into a merge), and a path reported as rewritten when it is
+// gone would send the refresh to re-read a fact the corpus no longer holds.
+//
+// The consumer happens to check `gone` first, so this contract is currently
+// belt-and-braces. It is asserted here rather than left to that ordering: the
+// two sets are read by more than one caller as the feature grows, and a
+// contract that holds only because of the reader's statement order is not a
+// contract.
+func TestApplyPrune_RewrittenExcludesPathsTheSameApplyRetired(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	env.writeFact(dupAPath, "SmartConsole bypass", "one recording")
+	env.writeFact(dupBPath, "SmartConsole bypass, again", "the same event")
+
+	d := env.deps()
+	var merged mergedFact
+	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(`{
+		"path":%q,"title":"SmartConsole bypass","body":"Both recordings, unioned.",
+		"type":"observation","domain":["security"],"confidence":0.9,"sources":2,
+		"entities":["SmartConsole"],"refs":[]}`, mergedPath)), &merged))
+
+	stats, err := ApplyPruneDecisions(ctx, env.svc.Facts(), env.svc.Search(),
+		// Raise dup-a's confidence, then merge it away in the same response.
+		[]PruneDecision{{Path: dupAPath, Action: "update", Confidence: 0.42}},
+		[]MergeEntry{{Paths: []string{dupAPath, dupBPath}, Merged: merged}},
+		reviewTool, d.OnProgress, env.branch, "", "kb")
+	require.NoError(t, err)
+
+	require.Contains(t, stats.Retired, dupAPath, "the fixture must actually retire the updated path")
+	require.NotContains(t, stats.Rewritten, dupAPath,
+		"a path this apply retired must not also be reported as rewritten — "+
+			"there is nothing left to re-read")
+}

--- a/internal/synthesize/motif_backfill.go
+++ b/internal/synthesize/motif_backfill.go
@@ -301,14 +301,9 @@ func planMotifBackfillWork(ctx context.Context, d Deps, sess *store.PipelineSess
 	health := backfillHealth{WithMotifs: with, Backlog: backlog, TotalFacts: total}
 	defer func() { recordBackfillHealth(sess, health) }()
 
-	targets, err := d.Motifs.LiveFactsWithoutMotifs(ctx, branch, maxBackfillFacts)
-	if err != nil || len(targets) == 0 {
+	payload, err := backfillPayloadFor(ctx, d, branch)
+	if err != nil || len(payload.Facts) == 0 {
 		return nil
-	}
-
-	payload := backfillPayload{
-		Facts:      backfillFactsFor(targets),
-		Vocabulary: buildBackfillHints(ctx, d, branch, targets),
 	}
 	health.Offered = len(payload.Facts)
 	health.Vocabulary = len(payload.Vocabulary)
@@ -324,6 +319,28 @@ func planMotifBackfillWork(ctx context.Context, d Deps, sess *store.PipelineSess
 		FactsJSON:  string(blob),
 		Priority:   motifBackfillPriority,
 	})
+}
+
+// backfillPayloadFor derives what a backfill item would offer RIGHT NOW: the
+// oldest facts still lacking a motif, plus the vocabulary to offer them.
+//
+// One derivation, two callers — the planner, and the mid-session refresh that
+// re-materialises the payload when a merge retires one of the facts it was
+// offering. The alternative is two constructions that happen to agree, which is
+// a test asserting an arrangement rather than a rule (the same reasoning that
+// put backfillFactsFor in one place).
+func backfillPayloadFor(ctx context.Context, d Deps, branch string) (backfillPayload, error) {
+	targets, err := d.Motifs.LiveFactsWithoutMotifs(ctx, branch, maxBackfillFacts)
+	if err != nil {
+		return backfillPayload{}, fmt.Errorf("motif backfill: live facts without motifs: %w", err)
+	}
+	if len(targets) == 0 {
+		return backfillPayload{}, nil
+	}
+	return backfillPayload{
+		Facts:      backfillFactsFor(targets),
+		Vocabulary: buildBackfillHints(ctx, d, branch, targets),
+	}, nil
 }
 
 // motifBackfillStepType is the work-item step type for the backfill pass.

--- a/internal/synthesize/motif_signal_test.go
+++ b/internal/synthesize/motif_signal_test.go
@@ -78,7 +78,7 @@ func TestShortlistWidener_ReservedSlotFiresOnAFullBand(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	// Budget >= 2, so a slot can be reserved without consuming the whole
@@ -122,7 +122,7 @@ func TestShortlistWidener_NoReservationAtBudgetOne(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	const corpus = 200
@@ -153,7 +153,7 @@ func TestShortlistWidener_IsInertWhenTheOrdinaryBandFillsTheBudget(t *testing.T)
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	// Every fact shares a motif, so every pair is widenable — yet nothing is
@@ -180,7 +180,7 @@ func TestShortlistWidener_DoesNotEnlargeTheBudget(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	pairs, _, err := selectRestatementCandidates(ctx, d, env.branch, nil, corpusSizeForBudget)
@@ -197,7 +197,7 @@ func TestShortlistWidener_IsInertWithoutMotifs(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	_, h, err := selectRestatementCandidates(ctx, d, env.branch, nil, corpusSizeForBudget)

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -107,6 +107,7 @@ type refreshStats struct {
 	PairsAdded       int
 	FactsRequeued    int  // partners re-scanned so an asymmetric discovery is not lost
 	AxisComplete     bool // false while the backfill is still filling the axis
+	StructuralAdded  int  // pairs found by path identity or a rare identifier
 }
 
 // refreshRestatementShortlist brings the standing candidate cache up to date.
@@ -209,6 +210,21 @@ func refreshRestatementShortlist(ctx context.Context, d Deps, branch string) (re
 		}
 	}
 
+	// The structural pass (#127). The KNN above finds what is CLOSE; this finds
+	// what the corpus's own filing and vocabulary say is the SAME — pairs no
+	// vector neighbourhood contains, which is precisely the population that
+	// survives longest.
+	//
+	// Degrades to "no structural candidates" rather than failing the refresh:
+	// it is an addition to a mechanism that worked without it.
+	structural, serr := structuralPairs(ctx, d, branch, requeue, declined)
+	if serr != nil {
+		log.Warn().Err(serr).Msg("review: structural duplicate detection skipped this session")
+	} else {
+		candidates = append(candidates, structural...)
+		stats.StructuralAdded = len(structural)
+	}
+
 	stats.PairsAdded = len(candidates)
 
 	// Nothing is recorded as covered until the axis is COMPLETE.
@@ -250,7 +266,8 @@ func newRestatementPair(id int64, path string, n store.TitleNeighbour) store.Res
 	p := store.RestatementPair{
 		APath: path, BPath: n.Path,
 		AFactID: id, BFactID: n.FactID,
-		TitleCos: n.Similarity,
+		TitleCos:  n.Similarity,
+		MatchKind: store.MatchTitleKNN,
 	}
 	if p.BPath < p.APath {
 		p.APath, p.BPath = p.BPath, p.APath
@@ -396,6 +413,16 @@ type restatementHealth struct {
 	// something, and the one worth reporting: a widened pair admitted into a
 	// slot nothing else wanted is free.
 	MotifSlotUsed bool
+	// StructuralAvailable / StructuralOffered describe the #127 detection
+	// route: how many structurally matched pairs were eligible this session,
+	// and how many actually reached the judge. Observability only — a
+	// detection that is never offered has to be visible as such, which is the
+	// failure this route exists to end.
+	StructuralAvailable int
+	StructuralOffered   int
+	// StandingStructural is how many structurally matched pairs the cache
+	// holds at all, whatever this session's scope and clusters made eligible.
+	StandingStructural int
 	// Probing is true when a defunded corpus spent its periodic probe slot —
 	// the one path by which its own evidence can change.
 	Probing bool
@@ -456,6 +483,7 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 		return nil, h, wrapf(reviewTool, err, "shortlist: stats")
 	}
 	h.StandingPairs, h.TailP99, h.TailP999 = stats.Count, stats.P99, stats.P999
+	h.StandingStructural = stats.Structural
 
 	verdicts, err := d.Abstraction.RecentRestatementVerdicts(ctx, branch, throttleWindow)
 	if err != nil {
@@ -539,6 +567,33 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 		}
 	}
 
+	// RESERVE one slot for a STRUCTURAL pair when one exists (#127).
+	//
+	// Same shape as the motif widener below, and for the same reason: a pair
+	// found by path identity or a shared rare identifier is evidence the title
+	// ranking cannot see, so it sits below the title-ranked band by definition.
+	// Without a reserved slot the detection would be real and inert — a
+	// duplicate correctly identified and never offered, which is this issue's
+	// own failure mode arriving one layer later.
+	//
+	// A BUDGET ALLOCATION, not a threshold (MN13): it changes what may be
+	// considered, never how much is spent, and the corpus's own throttle still
+	// decides whether anything is spent at all.
+	var structural []store.RestatementPair
+	if budget >= 2 {
+		sp, serr := d.Abstraction.RestatementPairsByMatchKind(ctx, branch,
+			[]string{store.MatchPathIdentity, store.MatchRareToken}, budget*shortlistOverfetch)
+		if serr != nil {
+			return nil, h, wrapf(reviewTool, serr, "shortlist: structural rank")
+		}
+		for _, p := range sp {
+			if eligible(p) {
+				structural = append(structural, p)
+			}
+		}
+	}
+	h.StructuralAvailable = len(structural)
+
 	// RESERVE one slot for a widened pair when one exists. A shared canonical
 	// motif is evidence ORTHOGONAL to title similarity — evidence the title
 	// axis cannot see — so the pairs it identifies are below the title-ranked
@@ -552,24 +607,67 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	// a corpus that can afford one judgment should spend it on its
 	// best-evidenced candidate rather than on orthogonal evidence about a
 	// lower-ranked one.
-	reserved := 0
-	if budget >= 2 && len(motifPairs) > 0 {
-		reserved = 1
+	// Two reservations, one slot each, and neither may take the last slot: a
+	// corpus that can afford two judgements should still spend one on its
+	// best-evidenced ordinary candidate.
+	structuralReserved, motifReserved := 0, 0
+	if budget >= 2 {
+		if len(structural) > 0 {
+			structuralReserved = 1
+		}
+		if len(motifPairs) > 0 {
+			motifReserved = 1
+		}
+		for structuralReserved+motifReserved >= budget {
+			if motifReserved > 0 {
+				motifReserved--
+				continue
+			}
+			structuralReserved--
+		}
 	}
 
 	var out []store.RestatementPair
-	for _, p := range ordinary {
-		if len(out) >= budget-reserved {
+	taken := map[string]struct{}{}
+	add := func(p store.RestatementPair) bool {
+		key := pathPairKey(p.APath, p.BPath)
+		if _, dup := taken[key]; dup {
+			return false
+		}
+		taken[key] = struct{}{}
+		out = append(out, p)
+		return true
+	}
+
+	// Structural first, within its own reservation. It is the only route by
+	// which a pair the title ranking places nowhere can be judged at all, and a
+	// route that fires only on underfill is decorative (the Q10 ruling on the
+	// motif widener, which this reservation copies).
+	used := 0
+	for _, p := range structural {
+		if used >= structuralReserved {
 			break
 		}
-		out = append(out, p)
+		if add(p) {
+			used++
+			h.StructuralOffered++
+		}
+	}
+	// The ordinary band takes everything the motif reservation does not hold —
+	// including any structural slot that went unused.
+	for _, p := range ordinary {
+		if len(out) >= budget-motifReserved {
+			break
+		}
+		add(p)
 	}
 	for _, p := range motifPairs {
 		if len(out) >= budget {
 			break
 		}
-		out = append(out, p)
-		h.MotifWidened++
+		if add(p) {
+			h.MotifWidened++
+		}
 	}
 	// A reserved slot the ordinary band could not have used is not "reserved"
 	// in any meaningful sense — report only when the signal actually displaced
@@ -831,6 +929,11 @@ func healthLines(h restatementHealth) []string {
 		// rider Q10). The GATE package needs to state how often it FIRED, and
 		// a line that only ever said "enabled" could not support that claim.
 		motifSignalLine(h),
+		// Likewise for the structural route (#127). Detection that never
+		// reaches the judge is this issue's own failure mode, so the line
+		// reports what was OFFERED beside what was found — the two numbers
+		// diverging is the symptom, and it has to be visible.
+		structuralSignalLine(h),
 	}
 }
 
@@ -847,6 +950,21 @@ func emittedLine(h restatementHealth) string {
 	return fmt.Sprintf("restatement candidates emitted: %d (%d selected but dropped "+
 		"unserved — a half no longer resolves; the pair stays standing and will "+
 		"be re-offered)", h.Emitted, h.Dropped)
+}
+
+// structuralSignalLine reports the path-identity / rare-token route.
+//
+// Standing, eligible and offered are three different populations and the gaps
+// between them are the interesting part: pairs detected but ineligible are
+// pairs prune already sees, while pairs eligible but not offered are the
+// budget saying no.
+func structuralSignalLine(h restatementHealth) string {
+	if h.StandingStructural == 0 {
+		return "structural duplicate detection: no path-identity or rare-token pairs stand in this corpus"
+	}
+	return fmt.Sprintf(
+		"structural duplicate detection: %d standing, %d eligible this session, %d offered",
+		h.StandingStructural, h.StructuralAvailable, h.StructuralOffered)
 }
 
 // motifSignalLine reports what the §7 motif widener contributed this session.
@@ -1080,4 +1198,67 @@ func pairSharesCanonicalMotif(ctx context.Context, d Deps, branch string, p stor
 		}
 	}
 	return false, nil
+}
+
+// ── structural detection ──────────────────────────────────────────────────
+
+// structuralPairs finds duplicate candidates by path identity and by shared
+// rare identifier tokens, and scores them on the title axis so they rank
+// sensibly against each other.
+//
+// A pair whose two title vectors are not both stored is DROPPED rather than
+// given an invented score: the ranking column means "title cosine", and a
+// placeholder there would be a number no measurement produced. The pair is not
+// lost — the axis backfill fills in over sessions, and the next refresh that
+// rescans either fact mints it.
+func structuralPairs(ctx context.Context, d Deps, branch string, requeue []int64, declined map[string]struct{}) ([]store.RestatementPair, error) {
+	if len(requeue) == 0 {
+		return nil, nil
+	}
+	titles, err := d.Abstraction.LiveEpistemicFactTitles(ctx, branch)
+	if err != nil {
+		return nil, wrapf(reviewTool, err, "shortlist: live fact titles")
+	}
+	matches := buildIdentityIndex(titles).structuralCandidates(requeue)
+	if len(matches) == 0 {
+		return nil, nil
+	}
+
+	idSet := map[int64]struct{}{}
+	for _, m := range matches {
+		idSet[m.a] = struct{}{}
+		idSet[m.b] = struct{}{}
+	}
+	ids := make([]int64, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	vecs, err := d.Abstraction.TitleVectorsByFactID(ctx, ids)
+	if err != nil {
+		return nil, wrapf(reviewTool, err, "shortlist: title vectors for structural pairs")
+	}
+
+	out := make([]store.RestatementPair, 0, len(matches))
+	for _, m := range matches {
+		if _, ok := declined[store.FactIDPairKey(m.a, m.b)]; ok {
+			continue
+		}
+		va, aok := vecs[m.a]
+		vb, bok := vecs[m.b]
+		if !aok || !bok {
+			continue
+		}
+		p := store.RestatementPair{
+			APath: titles[m.a].Path, BPath: titles[m.b].Path,
+			AFactID: m.a, BFactID: m.b,
+			TitleCos:  store.CosineSim(va, vb),
+			MatchKind: m.kind,
+		}
+		if p.BPath < p.APath {
+			p.APath, p.BPath = p.BPath, p.APath
+			p.AFactID, p.BFactID = p.BFactID, p.AFactID
+		}
+		out = append(out, p)
+	}
+	return out, nil
 }

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -120,7 +120,7 @@ type refreshStats struct {
 //
 // NO clustering runs in this path. The neighbour lookup is the same KNN the
 // similarity graph uses.
-func refreshRestatementShortlist(ctx context.Context, d Deps, branch string, dedupThreshold float64) (refreshStats, error) {
+func refreshRestatementShortlist(ctx context.Context, d Deps, branch string) (refreshStats, error) {
 	var stats refreshStats
 
 	// Diff against facts that are actually ON THE AXIS. A fact with no title
@@ -209,11 +209,7 @@ func refreshRestatementShortlist(ctx context.Context, d Deps, branch string, ded
 		}
 	}
 
-	kept, unscorable, err := filterByBlendedCosine(ctx, d, candidates, dedupThreshold)
-	if err != nil {
-		return stats, err
-	}
-	stats.PairsAdded = len(kept)
+	stats.PairsAdded = len(candidates)
 
 	// Nothing is recorded as covered until the axis is COMPLETE.
 	//
@@ -227,16 +223,13 @@ func refreshRestatementShortlist(ctx context.Context, d Deps, branch string, ded
 	// The cost is bounded to the fill period and vanishes the session coverage
 	// closes.
 	//
-	// A fact whose blended vector could not be read was not really scanned
-	// either, for the same reason and with the same consequence.
+	// Coverage is a statement about the TITLE axis and nothing else, because
+	// the title KNN above is the entire scan. An earlier version also withheld
+	// coverage from facts whose blended vector could not be read — necessary
+	// while a blended-cosine filter ran here, meaningless now that none does.
 	var covered []int64
 	if complete {
-		covered = make([]int64, 0, len(requeue))
-		for _, id := range requeue {
-			if _, bad := unscorable[id]; !bad {
-				covered = append(covered, id)
-			}
-		}
+		covered = append([]int64(nil), requeue...)
 	}
 	// Pairs are deleted for departed facts and for facts being scanned for the
 	// first time — never for requeued partners, whose existing pairs are
@@ -249,7 +242,7 @@ func refreshRestatementShortlist(ctx context.Context, d Deps, branch string, ded
 	// whole corpus — and its pairs should describe the finished axis, not the
 	// union of every half-filled state it passed through on the way.
 	return stats, d.Abstraction.ReplaceRestatementPairs(ctx, branch,
-		append(dropped, added...), kept, covered)
+		append(dropped, added...), candidates, covered)
 }
 
 // newRestatementPair canonicalises a pair so A-B and B-A are one row.
@@ -266,58 +259,36 @@ func newRestatementPair(id int64, path string, n store.TitleNeighbour) store.Res
 	return p
 }
 
-// filterByBlendedCosine drops pairs whose BLENDED (title+body) vectors already
-// sit at or above the model's calibrated dedup threshold.
+// NOTE ON THE FILTER THAT USED TO LIVE HERE (#127).
 //
-// Those pairs are not restatements the judge needs to see: mergeFacts already
-// merges them mechanically, so spending a judge slot on one is pure waste. The
-// threshold is the active model's own calibrated value
-// (internal/embeddings/params), not a constant invented here — the shortlist
-// contributes no absolute cosine of its own.
+// This function once dropped every candidate pair whose stored blended vectors
+// sat at or above the model's calibrated dedup threshold, on the rationale that
+// "mergeFacts already merges them mechanically, so spending a judge slot on one
+// is pure waste."
 //
-// Vectors come from the stored facts_vec rows. Nothing is re-embedded.
-func filterByBlendedCosine(ctx context.Context, d Deps, pairs []store.RestatementPair, dedupThreshold float64) ([]store.RestatementPair, map[int64]struct{}, error) {
-	unscorable := map[int64]struct{}{}
-	if len(pairs) == 0 {
-		return nil, unscorable, nil
-	}
-	idSet := map[int64]struct{}{}
-	for _, p := range pairs {
-		idSet[p.AFactID] = struct{}{}
-		idSet[p.BFactID] = struct{}{}
-	}
-	ids := make([]int64, 0, len(idSet))
-	for id := range idSet {
-		ids = append(ids, id)
-	}
-	vecs, err := d.Abstraction.BodyVectorsByFactID(ctx, ids)
-	if err != nil {
-		return nil, unscorable, wrapf(reviewTool, err, "shortlist: body vectors")
-	}
-
-	out := make([]store.RestatementPair, 0, len(pairs))
-	for _, p := range pairs {
-		a, aok := vecs[p.AFactID]
-		b, bok := vecs[p.BFactID]
-		if !aok || !bok {
-			// A fact with no stored vector cannot be scored — keeping the pair
-			// would mean guessing whether dedup already caught it. Report the
-			// missing side so the caller does not record it as covered.
-			if !aok {
-				unscorable[p.AFactID] = struct{}{}
-			}
-			if !bok {
-				unscorable[p.BFactID] = struct{}{}
-			}
-			continue
-		}
-		if store.CosineSim(a, b) >= dedupThreshold {
-			continue
-		}
-		out = append(out, p)
-	}
-	return out, unscorable, nil
-}
+// That rationale is false for precisely the population this shortlist exists to
+// serve. dedupCluster's mechanical merge only ever pairs facts that are in the
+// SAME cluster — every search hit is gated on cluster membership before it can
+// become a mergePair — and the shortlist exists because restatements whose
+// halves cluster APART are judged by nothing (gotchas/synthesize/prune-scope).
+// So a cross-cluster pair above the floor was deleted here as already-handled
+// and then handled by nothing: being a CERTAIN duplicate was the disqualifier.
+//
+// Measured on the live core corpus before the removal: all six confirmed
+// duplicate pairs sat at blended cosine 0.83–0.97 against a floor of 0.82 and
+// were absent from a 14,768-row standing cache whose surviving pairs topped out
+// at 0.77. The judge was being shown everything except the duplicates.
+//
+// The exclusion it was trying to express — "prune already sees this pair" — is
+// real, and is implemented once and correctly at SELECTION time as a cluster
+// co-membership check (clusterCoMembership). That check is exact and
+// session-aware; the cosine version was a proxy for it, and the proxy was
+// inverted.
+//
+// Nothing replaces it: an above-floor pair is the shortlist's best candidate,
+// not its waste. It is also the pair a mechanical merge would handle WORST —
+// mergeFacts picks a winner and discards the loser's body, while the judge is
+// required to preserve both.
 
 // ── selection ─────────────────────────────────────────────────────────────
 //
@@ -784,8 +755,7 @@ func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineS
 	}
 	health.Coverage = float64(have) / float64(total)
 
-	dedupThreshold := store.EmbedderThresholds(d.RI.Embedder()).Dedup
-	refresh, err := refreshRestatementShortlist(ctx, d, branch, dedupThreshold)
+	refresh, err := refreshRestatementShortlist(ctx, d, branch)
 	if err != nil {
 		health.Failure = "shortlist refresh failed"
 		log.Warn().Err(err).Str("session", sess.ID).

--- a/internal/synthesize/restatement_acceptance_test.go
+++ b/internal/synthesize/restatement_acceptance_test.go
@@ -92,7 +92,7 @@ func TestAcceptance_RealCorpusShortlist(t *testing.T) {
 	t.Logf("coverage complete: %d/%d", have, total)
 
 	seeded := time.Now()
-	refresh, err := refreshRestatementShortlist(ctx, d, branch, store.EmbedderThresholds(emb).Dedup)
+	refresh, err := refreshRestatementShortlist(ctx, d, branch)
 	require.NoError(t, err)
 	t.Logf("shortlist seeded in %s (%d KNN queries, %d pairs, %d partners requeued)",
 		time.Since(seeded).Round(time.Millisecond),

--- a/internal/synthesize/restatement_certainty_test.go
+++ b/internal/synthesize/restatement_certainty_test.go
@@ -1,0 +1,186 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// The pair used throughout this file: two facts about one event, filed under
+// two different freeform categories, whose stored vectors sit ABOVE the
+// model's mechanical dedup floor. That is the population #127 is about —
+// measured on the live core corpus, every confirmed duplicate pair had a
+// blended cosine at or above the floor (0.83–0.97 against a floor of 0.82)
+// while the pairs that DID reach the judge topped out at 0.77.
+const (
+	certainAPath = "kb/technology/security/vulnerabilities/network-security/alpha.md"
+	certainBPath = "kb/technology/security/vulnerabilities/network-appliances/beta.md"
+	certainTitle = "SmartConsole authentication bypass under active exploitation"
+	certainBody  = "The same event, recorded twice under two freeform categories."
+)
+
+// certaintyEnv builds a corpus whose only near-duplicate pair sits above the
+// mechanical dedup floor, with n filler facts scattered elsewhere on the axis.
+//
+// The two twins are placed by hand on the first two dimensions so the test
+// controls the cosine exactly; every other fact keeps the default hash vector,
+// which is far from both.
+func certaintyEnv(t *testing.T, n int) *restatementEnv {
+	t.Helper()
+	titleB := certainTitle + " (weekly recap)"
+	bodyB := certainBody + " Filed a second time."
+	emb := &restatementEmbedder{vectorFor: func(text string) []float32 {
+		switch text {
+		case certainTitle:
+			return axisVector(0)
+		case titleB:
+			return axisVector(0.02)
+		case certainTitle + " " + certainBody:
+			return axisVector(0.01)
+		case titleB + " " + bodyB:
+			return axisVector(0.03)
+		}
+		return nil
+	}}
+	env := newRestatementEnvWith(t, n, emb)
+	env.writeFact(certainAPath, certainTitle, certainBody)
+	env.writeFact(certainBPath, titleB, bodyB)
+	return env
+}
+
+// certainPairIsAboveTheFloor asserts the fixture actually does what it claims.
+//
+// A fixture chosen to make a test discriminate must be ASSERTED, not assumed
+// (the campaign's fixture-vacuity lesson): if these vectors drifted below the
+// floor the tests below would pass while measuring nothing.
+func certainPairIsAboveTheFloor(t *testing.T, env *restatementEnv) {
+	t.Helper()
+	ids := env.liveFactIDs()
+	vecs, err := env.svc.Abstraction().BodyVectorsByFactID(context.Background(),
+		[]int64{ids[certainAPath], ids[certainBPath]})
+	require.NoError(t, err)
+	cos := store.CosineSim(vecs[ids[certainAPath]], vecs[ids[certainBPath]])
+	require.GreaterOrEqual(t, cos, env.dedupThreshold(),
+		"fixture must sit at or above the mechanical dedup floor, or these tests measure nothing")
+}
+
+// TestShortlist_CertainDuplicatesReachTheStandingCache is the core of #127.
+//
+// The predicate that identifies a pair as a CERTAIN duplicate — blended cosine
+// at or above the model's dedup floor — used to be the predicate that deleted
+// it from the shortlist, on the rationale that mergeFacts would handle it.
+// mergeFacts only merges WITHIN a cluster, so for a cross-cluster pair nothing
+// handled it: certainty was the disqualifier.
+func TestShortlist_CertainDuplicatesReachTheStandingCache(t *testing.T) {
+	ctx := context.Background()
+	env := certaintyEnv(t, 0)
+	certainPairIsAboveTheFloor(t, env)
+
+	env.seedShortlist()
+
+	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100)
+	require.NoError(t, err)
+	require.True(t, containsPair(pairs, certainAPath, certainBPath),
+		"a duplicate pair above the mechanical floor must stand in the shortlist — "+
+			"no cluster-scoped merge will ever reach it")
+}
+
+// TestShortlist_CertainDuplicatesAreEnqueuedForTheJudge is the wiring half.
+//
+// Deliberately drives planRestatementShortlist rather than the helper: a test
+// that calls the helper asserts the helper works, not that anything calls it
+// (the campaign's path-vs-state rule). It asserts the item actually reaches the
+// queue, carrying both halves of the pair.
+func TestShortlist_CertainDuplicatesAreEnqueuedForTheJudge(t *testing.T) {
+	ctx := context.Background()
+	// 200 facts: shortlistBudget is corpus-scaled at 5 per 1000, so a small
+	// corpus budgets ZERO and the test would pass vacuously at 0 enqueued.
+	env := certaintyEnv(t, 200)
+	certainPairIsAboveTheFloor(t, env)
+
+	d := env.deps()
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	require.NoError(t, err)
+	require.NoError(t, planRestatementShortlist(ctx, d, sess, env.branch, nil))
+
+	require.True(t, shortlistQueueHoldsPair(t, env, sess.ID, certainAPath, certainBPath),
+		"the certain duplicate must be enqueued as a shortlist prune item")
+}
+
+// TestShortlist_CoClusteredCertainDuplicatesAreNotEnqueued pins the exclusion
+// that SURVIVES.
+//
+// "Prune already sees this pair" is a real exclusion and it is implemented
+// once, correctly, at selection time as a cluster co-membership check. This
+// test is the reason the fix is "delete the cosine proxy" rather than "delete
+// the exclusion": under a change that removed co-membership too, the test
+// above still passes and only this one fails.
+func TestShortlist_CoClusteredCertainDuplicatesAreNotEnqueued(t *testing.T) {
+	ctx := context.Background()
+	env := certaintyEnv(t, 200)
+	certainPairIsAboveTheFloor(t, env)
+
+	d := env.deps()
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	require.NoError(t, err)
+	coClustered := [][]factForLLM{{
+		{File: certainAPath}, {File: certainBPath},
+	}}
+	require.NoError(t, planRestatementShortlist(ctx, d, sess, env.branch, coClustered))
+
+	require.False(t, shortlistQueueHoldsPair(t, env, sess.ID, certainAPath, certainBPath),
+		"a pair prune already sees in one cluster must not also spend a shortlist slot")
+}
+
+// shortlistQueueHoldsPair reports whether a shortlist-originated work item in
+// this session carries exactly the two named paths.
+func shortlistQueueHoldsPair(t *testing.T, env *restatementEnv, sessionID, a, b string) bool {
+	t.Helper()
+	ctx := context.Background()
+	for {
+		item, err := env.svc.Pipeline().NextPipelineWorkItem(ctx, sessionID)
+		require.NoError(t, err)
+		if item == nil {
+			return false
+		}
+		if isShortlistItem(item.ClusterKey) && itemCarriesPaths(t, item.FactsJSON, a, b) {
+			return true
+		}
+		// Consume it so the next peek advances; the queue is a priority queue,
+		// not a cursor.
+		ok, err := env.svc.Pipeline().AnswerPipelineWorkItem(ctx, item.ID, "{}")
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+}
+
+func isShortlistItem(clusterKey string) bool {
+	return len(clusterKey) > len(restatementClusterKeyPrefix) &&
+		clusterKey[:len(restatementClusterKeyPrefix)] == restatementClusterKeyPrefix
+}
+
+func itemCarriesPaths(t *testing.T, factsJSON string, want ...string) bool {
+	t.Helper()
+	var facts []factForLLM
+	require.NoError(t, json.Unmarshal([]byte(factsJSON), &facts))
+	if len(facts) != len(want) {
+		return false
+	}
+	have := map[string]struct{}{}
+	for _, f := range facts {
+		have[f.File] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := have[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+var _ = fmt.Sprintf

--- a/internal/synthesize/restatement_dynamics_test.go
+++ b/internal/synthesize/restatement_dynamics_test.go
@@ -69,7 +69,7 @@ func TestDynamics_PartialBackfillClosesOverSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Less(t, have, total, "the first session covers only part of the corpus")
 
-	_, err = refreshRestatementShortlist(ctx, env.deps(), env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, env.deps(), env.branch)
 	require.NoError(t, err)
 	firstPairs := env.standingPairCount()
 
@@ -78,7 +78,7 @@ func TestDynamics_PartialBackfillClosesOverSessions(t *testing.T) {
 	for range 40 {
 		have, total, err = ensureTitleVectors(ctx, env.deps(), env.branch, tinyBudget)
 		require.NoError(t, err)
-		_, err = refreshRestatementShortlist(ctx, env.deps(), env.branch, env.dedupThreshold())
+		_, err = refreshRestatementShortlist(ctx, env.deps(), env.branch)
 		require.NoError(t, err)
 		if have == total {
 			break

--- a/internal/synthesize/restatement_helpers_test.go
+++ b/internal/synthesize/restatement_helpers_test.go
@@ -231,7 +231,7 @@ func (e *restatementEnv) seedShortlist() {
 	ctx := context.Background()
 	_, _, err := ensureTitleVectors(ctx, e.deps(), e.branch, titleBackfillBudget)
 	require.NoError(e.t, err)
-	_, err = refreshRestatementShortlist(ctx, e.deps(), e.branch, e.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, e.deps(), e.branch)
 	require.NoError(e.t, err)
 }
 

--- a/internal/synthesize/restatement_test.go
+++ b/internal/synthesize/restatement_test.go
@@ -113,7 +113,7 @@ func TestRefreshShortlist_SeedsThenGoesIncremental(t *testing.T) {
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
 
-	refresh, err := refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	refresh, err := refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 	require.Equal(t, 40, refresh.NeighbourQueries, "first refresh seeds every fact")
 
@@ -121,7 +121,7 @@ func TestRefreshShortlist_SeedsThenGoesIncremental(t *testing.T) {
 	require.NoError(t, err)
 	require.Positive(t, stats.Count, "the cache is populated")
 
-	refresh, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	refresh, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 	require.Zero(t, refresh.NeighbourQueries, "unchanged corpus does no work")
 
@@ -129,7 +129,7 @@ func TestRefreshShortlist_SeedsThenGoesIncremental(t *testing.T) {
 	_, _, err = ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
 
-	refresh, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	refresh, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 	require.LessOrEqual(t, refresh.NeighbourQueries, 1+pairNeighbourK,
 		"one edited fact costs its own lookup plus at most its partners'")
@@ -144,12 +144,12 @@ func TestRefreshShortlist_DropsPairsOfDepartedFacts(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	_, err = env.svc.Facts().DeleteFact(ctx, env.branch, "kb/f3.md", "retract f3")
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 1000)
@@ -160,10 +160,19 @@ func TestRefreshShortlist_DropsPairsOfDepartedFacts(t *testing.T) {
 	}
 }
 
-// TestRefreshShortlist_ExcludesPairsAtOrAboveDedup — the one absolute cosine in
-// play is the model's OWN calibrated dedup threshold, and pairs at or above it
-// are mergeFacts's business, not the judge's.
-func TestRefreshShortlist_ExcludesPairsAtOrAboveDedup(t *testing.T) {
+// TestRefreshShortlist_KeepsPairsAtOrAboveDedup — the inverse of what this
+// test asserted before #127.
+//
+// It used to pin "a pair the mechanical dedup gate already catches must never
+// reach the judge". The premise was false: the mechanical gate only catches
+// pairs inside ONE cluster, and this shortlist exists precisely for pairs whose
+// halves cluster apart, so above-floor cross-cluster pairs were dropped here
+// and caught nowhere. See the note where filterByBlendedCosine used to live.
+//
+// The real "prune already sees it" exclusion is asserted at its actual site, in
+// restatement_certainty_test.go — a co-clustered pair still reaches the cache
+// but is never enqueued.
+func TestRefreshShortlist_KeepsPairsAtOrAboveDedup(t *testing.T) {
 	ctx := context.Background()
 	env := newRestatementEnv(t, 0)
 	// Two facts with identical text: identical blended vectors, cosine 1.
@@ -176,17 +185,17 @@ func TestRefreshShortlist_ExcludesPairsAtOrAboveDedup(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100)
 	require.NoError(t, err)
-	for _, p := range pairs {
-		require.False(t, p.APath == "kb/twin-a.md" && p.BPath == "kb/twin-b.md",
-			"a pair the mechanical dedup gate already catches must never reach the judge")
-	}
-	// ...while the sub-dedup pair still stands, so the assertion above is about
-	// the filter rather than about the shortlist finding nothing.
+	require.True(t, containsPair(pairs, "kb/twin-a.md", "kb/twin-b.md"),
+		"a certain duplicate is the shortlist's best candidate, not its waste — "+
+			"no cluster-scoped merge reaches it when its halves cluster apart")
+	// ...and the sub-floor pair still stands, so the assertion above is about
+	// the removed filter rather than about the shortlist keeping everything
+	// indiscriminately.
 	require.True(t, containsPair(pairs, "kb/near-a.md", "kb/near-b.md"),
 		"a pair below the dedup floor is exactly what the judge should see")
 }
@@ -206,7 +215,7 @@ func TestRefreshShortlist_KeepsSimilarToNeighbours(t *testing.T) {
 	d := env.deps()
 	_, _, err := ensureTitleVectors(ctx, d, env.branch, titleBackfillBudget)
 	require.NoError(t, err)
-	_, err = refreshRestatementShortlist(ctx, d, env.branch, env.dedupThreshold())
+	_, err = refreshRestatementShortlist(ctx, d, env.branch)
 	require.NoError(t, err)
 
 	pairs, err := env.svc.Abstraction().RestatementPairsByRank(ctx, env.branch, 100)

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -839,6 +839,21 @@ func (reviewStrategy) Apply(ctx context.Context, d Deps, sess *store.PipelineSes
 			return wrapf(reviewTool, err, "apply prune")
 		}
 		recordStats(ctx, reviewTool, d, sess, stats)
+		// Bring the REST of this session's queue back into agreement with the
+		// corpus the merge just changed. Every still-queued item was
+		// materialised during Plan, so without this the session goes on to
+		// offer facts this very item retired — a judge slot, or one of the
+		// eight backfill slots, spent on a corpus state that is already gone.
+		//
+		// Non-fatal by construction: the mutations above have already landed
+		// and been recorded, so failing the item here would report an error for
+		// work that succeeded. A refresh that cannot run leaves the queue as
+		// stale as it was before this existed, which is a degradation, not a
+		// corruption.
+		if rerr := refreshInFlightItems(ctx, d, sess, branch, stats.Retired); rerr != nil {
+			log.Warn().Err(rerr).Str("session", sess.ID).
+				Msg("review: in-flight work items could not be refreshed after this merge")
+		}
 		// Attribution for the judge-outcome throttle. ONLY shortlist-originated
 		// items count: a cluster prune's merges say nothing about whether the
 		// shortlist is earning its slots, and counting them would keep a

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -850,7 +850,7 @@ func (reviewStrategy) Apply(ctx context.Context, d Deps, sess *store.PipelineSes
 		// work that succeeded. A refresh that cannot run leaves the queue as
 		// stale as it was before this existed, which is a degradation, not a
 		// corruption.
-		if rerr := refreshInFlightItems(ctx, d, sess, branch, stats.Retired); rerr != nil {
+		if rerr := refreshInFlightItems(ctx, d, sess, branch, stats); rerr != nil {
 			log.Warn().Err(rerr).Str("session", sess.ID).
 				Msg("review: in-flight work items could not be refreshed after this merge")
 		}
@@ -866,6 +866,14 @@ func (reviewStrategy) Apply(ctx context.Context, d Deps, sess *store.PipelineSes
 			return wrapf(reviewTool, err, "apply distill")
 		}
 		recordStats(ctx, reviewTool, d, sess, stats)
+		// Distill retires facts too, and the queue it leaves stale is not its
+		// own: measured live, a distill's subsumed facts sat in prune and
+		// discover items queued in the same session. Staleness is a property of
+		// the corpus changing, not of which vehicle changed it.
+		if rerr := refreshInFlightItems(ctx, d, sess, branch, stats); rerr != nil {
+			log.Warn().Err(rerr).Str("session", sess.ID).
+				Msg("review: in-flight work items could not be refreshed after this distill")
+		}
 		enqueueRaptorFollowups(ctx, d, sess, item, writtenFacts)
 
 	case motifAliasStepType:

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -376,6 +376,17 @@ func applyDiscoverStep(ctx context.Context, tool string, d Deps, sess *store.Pip
 	reinforced := applyReinforcements(ctx, d.Facts, d.Search, dec.payload,
 		dec.reinforcements, sess.Branch, fact.ID12(d.RI.ID()), d.OnProgress)
 	if len(reinforced) > 0 {
+		// Reinforcement REWRITES a live fact — it bumps sources and adds a ref
+		// — so every item still queued in this session is carrying a stale
+		// snapshot of it. Discover has no retire path of its own (it writes and
+		// reinforces; nothing here deletes), so this is the whole of discover's
+		// contribution to in-session staleness, and it is the mutated-but-live
+		// half rather than the retired half.
+		if rerr := refreshInFlightItems(ctx, d, sess, sess.Branch,
+			&ReviewStats{Rewritten: reinforced}); rerr != nil {
+			log.Warn().Err(rerr).Str("tool", tool).Str("session", sess.ID).
+				Msg("in-flight work items could not be refreshed after reinforcement")
+		}
 		// Deliberately NOT counted into ReviewStats. Reinforcement creates no
 		// fact, so counting it as Synthesized would overstate what the session
 		// added; and store.PipelineSessionStats has no column of its own for


### PR DESCRIPTION
The P3 dedup-repair stack. Measured root cause: certain cross-category duplicate pairs were found and then DELETED by the certainty filter, on a rationale (dedupCluster already merges them) that is false for cross-cluster pairs. Fix: stop dropping above-threshold pairs; refresh in-flight work items on any mutation across every vehicle; structural duplicate detection (path identity + corpus-derived rare tokens) with a reserved selection slot.

Reviewed clean by a cold Opus agent (isolated worktree): no HIGH/MED, one non-blocking LOW (df=2 blind spot, documented). MN5 blob byte-identical at every commit, MN13 satisfied (rarity derived from the corpus's own fact-weighted median DF), bisectable. Report: .claude/plans/motif/2026-08-25-127-review-findings.md.

Closes #127.