### PR TITLE
fix(merge): make merge loss impossible by construction — atomic replacement + evidence_weight carry-across (#101, #94, closes #107b)

### DIFF
--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -385,6 +385,21 @@ func mergeFacts(newFact, existing fact.Fact, existingPath string) fact.Fact {
 	merged.Motifs = fact.MergeMotifs(winner.Motifs, loser.Motifs)
 	merged.Confidence = max(newFact.Confidence, existing.Confidence)
 	merged.Sources = newFact.Sources + existing.Sources
+	// CARRY THE WEIGHT ACROSS (#94). Without this the merged fact starts at 0
+	// and stays there whenever computeEvidenceWeights declines to restamp it —
+	// which is the common case, because that gate reads the RAW Origin field
+	// and an agent writing through knomit_learn normally omits origin. The
+	// existing fact's stored weight then vanishes from the file, the index, and
+	// every weight-ordered query (knomit f62378e5, reproduced by
+	// TestLearnHandler_DedupMergeKeepsStoredEvidenceWeight).
+	//
+	// MAX, not the winner's: the merged fact pools BOTH facts' sources, and
+	// evidence weight is monotone in pooled evidence, so the larger of the two
+	// is a LOWER BOUND on what a full recompute would produce. Taking the
+	// winner's would still erase a weight whenever the unweighted fact won.
+	// This never overstates the evidence, and computeEvidenceWeights still
+	// overrides with a true recompute wherever its origin gate applies.
+	merged.EvidenceWeight = max(newFact.EvidenceWeight, existing.EvidenceWeight)
 	// Raw path, not existing.Path(): see the doc comment above.
 	merged.Refs = fact.AppendUnique(fact.UnionStrings(newFact.Refs, existing.Refs), existingPath)
 	return merged

--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -399,6 +399,23 @@ func mergeFacts(newFact, existing fact.Fact, existingPath string) fact.Fact {
 	// winner's would still erase a weight whenever the unweighted fact won.
 	// This never overstates the evidence, and computeEvidenceWeights still
 	// overrides with a true recompute wherever its origin gate applies.
+	//
+	// TODAY THE FIRST OPERAND IS ALWAYS ZERO, and that is worth stating rather
+	// than leaving for a reader to discover: `evidence_weight` is not a field
+	// of the learn schema, and computeEvidenceWeights runs AFTER this merge —
+	// so an incoming fact never arrives carrying one, and max() currently
+	// reduces to "keep the existing fact's weight". It is written as max
+	// because that is the RULE (never lose the larger evidence claim), and it
+	// stays correct if either of those two facts changes. Unlike a guard for an
+	// impossible failure, this costs no branch and asserts nothing false — but
+	// no test can exercise the other operand, so none pretends to.
+	//
+	// KNOWN BOUND (cold review, tracked follow-up): max is a lower bound on a
+	// true recompute, not the recompute itself — an existing weight of ~0.47
+	// merged with an incoming fact carrying sources: 20 justifies ~0.94. Left
+	// deliberately: it never overstates and never erases, and the correct fix
+	// is a hybrid, since a naive recompute mishandles a DERIVED existing fact
+	// whose lineage-composed weight max preserves better.
 	merged.EvidenceWeight = max(newFact.EvidenceWeight, existing.EvidenceWeight)
 	// Raw path, not existing.Path(): see the doc comment above.
 	merged.Refs = fact.AppendUnique(fact.UnionStrings(newFact.Refs, existing.Refs), existingPath)

--- a/internal/mcp/learn_evidence_weight_test.go
+++ b/internal/mcp/learn_evidence_weight_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+)
+
+// The reproduction knomit fact f62378e5 asks for by name.
+//
+// It records the defect as DERIVED BY READING the write path, not observed:
+// "a test that learns a high-confidence synthesis fact over an existing
+// weighted one and asserts the resulting file still carries evidence_weight
+// would confirm or kill it." This is that test.
+//
+// Three preconditions must all hold, and the fixture asserts each rather than
+// arranging them silently:
+//   1. the existing fact carries a stored evidence_weight;
+//   2. the incoming fact WINS newFactWins (higher confidence);
+//   3. the incoming fact OMITS origin — which the learn schema tells agents to
+//      do — so the merged Origin is empty and computeEvidenceWeights, which
+//      gates on the RAW field, skips the fact instead of restamping it.
+
+const weightedExistingPath = "kb/decisions/weighting/existing.md"
+
+// lenMatched pads body so that len(title+" "+body) equals want. The test
+// embedder keys on that length alone, so this is what makes the incoming fact
+// dedup-match the existing one — controlled, rather than hoped for.
+func lenMatched(t *testing.T, title, body string, want int) string {
+	t.Helper()
+	base := len(title) + 1 + len(body)
+	require.LessOrEqual(t, base, want, "body already longer than the target length")
+	return body + strings.Repeat(".", want-base)
+}
+
+func weightedFactContent(t *testing.T, title, body string, confidence float64, weight float64) string {
+	t.Helper()
+	w := ""
+	if weight > 0 {
+		w = fmt.Sprintf("evidence_weight: %g\n", weight)
+	}
+	return fmt.Sprintf("---\ntype: synthesis\ndomain: [global]\nconfidence: %g\nsources: 3\n"+
+		"entities: [designer]\nrefs: []\n%s---\n# %s\n\n%s\n", confidence, w, title, body)
+}
+
+func TestLearnHandler_DedupMergeKeepsStoredEvidenceWeight(t *testing.T) {
+	svc, ctx, emb := newPrinciplesTestRepo(t)
+	bg := context.Background()
+
+	const targetLen = 120
+	existingTitle := "Weighted synthesis"
+	existingBody := lenMatched(t, existingTitle, "the corpus already holds this claim", targetLen)
+
+	_, err := svc.Facts().WriteFact(bg, "agent/test", weightedExistingPath,
+		weightedFactContent(t, existingTitle, existingBody, 0.5, 0.8),
+		"seed a weighted synthesis fact", "test")
+	require.NoError(t, err)
+
+	// PRECONDITION 1, asserted: the stored file really carries a weight.
+	stored, err := svc.Facts().ReadFact(bg, "agent/test", weightedExistingPath, nil)
+	require.NoError(t, err)
+	require.Contains(t, stored.Content, "evidence_weight: 0.8",
+		"fixture: the existing fact must carry a stored weight, or this test measures nothing")
+
+	// The incoming fact: same embedding bucket (same length), HIGHER
+	// confidence so it wins, and no origin key at all.
+	incomingTitle := "Weighted synthesis restated"
+	incomingBody := lenMatched(t, incomingTitle, "the same claim, said again", targetLen)
+
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"moment_name": "restate",
+		"facts": []any{
+			map[string]any{
+				"topic":      "decisions",
+				"category":   "weighting",
+				"title":      incomingTitle,
+				"body":       incomingBody,
+				"type":       "synthesis",
+				"domain":     []any{"global"},
+				"confidence": 0.9,
+				"sources":    1,
+				"entities":   []any{"designer"},
+				"refs":       []any{},
+			},
+		},
+	}
+	res, err := LearnHandler(emb)(ctx, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "learn must succeed: %s", resultText(t, res))
+
+	// PRECONDITION 2, asserted: it actually dedup-merged into the existing
+	// fact rather than landing at a fresh path — otherwise nothing was merged
+	// and the assertion below would pass for the wrong reason.
+	require.Equal(t, weightedExistingPath, mergedFactPath(t, res),
+		"fixture: the incoming fact must have merged INTO the existing one")
+
+	merged, err := svc.Facts().ReadFact(bg, "agent/test", weightedExistingPath, nil)
+	require.NoError(t, err)
+	require.Contains(t, merged.Content, "Weighted synthesis restated",
+		"fixture: the incoming fact must have WON the merge")
+
+	require.Contains(t, merged.Content, "evidence_weight:",
+		"a dedup-merge must not erase the existing fact's stored evidence_weight — "+
+			"the merged fact rests on strictly more evidence, not less")
+}

--- a/internal/mcp/learn_evidence_weight_test.go
+++ b/internal/mcp/learn_evidence_weight_test.go
@@ -108,4 +108,13 @@ func TestLearnHandler_DedupMergeKeepsStoredEvidenceWeight(t *testing.T) {
 	require.Contains(t, merged.Content, "evidence_weight:",
 		"a dedup-merge must not erase the existing fact's stored evidence_weight — "+
 			"the merged fact rests on strictly more evidence, not less")
+
+	// The VALUE, not just the presence. mergeFacts carries MAX of the two
+	// operands, and the incoming fact carries none, so the existing 0.8 must
+	// survive intact. Asserting only that the key is present would pass for any
+	// number the merge happened to invent — the same "it changed" vs "it changed
+	// to the right thing" gap the mechanical-merge test was corrected for.
+	require.Contains(t, merged.Content, "evidence_weight: 0.8",
+		"MAX of the two operands: the incoming fact carries no weight, so the "+
+			"existing 0.8 is the answer")
 }

--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -272,22 +272,57 @@ func ApplyPruneDecisions(ctx context.Context,
 			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("merge serialize %s: %v", merged.Path(), err)})
 			continue
 		}
