### PR TITLE
fix(synthesize): throttle honesty — unproven state, real denominator, probe consumed on served (#117b)

### DIFF
--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -372,10 +372,18 @@ const shortlistOverfetch = 4
 const shortlistMotifWiden = 3
 
 // Throttle states, reported in health output.
+//
+// RESOLVED, not merged: a verdict counts when the judge merged the pair OR
+// retracted its redundant half (the verdicts-are-resolved-not-merged ruling).
+// These comments used to say "merged". They predate that ruling and named a
+// NARROWER event than the code has ever counted, which is half of why the
+// printed state looked impossible on live corpora (knomit#117b) — the other
+// half is the fall-through that throttleState now closes.
 const (
-	throttleOptimistic = "optimistic" // no history yet — the cap bounds the downside
-	throttleFunded     = "funded"     // the judge has merged something recently
-	throttleDefunded   = "defunded"   // enough judged, none merged: stop spending
+	throttleOptimistic = "optimistic" // no verdicts yet — the cap bounds the downside
+	throttleFunded     = "funded"     // the judge resolved a pair recently
+	throttleUnproven   = "unproven"   // judged, none resolved, too little evidence to defund
+	throttleDefunded   = "defunded"   // enough judged, none resolved: stop spending
 )
 
 // restatementClusterKeyPrefix marks a prune work item as shortlist-originated.
@@ -403,6 +411,12 @@ type restatementHealth struct {
 	Dropped        int
 	ResolutionRate float64
 	ThrottleState  string
+	// Judged is how many verdicts the rate above was actually computed over.
+	// The health line used to print the throttleWindow CONSTANT instead, so a
+	// corpus with no verdicts at all still read "over last 10 judged"
+	// (knomit#117b). The denominator has to be the real one or the rate above
+	// it cannot be interpreted.
+	Judged int
 	// MotifWidened counts pairs admitted ONLY because their facts share a
 	// canonical motif — candidates the title axis alone would not have reached.
 	// Reported so the signal's contribution is visible rather than inferred.
@@ -442,8 +456,22 @@ func shortlistBudget(n int) int {
 }
 
 // throttleState reads the corpus's own verdict history: optimistic with no
-// history, defunded once enough shortlist pairs have been judged and none
-// merged, funded again the moment one merges.
+// verdicts, unproven once pairs have been judged with nothing resolved but too
+// few to conclude, defunded once enough have been judged with none resolved,
+// funded the moment one resolves.
+//
+// unproven is not a cosmetic split of funded (knomit#117b). Every
+// 0 < len(verdicts) < throttleMinVerdicts with nothing resolved used to fall
+// THROUGH to funded, so the line claimed "the judge resolved a pair recently"
+// on the exact evidence that says it did not — observed live on knomit-kb at
+// one judged KEEP. That interval is also the trajectory INTO defunding, which
+// is the thing an operator needs to see coming rather than discover after the
+// corpus has gone quiet.
+//
+// Behaviourally inert BY CONSTRUCTION, and that is load-bearing: only
+// throttleDefunded is read by any branch, so an unproven corpus budgets and
+// probes exactly as a funded or optimistic one does. This changes what is
+// PRINTED, never what is spent.
 func throttleState(verdicts []store.RestatementVerdict) (float64, string) {
 	if len(verdicts) == 0 {
 		return 0, throttleOptimistic
@@ -455,8 +483,11 @@ func throttleState(verdicts []store.RestatementVerdict) (float64, string) {
 		}
 	}
 	rate := float64(resolved) / float64(len(verdicts))
-	if resolved == 0 && len(verdicts) >= throttleMinVerdicts {
-		return rate, throttleDefunded
+	if resolved == 0 {
+		if len(verdicts) >= throttleMinVerdicts {
+			return rate, throttleDefunded
+		}
+		return rate, throttleUnproven
 	}
 	return rate, throttleFunded
 }
@@ -490,6 +521,7 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 		return nil, h, wrapf(reviewTool, err, "shortlist: verdicts")
 	}
 	h.ResolutionRate, h.ThrottleState = throttleState(verdicts)
+	h.Judged = len(verdicts)
 
 	budget := shortlistBudget(n)
 	probing := false
@@ -674,16 +706,17 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	// something (designer rider).
 	h.MotifSlotUsed = h.MotifWidened > 0 && len(ordinary) >= budget
 
-	if probing && len(out) > 0 {
-		// The probe is spent only if it actually put something in front of the
-		// judge. A session that found nothing to offer produced no evidence,
-		// and charging it a probe would buy another full interval of silence
-		// for nothing.
-		h.Probing = true
-		if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, 0); err != nil {
-			return nil, h, wrapf(reviewTool, err, "shortlist: consume probe")
-		}
-	}
+	// Selection can only PROPOSE a probe; whether the slot is spent depends on
+	// what reached the judge, and only enqueue knows that. So the consumption
+	// moved to planRestatementShortlist (knomit#117b).
+	//
+	// probeAllowed has always documented the contract as "consumed by the
+	// caller, and only when a pair was actually emitted" — this is the first
+	// code that meets it. The gap mattered because selected != served since
+	// knomit#117a: a probe whose one pair fails to load at item creation put
+	// NOTHING in front of the judge, yet bought a full interval of silence.
+	// That is the self-defunding latch re-introduced at a slower rate.
+	h.Probing = probing && len(out) > 0
 	if len(out) > 0 {
 		// The operating point is not a threshold anyone chose: it is whatever
 		// absolute cosine the last funded pair happens to sit at in THIS repo.
@@ -823,6 +856,12 @@ func enqueueRestatementItems(ctx context.Context, d Deps, sess *store.PipelineSe
 func applyEmissionOutcome(h *restatementHealth, served, dropped int) {
 	h.Emitted = served
 	h.Dropped = dropped
+	// The same correction applied to the probe (knomit#117b). Selection
+	// proposed one; a slot is only SPENT if something actually reached the
+	// judge. Downgrading here also stops the health line rendering "(probing)"
+	// for a session that probed nothing — the identical selected-vs-served
+	// lie this function exists to end, wearing the throttle's clothes.
+	h.Probing = h.Probing && served > 0
 }
 
 // planRestatementShortlist runs the whole phase-0 sequence for one session:
@@ -893,6 +932,21 @@ func planRestatementShortlist(ctx context.Context, d Deps, sess *store.PipelineS
 	// exactly why it is worth closing now rather than when something starts
 	// reading it.
 	applyEmissionOutcome(&health, served, dropped)
+	if health.Probing {
+		// Consume the probe HERE, and only here: health.Probing is true at this
+		// point only if a pair actually reached the judge, which is the
+		// contract probeAllowed documents.
+		//
+		// A failure is not fatal and is self-healing: probeAllowed HOLDS the
+		// counter at the interval rather than bumping past it, so a corpus that
+		// could not record the consumption stays eligible and probes again next
+		// session. Failing a review over that bookkeeping write would cost more
+		// than the one extra probe it prevents.
+		if perr := d.Abstraction.SetProbeSessionsWaited(ctx, branch, 0); perr != nil {
+			log.Warn().Err(perr).Str("session", sess.ID).
+				Msg("review: probe slot not consumed; corpus stays eligible next session")
+		}
+	}
 	if err != nil {
 		return err
 	}
@@ -924,7 +978,7 @@ func healthLines(h restatementHealth) []string {
 		fmt.Sprintf("operating point: title-cos %.3f (this corpus, this session)", h.OperatingPoint),
 		emittedLine(h),
 		fmt.Sprintf("shortlist throttle: %s%s (trailing resolution-rate %.0f%% over last %d judged)",
-			h.ThrottleState, probeSuffix(h), h.ResolutionRate*100, throttleWindow),
+			h.ThrottleState, probeSuffix(h), h.ResolutionRate*100, h.Judged),
 		// The motif signal's actual contribution, not its existence (designer
 		// rider Q10). The GATE package needs to state how often it FIRED, and
 		// a line that only ever said "enabled" could not support that claim.

--- a/internal/synthesize/restatement_dynamics_test.go
+++ b/internal/synthesize/restatement_dynamics_test.go
@@ -170,24 +170,35 @@ func TestDynamics_DefundAndProbeRecoveryOverSessions(t *testing.T) {
 	require.GreaterOrEqual(t, len(declined), throttleMinVerdicts)
 
 	// Quiet sessions, then exactly one probe.
+	//
+	// Driven through planRestatementShortlist, NOT selectRestatementCandidates
+	// (knomit#117b). The probe slot is consumed by the CALLER now, after
+	// enqueue, so a loop that stops at selection never exercises consumption at
+	// all: probeAllowed HOLDS its counter at the interval, so every subsequent
+	// session stays eligible and this loop counts three probes instead of one.
+	// Asserting at selection would assert that the helper works, not that
+	// anything spends the slot -- the campaign's path-vs-state rule, the same
+	// shape that rewrote the #117a wiring test.
 	probed := 0
-	var probePair store.RestatementPair
+	var probeA, probeB string
 	for range throttleProbeInterval + 1 {
-		pairs, health, err = selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
-		require.NoError(t, err)
-		if health.Probing {
+		sess, serr := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+		require.NoError(t, serr)
+		require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
+		items := env.workItems(sess.ID)
+		if healthLineSaysProbing(sess) {
 			probed++
-			require.Len(t, pairs, 1, "a probe is one slot, not a batch")
-			probePair = pairs[0]
+			require.Len(t, items, 1, "a probe is one slot, not a batch")
+			probeA, probeB = itemPairPaths(t, items[0].FactsJSON)
 		} else {
-			require.Empty(t, pairs, "a defunded corpus is silent between probes")
+			require.Empty(t, items, "a defunded corpus is silent between probes")
 		}
 	}
 	require.Equal(t, 1, probed, "exactly one probe per interval")
 
 	// Resolve the probe: the corpus funds itself again from evidence only the
 	// probe could have produced.
-	env.recordVerdict(probePair.APath, probePair.BPath, true)
+	env.recordVerdict(probeA, probeB, true)
 	pairs, health, err = selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
 	require.NoError(t, err)
 	require.Equal(t, throttleFunded, health.ThrottleState)

--- a/internal/synthesize/restatement_test.go
+++ b/internal/synthesize/restatement_test.go
@@ -244,9 +244,15 @@ func TestThrottleState_StartsOptimisticDefundsOnAllKeepRestoresOnResolution(t *t
 	require.Equal(t, throttleOptimistic, state, "no history means try it")
 	require.Zero(t, rate)
 
-	// Not enough evidence yet: a couple of keeps must not defund a corpus.
+	// Not enough evidence yet: a couple of keeps must not defund a corpus --
+	// but they must not read as FUNDED either. This assertion said
+	// throttleFunded because the code fell THROUGH to it, while the comment
+	// above named the property actually under test. Judged-with-nothing-resolved
+	// is its own state now (knomit#117b); both halves are asserted so the
+	// not-defunded property cannot silently ride on the state name again.
 	_, state = throttleState(keepVerdicts(throttleMinVerdicts - 1))
-	require.Equal(t, throttleFunded, state)
+	require.Equal(t, throttleUnproven, state)
+	require.NotEqual(t, throttleDefunded, state, "a couple of keeps must not defund a corpus")
 
 	_, state = throttleState(keepVerdicts(throttleMinVerdicts))
 	require.Equal(t, throttleDefunded, state, "enough judged, none resolved")

--- a/internal/synthesize/restatement_throttle_honesty_test.go
+++ b/internal/synthesize/restatement_throttle_honesty_test.go
@@ -1,0 +1,217 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// knomit#117b. The throttle told an operator three things it had not earned:
+// a STATE (funded, on evidence that nothing had resolved), a DENOMINATOR (the
+// throttleWindow constant, on a corpus with no verdicts at all), and a PROBE
+// (spent on a pair that never reached the judge).
+//
+// The first two are display defects and the third is behavioural, so they are
+// pinned separately below. Assertions read the RENDERED health line wherever
+// the issue was filed on the rendered line — a restatementHealth field can be
+// right while the line an operator reads is wrong, which is the whole family
+// of bugs this file covers.
+
+// throttleHealthLine returns the throttle line as the operator sees it.
+func throttleHealthLine(sess *store.PipelineSession) string {
+	for _, line := range sess.Health {
+		if strings.HasPrefix(line, "shortlist throttle:") {
+			return line
+		}
+	}
+	return ""
+}
+
+// emittedHealthLine returns the emission line as the operator sees it.
+func emittedHealthLine(sess *store.PipelineSession) string {
+	for _, line := range sess.Health {
+		if strings.HasPrefix(line, "restatement candidates emitted:") {
+			return line
+		}
+	}
+	return ""
+}
+
+func healthLineSaysProbing(sess *store.PipelineSession) bool {
+	return strings.Contains(throttleHealthLine(sess), "(probing)")
+}
+
+func itemPairPaths(t *testing.T, factsJSON string) (string, string) {
+	t.Helper()
+	var facts []factForLLM
+	require.NoError(t, json.Unmarshal([]byte(factsJSON), &facts))
+	require.Len(t, facts, 2, "a shortlist work item carries exactly the pair")
+	return facts[0].File, facts[1].File
+}
+
+// defund records enough all-keep verdicts to put the corpus below the floor,
+// without going through selection — what defunds a corpus is the verdict
+// history, and building it directly keeps the fixture independent of whatever
+// selection happens to offer.
+func defundCorpus(t *testing.T, env *restatementEnv) {
+	t.Helper()
+	for i := range throttleMinVerdicts {
+		env.recordVerdict(fmt.Sprintf("kb/f%d.md", 2*i), fmt.Sprintf("kb/f%d.md", 2*i+1), false)
+	}
+}
+
+// TestThrottle_UnprovenDoesNotGateSpending is the load-bearing half of the new
+// state: `unproven` must be a DISPLAY state and nothing else.
+//
+// Only throttleDefunded is read by any branch, so a corpus that has judged a
+// couple of pairs without resolving them must budget exactly what it budgeted
+// before those verdicts existed. If `unproven` ever starts gating — the obvious
+// wrong turn, since it looks like "half-defunded" — this is what catches it.
+func TestThrottle_UnprovenDoesNotGateSpending(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 600)
+	env.seedShortlist()
+
+	basePairs, baseHealth, err := selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+	require.NoError(t, err)
+	require.Equal(t, throttleOptimistic, baseHealth.ThrottleState, "no verdicts yet")
+
+	// FIXTURE ASSERTION, not an assumption (the #130 vacuity rule): a corpus
+	// budgeting one slot cannot distinguish "unrestricted" from "restricted to
+	// a probe", and the comparison below would pass on both.
+	require.Greater(t, len(basePairs), 1,
+		"the fixture must budget more than a single slot or the comparison below is vacuous")
+
+	// Judge some, resolve nothing, and stay BELOW the defund floor.
+	judged := throttleMinVerdicts - 2
+	require.Positive(t, judged)
+	require.Less(t, judged, throttleMinVerdicts)
+	for i := range judged {
+		env.recordVerdict(basePairs[i].APath, basePairs[i].BPath, false)
+	}
+
+	pairs, health, err := selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+	require.NoError(t, err)
+	require.Equal(t, throttleUnproven, health.ThrottleState,
+		"judged with nothing resolved, below the floor, is its own state")
+	require.False(t, health.Probing, "an unproven corpus is not defunded and owes no probe")
+	require.Equal(t, len(basePairs), len(pairs),
+		"unproven must spend exactly what it spent before those verdicts — it is a DISPLAY state")
+}
+
+// TestHealthLine_ThrottleDenominatorIsWhatWasActuallyJudged pins the second
+// display defect: the line printed the throttleWindow CONSTANT as its
+// denominator, so a corpus that had never judged anything still reported
+// "trailing resolution-rate 0% over last 10 judged". A rate is uninterpretable
+// without its real denominator, and this one was decorative.
+func TestHealthLine_ThrottleDenominatorIsWhatWasActuallyJudged(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 600)
+	env.seedShortlist()
+
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	require.NoError(t, err)
+	require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
+
+	line := throttleHealthLine(sess)
+	require.NotEmpty(t, line, "no throttle line rendered — every assertion below would be vacuous")
+	require.Contains(t, line, "over last 0 judged", "nothing has been judged")
+	require.NotContains(t, line, fmt.Sprintf("over last %d judged", throttleWindow),
+		"the window constant is not a judged count")
+
+	// And it tracks the REAL count rather than being pinned to zero: judge a
+	// number that is neither 0 nor throttleWindow, so the assertion pins WHICH
+	// value the denominator took, not merely that it moved (the X2 rule).
+	pairs, _, err := selectRestatementCandidates(ctx, env.deps(), env.branch, nil, 600)
+	require.NoError(t, err)
+	judged := throttleMinVerdicts - 2
+	require.GreaterOrEqual(t, len(pairs), judged, "fixture must offer enough pairs to judge")
+	require.NotEqual(t, throttleWindow, judged)
+	require.NotZero(t, judged)
+	for i := range judged {
+		env.recordVerdict(pairs[i].APath, pairs[i].BPath, false)
+	}
+
+	sess2, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	require.NoError(t, err)
+	require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess2, env.branch, nil))
+	require.Contains(t, throttleHealthLine(sess2), fmt.Sprintf("over last %d judged", judged))
+}
+
+// TestProbe_IsNotConsumedWhenTheSelectedPairIsNeverServed is the behavioural
+// fix, and the one an existing test could not reach.
+//
+// TestDynamics_ProbeIsNotConsumedWhenNothingIsEmitted already covers the case
+// where selection finds NOTHING to offer. The uncovered case is the one core
+// actually hit: selection offers a pair, and the pair dies at item creation
+// because a half no longer resolves (knomit#117a). Selection saw len(out) > 0
+// and charged the probe, so a session that put nothing in front of a judge
+// bought a full interval of silence — the self-defunding latch reintroduced at
+// a slower rate, which is exactly what the probe exists to prevent.
+func TestProbe_IsNotConsumedWhenTheSelectedPairIsNeverServed(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 600)
+	env.seedShortlist()
+	defundCorpus(t, env)
+
+	// An unservable pair, ranked above anything this corpus produced on its
+	// own: its B half is a fact id that does not resolve, so selection picks it
+	// and enqueue drops it. A probe budgets exactly ONE slot, so out-ranking is
+	// enough to guarantee it is the pair selected.
+	//
+	// Deliberately NOT done by clearing the other pairs: dropping every fact id
+	// also marks those facts uncovered, and planRestatementShortlist refreshes
+	// the cache before selecting, so the organic pairs come straight back.
+	// Out-rank, do not clear.
+	ids := env.liveFactIDs()
+	require.NoError(t, env.svc.Abstraction().ReplaceRestatementPairs(ctx, env.branch, nil,
+		[]store.RestatementPair{{
+			APath: "kb/f100.md", BPath: "kb/gone.md",
+			AFactID: ids["kb/f100.md"], BFactID: 999999,
+			TitleCos: 0.999,
+		}}, nil))
+
+	// Run out the interval. Exactly one session arms a probe and selects the
+	// unservable pair; it must NOT be recorded as having probed.
+	dropped := 0
+	for range throttleProbeInterval {
+		sess, serr := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+		require.NoError(t, serr)
+		require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
+		require.Empty(t, env.workItems(sess.ID), "nothing servable can reach the queue")
+		if strings.Contains(emittedHealthLine(sess), "dropped unserved") {
+			dropped++
+			require.False(t, healthLineSaysProbing(sess),
+				"a session that served nothing has not probed, whatever it selected")
+		}
+	}
+	// CODE-REACHED assertion (the T4/V5 rule): without this the test passes on
+	// a corpus that never armed a probe at all, and would still pass with the
+	// consumption bug fully intact.
+	require.Equal(t, 1, dropped,
+		"exactly one session must have armed a probe and had its pair dropped")
+
+	// The probe was never spent, so the corpus is still owed one: make a
+	// SERVABLE pair available and the very next session must probe. Under the
+	// old code the dropped session consumed the slot, so this session would be
+	// silent and the corpus would wait another full interval for nothing.
+	require.NoError(t, env.svc.Abstraction().ReplaceRestatementPairs(ctx, env.branch, nil,
+		[]store.RestatementPair{{
+			APath: "kb/f101.md", BPath: "kb/f102.md",
+			AFactID: ids["kb/f101.md"], BFactID: ids["kb/f102.md"],
+			TitleCos: 0.9999,
+		}}, nil))
+
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	require.NoError(t, err)
+	require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
+	require.True(t, healthLineSaysProbing(sess),
+		"the probe budget was still owed, not burned on a session that served nothing")
+	require.Len(t, env.workItems(sess.ID), 1, "a probe is one slot")
+}


### PR DESCRIPTION
Four independent throttle-instrumentation defects: (1) state fell through to 'funded' for 0<verdicts<5 with nothing resolved → new 'unproven' state (behaviourally inert, no migration); (2) 'merged' comments corrected to 'resolved' per verdicts-are-resolved-not-merged; (3) health line printed the throttleWindow constant → now the measured Judged count; (4) probe consumption moved after enqueue, gated on served (not selected), per self-defunding-latch — a session that selects but fails to serve no longer consumes the probe.

Cold-reviewed clean (fresh Opus, isolated worktree): no HIGH/MED/LOW, all six sabotages reproduced on their unique tests, MN5 blob intact, MN13 clean (unproven is a string, Judged is a measured count), bisectable, gofmt clean. The emitted:0 half of #117 is moot post-#127.

Closes #117.