### PR TITLE
fix: record who opened a pipeline session (#123)

### DIFF
--- a/internal/mcp/actor.go
+++ b/internal/mcp/actor.go
@@ -1,0 +1,101 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+
+	"knomit/internal/synthesize"
+)
+
+// actorMaxLen caps each component of the composed handle.
+//
+// MN13 classification: this is a DEFENSIVE RESOURCE BOUND on untrusted input,
+// not a corpus property. Every byte below arrives from the caller — the session
+// id is a header value and the client name/version are whatever `initialize`
+// declared — so an unbounded one would ride into a DB column and into every log
+// line built from it. internal/web/observability.go already caps exactly these
+// fields for exactly this reason (truncateForLog); 128 is the same order of
+// magnitude, comfortably above a UUID-shaped id and any plausible client name.
+const actorMaxLen = 128
+
+// actorFromRequest composes the correlation handle recorded as
+// pipeline_sessions.created_by.
+//
+// IT IS NOT AN IDENTITY AND NOT AUTHENTICATION. The session id comes from the
+// caller's own Mcp-Session-Id header and this server does not verify it —
+// measured: a fabricated id that never ran `initialize` is accepted and reaches
+// the handler, just with no client info attached. The MCP specification says a
+// session id "is not evidence of who the caller is" and MUST NOT be treated as
+// authentication. What this records is what the opening call SAID, which is
+// enough to correlate an unexpected session against the HTTP log (which already
+// logs the same value as `mcp_session`) and nothing more (knomit#123).
+//
+// The value is scheme-prefixed so the kind of claim is legible in the value
+// itself rather than in the reader's assumptions:
+//
+//	mcp-session:<id>
+//	mcp-session:<id> client:<name>/<version>
+//
+// The client clause appears only when the session actually initialized against
+// this process. It is an enrichment; the id is the key.
+//
+// Returns "" when there is no MCP session at all — an in-process caller. That
+// is honest absence rather than an invented "unknown": over HTTP a tools/call
+// without a session id is rejected before any handler runs, so on that path the
+// id is always present.
+func actorFromRequest(ctx context.Context, req mcpgo.CallToolRequest) string {
+	sess := mcpserver.ClientSessionFromContext(ctx)
+	if sess == nil {
+		return ""
+	}
+	// Prefer the session object over req.Header: it is what the server
+	// dispatched this call under, so the two can never disagree about which
+	// session the row is attributed to.
+	id := sanitizeActorPart(sess.SessionID())
+	if id == "" {
+		return ""
+	}
+	out := "mcp-session:" + id
+
+	if info, ok := sess.(mcpserver.SessionWithClientInfo); ok {
+		ci := info.GetClientInfo()
+		name := sanitizeActorPart(ci.Name)
+		if name != "" {
+			out += " client:" + name
+			if ver := sanitizeActorPart(ci.Version); ver != "" {
+				out += "/" + ver
+			}
+		}
+	}
+	return out
+}
+
+// sanitizeActorPart makes one caller-supplied component safe to store and to
+// log: control characters (newlines above all — a log line is one line) and
+// spaces are dropped, since space separates the clauses of the composed value,
+// and the result is capped. Returns "" for a component with nothing left.
+func sanitizeActorPart(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsControl(r) || unicode.IsSpace(r) {
+			continue
+		}
+		if b.Len()+utf8.RuneLen(r) > actorMaxLen {
+			break
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// withActor attaches the composed handle to ctx for Pipeline.StartSession to
+// bind onto the session row. Called by the two handlers that open pipeline
+// sessions (knomit_review and knomit_hypothesize); both drive the same engine.
+func withActor(ctx context.Context, req mcpgo.CallToolRequest) context.Context {
+	return synthesize.WithActor(ctx, actorFromRequest(ctx, req))
+}

--- a/internal/mcp/actor_test.go
+++ b/internal/mcp/actor_test.go
@@ -1,0 +1,129 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSession is a ClientSession that also carries client info, matching what
+// every real transport session implements (streamable HTTP, SSE, stdio and
+// in-process all satisfy SessionWithClientInfo).
+type fakeSession struct {
+	id   string
+	info mcpgo.Implementation
+}
+
+func (f *fakeSession) Initialize()       {}
+func (f *fakeSession) Initialized() bool { return true }
+func (f *fakeSession) NotificationChannel() chan<- mcpgo.JSONRPCNotification {
+	return make(chan mcpgo.JSONRPCNotification, 1)
+}
+func (f *fakeSession) SessionID() string                     { return f.id }
+func (f *fakeSession) GetClientInfo() mcpgo.Implementation   { return f.info }
+func (f *fakeSession) SetClientInfo(ci mcpgo.Implementation) { f.info = ci }
+func (f *fakeSession) GetClientCapabilities() mcpgo.ClientCapabilities {
+	return mcpgo.ClientCapabilities{}
+}
+func (f *fakeSession) SetClientCapabilities(mcpgo.ClientCapabilities) {}
+
+var _ mcpserver.SessionWithClientInfo = (*fakeSession)(nil)
+
+// sessionOnly is a ClientSession WITHOUT client info — the shape a session
+// takes when the caller never ran `initialize` against this process.
+type sessionOnly struct{ id string }
+
+func (s *sessionOnly) Initialize()       {}
+func (s *sessionOnly) Initialized() bool { return true }
+func (s *sessionOnly) NotificationChannel() chan<- mcpgo.JSONRPCNotification {
+	return make(chan mcpgo.JSONRPCNotification, 1)
+}
+func (s *sessionOnly) SessionID() string { return s.id }
+
+var _ mcpserver.ClientSession = (*sessionOnly)(nil)
+
+func withSession(s mcpserver.ClientSession) context.Context {
+	return mcpserver.NewMCPServer("t", "1").WithContext(context.Background(), s)
+}
+
+// The composed handle is scheme-prefixed so a reader can see what KIND of
+// claim it is from the value alone — `mcp-session:` says "the caller told us
+// this", which is the whole point of knomit#123's honesty requirement. The
+// client clause is an enrichment layered on the id, never a replacement for it.
+func TestActorFromRequest_Composition(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sess mcpserver.ClientSession
+		want string
+	}{
+		{
+			name: "session id plus client info",
+			sess: &fakeSession{id: "sid-1", info: mcpgo.Implementation{Name: "claude-code", Version: "1.2.3"}},
+			want: "mcp-session:sid-1 client:claude-code/1.2.3",
+		},
+		{
+			// Measured against the real transport: a call arriving under a
+			// session this process never saw `initialize` for still carries an
+			// id, and carries NO client info. The id alone must still be
+			// recorded — it is the join key to the HTTP log.
+			name: "session id, no client info recorded",
+			sess: &fakeSession{id: "sid-2"},
+			want: "mcp-session:sid-2",
+		},
+		{
+			name: "session that cannot carry client info at all",
+			sess: &sessionOnly{id: "sid-3"},
+			want: "mcp-session:sid-3",
+		},
+		{
+			name: "client name without a version",
+			sess: &fakeSession{id: "sid-4", info: mcpgo.Implementation{Name: "someclient"}},
+			want: "mcp-session:sid-4 client:someclient",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := actorFromRequest(withSession(tc.sess), mcpgo.CallToolRequest{})
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// No MCP session at all: an in-process caller. Honest absence — NOT an invented
+// "unknown" sentinel, which would be indistinguishable from a real handle that
+// happened to say "unknown".
+func TestActorFromRequest_NoSessionIsEmpty(t *testing.T) {
+	require.Equal(t, "", actorFromRequest(context.Background(), mcpgo.CallToolRequest{}))
+}
+
+// A session id that sanitizes away to nothing yields no handle rather than a
+// bare scheme prefix `mcp-session:`, which would read as a recorded attribution
+// while naming nobody.
+func TestActorFromRequest_UnusableSessionIDIsEmpty(t *testing.T) {
+	got := actorFromRequest(withSession(&sessionOnly{id: "\n\t  "}), mcpgo.CallToolRequest{})
+	require.Equal(t, "", got)
+}
+
+// Every byte of the handle is caller-supplied. It lands in a DB column and in
+// log lines, so it is capped and stripped of control characters — a newline in
+// particular would split one log line into two, one of them attacker-shaped.
+func TestActorFromRequest_CallerSuppliedBytesAreBounded(t *testing.T) {
+	long := strings.Repeat("x", actorMaxLen*3)
+	got := actorFromRequest(withSession(&fakeSession{
+		id:   long,
+		info: mcpgo.Implementation{Name: "ev\nil na\tme", Version: long},
+	}), mcpgo.CallToolRequest{})
+
+	require.NotContains(t, got, "\n", "a newline would forge a second log line")
+	require.NotContains(t, got, "\t")
+	require.Contains(t, got, "client:evilname/", "control chars are dropped, the rest is kept")
+
+	// Each component is capped independently, so the id being over-long cannot
+	// crowd the client clause out of the value.
+	id := strings.TrimPrefix(strings.SplitN(got, " ", 2)[0], "mcp-session:")
+	require.Len(t, id, actorMaxLen, "the id component is capped, not merely shortened somewhere")
+	require.Less(t, len(got), actorMaxLen*3, "the whole handle stays bounded")
+}

--- a/internal/mcp/hypothesize.go
+++ b/internal/mcp/hypothesize.go
@@ -124,7 +124,10 @@ func HypothesizeHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.C
 			if perr != nil {
 				return mcpgo.NewToolResultError(perr.Error()), nil
 			}
-			result, err = synthesize.NewHypothesizer(ri, logProgress, effort, scope).StartSession(ctx)
+			// Attribute the session this call is about to open (knomit#123).
+			// Only the start path needs it: StartSession is the sole reader.
+			result, err = synthesize.NewHypothesizer(ri, logProgress, effort, scope).
+				StartSession(withActor(ctx, req))
 		} else {
 			// Effort and scope are deliberately NOT parsed on the continue path:
 			// an invalid effort must not be able to wedge a live session, and the

--- a/internal/mcp/mock_pipeline_index_test.go
+++ b/internal/mcp/mock_pipeline_index_test.go
@@ -100,18 +100,18 @@ func (mr *MockPipelineIndexMockRecorder) CompletePipelineSession(ctx, id any) *g
 }
 
 // CreatePipelineSession mocks base method.
-func (m *MockPipelineIndex) CreatePipelineSession(ctx context.Context, tool, branch string) (*store.PipelineSession, error) {
+func (m *MockPipelineIndex) CreatePipelineSession(ctx context.Context, tool, branch, createdBy string) (*store.PipelineSession, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePipelineSession", ctx, tool, branch)
+	ret := m.ctrl.Call(m, "CreatePipelineSession", ctx, tool, branch, createdBy)
 	ret0, _ := ret[0].(*store.PipelineSession)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePipelineSession indicates an expected call of CreatePipelineSession.
-func (mr *MockPipelineIndexMockRecorder) CreatePipelineSession(ctx, tool, branch any) *gomock.Call {
+func (mr *MockPipelineIndexMockRecorder) CreatePipelineSession(ctx, tool, branch, createdBy any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePipelineSession", reflect.TypeOf((*MockPipelineIndex)(nil).CreatePipelineSession), ctx, tool, branch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePipelineSession", reflect.TypeOf((*MockPipelineIndex)(nil).CreatePipelineSession), ctx, tool, branch, createdBy)
 }
 
 // GetPipelineSession mocks base method.

--- a/internal/mcp/review.go
+++ b/internal/mcp/review.go
@@ -85,6 +85,10 @@ func ReviewHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallTo
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
+		// Attribute whatever session this call opens. Harmless on a continue
+		// call, which creates none — the handle is read only by StartSession
+		// (knomit#123).
+		ctx = withActor(ctx, req)
 		reviewer := synthesize.NewReviewerWithOptions(ri, logProgress, effort, scope)
 
 		sessionID := req.GetString("session_id", "")

--- a/internal/mcp/review_actor_wiring_test.go
+++ b/internal/mcp/review_actor_wiring_test.go
@@ -1,0 +1,167 @@
+package mcp
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// This is the wiring test for knomit#123, and it goes through the REAL
+// streamable-HTTP transport on purpose.
+//
+// A test that called actorFromRequest directly would assert that the helper
+// composes a string — not that anything CALLS it, and not that a session id
+// reaches a handler at all. That is the #117a trap this campaign has now hit
+// three times ("a test that calls the helper is not a test of the wiring"). So
+// this drives an `initialize` and a `tools/call` over
+// mcpserver.NewStreamableHTTPServer — the exact construction
+// internal/web/server.go uses — and then reads the pipeline_sessions row the
+// call created.
+//
+// Deleting the `ctx = withActor(ctx, req)` line in ReviewHandler fails this
+// test and nothing else in the suite.
+
+// actorE2E stands up the production MCP HTTP stack over a single repo: the
+// streamable-HTTP server wrapping the real NewServer, behind a middleware that
+// puts the RepoInstance on the request context exactly as web's repo middleware
+// does. Returns the test server and the store so the row can be read back.
+func actorE2E(t *testing.T) (*httptest.Server, *store.Service) {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:         "alpha",
+		AgentBranch:  "agent/test",
+		Svc:          svc,
+		Ontology:     fact.CodeOntology(),
+		OntologyRoot: "kb",
+	})
+
+	mcpHandler := mcpserver.NewStreamableHTTPServer(NewServer("kb", nil, false))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mcpHandler.ServeHTTP(w, r.WithContext(repos.WithRepoInstance(r.Context(), ri)))
+	}))
+	t.Cleanup(ts.Close)
+	return ts, svc
+}
+
+// rpc posts one JSON-RPC message and returns the body plus the response headers.
+func rpc(t *testing.T, ts *httptest.Server, body string, hdrs map[string]string) (string, http.Header) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	for k, v := range hdrs {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return string(b), resp.Header
+}
+
+// startReview runs initialize + a knomit_review start call, and returns the MCP
+// session id the server minted alongside the pipeline session id it opened.
+func startReview(t *testing.T, ts *httptest.Server, clientName, clientVersion string) (mcpSessionID, pipelineSessionID string) {
+	t.Helper()
+
+	initBody := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18",` +
+		`"capabilities":{},"clientInfo":{"name":"` + clientName + `","version":"` + clientVersion + `"}}}`
+	_, hdr := rpc(t, ts, initBody, nil)
+	mcpSessionID = hdr.Get("Mcp-Session-Id")
+	require.NotEmpty(t, mcpSessionID, "the transport must mint a session id at initialize")
+
+	callBody := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"knomit_review","arguments":{}}}`
+	raw, _ := rpc(t, ts, callBody, map[string]string{"Mcp-Session-Id": mcpSessionID})
+
+	// The handler must have RUN. A tools/call rejected by the transport (a
+	// missing or bad session id is rejected before dispatch) returns a bare
+	// error body, and every assertion below would then be comparing absence
+	// against absence.
+	var env struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	require.NoErrorf(t, json.Unmarshal([]byte(raw), &env), "tools/call did not return JSON-RPC: %s", raw)
+	require.NotEmpty(t, env.Result.Content, "tools/call produced no content: %s", raw)
+	require.False(t, env.Result.IsError, "review returned an error: %s", env.Result.Content[0].Text)
+
+	var res struct {
+		SessionID string `json:"session_id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(env.Result.Content[0].Text), &res))
+	require.NotEmpty(t, res.SessionID, "review must report the session it opened: %s", env.Result.Content[0].Text)
+	return mcpSessionID, res.SessionID
+}
+
+// TestReviewHandler_RecordsOpeningCallerOnTheSessionRow: a review session opened
+// over MCP carries the opening call's correlation handle on its
+// pipeline_sessions row — which is the whole of #123. Asserted against the ROW,
+// not against the handler's return value: the row is what a forensic query reads
+// an hour later, and it is the only thing that survives the turn.
+func TestReviewHandler_RecordsOpeningCallerOnTheSessionRow(t *testing.T) {
+	ts, svc := actorE2E(t)
+
+	mcpSessionID, pipelineSessionID := startReview(t, ts, "knomit-actor-e2e", "4.5.6")
+
+	sess, err := svc.Pipeline().GetPipelineSession(t.Context(), pipelineSessionID)
+	require.NoError(t, err)
+	require.NotNil(t, sess, "the session row must exist")
+
+	require.Equal(t,
+		"mcp-session:"+mcpSessionID+" client:knomit-actor-e2e/4.5.6",
+		sess.CreatedBy,
+		"the row must name the caller that opened it")
+}
+
+// The handle must identify THIS caller, not merely be non-empty. Two clients
+// opening two sessions must leave two DIFFERENT handles: an implementation that
+// stamped a constant, or that recorded the process rather than the request,
+// passes the test above and fails this one — and would answer the forensic
+// question confidently and wrongly, which is worse than the blank #123 reports.
+//
+// Two separate servers, because within one repo+tool+branch the second start
+// abandons the first (that is the work-stealing model #123 exists to make
+// legible) and both rows would still be readable but the test would be about
+// displacement rather than attribution.
+func TestReviewHandler_DistinctCallersGetDistinctHandles(t *testing.T) {
+	tsA, svcA := actorE2E(t)
+	tsB, svcB := actorE2E(t)
+
+	mcpA, pipeA := startReview(t, tsA, "client-alpha", "1.0.0")
+	mcpB, pipeB := startReview(t, tsB, "client-beta", "2.0.0")
+	require.NotEqual(t, mcpA, mcpB, "the fixture must present two distinct callers")
+
+	rowA, err := svcA.Pipeline().GetPipelineSession(t.Context(), pipeA)
+	require.NoError(t, err)
+	rowB, err := svcB.Pipeline().GetPipelineSession(t.Context(), pipeB)
+	require.NoError(t, err)
+
+	require.NotEqual(t, rowA.CreatedBy, rowB.CreatedBy, "two callers must not share one handle")
+	require.Contains(t, rowA.CreatedBy, "client:client-alpha/1.0.0")
+	require.Contains(t, rowB.CreatedBy, "client:client-beta/2.0.0")
+	require.Contains(t, rowA.CreatedBy, mcpA)
+	require.Contains(t, rowB.CreatedBy, mcpB)
+}