+		// ONE COMMIT for the whole merge (#101): the merged fact and every
+		// source it subsumes.
+		//
+		// A merge used to be a write followed by N separate deletes, so an
+		// interruption between them left the corpus holding BOTH the merged
+		// fact and the originals it replaced — a duplicate set manufactured by
+		// the mechanism that exists to remove duplicates, and one no later
+		// session can recognise as half-done. Batched, the merge either
+		// happened or it did not.
+		//
+		// This is the "loss impossible by construction" direction rather than
+		// "detect and refuse": there is no lossy state to detect, because the
+		// state cannot exist.
 		msg := fmt.Sprintf("synthesize-%s: merge %s", recipeName, strings.Join(m.Paths, ", "))
-		if _, err := gs.WriteFact(ctx, agentBranch, merged.Path(), content, msg, "subsume"); err != nil {
-			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("merge write %s: %v", merged.Path(), err)})
-			continue
-		}
+		files := map[string]string{merged.Path(): content}
 
-		// Delete source facts (losers get retract tag).
+		var deletes []string
 		for _, src := range m.Paths {
 			if deletedPaths[src] {
+				continue // a retract earlier in this same call already took it
+			}
+			// NOTE: there is deliberately NO "src != merged.Path()" guard here.
+			// normalizeFactPath mints the merged fact a fresh uuid filename
+			// (#107a), so the merged path cannot be one of the sources — the
+			// merge deleting itself is impossible by construction, not by
+			// check. A guard for it was written and then removed: no sabotage
+			// could make any test fail without it, because no input reaches it.
+			// Same call the Phase-3 review made on applyReinforcements (L7) —
+			// a handled failure mode that does not exist reads as a risk that
+			// was considered, which is worse than no branch at all.
+			// A source that is already gone is not an error and must not fail
+			// the batch: batchWrite REFUSES a delete of a missing path, so one
+			// absent source would abort a merge that is otherwise complete.
+			exists, eerr := gs.FactExists(ctx, agentBranch, src)
+			if eerr != nil {
+				onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("merge source %s: %v", src, eerr)})
 				continue
 			}
