### PR TITLE
fix(test): pass createdBy at #117b's CreatePipelineSession call sites (dev-compile hotfix)

### DIFF
--- a/internal/synthesize/restatement_dynamics_test.go
+++ b/internal/synthesize/restatement_dynamics_test.go
@@ -182,7 +182,7 @@ func TestDynamics_DefundAndProbeRecoveryOverSessions(t *testing.T) {
 	probed := 0
 	var probeA, probeB string
 	for range throttleProbeInterval + 1 {
-		sess, serr := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+		sess, serr := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
 		require.NoError(t, serr)
 		require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
 		items := env.workItems(sess.ID)

--- a/internal/synthesize/restatement_throttle_honesty_test.go
+++ b/internal/synthesize/restatement_throttle_honesty_test.go
@@ -115,7 +115,7 @@ func TestHealthLine_ThrottleDenominatorIsWhatWasActuallyJudged(t *testing.T) {
 	env := newRestatementEnv(t, 600)
 	env.seedShortlist()
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
 
@@ -138,7 +138,7 @@ func TestHealthLine_ThrottleDenominatorIsWhatWasActuallyJudged(t *testing.T) {
 		env.recordVerdict(pairs[i].APath, pairs[i].BPath, false)
 	}
 
-	sess2, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	sess2, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess2, env.branch, nil))
 	require.Contains(t, throttleHealthLine(sess2), fmt.Sprintf("over last %d judged", judged))
@@ -181,7 +181,7 @@ func TestProbe_IsNotConsumedWhenTheSelectedPairIsNeverServed(t *testing.T) {
 	// unservable pair; it must NOT be recorded as having probed.
 	dropped := 0
 	for range throttleProbeInterval {
-		sess, serr := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+		sess, serr := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
 		require.NoError(t, serr)
 		require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
 		require.Empty(t, env.workItems(sess.ID), "nothing servable can reach the queue")
@@ -208,7 +208,7 @@ func TestProbe_IsNotConsumedWhenTheSelectedPairIsNeverServed(t *testing.T) {
 			TitleCos: 0.9999,
 		}}, nil))
 
-	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch)
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
 	require.NoError(t, err)
 	require.NoError(t, planRestatementShortlist(ctx, env.deps(), sess, env.branch, nil))
 	require.True(t, healthLineSaysProbing(sess),


### PR DESCRIPTION
SEMANTIC MERGE CONFLICT repair. #123 added a createdBy parameter to CreatePipelineSession and swept every call site on its branch; #117b (merged first) added five new call sites its sweep could not have seen. Both PRs were green on their own bases and merged cleanly at the text level, but the combined dev did not compile — 'not enough arguments in call to CreatePipelineSession' in two _test.go files, which made go test ./internal/synthesize/ unrunnable. Five lines, each now passing "" for createdBy as every other test call site does. go vet clean; synthesize + store packages both green. MN5 untouched. The class is caught only by building the MERGE RESULT (go vet, since go build ignores _test.go), not either branch — recorded in kb/meta/methodology/build-the-merge-result.