--- a/internal/mcp/review_actor_wiring_test.go
+++ b/internal/mcp/review_actor_wiring_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -44,11 +45,29 @@ func actorE2E(t *testing.T) (*httptest.Server, *store.Service) {
 	t.Cleanup(func() { _ = svc.Close() })
 	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
 
+	// Seed enough facts to cluster. Without them a start call finds no seeds,
+	// completes the session on the spot, and leaves nothing ACTIVE — which
+	// makes the displacement half of this file untestable and, worse, would
+	// pass vacuously: "no session was displaced" is what an unseeded corpus
+	// produces AND what a broken implementation produces.
+	for _, slug := range []string{"alpha", "beta", "gamma"} {
+		f := fact.NewFact("kb/test/" + slug + ".md")
+		f.Title = slug
+		f.Body = "body of " + slug
+		f.Type = fact.Observation
+		f.Domain = []string{"test"}
+		f.Confidence = 0.5
+		f.Sources = 1
+		body, err := fact.SerializeFact(f)
+		require.NoError(t, err)
+		_, err = svc.Facts().WriteFact(context.Background(), "agent/test", f.Path(), body, "seed", "")
+		require.NoError(t, err)
+	}
+
 	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
 		Name:         "alpha",
 		AgentBranch:  "agent/test",
 		Svc:          svc,
-		Ontology:     fact.CodeOntology(),
 		OntologyRoot: "kb",
 	})
 