-			srcMsg := fmt.Sprintf("synthesize-%s: subsumed by %s", recipeName, merged.Path())
-			if _, err := gs.DeleteFact(ctx, agentBranch, src, srcMsg); err != nil {
-				onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("merge delete source %s: %v", src, err)})
+			if !exists {
 				continue
 			}
+			deletes = append(deletes, src)
+		}
+
+		if _, _, err := gs.BatchWriteFacts(ctx, agentBranch, files, deletes, msg, "subsume"); err != nil {
+			// Atomic in both directions: nothing landed, so nothing is
+			// recorded. The sources stay live and the pair is offered again.
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("merge %s: %v", merged.Path(), err)})
+			continue
+		}
+		for _, src := range deletes {
 			deletedPaths[src] = true
 		}
 		onProgress(ProgressEvent{Phase: "detail-merge", Message: "merge " + merged.Path()})

--- a/internal/synthesize/decision.go
+++ b/internal/synthesize/decision.go
@@ -302,9 +302,23 @@ func ApplyPruneDecisions(ctx context.Context,
 			// Same call the Phase-3 review made on applyReinforcements (L7) —
 			// a handled failure mode that does not exist reads as a risk that
 			// was considered, which is worse than no branch at all.
-			// A source that is already gone is not an error and must not fail
-			// the batch: batchWrite REFUSES a delete of a missing path, so one
-			// absent source would abort a merge that is otherwise complete.
+			// A source that is already gone is skipped so that deletedPaths —
+			// and therefore ReviewStats.Retired — names only what this call
+			// ACTUALLY removed. That list drives the in-flight refresh, which
+			// strips those paths out of still-queued work items, so a path
+			// reported as retired when nothing removed it would delete a LIVE
+			// fact from the judge's view. Same contract, and the same failure,
+			// as the retract branch's delete-then-record ordering above.
+			//
+			// It is NOT an abort guard, though an earlier version of this
+			// comment said so. Measured: batchWrite refuses a delete only when
+			// the path's parent SUBTREE is absent from the tree entirely
+			// ("subtree not found"); a missing leaf inside an existing
+			// directory is a silent no-op, and go-git keeps a subtree that has
+			// had its last file removed. A merge source is by construction a
+			// fact that existed at a real path, so it can never reach the
+			// erroring case — guarding against it would be a handled failure
+			// mode that does not exist (the L7 call again).
 			exists, eerr := gs.FactExists(ctx, agentBranch, src)
 			if eerr != nil {
 				onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("merge source %s: %v", src, eerr)})

--- a/internal/synthesize/decision_atomic_merge_test.go
+++ b/internal/synthesize/decision_atomic_merge_test.go
@@ -1,0 +1,102 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A merge used to be a write followed by N separate deletes. An interruption
+// between them left the corpus holding BOTH the merged fact and the originals
+// it replaced — a duplicate set manufactured by the mechanism that exists to
+// remove duplicates, and one no later session can recognise as half-done.
+//
+// The designer's ruling was to make that state impossible by construction
+// rather than to detect and refuse it, so the assertion is about the COMMIT
+// COUNT: one merge, one commit. Counting is what discriminates — every
+// end-state assertion (merged fact present, sources gone) is identical whether
+// the work took one commit or four.
+
+// branchCommits counts commits on the branch.
+func branchCommits(t *testing.T, env *restatementEnv) int {
+	t.Helper()
+	entries, err := env.svc.Search().Log(context.Background(), env.branch, "")
+	require.NoError(t, err)
+	return len(entries)
+}
+
+// mergedTitle is how the merged fact is FOUND. Its path is not predictable:
+// normalizeFactPath (#107a) replaces the filename with a fresh uuid, which is
+// exactly what makes the merged fact unable to collide with a source. Looking
+// it up by the literal fixture path is the mistake five existing tests already
+// had to be corrected for.
+const mergedTitle = "Merged claim"
+
+// mergeTwoInto runs ApplyPruneDecisions with a single merge subsuming the two
+// given paths, and returns the merged fact's ACTUAL path.
+func mergeTwoInto(t *testing.T, env *restatementEnv, a, b string) (*ReviewStats, string) {
+	t.Helper()
+	out := "kb/alpha/merged-result.md"
+	var mf mergedFact
+	require.NoError(t, json.Unmarshal([]byte(fmt.Sprintf(`{
+		"path":%q,"title":"Merged claim","body":"Both recordings, unioned.",
+		"type":"observation","domain":["alpha"],"confidence":0.9,"sources":2,
+		"entities":["Widget"],"refs":[]}`, out)), &mf))
+
+	d := env.deps()
+	stats, err := ApplyPruneDecisions(context.Background(), env.svc.Facts(), env.svc.Search(),
+		nil, []MergeEntry{{Paths: []string{a, b}, Merged: mf}},
+		reviewTool, d.OnProgress, env.branch, "", "kb")
+	require.NoError(t, err)
+	return stats, mergedFactPath(t, env.svc, env.branch, mergedTitle)
+}
+
+func TestApplyPruneMerge_WriteAndSourceDeletesShareOneCommit(t *testing.T) {
+	env := newRestatementEnv(t, 0)
+	env.writeFact("kb/alpha/one.md", "One", "first recording")
+	env.writeFact("kb/alpha/two.md", "Two", "second recording")
+
+	before := branchCommits(t, env)
+	stats, _ := mergeTwoInto(t, env, "kb/alpha/one.md", "kb/alpha/two.md")
+	after := branchCommits(t, env)
+
+	require.Equal(t, 1, stats.Merged, "fixture: the merge must actually have applied")
+	require.Len(t, stats.Retired, 2, "fixture: both sources must have been retired")
+
+	require.Equal(t, 1, after-before,
+		"a merge must land as ONE commit — a write plus %d separate deletes leaves the "+
+			"corpus holding the merged fact AND its originals if anything interrupts it",
+		len(stats.Retired))
+}
+
+// TestApplyPruneMerge_AlreadyMissingSourceDoesNotAbortTheMerge — batchWrite
+// REFUSES a delete of a missing path, so an absent source would take down a
+// merge that is otherwise complete. That is a new failure mode created by
+// batching, and it is the reason the delete list is filtered rather than
+// passed through.
+func TestApplyPruneMerge_AlreadyMissingSourceDoesNotAbortTheMerge(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	env.writeFact("kb/alpha/one.md", "One", "first recording")
+	env.writeFact("kb/alpha/two.md", "Two", "second recording")
+
+	// A source that is already gone by the time the merge runs.
+	_, err := env.svc.Facts().DeleteFact(ctx, env.branch, "kb/alpha/two.md", "gone already")
+	require.NoError(t, err)
+	exists, err := env.svc.Facts().FactExists(ctx, env.branch, "kb/alpha/two.md")
+	require.NoError(t, err)
+	require.False(t, exists, "fixture: the source must really be absent")
+
+	stats, out := mergeTwoInto(t, env, "kb/alpha/one.md", "kb/alpha/two.md")
+
+	require.Equal(t, 1, stats.Merged,
+		"an already-absent source is not an error — the merge must still land")
+	merged, err := env.svc.Facts().FactExists(ctx, env.branch, out)
+	require.NoError(t, err)
+	require.True(t, merged, "the merged fact must have been written")
+	require.Equal(t, []string{"kb/alpha/one.md"}, stats.Retired,
+		"only the source this call actually removed is reported as retired")
+}