@@ -164,4 +183,79 @@ func TestReviewHandler_DistinctCallersGetDistinctHandles(t *testing.T) {
 	require.Contains(t, rowB.CreatedBy, "client:client-beta/2.0.0")
 	require.Contains(t, rowA.CreatedBy, mcpA)
 	require.Contains(t, rowB.CreatedBy, mcpB)
+}
+
+// startReviewEnvelope is startReview's sibling: it returns the whole decoded
+// start envelope rather than just the session id, for assertions about what the
+// winner is TOLD rather than what the row records.
+func startReviewEnvelope(t *testing.T, ts *httptest.Server, clientName, clientVersion string) (mcpSessionID string, env map[string]any) {
+	t.Helper()
+	initBody := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18",` +
+		`"capabilities":{},"clientInfo":{"name":"` + clientName + `","version":"` + clientVersion + `"}}}`
+	_, hdr := rpc(t, ts, initBody, nil)
+	mcpSessionID = hdr.Get("Mcp-Session-Id")
+	require.NotEmpty(t, mcpSessionID)
+
+	callBody := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"knomit_review","arguments":{}}}`
+	raw, _ := rpc(t, ts, callBody, map[string]string{"Mcp-Session-Id": mcpSessionID})
+
+	var rpcEnv struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	require.NoErrorf(t, json.Unmarshal([]byte(raw), &rpcEnv), "tools/call did not return JSON-RPC: %s", raw)
+	require.NotEmpty(t, rpcEnv.Result.Content, "tools/call produced no content: %s", raw)
+	require.False(t, rpcEnv.Result.IsError, "review returned an error: %s", rpcEnv.Result.Content[0].Text)
+
+	require.NoError(t, json.Unmarshal([]byte(rpcEnv.Result.Content[0].Text), &env))
+	require.NotEmpty(t, env["session_id"], "review must report the session it opened")
+	return mcpSessionID, env
+}
+
+// Within one repo+tool+branch there is exactly ONE session, and starting a new
+// one silently displaces whatever was in flight. #113 made the winner's envelope
+// say WHAT it displaced; on its own that is an id with nothing behind it, since
+// the loser's row is reapable and a resuming caller cannot look it up later.
+// This pins the other half: the envelope says WHOSE session it took.
+//
+// Both starts go through the SAME server, because sharing the repo+tool+branch
+// is precisely what makes the second displace the first.
+func TestReviewHandler_EnvelopeNamesWhoWasDisplaced(t *testing.T) {
+	ts, _ := actorE2E(t)
+
+	firstMCP, firstEnv := startReviewEnvelope(t, ts, "the-loser", "1.0.0")
+	// The fixture must actually reach the displacement branch: only an ACTIVE
+	// session gets abandoned, so a first session that completed on the spot
+	// would make every assertion below compare absence against absence.
+	require.NotContains(t, firstEnv, "done",
+		"the first session must still be in flight, or there is nothing to displace")
+	require.Contains(t, firstEnv, "item", "the first session must hold a work item")
+
+	// The first start displaced nothing, so it must say nothing — an
+	// unconditional field would make "displaced someone" indistinguishable
+	// from "went first".
+	require.NotContains(t, firstEnv, "abandoned_session")
+	require.NotContains(t, firstEnv, "abandoned_session_created_by")
+
+	_, secondEnv := startReviewEnvelope(t, ts, "the-winner", "2.0.0")
+
+	require.Equal(t, firstEnv["session_id"], secondEnv["abandoned_session"],
+		"the winner must name the session it displaced")
+	require.Equal(t,
+		"mcp-session:"+firstMCP+" client:the-loser/1.0.0",
+		secondEnv["abandoned_session_created_by"],
+		"and must name WHO opened it — the loser's handle, not the winner's")
+
+	// Explicitly the LOSER's handle and not the winner's. An implementation
+	// that populated the field from the new session rather than the displaced
+	// one produces a well-formed and entirely wrong answer, and the two clients
+	// are named differently here precisely so that answer is distinguishable.
+	displaced, _ := secondEnv["abandoned_session_created_by"].(string)
+	require.Contains(t, displaced, "client:the-loser/1.0.0")
+	require.NotContains(t, displaced, "the-winner",
+		"the displaced handle must not be the displacing caller's own")
 }

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -195,7 +195,7 @@ type ToolSessionIndex interface {
 
 // PipelineIndex is the interface for pipeline session management. Implemented by *pipelineIndex.
 type PipelineIndex interface {
-	CreatePipelineSession(ctx context.Context, tool, branch string) (*PipelineSession, error)
+	CreatePipelineSession(ctx context.Context, tool, branch, createdBy string) (*PipelineSession, error)
 	GetPipelineSession(ctx context.Context, id string) (*PipelineSession, error)
 	MarkPipelineSessionScoped(ctx context.Context, id string) error
 	AdvancePipelineSessionPhase(ctx context.Context, id, from, to string) (advanced bool, err error)

--- a/internal/store/pipeline_index.go
+++ b/internal/store/pipeline_index.go
@@ -41,6 +41,16 @@ type PipelineSession struct {
 	// out only when its next answer was rejected as "not active" — after it had
 	// composed one (knomit#113 / #121 residue).
 	Abandoned string
+	// CreatedBy is the correlation handle for whoever opened this session —
+	// NOT an identity, NOT authentication. See the column comment in
+	// session_schema.sql: over MCP the value derives from a client-supplied,
+	// server-unverified session id, so it records what the opening call SAID,
+	// not who the caller WAS. Empty for in-process callers (knomit#123).
+	//
+	// Unlike Scoped, this is known at insert time, so it rides the INSERT
+	// rather than a follow-up UPDATE: a crash between two writes would leave
+	// exactly the unattributable row this column exists to prevent.
+	CreatedBy string
 	CreatedAt string
 	UpdatedAt string
 }
@@ -122,7 +132,13 @@ func (pi *pipelineIndex) SetPipelineWatermark(ctx context.Context, tool, branch,
 
 // CreatePipelineSession creates a new session for the given tool+branch. Any
 // existing active session for the same tool+branch is abandoned first.
-func (pi *pipelineIndex) CreatePipelineSession(ctx context.Context, tool, branch string) (*PipelineSession, error) {
+//
+// createdBy is recorded verbatim as the session's correlation handle. It is
+// caller-supplied and deliberately unvalidated here — composing and sanitizing
+// it is the request boundary's job (internal/mcp/actor.go), which is the only
+// layer that knows what the claim is made of. Empty is a legitimate value: an
+// in-process caller has no request to attribute to.
+func (pi *pipelineIndex) CreatePipelineSession(ctx context.Context, tool, branch, createdBy string) (*PipelineSession, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	// Own transaction on the session DB. We deliberately do NOT consult any
@@ -163,13 +179,14 @@ func (pi *pipelineIndex) CreatePipelineSession(ctx context.Context, tool, branch
 		Status:    "active",
 		Phase:     "work",
 		Abandoned: abandoned,
+		CreatedBy: createdBy,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
 
 	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO pipeline_sessions(id, tool, branch, status, phase, created_at, updated_at, last_used_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		s.ID, s.Tool, s.Branch, s.Status, s.Phase, s.CreatedAt, s.UpdatedAt, now,
+		`INSERT INTO pipeline_sessions(id, tool, branch, status, phase, created_by, created_at, updated_at, last_used_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.Tool, s.Branch, s.Status, s.Phase, s.CreatedBy, s.CreatedAt, s.UpdatedAt, now,
 	); err != nil {
 		return nil, fmt.Errorf("CreatePipelineSession insert: %w", err)
 	}