--- a/internal/synthesize/decision_atomic_merge_test.go
+++ b/internal/synthesize/decision_atomic_merge_test.go
@@ -72,12 +72,22 @@ func TestApplyPruneMerge_WriteAndSourceDeletesShareOneCommit(t *testing.T) {
 		len(stats.Retired))
 }
 
-// TestApplyPruneMerge_AlreadyMissingSourceDoesNotAbortTheMerge — batchWrite
-// REFUSES a delete of a missing path, so an absent source would take down a
-// merge that is otherwise complete. That is a new failure mode created by
-// batching, and it is the reason the delete list is filtered rather than
-// passed through.
-func TestApplyPruneMerge_AlreadyMissingSourceDoesNotAbortTheMerge(t *testing.T) {
+// TestApplyPruneMerge_RetiredNamesOnlyTheSourcesThisCallRemoved.
+//
+// Renamed from "…AlreadyMissingSourceDoesNotAbortTheMerge", which claimed more
+// than it pinned. The cold review showed the merge does NOT abort on a missing
+// source even with the filter removed — only the Retired list changes — and
+// measuring it settled why: batchWrite refuses a delete only when the path's
+// parent SUBTREE is absent entirely; a missing leaf inside an existing
+// directory is a silent no-op, and go-git keeps a subtree whose last file was
+// removed. A merge source always lived at a real path, so the erroring case is
+// unreachable from here and there is nothing to test about it.
+//
+// What the filter actually buys is the thing this test now names: Retired must
+// list only what this call removed, because #127's in-flight refresh uses it to
+// strip paths out of still-queued items. A path reported as retired when
+// nothing removed it deletes a LIVE fact from the judge's view.
+func TestApplyPruneMerge_RetiredNamesOnlyTheSourcesThisCallRemoved(t *testing.T) {
 	ctx := context.Background()
 	env := newRestatementEnv(t, 0)
 	env.writeFact("kb/alpha/one.md", "One", "first recording")
@@ -94,6 +104,10 @@ func TestApplyPruneMerge_AlreadyMissingSourceDoesNotAbortTheMerge(t *testing.T) 
 
 	require.Equal(t, 1, stats.Merged,
 		"an already-absent source is not an error — the merge must still land")
+	require.True(t, stats.Merged == 1 && len(stats.Retired) == 1,
+		"fixture: exactly one source was removable, so the two outcomes are "+
+			"distinguishable — Merged says the merge landed, Retired says which "+
+			"source it took")
 	merged, err := env.svc.Facts().FactExists(ctx, env.branch, out)
 	require.NoError(t, err)
 	require.True(t, merged, "the merged fact must have been written")

--- a/internal/synthesize/dedup.go
+++ b/internal/synthesize/dedup.go
@@ -274,6 +274,28 @@ func dedupCluster(
 		// location, and without it the loser's motifs are simply deleted along
 		// with the loser, losing authored data that no derived state can rebuild.
 		fullWinner.Motifs = fact.MergeMotifs(fullWinner.Motifs, fullLoser.Motifs)
+		// RECOMPUTE the evidence weight from the pooled lineage (#94).
+		//
+		// The merge pools the loser's sources onto the winner two lines above,
+		// and evidence weight is DEFINED as a function of the pooled evidence —
+		// so a weight carried over unchanged describes evidence the surviving
+		// fact no longer has. Not an erasure like the learn path: a stale
+		// number, which is harder to notice and just as wrong.
+		//
+		// computeTransfer is the SAME call ApplyPruneDecisions uses, deliberately.
+		// Two merge paths deriving one field two ways is the "same operation,
+		// two callers, one silently wrong" drift this package keeps hitting;
+		// one mechanism cannot drift from itself. It runs before the loser is
+		// deleted, because it reads both facts.
+		//
+		// Only the WEIGHT is taken. Sources stays with mergeFacts, which owns
+		// the merge rule and whose hypothesis handling
+		// (loserCorroborations) is already pinned by tests; the two agree on
+		// every ordinary pair and disagree only when the WINNER is a
+		// hypothesis, where mergeFacts' answer is the tested one.
+		mergedWeight, _, _ := computeTransfer(ctx, gs, agentBranch, localRepoID,
+			[]string{winnerFact.File, loserFact.File})
+		fullWinner.EvidenceWeight = mergedWeight
 		// Refs = union of both refs + loser's path, and — separately — the
 		// snapshot of what the two operands already carried.
 		mergedRefs, carriedRefs := dedupMergeRefs(fullWinner.Refs, fullLoser.Refs, loserFact.File)

--- a/internal/synthesize/dedup_evidence_weight_test.go
+++ b/internal/synthesize/dedup_evidence_weight_test.go
@@ -1,0 +1,111 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+)
+
+// The THIRD merge site, which neither issue #94 nor knomit fact f62378e5 names.
+//
+// dedupCluster's mechanical merge pools the loser's sources onto the winner
+// (fullWinner.Sources) but never touches fullWinner.EvidenceWeight — the string
+// does not appear in internal/synthesize/dedup.go at all. So the surviving fact
+// carries a weight computed against the evidence it had BEFORE the merge, while
+// now resting on strictly more of it. Not an erasure like the learn path: a
+// silent staleness, which is harder to see and just as wrong.
+//
+// evidence_weight is defined as a function of the pooled evidence, so a merge
+// that pools evidence must recompute it — the same rule, and the same
+// mechanism, ApplyPruneDecisions already uses.
+
+// weightedDedupFact writes a fact carrying an explicit evidence_weight, placed
+// at a chosen point on the embedding axis so the pair is a mechanical
+// near-duplicate by construction rather than by luck.
+func weightedDedupFact(t *testing.T, env *restatementEnv, path, title, body string, conf float64, sources int, weight float64) {
+	t.Helper()
+	f := fact.NewFact(path)
+	f.Title = title
+	f.Body = body
+	f.Type = fact.Observation
+	f.Domain = []string{"alpha"}
+	f.Entities = []string{"Widget"}
+	f.Refs = []string{}
+	f.Confidence = conf
+	f.Sources = sources
+	f.EvidenceWeight = weight
+	rendered, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	require.Contains(t, rendered, "evidence_weight:",
+		"fixture: the fact must actually be written with a weight")
+	_, err = env.svc.Facts().WriteFact(context.Background(), env.branch, f.Path(), rendered,
+		"write "+path, "test")
+	require.NoError(t, err)
+}
+
+func TestDedupCluster_MergeRecomputesEvidenceWeightFromPooledRefs(t *testing.T) {
+	ctx := context.Background()
+
+	// Both facts land on the same point of the axis, so the mechanical gate
+	// sees a near-duplicate pair with certainty.
+	emb := &restatementEmbedder{vectorFor: func(string) []float32 { return axisVector(0) }}
+	env := newRestatementEnvWith(t, 0, emb)
+
+	const winnerPath = "kb/alpha/winner.md"
+	const loserPath = "kb/alpha/loser.md"
+	// The winner is the higher-confidence fact, so mergeFacts keeps it — and
+	// its stored weight is the stale number under test.
+	const staleWeight = 0.20
+	weightedDedupFact(t, env, winnerPath, "Widget fails closed", "one recording", 0.9, 2, staleWeight)
+	weightedDedupFact(t, env, loserPath, "Widget fails closed again", "another recording", 0.5, 3, 0.15)
+
+	cluster := []factForLLM{
+		{File: winnerPath, Title: "Widget fails closed", Body: "one recording",
+			Type: "observation", Confidence: 0.9, Sources: 2},
+		{File: loserPath, Title: "Widget fails closed again", Body: "another recording",
+			Type: "observation", Confidence: 0.5, Sources: 3},
+	}
+
+	// The two candidate answers, computed BEFORE the merge because the loser is
+	// deleted by it. Asserting the merged weight is merely "bigger than the
+	// stale one" is too weak — a recompute over the WINNER ALONE also clears
+	// that bar, and the first draft of this test passed under exactly that
+	// sabotage. What has to be pinned is that the recompute POOLED both facts.
+	localID := fact.ID12(env.ri.ID())
+	pooledWeight, _, _ := computeTransfer(ctx, env.svc.Facts(), env.branch, localID,
+		[]string{winnerPath, loserPath})
+	winnerOnlyWeight, _, _ := computeTransfer(ctx, env.svc.Facts(), env.branch, localID,
+		[]string{winnerPath})
+	require.Greater(t, pooledWeight, winnerOnlyWeight,
+		"fixture: pooling must move the weight, or this test cannot tell a pooled "+
+			"recompute from a winner-only one")
+	require.Greater(t, winnerOnlyWeight, staleWeight,
+		"fixture: even the WRONG answer beats the stale value, which is why "+
+			"'greater than stale' is not the assertion")
+
+	d := env.deps()
+	surviving, err := dedupCluster(ctx, cluster, env.svc.Facts(), env.svc.Search(),
+		env.dedupThreshold(), reviewTool, d.OnProgress, env.branch, fact.ID12(env.ri.ID()))
+	require.NoError(t, err)
+
+	// PRECONDITION, asserted: the merge actually happened. Without this the
+	// weight assertion below would pass on a session where nothing merged.
+	require.Len(t, surviving, 1, "fixture: the pair must have merged mechanically")
+	require.Equal(t, winnerPath, surviving[0].File, "fixture: the higher-confidence fact must win")
+	require.Equal(t, 5, surviving[0].Sources,
+		"fixture: the merge must have POOLED the sources (2+3) — that is what makes the "+
+			"pre-merge weight stale")
+
+	read, err := env.svc.Facts().ReadFact(ctx, env.branch, winnerPath, nil)
+	require.NoError(t, err)
+	merged, err := fact.ParseFact(winnerPath, read.Content)
+	require.NoError(t, err)
+
+	require.InDelta(t, pooledWeight, merged.EvidenceWeight, 1e-9,
+		"the surviving fact rests on BOTH facts' evidence, so its weight must be the "+
+			"recompute over the pooled refs — not the winner's stale value (%.4f) and "+
+			"not a recompute over the winner alone (%.4f)", staleWeight, winnerOnlyWeight)
+}


### PR DESCRIPTION
The atomic-merge stack, per the designer's ruling: make data loss impossible by construction rather than flag-for-a-human. #101: a merge lands the merged write and all source deletes in ONE BatchWriteFacts commit (the fresh-uuid path from #107a already prevents collision). #94: carry/recompute evidence_weight across every merge path — mechanical path recomputes via computeTransfer (pooled refs), learn path carries max (erasure fix; residual under-count tracked in #152). Closes #107b by construction (nothing left to refuse).

Reviewed clean by a cold Opus agent: no HIGH, both data-loss-critical properties (single-commit atomicity + pooled recompute) sabotage-tested. MN5 intact both commits, MN13 clean, bisectable. Report: .claude/plans/motif/2026-08-25-atomic-merge-review-findings.md.

Closes #101
Closes #94
Closes #107