@@ -185,11 +202,11 @@ func (pi *pipelineIndex) GetPipelineSession(ctx context.Context, id string) (*Pi
 	var s PipelineSession
 	var scoped int
 	err := pi.sessionDB.QueryRowContext(ctx,
-		`SELECT id, tool, branch, status, phase, scoped,
+		`SELECT id, tool, branch, status, phase, scoped, created_by,
 		        stat_pruned, stat_merged, stat_updated, stat_synthesized,
 		        created_at, updated_at
 		 FROM pipeline_sessions WHERE id = ?`, id,
-	).Scan(&s.ID, &s.Tool, &s.Branch, &s.Status, &s.Phase, &scoped,
+	).Scan(&s.ID, &s.Tool, &s.Branch, &s.Status, &s.Phase, &scoped, &s.CreatedBy,
 		&s.Stats.Pruned, &s.Stats.Merged, &s.Stats.Updated, &s.Stats.Synthesized,
 		&s.CreatedAt, &s.UpdatedAt)
 	if err == sql.ErrNoRows {

--- a/internal/store/pipeline_index.go
+++ b/internal/store/pipeline_index.go
@@ -31,8 +31,9 @@ type PipelineSession struct {
 	// after the turn that produced it.
 	Health []string
 	// Abandoned is the id of the active session this one DISPLACED at creation,
-	// if there was one. IN MEMORY ONLY, like Health, and set by
-	// CreatePipelineSession alone — it describes one moment, not a stored
+	// if there was one, and AbandonedCreatedBy is that session's own
+	// correlation handle. IN MEMORY ONLY, like Health, and set by
+	// CreatePipelineSession alone — they describe one moment, not a stored
 	// property of the row.
 	//
 	// Starting a session abandons any active session for the same tool+branch.
@@ -41,6 +42,13 @@ type PipelineSession struct {
 	// out only when its next answer was rejected as "not active" — after it had
 	// composed one (knomit#113 / #121 residue).
 	Abandoned string
+	// AbandonedCreatedBy carries the displaced session's created_by, read in
+	// the same statement that finds it. The id alone tells the winner THAT it
+	// took someone's slot; the handle tells it WHOSE, which is the answer a
+	// resuming caller actually needs and the only one available from state
+	// (knomit#123). Empty when nothing was displaced, and equally when the
+	// displaced session was opened in-process and carried no handle.
+	AbandonedCreatedBy string
 	// CreatedBy is the correlation handle for whoever opened this session —
 	// NOT an identity, NOT authentication. See the column comment in
 	// session_schema.sql: over MCP the value derives from a client-supplied,
@@ -158,11 +166,11 @@ func (pi *pipelineIndex) CreatePipelineSession(ctx context.Context, tool, branch
 	// continue call is rejected, after spending a turn composing an answer to
 	// an item that no longer exists. Nothing here can notify the loser, so the
 	// least this can do is let the winner's result say what it displaced.
-	var abandoned string
+	var abandoned, abandonedBy string
 	if err := tx.QueryRowContext(ctx,
-		`SELECT id FROM pipeline_sessions WHERE tool = ? AND branch = ? AND status = 'active' LIMIT 1`,
+		`SELECT id, created_by FROM pipeline_sessions WHERE tool = ? AND branch = ? AND status = 'active' LIMIT 1`,
 		tool, branch,
-	).Scan(&abandoned); err != nil && err != sql.ErrNoRows {
+	).Scan(&abandoned, &abandonedBy); err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("CreatePipelineSession find active: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx,
@@ -173,15 +181,16 @@ func (pi *pipelineIndex) CreatePipelineSession(ctx context.Context, tool, branch
 	}
 
 	s := &PipelineSession{
-		ID:        uuid.New().String(),
-		Tool:      tool,
-		Branch:    branch,
-		Status:    "active",
-		Phase:     "work",
-		Abandoned: abandoned,
-		CreatedBy: createdBy,
-		CreatedAt: now,
-		UpdatedAt: now,
+		ID:                 uuid.New().String(),
+		Tool:               tool,
+		Branch:             branch,
+		Status:             "active",
+		Phase:              "work",
+		Abandoned:          abandoned,
+		AbandonedCreatedBy: abandonedBy,
+		CreatedBy:          createdBy,
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}
 
 	if _, err := tx.ExecContext(ctx,

--- a/internal/store/pipeline_index_claim_test.go
+++ b/internal/store/pipeline_index_claim_test.go
@@ -24,7 +24,7 @@ func TestAnswerPipelineWorkItem_ClaimsExactlyOnce(t *testing.T) {
 	pi := svc.Pipeline()
 	ctx := context.Background()
 
-	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test")
+	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test", "")
 	require.NoError(t, err)
 	require.NoError(t, pi.InsertPipelineWorkItem(ctx, PipelineWorkItem{
 		SessionID: sess.ID, StepType: "prune", ClusterKey: "c0", FactsJSON: "[]",
@@ -76,7 +76,7 @@ func TestNextPipelineWorkItem_TiebreakByIDAscending(t *testing.T) {
 	pi := svc.Pipeline()
 	ctx := context.Background()
 
-	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test")
+	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test", "")
 	require.NoError(t, err)
 
 	// Three items at the same priority, plus one strictly higher that must

--- a/internal/store/pipeline_index_phase_test.go
+++ b/internal/store/pipeline_index_phase_test.go
@@ -17,7 +17,7 @@ func TestPipelineSession_PhaseDefault(t *testing.T) {
 	svc := newPhaseTestService(t)
 	pi := svc.Pipeline()
 
-	created, err := pi.CreatePipelineSession(context.Background(), "review", "agent/test")
+	created, err := pi.CreatePipelineSession(context.Background(), "review", "agent/test", "")
 	require.NoError(t, err)
 	require.Equal(t, "work", created.Phase, "new session must start in phase=work")
 
@@ -34,7 +34,7 @@ func TestPipelineSession_AdvancePhase_MatchingFrom(t *testing.T) {
 	pi := svc.Pipeline()
 	ctx := context.Background()
 
-	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test")
+	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test", "")
 	require.NoError(t, err)
 
 	advanced, err := pi.AdvancePipelineSessionPhase(ctx, sess.ID, "work", "reflect")
@@ -61,7 +61,7 @@ func TestPipelineSession_AdvancePhase_NonMatchingFrom(t *testing.T) {
 	pi := svc.Pipeline()
 	ctx := context.Background()
 
-	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test")
+	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test", "")
 	require.NoError(t, err)
 
 	// First caller wins the work -> reflect transition.
@@ -88,7 +88,7 @@ func TestPipelineSession_AdvancePhase_UpdatesTimestamp(t *testing.T) {
 	pi := svc.Pipeline()
 	ctx := context.Background()
 
-	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test")
+	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test", "")
 	require.NoError(t, err)
 	createdTS := sess.UpdatedAt
 

--- a/internal/store/pipeline_index_stats_test.go
+++ b/internal/store/pipeline_index_stats_test.go
@@ -21,7 +21,7 @@ func TestAddPipelineSessionStats_Accumulates(t *testing.T) {
 	pi := svc.Pipeline()
 	ctx := context.Background()
 
-	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test")
+	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test", "")
 	require.NoError(t, err)
 
 	got, err := pi.GetPipelineSession(ctx, sess.ID)
@@ -47,7 +47,7 @@ func TestAddPipelineSessionStats_ConcurrentAddsAllLand(t *testing.T) {
 	pi := svc.Pipeline()
 	ctx := context.Background()
 
-	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test")
+	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test", "")
 	require.NoError(t, err)
 
 	const callers = 8

--- a/internal/store/pipeline_session_created_by_test.go
+++ b/internal/store/pipeline_session_created_by_test.go
@@ -1,0 +1,81 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// pipeline_sessions.created_by (knomit#123) records who opened a session, so
+// that an unexpected session is attributable within its retention window.
+//
+// The fixture below is built to DISCRIMINATE, which for this column means one
+// specific thing: two sessions created with two DIFFERENT handles must come
+// back carrying their OWN handle. Asserting only "the value round-trips" would
+// pass against an implementation that stores the first caller's handle on every
+// row, or that reads the column from the wrong row — both of which produce a
+// non-empty, plausible-looking answer to the forensic question and a wrong one.
+//
+// The two sessions are on DIFFERENT branches on purpose: CreatePipelineSession
+// abandons any active session for the same tool+branch, so two on one branch
+// would leave the first abandoned and make the test about lifecycle instead.
+func TestCreatePipelineSession_CreatedByIsPerRow(t *testing.T) {
+	svc := newPhaseTestService(t)
+	pi := svc.Pipeline()
+	ctx := context.Background()
+
+	const handleA = "mcp-session:aaaa-1111 client:claude-code/1.2.3"
+	const handleB = "mcp-session:bbbb-2222 client:some-other-client/9"
+	require.NotEqual(t, handleA, handleB, "the fixture must be able to tell the two apart")
+
+	a, err := pi.CreatePipelineSession(ctx, "review", "agent/alpha", handleA)
+	require.NoError(t, err)
+	b, err := pi.CreatePipelineSession(ctx, "review", "agent/beta", handleB)
+	require.NoError(t, err)
+	require.NotEqual(t, a.ID, b.ID, "two distinct sessions")
+
+	// The value the constructor hands back.
+	require.Equal(t, handleA, a.CreatedBy)
+	require.Equal(t, handleB, b.CreatedBy)
+
+	// The value that survived to the row — the one a forensic query reads.
+	gotA, err := pi.GetPipelineSession(ctx, a.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotA)
+	gotB, err := pi.GetPipelineSession(ctx, b.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotB)
+
+	require.Equal(t, handleA, gotA.CreatedBy, "session A must carry A's handle, not B's and not the first-written one")
+	require.Equal(t, handleB, gotB.CreatedBy, "session B must carry B's handle")
+
+	// Everything else on the row must be unaffected — the added column must not
+	// have shifted the SELECT's scan order onto the wrong destinations, which is
+	// a failure mode that leaves created_by itself looking perfectly correct.
+	require.Equal(t, "agent/alpha", gotA.Branch)
+	require.Equal(t, "review", gotA.Tool)
+	require.Equal(t, "active", gotA.Status)
+	require.Equal(t, "work", gotA.Phase)
+	require.False(t, gotA.Scoped)
+}
+
+// An in-process caller — a test, or a local tool driving Reviewer directly —
+// has no request to attribute the session to, and passes "". That is a
+// legitimate, reachable state, so it is asserted rather than guarded against:
+// the column is NOT NULL DEFAULT ” and empty means "the opening call carried
+// no handle", never "unknown".
+func TestCreatePipelineSession_EmptyCreatedByRoundTrips(t *testing.T) {
+	svc := newPhaseTestService(t)
+	pi := svc.Pipeline()
+	ctx := context.Background()
+
+	sess, err := pi.CreatePipelineSession(ctx, "review", "agent/test", "")
+	require.NoError(t, err)
+	require.Empty(t, sess.CreatedBy)
+
+	got, err := pi.GetPipelineSession(ctx, sess.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "", got.CreatedBy, "empty must survive as empty, not become a sentinel")
+}

--- a/internal/store/session_db_test.go
+++ b/internal/store/session_db_test.go
@@ -165,7 +165,7 @@ func TestMarkPipelineSessionScoped_SetsFlag(t *testing.T) {
 	svc := openSessionTestStore(t)
 	ctx := context.Background()
 
-	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "hypothesize", "agent/test")
+	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "hypothesize", "agent/test", "")
 	require.NoError(t, err)
 	require.False(t, sess.Scoped, "newly created session must not be scoped")
 

--- a/internal/store/session_schema.sql
+++ b/internal/store/session_schema.sql
@@ -51,6 +51,24 @@ CREATE TABLE pipeline_sessions (
     status       TEXT NOT NULL DEFAULT 'active',
     phase        TEXT NOT NULL DEFAULT 'work',
     scoped       INTEGER NOT NULL DEFAULT 0, -- 1 when session was started with a scope filter
+    -- WHO opened this session, as a CORRELATION HANDLE — emphatically NOT an
+    -- identity and NOT authentication (knomit#123). Over MCP the value derives
+    -- from the caller's own `Mcp-Session-Id` header, which this server does
+    -- not verify: a fabricated id is accepted and runs. The MCP specification
+    -- is explicit that a session id "is not evidence of who the caller is" and
+    -- MUST NOT be treated as authentication. Read this column as "the opening
+    -- call said it was this", never as "this caller was".
+    --
+    -- Scheme-prefixed so the KIND of claim is visible in the value itself:
+    -- `mcp-session:<id>`, plus ` client:<name>/<version>` when the caller ran
+    -- `initialize` against this process. Empty for in-process callers (tests,
+    -- local tools) — honest absence, not "unknown".
+    --
+    -- Its worth is joinability: the same id is logged as `mcp_session` by the
+    -- HTTP slow-request line, so within the idle-reap window
+    -- (pipeline_idle_ttl, 1h) an unexpected session is one query rather than a
+    -- forensic pass over checkpointed DB copies.
+    created_by   TEXT NOT NULL DEFAULT '',
     -- Running work-item stat totals. They live on the row, not in memory, because
     -- the engine is per-call stateless: the MCP handler builds a fresh Reviewer
     -- for every continue call, so nothing accumulated on that struct survives.

--- a/internal/synthesize/actor.go
+++ b/internal/synthesize/actor.go
@@ -1,0 +1,39 @@
+package synthesize
+
+import "context"
+
+// The actor is the correlation handle recorded on a session's row as
+// pipeline_sessions.created_by (knomit#123). It travels on the context because
+// it is request-scoped and read EXACTLY ONCE — at StartSession, next to the
+// branch binding — after which it lives on the row like Branch and Scoped. The
+// alternative, threading it through NewReviewer → NewReviewerWithEffort →
+// NewReviewerWithOptions → NewPipeline and NewHypothesizer, would ripple five
+// constructors and every test call site to deliver a value nothing below
+// StartSession ever reads again.
+//
+// Context is already this codebase's carrier for request-scoped identity
+// (repos.BindingFromContext, obs/reqinfo.FromContext); this is the same shape.
+// It stops at the engine boundary on purpose: the store takes createdBy as an
+// explicit parameter, so nothing below Pipeline reaches into a context for it.
+//
+// What the value MEANS — that it is client-supplied and unverified, and must
+// never be read as authentication — is documented at the two ends that own it:
+// the schema column comment and internal/mcp/actor.go, which composes it.
+
+type actorKey struct{}
+
+// WithActor returns a context carrying the correlation handle for whoever is
+// making this request. Set at the MCP request boundary; read by
+// Pipeline.StartSession.
+func WithActor(ctx context.Context, actor string) context.Context {
+	return context.WithValue(ctx, actorKey{}, actor)
+}
+
+// actorFromContext returns the handle WithActor stored, or "" when there is
+// none. Empty is a legitimate, reachable answer — every in-process caller
+// (tests, local tools driving Reviewer directly) has no request to attribute
+// to — so this deliberately has no "unknown" sentinel and no error.
+func actorFromContext(ctx context.Context) string {
+	actor, _ := ctx.Value(actorKey{}).(string)
+	return actor
+}

--- a/internal/synthesize/backfill_refusals_test.go
+++ b/internal/synthesize/backfill_refusals_test.go
@@ -33,7 +33,7 @@ func TestApplyMotifBackfill_RefusedNameReachesTheAgent(t *testing.T) {
 	d := env.deps()
 	env.writeFact("kb/a.md", "A", "body a")
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 
 	// Five hyphen segments — the validator counts segments, not concepts, and
@@ -65,7 +65,7 @@ func TestApplyMotifBackfill_ValidAssignmentProducesNoNotice(t *testing.T) {
 	d := env.deps()
 	env.writeFact("kb/a.md", "A", "body a")
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 
 	res := motifBackfillResult{Assignments: []motifAssignment{
@@ -99,7 +99,7 @@ func TestApplyMotifBackfill_SubjectStripIsReportedAsItsOwnCase(t *testing.T) {
 	// is an instance of.
 	env.writeFact("kb/widget/cache.md", "Cache", "body a")
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 
 	res := motifBackfillResult{Assignments: []motifAssignment{
@@ -130,7 +130,7 @@ func TestContinueSession_BackfillRefusalReachesTheCaller(t *testing.T) {
 	env := newRestatementEnv(t, 0)
 	env.writeFact("kb/a.md", "A", "body a")
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 
 	offered := offeredBackfillForTest(t, ctx, env)
@@ -169,7 +169,7 @@ func TestContinueSession_BackfillRefusalReachesTheCaller(t *testing.T) {
 // applyMotifBackfill directly and do not read its notices.
 func sessionForBackfillTest(t *testing.T, ctx context.Context, env *restatementEnv) *store.PipelineSession {
 	t.Helper()
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	return sess
 }

--- a/internal/synthesize/decision_reflect_test.go
+++ b/internal/synthesize/decision_reflect_test.go
@@ -277,7 +277,7 @@ func newReflectTestEnv(t *testing.T) (*store.Service, *store.PipelineSession) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = svc.Close() })
 	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
-	sess, err := svc.Pipeline().CreatePipelineSession(context.Background(), "review", "agent/test")
+	sess, err := svc.Pipeline().CreatePipelineSession(context.Background(), "review", "agent/test", "")
 	require.NoError(t, err)
 	return svc, sess
 }

--- a/internal/synthesize/hypothesize_engine_test.go
+++ b/internal/synthesize/hypothesize_engine_test.go
@@ -239,7 +239,7 @@ func TestHypothesizer_DiscoverParseFailure_NonFatal(t *testing.T) {
 	svc, ri := newHypothesizeTestRepo(t)
 	ctx := context.Background()
 
-	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "hypothesize", "agent/test")
+	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "hypothesize", "agent/test", "")
 	require.NoError(t, err)
 	insertManualDiscoverItem(t, svc, sess.ID)
 
@@ -279,7 +279,7 @@ func TestHypothesizer_ConcurrentDiscoverSubmission_WritesOnce(t *testing.T) {
 	svc, ri := newHypothesizeTestRepo(t)
 	ctx := context.Background()
 
-	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "hypothesize", "agent/test")
+	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "hypothesize", "agent/test", "")
 	require.NoError(t, err)
 	insertManualDiscoverItem(t, svc, sess.ID)
 

--- a/internal/synthesize/identity_test.go
+++ b/internal/synthesize/identity_test.go
@@ -201,7 +201,7 @@ func TestStructural_ReachesTheJudge(t *testing.T) {
 	})
 
 	d := env.deps()
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planRestatementShortlist(ctx, d, sess, env.branch, nil))
 

--- a/internal/synthesize/inflight_test.go
+++ b/internal/synthesize/inflight_test.go
@@ -37,7 +37,7 @@ func newInflightEnv(t *testing.T) *inflightEnv {
 	env := newRestatementEnv(t, maxBackfillFacts+4)
 	env.writeFact(dupAPath, "SmartConsole bypass", "one recording of the event")
 	env.writeFact(dupBPath, "SmartConsole bypass, again", "the same event, second category")
-	sess, err := env.svc.Pipeline().CreatePipelineSession(context.Background(), reviewTool, env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(context.Background(), reviewTool, env.branch, "")
 	require.NoError(t, err)
 	return &inflightEnv{restatementEnv: env, sess: sess}
 }

--- a/internal/synthesize/motif_alias_judge_test.go
+++ b/internal/synthesize/motif_alias_judge_test.go
@@ -176,7 +176,7 @@ func TestMotifAliasDecode_WrongEnvelopeKeyIsLoud(t *testing.T) {
 // regressing.
 func TestMotifAliasHealth_CoexistsWithRestatementLines(t *testing.T) {
 	env := motifVocabEnv(t, minJudgeVocabulary+4)
-	sess, err := env.svc.Pipeline().CreatePipelineSession(context.Background(), "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(context.Background(), "review", env.branch, "")
 	require.NoError(t, err)
 
 	recordRestatementHealth(sess, restatementHealth{StandingPairs: 7})
@@ -196,7 +196,7 @@ func TestMotifAliasHealth_CoexistsWithRestatementLines(t *testing.T) {
 // to stay distinguishable, which is the whole reason these descriptors exist.
 func TestMotifAliasHealth_BelowFloorIsReported(t *testing.T) {
 	env := motifVocabEnv(t, minJudgeVocabulary-1)
-	sess, err := env.svc.Pipeline().CreatePipelineSession(context.Background(), "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(context.Background(), "review", env.branch, "")
 	require.NoError(t, err)
 
 	require.NoError(t, planMotifAliasWork(context.Background(), env.deps(), sess, env.branch))
@@ -211,7 +211,7 @@ func TestMotifAliasHealth_BelowFloorIsReported(t *testing.T) {
 func TestMotifAliasWorkItem_PayloadCarriesTitlesForBothSides(t *testing.T) {
 	ctx := context.Background()
 	env := motifVocabEnv(t, minJudgeVocabulary+4)
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planMotifAliasWork(ctx, env.deps(), sess, env.branch))
 
@@ -235,7 +235,7 @@ func TestMotifAliasWorkItem_PayloadCarriesTitlesForBothSides(t *testing.T) {
 func TestMotifAliasWorkItem_OneItemPerSession(t *testing.T) {
 	ctx := context.Background()
 	env := motifVocabEnv(t, minJudgeVocabulary+6)
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planMotifAliasWork(ctx, env.deps(), sess, env.branch))
 

--- a/internal/synthesize/motif_backfill_test.go
+++ b/internal/synthesize/motif_backfill_test.go
@@ -238,7 +238,7 @@ func TestBackfillHealth_ReportsCoverage(t *testing.T) {
 	env.writeFact("kb/b.md", "Bravo", "body")
 	require.NoError(t, env.svc.Motifs().RebuildAliases(ctx, env.branch))
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	sess.Health = []string{"another producer's line"}
 	require.NoError(t, planMotifBackfillWork(ctx, env.deps(), sess, env.branch))
@@ -258,7 +258,7 @@ func TestBackfillWorkItem_PayloadCarriesVocabularyAndResidue(t *testing.T) {
 	env.writeFact("kb/target.md", "Target exhausts under retry storms", "body")
 	require.NoError(t, env.svc.Motifs().RebuildAliases(ctx, env.branch))
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planMotifBackfillWork(ctx, env.deps(), sess, env.branch))
 

--- a/internal/synthesize/motif_define_test.go
+++ b/internal/synthesize/motif_define_test.go
@@ -19,7 +19,7 @@ import (
 func TestMotifDefine_PayloadCarriesNoCarrierContent(t *testing.T) {
 	ctx := context.Background()
 	env := motifVocabEnv(t, 4)
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planMotifDefineWork(ctx, env.deps(), sess, env.branch))
 
@@ -212,7 +212,7 @@ func TestMotifDefine_RegisterRejectsCarrierEntityNames(t *testing.T) {
 
 	// The blindness guard is what makes this achievable: the payload never
 	// carried "Postgres", so a compliant writer could not have used it.
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planMotifDefineWork(ctx, env.deps(), sess, env.branch))
 	item, err := env.svc.Pipeline().NextPipelineWorkItem(ctx, sess.ID)
@@ -285,7 +285,7 @@ func TestMotifVocabulary_ReachesTheHealthLines(t *testing.T) {
 	env.writeFactWithMotifs("kb/b.md", "B", "body", []string{"silent-fallback"})
 	require.NoError(t, env.svc.Motifs().RebuildAliases(ctx, env.branch))
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	sess.Health = []string{"a line from another producer"}
 	require.NoError(t, planMotifDefineWork(ctx, env.deps(), sess, env.branch))

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -125,14 +125,21 @@ func (p *Pipeline) deps() Deps {
 // This is the ONLY place the engine reads ri.AgentBranch(). The value becomes
 // sess.Branch and travels with the session for the rest of its lifetime; every
 // method below reads it back off the row
-// (invariants/synthesize/session-branch-binding).
+// (invariants/synthesize/session-branch-binding). The caller's correlation
+// handle is bound at the same moment and for the same reason — see actor.go.
 func (p *Pipeline) StartSession(ctx context.Context) (*PipelineResult, error) {
 	tool := p.strategy.Tool()
 	totalStart := time.Now()
 	d := p.deps()
 	branch := p.ri.AgentBranch()
+	// Read ONCE, here, for the same reason the branch is: the value describes
+	// the call that opened the session, and the MCP handler builds a fresh
+	// engine per continue call, so a later read would see a different request
+	// (or none). It goes onto the row and is never read from the context again
+	// (knomit#123). Empty is normal for in-process callers.
+	actor := actorFromContext(ctx)
 
-	sess, err := d.Pipeline.CreatePipelineSession(ctx, tool, branch)
+	sess, err := d.Pipeline.CreatePipelineSession(ctx, tool, branch, actor)
 	if err != nil {
 		return nil, wrapf(tool, err, "create session")
 	}

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -232,6 +232,7 @@ func (p *Pipeline) stampIdentity(res *PipelineResult, sess *store.PipelineSessio
 	res.RepoID = p.ri.ID()
 	res.WriteBranch = sess.Branch
 	res.AbandonedSession = sess.Abandoned
+	res.AbandonedSessionCreatedBy = sess.AbandonedCreatedBy
 }
 
 // ContinueSession processes the model's response for the current work item and

--- a/internal/synthesize/restatement_certainty_test.go
+++ b/internal/synthesize/restatement_certainty_test.go
@@ -104,7 +104,7 @@ func TestShortlist_CertainDuplicatesAreEnqueuedForTheJudge(t *testing.T) {
 	certainPairIsAboveTheFloor(t, env)
 
 	d := env.deps()
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planRestatementShortlist(ctx, d, sess, env.branch, nil))
 
@@ -126,7 +126,7 @@ func TestShortlist_CoClusteredCertainDuplicatesAreNotEnqueued(t *testing.T) {
 	certainPairIsAboveTheFloor(t, env)
 
 	d := env.deps()
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
 	require.NoError(t, err)
 	coClustered := [][]factForLLM{{
 		{File: certainAPath}, {File: certainBPath},

--- a/internal/synthesize/restatement_emission_honesty_test.go
+++ b/internal/synthesize/restatement_emission_honesty_test.go
@@ -26,7 +26,7 @@ func TestEnqueueRestatementItems_DropsAreCountedAndReported(t *testing.T) {
 	ctx := context.Background()
 	env := newRestatementEnv(t, 3)
 	d := env.deps()
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 
 	ids := env.factIDs()
@@ -115,7 +115,7 @@ func TestPlanRestatementShortlist_HealthEmittedMatchesTheQueue(t *testing.T) {
 	// NON-ZERO and the equality means something).
 	env := newRestatementEnv(t, 400)
 	env.seedShortlist()
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 
 	// Both ranked above anything the corpus produced on its own, so selection

--- a/internal/synthesize/restatement_test.go
+++ b/internal/synthesize/restatement_test.go
@@ -556,7 +556,7 @@ func TestApply_AttributesOnlyShortlistVerdicts(t *testing.T) {
 	}
 
 	d := env.deps()
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 	env.seedShortlist()
 
@@ -628,7 +628,7 @@ func TestApply_SkipsVerdictWhenAnEndpointIsAlreadyGone(t *testing.T) {
 	ctx := context.Background()
 	env := newRestatementEnv(t, 4)
 	d := env.deps()
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, "review", env.branch, "")
 	require.NoError(t, err)
 
 	item := &store.PipelineWorkItem{

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -167,14 +167,15 @@ func reviewResultPage(res *PipelineResult, page int) (*ReviewResult, error) {
 		// Identity and displacement cross the engine→wire boundary here. The
 		// engine struct is the source of a copy; this projection is what a
 		// client actually receives (knomit#113).
-		Repo:             res.Repo,
-		RepoID:           res.RepoID,
-		WriteBranch:      res.WriteBranch,
-		AbandonedSession: res.AbandonedSession,
-		Done:             res.Done,
-		Summary:          res.Summary,
-		Progress:         res.Progress,
-		Health:           res.Health,
+		Repo:                      res.Repo,
+		RepoID:                    res.RepoID,
+		WriteBranch:               res.WriteBranch,
+		AbandonedSession:          res.AbandonedSession,
+		AbandonedSessionCreatedBy: res.AbandonedSessionCreatedBy,
+		Done:                      res.Done,
+		Summary:                   res.Summary,
+		Progress:                  res.Progress,
+		Health:                    res.Health,
 	}
 	if res.Item == nil {
 		return out, nil

--- a/internal/synthesize/review_phase_test.go
+++ b/internal/synthesize/review_phase_test.go
@@ -349,7 +349,7 @@ func newPhaseTestReviewer(t *testing.T) (*Reviewer, *store.Service) {
 // that just want to exercise the dispatcher).
 func manualSession(t *testing.T, svc *store.Service, branch string) *store.PipelineSession {
 	t.Helper()
-	sess, err := svc.Pipeline().CreatePipelineSession(context.Background(), "review", branch)
+	sess, err := svc.Pipeline().CreatePipelineSession(context.Background(), "review", branch, "")
 	require.NoError(t, err)
 	return sess
 }

--- a/internal/synthesize/sources_pooling_test.go
+++ b/internal/synthesize/sources_pooling_test.go
@@ -200,7 +200,7 @@ func TestApplyReflectDecisions_ProposeSourcesIsOne(t *testing.T) {
 	seedFactWithSources(t, svc, branch, "kb/technology/a.md", 2)
 	seedFactWithSources(t, svc, branch, "kb/technology/b.md", 3)
 
-	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "review", branch)
+	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "review", branch, "")
 	require.NoError(t, err)
 
 	result := ReflectResult{Propose: []ProposeEntry{{

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -209,8 +209,12 @@ type PipelineResult struct {
 	// any (the #121 residue). Starting a session abandons any active session
 	// for the same tool+branch, and that was invisible on both sides.
 	AbandonedSession string
-	Item             *PipelineItem
-	Done             bool
+	// AbandonedSessionCreatedBy is the displaced session's correlation handle
+	// — WHOSE slot this one took, not merely that it took one (knomit#123).
+	// Empty when nothing was displaced or when the loser carried no handle.
+	AbandonedSessionCreatedBy string
+	Item                      *PipelineItem
+	Done                      bool
 	// Summary is populated only on the completing turn. It reuses ReviewStats
 	// because that is the type already on the wire and in the session row;
 	// the name is review-flavoured but the counters are not.

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -283,11 +283,17 @@ type ReviewResult struct {
 	// slot, and the loser found out only when its next answer was rejected as
 	// "not active" — after composing one. Nothing can notify the loser; this
 	// lets the winner's result say what it displaced.
-	AbandonedSession string          `json:"abandoned_session,omitempty"`
-	Item             *ReviewItem     `json:"item,omitempty"`
-	Done             bool            `json:"done,omitempty"`
-	Summary          *ReviewStats    `json:"summary,omitempty"`
-	Progress         *ReviewProgress `json:"progress,omitempty"`
+	AbandonedSession string `json:"abandoned_session,omitempty"`
+	// AbandonedSessionCreatedBy names WHO opened the session this one
+	// displaced. `abandoned_session` alone is an id with nothing behind it —
+	// the loser's row is reapable and a resuming caller cannot look it up
+	// later. Read it as a correlation handle, not an identity: see the
+	// created_by column comment (knomit#123).
+	AbandonedSessionCreatedBy string          `json:"abandoned_session_created_by,omitempty"`
+	Item                      *ReviewItem     `json:"item,omitempty"`
+	Done                      bool            `json:"done,omitempty"`
+	Summary                   *ReviewStats    `json:"summary,omitempty"`
+	Progress                  *ReviewProgress `json:"progress,omitempty"`
 	// Health carries corpus-health descriptors for this session. Read by the
 	// agent, by nothing in the engine.
 	Health []string `json:"health,omitempty"`


### PR DESCRIPTION
Adds a created_by column to pipeline_sessions (ephemeral session DB, no migration) and names who a displaced session belonged to in the review envelope. Records a CORRELATION HANDLE (mcp-session:<id> [+ client:<name>/<ver>]), NOT an attested identity — the MCP session id is client-supplied and unverified, per invariant continuity-mistaken-for-identity. Sanitized + capped (actorMaxLen=128, a defensive bound on untrusted bytes).

Cold-reviewed clean (fresh Opus, isolated worktree): no HIGH/MED/LOW. The identity-honesty question resolved clean — no consumer branches on created_by, honesty is in the value + the scheme prefix + clause-forgery prevention. All sabotages reproduced on their unique tests, MN5 intact at both commits, MN13 clean, bisectable, no migration.

Closes #123.