### PR TITLE
Decouple repo creation from the HTTP request (202 + poll)

### DIFF
--- a/internal/repos/create_job.go
+++ b/internal/repos/create_job.go
@@ -1,0 +1,304 @@
+package repos
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/segmentio/ksuid"
+)
+
+// DefaultCreateTimeout bounds a detached create's total wall-clock.
+//
+// CLASSIFICATION (MN13): an OPERATIONAL BOUND, not a corpus property. It
+// measures nothing about any repository's content or distribution — it is the
+// wall-clock ceiling on one operation, set so a create that has stopped making
+// progress cannot hold a name reservation forever. Deps.CreateTimeout
+// overrides it, which is how the timeout path is testable in milliseconds
+// rather than in half-hours.
+//
+// Deliberately far LOOSER than cfg.Git.NetworkTimeout (120s default), which
+// already bounds each individual git network operation. This is the backstop
+// for everything that timeout does not cover — a large clone's local indexing,
+// an ontology write, a wedged SQLite handle — so it must not fire on a
+// legitimately slow but progressing create.
+const DefaultCreateTimeout = 30 * time.Minute
+
+// CreateJobTTL is how long a FINISHED job stays readable before it is reaped.
+//
+// CLASSIFICATION (MN13): an OPERATIONAL BOUND on retention, not a corpus
+// property. It exists to outlive a realistic client reconnect window: the
+// whole point of a detached create is that the client which started it may be
+// gone when it ends, so the terminal outcome has to still be there when that
+// client (or another) comes back to ask. An hour covers a closed laptop lid.
+// It is deliberately NOT a durability guarantee — the job record is a
+// courtesy, and the authoritative answer to "does this repo exist" is always
+// the registry.
+const CreateJobTTL = time.Hour
+
+// CreateState is the lifecycle state of a detached create.
+//
+// Terminal states are CreateDone and CreateFailed. There is no separate
+// "timed out" state: a create that exceeds its deadline is a create that
+// failed, and its error says so — see CreateStatus.TimedOut, which is derived
+// from that error rather than tracked alongside it, so the two cannot
+// disagree.
+type CreateState string
+
+const (
+	// CreateRunning is the only non-terminal state.
+	CreateRunning CreateState = "running"
+	// CreateDone means the repo exists and is registered.
+	CreateDone CreateState = "done"
+	// CreateFailed means the repo does NOT exist: Create rolled back its
+	// partial database and its registry row before returning. This is the
+	// legible terminal state the #67 ruling asks for — "the repo is not
+	// there, and here is why" — rather than a registry row pointing at a
+	// half-written file.
+	CreateFailed CreateState = "failed"
+)
+
+// CreateStatus is an immutable snapshot of a CreateJob, safe to read from any
+// goroutine at any time, running or finished. It is what a polling client
+// sees.
+type CreateStatus struct {
+	ID    string
+	Name  string
+	Mode  string
+	State CreateState
+
+	// Step/Message/Pct are the most recent progress report. They are a
+	// LATEST-VALUE snapshot, not a stream: a poll arriving between two steps
+	// sees the earlier one, and a poll arriving after three sees only the
+	// third. Nothing downstream needs the intermediate ones.
+	Step    string
+	Message string
+	Pct     int
+
+	// Err is nil unless State is CreateFailed.
+	Err error
+	// TimedOut reports whether the failure was the create's own deadline
+	// expiring rather than a create error.
+	TimedOut bool
+
+	StartedAt  time.Time
+	FinishedAt time.Time
+}
+
+// CreateJob is a repo create running DETACHED from whatever asked for it.
+//
+// The ownership boundary is the whole point of this type. The work runs on a
+// context derived from the MANAGER's lifetime with the manager's create
+// deadline — never on an HTTP request's context — so a client that
+// disconnects, or never polls again, changes nothing about whether the repo
+// gets created. Callers OBSERVE a job; they do not own it.
+//
+// Bounded on purpose, and NOT fire-and-forget: the deadline guarantees every
+// job reaches a terminal state, so a wedged create surfaces as a failure
+// rather than an eternal "creating…".
+//
+// Progress is a mutex-guarded latest value rather than a channel, and that is
+// deliberate. A channel needs a consumer, and the consumer here is exactly the
+// thing that is allowed to vanish; a bounded channel with no reader eventually
+// blocks its sender, parking the create goroutine forever and reproducing
+// 'transient-state-becomes-permanent' — the incident's own motif — in a new
+// place. A latest-value field cannot block, so that failure mode is designed
+// out rather than guarded against.
+type CreateJob struct {
+	id   string
+	name string
+	mode string
+
+	done chan struct{}
+
+	startedAt time.Time
+
+	mu         sync.Mutex
+	state      CreateState
+	step       string
+	message    string
+	pct        int
+	ri         *RepoInstance
+	err        error
+	timedOut   bool
+	finishedAt time.Time
+}
+
+// ID returns the job's identifier, minted at start. It is what a client holds
+// on to across a disconnect.
+func (j *CreateJob) ID() string { return j.id }
+
+// Done is closed when the job reaches a terminal state.
+func (j *CreateJob) Done() <-chan struct{} { return j.done }
+
+// Result returns the terminal outcome, blocking until the job finishes.
+// Callers that must not block poll Status instead.
+func (j *CreateJob) Result() (*RepoInstance, error) {
+	<-j.done
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.ri, j.err
+}
+
+// Status snapshots the job without blocking.
+func (j *CreateJob) Status() CreateStatus {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return CreateStatus{
+		ID:         j.id,
+		Name:       j.name,
+		Mode:       j.mode,
+		State:      j.state,
+		Step:       j.step,
+		Message:    j.message,
+		Pct:        j.pct,
+		Err:        j.err,
+		TimedOut:   j.timedOut,
+		StartedAt:  j.startedAt,
+		FinishedAt: j.finishedAt,
+	}
+}
+
+// record is the emit callback handed to Create. It overwrites the latest
+// progress value and returns immediately — there is no consumer to wait for.
+func (j *CreateJob) record(e Event) {
+	j.mu.Lock()
+	j.step, j.message, j.pct = e.Step, e.Message, e.Pct
+	j.mu.Unlock()
+}
+
+// finish records the terminal outcome and releases every waiter.
+func (j *CreateJob) finish(ri *RepoInstance, err error, timedOut bool) {
+	j.mu.Lock()
+	j.ri, j.err, j.timedOut = ri, err, timedOut
+	j.finishedAt = time.Now().UTC()
+	if err != nil {
+		j.state = CreateFailed
+	} else {
+		j.state = CreateDone
+	}
+	j.mu.Unlock()
+	close(j.done)
+}
+
+// createTimeout is the manager's configured create deadline, or the package
+// default when unset.
+func (m *Manager) createTimeout() time.Duration {
+	if d := m.deps.CreateTimeout; d > 0 {
+		return d
+	}
+	return DefaultCreateTimeout
+}
+
+// CreateJobByID returns a create job by id. The second result is false for an
+// id that never existed AND for one whose job has aged past CreateJobTTL — the
+// two are deliberately indistinguishable, because a client cannot act
+// differently on them and the registry answers "does this repo exist" either
+// way.
+func (m *Manager) CreateJobByID(id string) (*CreateJob, bool) {
+	m.createJobsMu.Lock()
+	defer m.createJobsMu.Unlock()
+	j, ok := m.createJobs[id]
+	return j, ok
+}
+
+// reapCreateJobsLocked drops FINISHED jobs older than CreateJobTTL. A running
+// job is never reaped however long it runs — its own deadline is what bounds
+// it, and dropping a live job would lose the outcome a client is waiting for.
+//
+// Called from the registration path rather than a ticker: the map only grows
+// when a create starts, so sweeping there bounds it without another goroutine
+// to start, stop, and race against Close. Callers must hold createJobsMu.
+func (m *Manager) reapCreateJobsLocked(now time.Time) {
+	for id, j := range m.createJobs {
+		st := j.Status()
+		if st.State == CreateRunning {
+			continue
+		}
+		if now.Sub(st.FinishedAt) > CreateJobTTL {
+			delete(m.createJobs, id)
+		}
+	}
+}
+
+// StartCreate runs a repo create DETACHED from the caller and returns
+// immediately with a handle to observe it.
+//
+// The work runs on context.WithTimeout(m.ctx, …) — parented to the MANAGER,
+// not to the caller. This is the fix for issue #67: the HTTP handler used to
+// pass r.Context() into Create, which made a repo's creation the property of
+// the request that asked for it. A client that closed its tab cancelled the
+// create at its next step boundary, discarding a clone that may already have
+// completed; and nothing bounded a create that simply never progressed.
+//
+// Note the signature: there is NO ctx parameter. That is not an oversight and
+// should not be "fixed" — a context parameter here is an invitation to pass
+// the request's, which is the bug.
+//
+// BOUNDED, not fire-and-forget. Every job ends: either Create returns, or the
+// deadline expires and Create's own step-boundary checks unwind it through
+// cleanup(), removing the partial .db and the registry row. Both outcomes are
+// terminal, both are recorded on the job, and both are LOGGED — the log line
+// matters precisely because the client that asked may no longer be there to
+// read the status.
+//
+// WHAT THIS MUST NEVER TOUCH: the background index heal. Manager.Add → openOne
+// takes no context at all; the builder reads m.ctx, from which indexCtx is
+// derived (builder.go). The create deadline is therefore NOT an ancestor of
+// indexCtx, and cancelling it — including the defer cancel() below, which
+// fires the instant Create returns — cannot stop a heal that is still running.
+// Threading this context into openOne would reinstate incident
+// kb/incidents/repos/clone-create-index-stuck-indexing: a cancelled heal
+// returns without markIndexReady/markIndexFailed and pins IndexStatus at
+// 'indexing' forever. Guarded by
+// TestStartCreate_JobDeadlineDoesNotPinTheIndexAtIndexing.
+func (m *Manager) StartCreate(spec CreateSpec) *CreateJob {
+	now := time.Now().UTC()
+	j := &CreateJob{
+		id:        ksuid.New().String(),
+		name:      spec.Name,
+		mode:      spec.Mode,
+		done:      make(chan struct{}),
+		startedAt: now,
+		state:     CreateRunning,
+	}
+
+	m.createJobsMu.Lock()
+	if m.createJobs == nil {
+		m.createJobs = make(map[string]*CreateJob)
+	}
+	m.reapCreateJobsLocked(now)
+	m.createJobs[j.id] = j
+	m.createJobsMu.Unlock()
+
+	timeout := m.createTimeout()
+
+	go func() {
+		// Parented to the manager, never to a request; cancelled on the way
+		// out so the timer is released rather than left to fire.
+		ctx, cancel := context.WithTimeout(m.ctx, timeout)
+		defer cancel()
+
+		ri, err := m.Create(ctx, spec, j.record)
+		timedOut := err != nil && errors.Is(err, context.DeadlineExceeded)
+
+		switch {
+		case timedOut:
+			log.Error().Str("repo", spec.Name).Str("mode", spec.Mode).
+				Str("create_id", j.id).Dur("timeout", timeout).
+				Msg("repo create exceeded its deadline; partial repo rolled back")
+		case err != nil:
+			log.Error().Err(err).Str("repo", spec.Name).Str("mode", spec.Mode).
+				Str("create_id", j.id).Msg("repo create failed; partial repo rolled back")
+		default:
+			log.Info().Str("repo", spec.Name).Str("mode", spec.Mode).
+				Str("create_id", j.id).Msg("repo create finished")
+		}
+
+		j.finish(ri, err, timedOut)
+	}()
+
+	return j
+}

--- a/internal/repos/create_job_test.go
+++ b/internal/repos/create_job_test.go
@@ -1,0 +1,174 @@
+package repos
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/config"
+)
+
+// TestStartCreate_DeadlineRollsBackToTerminalState pins requirement (2) of the
+// #67 ruling: on TIMEOUT the repo must land in a legible TERMINAL state, not
+// half-created limbo.
+//
+// The deadline is already expired when the worker goroutine starts, so Create
+// unwinds at its first step boundary — deterministically, with no sleeping and
+// no race. What the test then asserts is that the unwind is COMPLETE: the
+// registry row Create inserts before that boundary is gone, no database file
+// survives under repos/, and the name is free again. A create that failed but
+// left any of those behind is precisely the limbo the ruling forbids.
+func TestStartCreate_DeadlineRollsBackToTerminalState(t *testing.T) {
+	home := t.TempDir()
+	m := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: home},
+		AgentBranch: "machine/test",
+		// Already expired by the time the goroutine runs.
+		CreateTimeout: time.Nanosecond,
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+
+	job := m.StartCreate(CreateSpec{Name: "work", Mode: "preset", OntologyPreset: "default"})
+	ri, err := job.Result()
+	require.Nil(t, ri)
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"a create that outruns its own deadline must fail WITH the deadline error")
+
+	st := job.Status()
+	require.Equal(t, CreateFailed, st.State)
+	require.True(t, st.TimedOut, "the failure must be attributable to the deadline, not merely to 'an error'")
+	require.False(t, st.FinishedAt.IsZero(), "a terminal job must carry when it became terminal")
+
+	// The three faces of "terminal, not limbo" — all three, because each one
+	// alone is survivable by a different half-rollback. A registry row with no
+	// file reports as a MISSING repo offering to rehydrate itself; a file with
+	// no row is an orphan; and a live map entry is a repo the API will serve.
+	require.Nil(t, m.Get("work"), "the failed name must not be registered live")
+
+	reg := m.Repos()
+	require.NotNil(t, reg)
+	_, found, gerr := reg.ByName("work")
+	require.NoError(t, gerr)
+	require.False(t, found, "the registry row inserted before the deadline check must be rolled back")
+
+	dbs, gerr := filepath.Glob(filepath.Join(home, "repos", "*.db"))
+	require.NoError(t, gerr)
+	require.Empty(t, dbs, "the partial database must be removed, not left on disk")
+
+	// And the name is genuinely free: the reservation was released, so the
+	// same create can simply be retried. (A leaked reservation would answer
+	// ErrCreateInFlight forever, which is limbo wearing a different hat.)
+	retry := m.StartCreate(CreateSpec{Name: "work", Mode: "preset", OntologyPreset: "default"})
+	_, rerr := retry.Result()
+	require.ErrorIs(t, rerr, context.DeadlineExceeded,
+		"the retry must reach the deadline check, i.e. NOT be refused as already in flight")
+}
+
+// TestStartCreate_DoesNotUseTheCallersContext pins requirement (1): the create
+// is detached. StartCreate takes NO context from its caller — there is nowhere
+// to pass a request context in — and the work it starts runs on the manager's
+// lifetime.
+//
+// The observable form: a create started while a caller-side context is already
+// dead still produces a repo, and nobody has to observe the job for it to
+// finish. Under the pre-fix shape (handler passing r.Context() into Create)
+// the equivalent call produced nothing at all; the web-layer half of that is
+// asserted in TestPostRepos_ClientDisconnectDoesNotAbortTheCreate.
+func TestStartCreate_DoesNotUseTheCallersContext(t *testing.T) {
+	m := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: t.TempDir()},
+		AgentBranch: "machine/test",
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+
+	dead, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.Error(t, dead.Err()) // the caller's world is already over
+
+	job := m.StartCreate(CreateSpec{Name: "work", Mode: "preset", OntologyPreset: "default"})
+
+	// Nothing consumes progress here, on purpose: a detached create has no
+	// consumer to wait for, so a create that only completes when someone is
+	// watching would be the same "held by its observer" bug in a new place.
+	select {
+	case <-job.Done():
+	case <-time.After(60 * time.Second):
+		t.Fatal("create never finished with nobody observing the job")
+	}
+
+	ri, err := job.Result()
+	require.NoError(t, err)
+	require.NotNil(t, ri)
+	require.NotNil(t, m.Get("work"))
+
+	st := job.Status()
+	require.Equal(t, CreateDone, st.State)
+	require.Equal(t, 100, st.Pct, "a finished job must carry the last progress it recorded")
+	require.Equal(t, "done", st.Step)
+}
+
+// TestStartCreate_JobDeadlineDoesNotPinTheIndexAtIndexing is the INCIDENT
+// ORACLE for this fix.
+//
+// kb/incidents/repos/clone-create-index-stuck-indexing: the background index
+// heal shared syncCtx/syncWg with the reconcile loop; ActivateSync's
+// syncCancel()+syncWg.Wait() cancelled the in-flight heal, which returned on
+// `ctx.Err() != nil` WITHOUT markIndexReady/markIndexFailed — pinning
+// IndexStatus at 'indexing' forever. The repair gave the heal its own
+// indexCtx/indexWg, cancelled only by real teardown.
+//
+// This fix introduces a NEW context that expires: the create's own deadline,
+// which StartCreate also cancels (defer cancel()) the instant Create returns.
+// If that context were ever threaded down into openOne — the obvious-looking
+// "make the create properly cancellable" change — it would become the parent
+// of indexCtx, and the deferred cancel would kill a still-running heal exactly
+// as ActivateSync once did. Same pin, new cause.
+//
+// The structural reason it does not: Manager.Add → openOne takes no context at
+// all and reads m.ctx. This test refuses to take that on trust.
+//
+// PRESET MODE IS LOAD-BEARING HERE, and clone mode is not interchangeable with
+// it. In clone mode ActivateSync's synchronous reconcile blocks on the branch
+// lock the heal holds, so Create returns only after the index is ALREADY
+// 'ready' (measured: 5/5 runs) — the cancel would then land on finished work
+// and the test would pass under the very sabotage it exists to catch. Preset
+// mode has no ActivateSync, so Create returns while the heal is still in
+// flight (measured: 50/50 runs), which is the only arrangement in which the
+// cancellation can do damage.
+func TestStartCreate_JobDeadlineDoesNotPinTheIndexAtIndexing(t *testing.T) {
+	m := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: t.TempDir()},
+		AgentBranch: "machine/test",
+		Embedder:    testEmbedder{},
+	})
+	require.NoError(t, m.Start())
+	t.Cleanup(func() { _ = m.Close() })
+
+	job := m.StartCreate(CreateSpec{Name: "work", Mode: "preset", OntologyPreset: "default"})
+	ri, err := job.Result()
+	require.NoError(t, err)
+	require.NotNil(t, ri)
+
+	// ANTI-VACUITY — asserted, not assumed. The create context is cancelled
+	// the instant Create returns, so this test discriminates only while the
+	// heal is still running at that instant. If a future change made the heal
+	// finish first, this test would quietly stop catching the regression it
+	// exists for; failing here says so out loud instead.
+	state, _, _ := ri.IndexStatus()
+	require.Equal(t, "indexing", state,
+		"the index heal must still be in flight when the create context is cancelled, "+
+			"or this test cannot detect the create deadline killing it")
+
+	// The property: that cancellation is harmless. Pinned at 'indexing' is the
+	// incident reproducing itself through the new deadline.
+	require.Eventually(t, func() bool {
+		s, _, _ := ri.IndexStatus()
+		return s == "ready"
+	}, 30*time.Second, 50*time.Millisecond,
+		"the detached create's cancelled context must not stop the background index heal")
+}

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/rs/zerolog/log"
@@ -31,6 +32,11 @@ type Deps struct {
 	// doSync/doPush immediately on startup which can race with test
 	// assertions about remote state. Production leaves this unset.
 	DisableBackgroundSync bool
+	// CreateTimeout bounds a DETACHED create (Manager.StartCreate). Unset
+	// means DefaultCreateTimeout. Unlike DisableBackgroundSync this is not a
+	// test-only flag — it is a real operational knob that tests also set, to
+	// reach the timeout path in milliseconds rather than in half-hours.
+	CreateTimeout time.Duration
 }
 
 // Manager owns the full lifecycle of all registered repositories:
@@ -91,6 +97,17 @@ type Manager struct {
 	inflightMu      sync.Mutex
 	creating        map[string]struct{}
 	creatingOrigins map[string]struct{}
+
+	// createJobs holds the detached create jobs (StartCreate), keyed by job
+	// id, so a client that started a create and then lost its connection can
+	// come back and ask how it ended. Finished entries are reaped past
+	// CreateJobTTL on the registration path — see reapCreateJobsLocked.
+	//
+	// It has its OWN mutex rather than sharing m.mu or inflightMu: a status
+	// poll must never queue behind a lifecycle operation holding m.mu, and a
+	// job outlives the name reservation inflightMu guards.
+	createJobsMu sync.Mutex
+	createJobs   map[string]*CreateJob
 }
 
 // ResolveAuth resolves a transport.AuthMethod for the given config and remote

--- a/internal/web/hal/anchor.go
+++ b/internal/web/hal/anchor.go
@@ -46,6 +46,15 @@ func (b URLBuilder) Repos() string { return b.Base + "/repos" }
 // Repo returns a single repo resource URL.
 func (b URLBuilder) Repo(repo string) string { return b.Base + "/repos/" + repo }
 
+// RepoCreate returns the poll URL for one detached repo-create job — the
+// resource POST /repos answers 202 with.
+//
+// A SIBLING of /repos, not a child, and deliberately so: repo names use the
+// alphabet [a-z0-9_-], so "creates" is a legal repo name, and a
+// /repos/creates/{id} route would shadow every route under /repos/{repo} for a
+// repo actually called that.
+func (b URLBuilder) RepoCreate(id string) string { return b.Base + "/repo-creates/" + id }
+
 // Branches returns the branch collection URL for a repo.
 func (b URLBuilder) Branches(repo string) string {
 	return b.Repo(repo) + "/branches"

--- a/internal/web/handlers_archived_hal_test.go
+++ b/internal/web/handlers_archived_hal_test.go
@@ -9,20 +9,75 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"knomit/internal/config"
 	"knomit/internal/repos"
 )
 
-// createViaAPI POSTs a preset-create and drains the NDJSON stream.
+// createViaAPI POSTs a preset-create and polls the returned create job to
+// completion, so callers can treat it as "the repo now exists".
+//
+// The polling is not ceremony: POST /repos answers 202 and returns before the
+// repo is registered (issue #67 — the response no longer holds the work), so a
+// test that went straight from create to DELETE would race the create it just
+// asked for. Every consumer of an async create has to wait somewhere; for
+// tests, here is that somewhere.
 func createViaAPI(t *testing.T, r http.Handler, name string) {
 	t.Helper()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/repos",
 		strings.NewReader(`{"name":"`+name+`","mode":"preset","ontology_preset":"default"}`))
 	r.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
+	if rec.Code != http.StatusAccepted {
 		t.Fatalf("create %s: status %d body %s", name, rec.Code, rec.Body.String())
+	}
+	awaitCreate(t, r, rec)
+}
+
+// awaitCreate polls the create job named by a 202 response until it reaches a
+// terminal state, failing the test on a failed create or on a job that never
+// finishes.
+func awaitCreate(t *testing.T, r http.Handler, accepted *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(accepted.Body.Bytes(), &body); err != nil {
+		t.Fatalf("202 body is not JSON: %v (%s)", err, accepted.Body.String())
+	}
+	// FOLLOW THE LINK the server gave us rather than rebuilding the path.
+	// Hardcoding it here would make every test that creates a repo fail
+	// whenever the route moves, which drowns the ONE test that is actually
+	// about where the route lives (TestReposNamedCreatesStaysReachable) in
+	// noise from tests that do not care.
+	self := accepted.Header().Get("Location")
+	if self == "" {
+		t.Fatalf("202 carries no Location header: %s", accepted.Body.String())
+	}
+	self = strings.TrimPrefix(self, APIBase)
+	if id, _ := body["create_id"].(string); id == "" {
+		t.Fatalf("202 body carries no create_id: %s", accepted.Body.String())
+	}
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, self, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("poll %s: status %d body %s", self, rec.Code, rec.Body.String())
+		}
+		var st map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &st); err != nil {
+			t.Fatalf("poll body is not JSON: %v (%s)", err, rec.Body.String())
+		}
+		switch st["state"] {
+		case "done":
+			return st
+		case "failed":
+			t.Fatalf("create failed: %v", st["error"])
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("create never reached a terminal state: %v", st)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/internal/web/handlers_origin_hal_test.go
+++ b/internal/web/handlers_origin_hal_test.go
@@ -921,9 +921,11 @@ func TestHandleHALSetOrigin_RefusesARemoteWithADifferentOntology(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/repos",
 		strings.NewReader(`{"name":"kb","mode":"preset","ontology_preset":"code"}`)))
-	if rec.Code != http.StatusOK {
+	if rec.Code != http.StatusAccepted {
 		t.Fatalf("create: status = %d, body = %s", rec.Code, rec.Body.String())
 	}
+	// POST /repos is 202: the repo is not there until the job finishes.
+	awaitCreate(t, r, rec)
 
 	// A remote that is a knowledge base on a DIFFERENT one (the default).
 	url := seedKnomitRemoteForTest(t, filepath.Join(root, "remote.git"), "seed")
@@ -954,9 +956,11 @@ func TestHandleHALSetOrigin_PlainRemoteIsAllowedAndKeepsTheOntology(t *testing.T
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/repos",
 		strings.NewReader(`{"name":"kb","mode":"preset","ontology_preset":"code"}`)))
-	if rec.Code != http.StatusOK {
+	if rec.Code != http.StatusAccepted {
 		t.Fatalf("create: status = %d, body = %s", rec.Code, rec.Body.String())
 	}
+	// POST /repos is 202: the repo is not there until the job finishes.
+	awaitCreate(t, r, rec)
 
 	url := seedPlainRemoteForTest(t, filepath.Join(root, "remote.git"))
 

--- a/internal/web/handlers_repos_create.go
+++ b/internal/web/handlers_repos_create.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
+
 	"knomit/internal/repos"
 	"knomit/internal/web/hal"
 )
@@ -37,9 +39,21 @@ type createRepoRequest struct {
 const maxCreateBodyBytes = 6*MaxOntologyBytes + 4*1024
 
 // handleHALReposCreate serves POST /api/v1/repos. It pre-validates (returning
-// problem+json on rejection), then streams newline-delimited JSON progress
-// (application/x-ndjson) ending in a terminal {"type":"done"} or
-// {"type":"error"} line.
+// problem+json on rejection), then starts the create DETACHED and answers
+// 202 Accepted with the job's identity and a link to poll.
+//
+// THE RESPONSE NO LONGER HOLDS THE WORK (issue #67). It used to stream NDJSON
+// progress until the create finished, with r.Context() passed straight into
+// Manager.Create — which made a repo's creation the property of the request
+// that asked for it: a client that closed its tab cancelled the create at its
+// next step boundary, discarding a clone that may already have completed.
+//
+// 202 makes that structurally impossible rather than merely fixed. There is no
+// window in which the client owns the work, because the client never holds it
+// at all: it starts a job, gets an id, and asks about it afterwards. A client
+// that never comes back changes nothing — the job is bounded by its own
+// deadline and lands in a terminal state either way, which StartCreate also
+// logs for exactly the reader who is no longer here.
 func handleHALReposCreate(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// ontology_yaml rides in this body for modes "custom" and "initialize", so the
@@ -84,46 +98,82 @@ func handleHALReposCreate(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
 			}
 		}
 
+		// Preflight still runs on the REQUEST's context, and correctly so: it
+		// is the only part of a create the caller genuinely owns. Its refusals
+		// are the documented 4xx statuses, and they must stay refusals of the
+		// request rather than becoming the terminal state of a job nobody
+		// asked to start.
 		if err := m.CreatePreflight(r.Context(), spec); err != nil {
 			status, title := createErrStatus(err)
 			hal.WriteProblem(w, status, title, err.Error(), r.URL.Path)
 			return
 		}
 
-		flusher, _ := w.(http.Flusher)
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		w.WriteHeader(http.StatusOK)
-		enc := json.NewEncoder(w)
-		emit := func(e repos.Event) {
-			_ = enc.Encode(map[string]any{
-				"type": "progress", "step": e.Step, "message": e.Message, "pct": e.Pct,
-			})
-			if flusher != nil {
-				flusher.Flush()
-			}
-		}
+		job := m.StartCreate(spec)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Location", b.RepoCreate(job.ID()))
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(createStatusBody(b, job.Status()))
+	}
+}
 
-		ri, err := m.Create(r.Context(), spec, emit)
-		if err != nil {
-			_ = enc.Encode(map[string]any{
-				"type": "error", "title": "Create failed", "detail": err.Error(),
-			})
-			if flusher != nil {
-				flusher.Flush()
-			}
+// handleHALRepoCreateStatus serves GET /api/v1/repo-creates/{id} — the poll
+// target the 202 points at. It reports progress while running and the terminal
+// outcome afterwards, for CreateJobTTL past the finish.
+//
+// NOTE ON THE PATH: this is deliberately NOT /repos/creates/{id}. Repo names
+// use the alphabet [a-z0-9_-], so "creates" is a legal repo name, and chi
+// resolves a static segment in preference to a {repo} param without
+// backtracking — a repo actually named "creates" would become unreachable at
+// every route under /repos/{repo}. A sibling collection has no such shadow.
+func handleHALRepoCreateStatus(b hal.URLBuilder, m *repos.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		job, ok := m.CreateJobByID(id)
+		if !ok {
+			// Unknown and expired are one answer on purpose: a client cannot
+			// act differently on them, and the registry is the authoritative
+			// answer to whether the repo exists.
+			hal.WriteProblem(w, http.StatusNotFound, "Unknown create",
+				"no create job with that id (it may have expired)", r.URL.Path)
 			return
 		}
-		_ = enc.Encode(map[string]any{
-			"type": "done",
-			"repo": map[string]any{
-				"name":   ri.Name(),
-				"_links": hal.LinkMap{"self": {Href: b.Repo(ri.Name())}},
-			},
-		})
-		if flusher != nil {
-			flusher.Flush()
-		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(createStatusBody(b, job.Status()))
 	}
+}
+
+// createStatusBody renders one create job for the wire. Both the 202 and the
+// poll use it, so a client parses ONE shape and the initial response is
+// literally the first poll result.
+func createStatusBody(b hal.URLBuilder, st repos.CreateStatus) map[string]any {
+	body := map[string]any{
+		"create_id": st.ID,
+		"name":      st.Name,
+		"mode":      st.Mode,
+		"state":     string(st.State),
+		"step":      st.Step,
+		"message":   st.Message,
+		"pct":       st.Pct,
+		"_links":    hal.LinkMap{"self": {Href: b.RepoCreate(st.ID)}},
+	}
+	switch st.State {
+	case repos.CreateDone:
+		// The repo link appears only once the repo actually exists — a link
+		// offered while the create is still running would 404, and one offered
+		// after a failure would point at something that was rolled back.
+		body["repo"] = map[string]any{
+			"name":   st.Name,
+			"_links": hal.LinkMap{"self": {Href: b.Repo(st.Name)}},
+		}
+	case repos.CreateFailed:
+		body["error"] = st.Err.Error()
+		// Named separately from the message because a deadline and a genuine
+		// create failure call for different client behaviour: one is worth
+		// retrying as-is, the other is not.
+		body["timed_out"] = st.TimedOut
+	}
+	return body
 }
 
 func createErrStatus(err error) (int, string) {

--- a/internal/web/handlers_repos_create_test.go
+++ b/internal/web/handlers_repos_create_test.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -11,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"knomit/internal/config"
 	"knomit/internal/repos"
@@ -47,7 +47,15 @@ func newRealManagerWithLocalOriginRoot(t *testing.T, root string) *repos.Manager
 	return m
 }
 
-func TestPostRepos_StreamsNDJSONAndCreates(t *testing.T) {
+// TestPostRepos_AcceptsAndCreates pins the 202 contract: POST answers
+// immediately with the job's identity and a Location pointing at the poll
+// resource, and the create it started really does produce the repo.
+//
+// It replaces the old NDJSON-stream test. The stream is gone on purpose — a
+// response that streamed until the create finished was the mechanism by which
+// the request OWNED the work (issue #67); 202 removes the ownership rather
+// than patching around it.
+func TestPostRepos_AcceptsAndCreates(t *testing.T) {
 	s := &Server{Manager: newRealManager(t)}
 	r := s.NewAPIRouter()
 
@@ -56,30 +64,51 @@ func TestPostRepos_StreamsNDJSONAndCreates(t *testing.T) {
 		strings.NewReader(`{"name":"work","mode":"preset","ontology_preset":"default"}`))
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202, body=%s", rec.Code, rec.Body.String())
 	}
-	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/x-ndjson") {
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
 		t.Fatalf("content-type = %q", ct)
 	}
-	var lastType string
-	sc := bufio.NewScanner(strings.NewReader(rec.Body.String()))
-	for sc.Scan() {
-		line := strings.TrimSpace(sc.Text())
-		if line == "" {
-			continue
-		}
-		var m map[string]any
-		if err := json.Unmarshal([]byte(line), &m); err != nil {
-			t.Fatalf("bad ndjson line %q: %v", line, err)
-		}
-		lastType, _ = m["type"].(string)
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("bad 202 body %q: %v", rec.Body.String(), err)
 	}
-	if lastType != "done" {
-		t.Fatalf("last type = %q, want done", lastType)
+	id, _ := body["create_id"].(string)
+	if id == "" {
+		t.Fatalf("202 body carries no create_id: %v", body)
+	}
+	if got := rec.Header().Get("Location"); !strings.HasSuffix(got, "/repo-creates/"+id) {
+		t.Fatalf("Location = %q, want a /repo-creates/%s URL", got, id)
+	}
+	// The 202 is answered BEFORE the work is done, which is the whole point:
+	// state is "running", not a result.
+	if body["state"] != "running" {
+		t.Fatalf("state = %v, want running", body["state"])
+	}
+
+	final := awaitCreate(t, r, rec)
+	if final["state"] != "done" {
+		t.Fatalf("final state = %v", final["state"])
+	}
+	repo, _ := final["repo"].(map[string]any)
+	if repo == nil || repo["name"] != "work" {
+		t.Fatalf("terminal poll carries no repo: %v", final)
 	}
 	if s.Manager.Get("work") == nil {
 		t.Fatal("repo not registered")
+	}
+}
+
+// TestGetRepoCreate_UnknownIDIs404 pins the poll resource's refusal. Unknown
+// and expired are deliberately one answer — see handleHALRepoCreateStatus.
+func TestGetRepoCreate_UnknownIDIs404(t *testing.T) {
+	s := &Server{Manager: newRealManager(t)}
+	r := s.NewAPIRouter()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/repo-creates/nosuchjob", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -182,8 +211,8 @@ func TestPostRepos_BodyUnderTheCapIsNotRejectedAsOversize(t *testing.T) {
 	if rec.Code == http.StatusRequestEntityTooLarge {
 		t.Fatalf("a body well under the cap was rejected as oversize: %s", rec.Body.String())
 	}
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -220,8 +249,8 @@ func TestPostRepos_YAMLUnderTheCapWhoseJSONEncodingExceedsItIsAccepted(t *testin
 		t.Fatalf("an ontology of %d raw bytes (under the %d cap) was rejected as oversize: %s",
 			len(raw), MaxOntologyBytes, rec.Body.String())
 	}
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -330,5 +359,147 @@ func TestPostRepos_CloneOfARefLessRemoteIs409NotAStreamedError(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "one commit is enough") {
 		t.Fatalf("body does not tell the user how to fix it: %s", rec.Body.String())
+	}
+}
+
+// TestPostRepos_ClientDisconnectDoesNotAbortTheCreate is the web-layer half of
+// issue #67: the repo's creation must not be the property of the request that
+// asked for it.
+//
+// Before the fix the handler passed r.Context() straight into Manager.Create,
+// so a client that went away cancelled the create at its next step boundary —
+// discarding, in clone mode, a network fetch that may already have completed,
+// and making the outcome of a slow create depend on whether a browser tab
+// stayed open.
+//
+// Under 202 the request cannot own the work by construction, so what this test
+// guards is that nothing SNEAKS the request's context back in — the preflight
+// still legitimately receives it, and a future change that also handed it to
+// the create would be invisible to every other test here.
+//
+// The request context is cancelled BEFORE the handler runs, which makes the
+// test deterministic rather than a race against a fast create: there is no
+// window in which the create could have finished first.
+func TestPostRepos_ClientDisconnectDoesNotAbortTheCreate(t *testing.T) {
+	s := &Server{Manager: newRealManager(t)}
+	r := s.NewAPIRouter()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the client is already gone
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/repos",
+		strings.NewReader(`{"name":"work","mode":"preset","ontology_preset":"default"}`)).WithContext(ctx)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202, body=%s", rec.Code, rec.Body.String())
+	}
+
+	// The repo is created regardless. It is NOT registered by the instant the
+	// handler returns — 202 answers before the work is done — so this waits on
+	// the effect rather than assuming otherwise.
+	deadline := time.Now().Add(60 * time.Second)
+	for s.Manager.Get("work") == nil {
+		if time.Now().After(deadline) {
+			t.Fatalf("repo was never created: the create is still tied to the request context")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestGetRepoCreate_TimeoutIsReadableAsATerminalFailure is the HTTP-visible
+// half of requirement (2): when a detached create exceeds its own deadline,
+// the client that comes back to ask does not find "still running" or a
+// half-created repo — it finds a terminal failure that says it timed out, and
+// the repo genuinely is not there.
+//
+// This is what the 202 shape buys that a stream could not: the outcome of a
+// create outlives the connection that started it.
+func TestGetRepoCreate_TimeoutIsReadableAsATerminalFailure(t *testing.T) {
+	m := repos.New(context.Background(), repos.Deps{
+		Cfg:         config.Config{Home: t.TempDir()},
+		AgentBranch: "machine/test",
+		// Already expired when the create's goroutine runs.
+		CreateTimeout: time.Nanosecond,
+	})
+	if err := m.Start(); err != nil {
+		t.Fatalf("start manager: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+
+	s := &Server{Manager: m}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/repos",
+		strings.NewReader(`{"name":"work","mode":"preset","ontology_preset":"default"}`)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202, body=%s", rec.Code, rec.Body.String())
+	}
+	var accepted map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &accepted); err != nil {
+		t.Fatalf("bad 202 body: %v", err)
+	}
+	id, _ := accepted["create_id"].(string)
+
+	deadline := time.Now().Add(60 * time.Second)
+	var st map[string]any
+	for {
+		poll := httptest.NewRecorder()
+		r.ServeHTTP(poll, httptest.NewRequest(http.MethodGet, "/repo-creates/"+id, nil))
+		if poll.Code != http.StatusOK {
+			t.Fatalf("poll status = %d, body=%s", poll.Code, poll.Body.String())
+		}
+		if err := json.Unmarshal(poll.Body.Bytes(), &st); err != nil {
+			t.Fatalf("bad poll body: %v", err)
+		}
+		if st["state"] != "running" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("create never became terminal: %v", st)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if st["state"] != "failed" {
+		t.Fatalf("state = %v, want failed", st["state"])
+	}
+	if st["timed_out"] != true {
+		t.Fatalf("timed_out = %v, want true — a deadline must be distinguishable from a create error", st["timed_out"])
+	}
+	if msg, _ := st["error"].(string); msg == "" {
+		t.Fatalf("failed poll carries no error text: %v", st)
+	}
+	if _, ok := st["repo"]; ok {
+		t.Fatalf("a failed create must not offer a repo link: %v", st)
+	}
+	if m.Get("work") != nil {
+		t.Fatal("the timed-out repo must not be registered")
+	}
+}
+
+// TestReposNamedCreatesStaysReachable pins the reason the create-status route
+// is /repo-creates/{id} and not /repos/creates/{id}.
+//
+// Repo names use the alphabet [a-z0-9_-], so "creates" is a legal repo name.
+// chi prefers a static path segment over a {param} edge and does NOT backtrack
+// when the static branch fails to match the rest of the path — so a
+// /repos/creates/... route would not merely shadow one URL, it would make a
+// repo actually called "creates" unreachable at EVERY route under
+// /repos/{repo}. A sibling collection has no such shadow, and this test fails
+// the moment someone nests it back.
+func TestReposNamedCreatesStaysReachable(t *testing.T) {
+	s := &Server{Manager: newRealManager(t)}
+	r := s.NewAPIRouter()
+	createViaAPI(t, r, "creates")
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/repos/creates/branches", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /repos/creates/branches = %d, want 200 — a repo named "+
+			"\"creates\" is shadowed by the create-status route; body=%s",
+			rec.Code, rec.Body.String())
 	}
 }

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -105,6 +105,13 @@ func (s *Server) NewAPIRouter() chi.Router {
 	r.Get("/repos", handleHALRepos(b, s.Manager))
 	r.Post("/repos", handleHALReposCreate(b, s.Manager))
 
+	// The poll target for the 202 that POST /repos answers with. A SIBLING
+	// collection rather than "/repos/creates/{id}": "creates" is a legal repo
+	// name ([a-z0-9_-]), and chi prefers a static segment over the {repo}
+	// param without backtracking, so nesting it here would make a repo
+	// actually named "creates" unreachable at every route below.
+	r.Get("/repo-creates/{id}", handleHALRepoCreateStatus(b, s.Manager))
+
 	// Probes an origin before create, so the wizard can classify it (has refs
 	// / empty / unreachable) instead of asking the user to declare that up
 	// front. Collection-level for the same reason as the ontology block below:

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -96,9 +96,24 @@ paths:
       tags: [repos]
       summary: Create a repository
       description: |
-        Initiates repo creation and streams progress as newline-delimited JSON
-        (NDJSON). Each line is a `CreateRepoEvent` object. The stream ends with
-        a `done` or `error` event.
+        Starts repo creation and returns `202 Accepted` immediately with the
+        job's `create_id` and a `Location` header pointing at
+        `/repo-creates/{id}`. Poll that resource for progress and for the
+        terminal outcome.
+
+        THE RESPONSE DOES NOT HOLD THE WORK. The create runs on the server's
+        own bounded context with its own deadline, so it is unaffected by what
+        the client does next: disconnecting, never polling, or polling from a
+        different session all leave the create running to the same terminal
+        state. This is deliberate — the previous shape streamed progress until
+        the create finished and scoped the work to the request, which meant a
+        closed browser tab could cancel a clone that had already completed.
+
+        Because the outcome outlives the connection, a create that fails or
+        exceeds its deadline is still readable afterwards, for a limited
+        retention window, at `/repo-creates/{id}`. A failed create leaves NO
+        repo behind: the partial database and the registry row are rolled back
+        before the job becomes terminal.
 
         409 covers several distinct conflicts: the name is already taken, the
         origin URL is already in use by another active repo, a create for the
@@ -114,18 +129,18 @@ paths:
           (mode=clone) — use mode=initialize.
         - the branch already has one (mode=initialize) — use mode=clone.
 
-        All three checks run BEFORE the stream opens, from the server's own
+        All three checks run BEFORE the 202 is committed, from the server's own
         probes of the origin rather than anything trusted from an earlier
         client-side probe — which is what makes these 409s reachable at all.
-        A condition that can only be produced once the 200 is committed is not
-        a 409 to any client.
+        A condition that can only be produced once the job has started is not
+        a 409 to any client; it surfaces as a `failed` poll result instead.
 
         They are deliberately narrow. Only a remote the server could actually
         see is refused: one that is unreachable, or that needs credentials the
         request did not carry, establishes nothing either way, so it proceeds
-        and fails as an `error` event inside the 200 stream instead. Create
-        re-asserts all three conditions itself regardless — the pre-stream
-        probes are advisory, and a remote can change in between.
+        and fails as a `failed` poll result instead. Create re-asserts all
+        three conditions itself regardless — the pre-flight probes are
+        advisory, and a remote can change in between.
 
         The ontology question is asked of the branch the create will actually
         READ, which is not always the branch named: when the remote already
@@ -142,15 +157,56 @@ paths:
           application/json:
             schema: { $ref: "#/components/schemas/CreateRepoRequest" }
       responses:
-        "200":
-          description: NDJSON stream of creation progress events
+        "202":
+          description: |
+            Creation accepted and started. The body is the job's first status
+            snapshot — the same shape `/repo-creates/{id}` returns — so a
+            client needs to parse only one thing.
+          headers:
+            Location:
+              description: URL of the create job to poll.
+              schema: { type: string }
           content:
-            application/x-ndjson:
+            application/json:
               schema:
-                $ref: "#/components/schemas/CreateRepoEvent"
+                $ref: "#/components/schemas/RepoCreateStatus"
         "400": { $ref: "#/components/responses/Problem" }
         "409": { $ref: "#/components/responses/Problem" }
         "413": { $ref: "#/components/responses/Problem" }
+
+  /repo-creates/{id}:
+    get:
+      tags: [repos]
+      summary: Read the status of a repo-create job
+      description: |
+        Reports a detached create's progress while it runs and its terminal
+        outcome after it ends. This is the poll target `POST /repos` hands back.
+
+        A SIBLING of `/repos` rather than a path beneath it, on purpose: repo
+        names use the alphabet `[a-z0-9_-]`, so `creates` is a legal repo name,
+        and a `/repos/creates/{id}` route would shadow every route belonging to
+        a repo actually called that.
+
+        Finished jobs are retained for a limited window (one hour) so a client
+        that lost its connection can still learn how the create ended. After
+        that the job is reaped and this returns 404 — the same answer as an id
+        that never existed, because a client cannot act differently on the two,
+        and `GET /repos/{repo}` is the authoritative answer to whether the repo
+        exists.
+      operationId: getRepoCreate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Current status of the create job.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoCreateStatus"
+        "404": { $ref: "#/components/responses/Problem" }
 
   /repos:probe-origin:
     post:
@@ -2467,37 +2523,59 @@ components:
         origin:
           $ref: "#/components/schemas/CreateRepoOrigin"
 
-    CreateRepoEvent:
+    RepoCreateStatus:
       type: object
       description: |
-        One line of the NDJSON creation stream. Each object carries a `type`
-        discriminator and optional progress fields. The stream always ends with
-        a `done` or `error` event.
-      required: [type]
+        The state of one detached repo-create job. Returned both by the 202
+        that starts it and by every poll of `/repo-creates/{id}`, so a client
+        parses one shape and the 202 body is literally the first poll result.
+
+        `step`/`message`/`pct` are a LATEST-VALUE snapshot, not a stream: a
+        poll that arrives between two steps reports the earlier one, and a
+        poll that arrives after three reports only the third. No intermediate
+        step is guaranteed to be observed by anyone.
+      required: [create_id, name, mode, state]
       properties:
-        type:
+        create_id:
           type: string
-          enum: [progress, done, error]
-          description: Event kind.
+          description: Job identity. Stable for the job's whole life.
+        name:
+          type: string
+          description: Requested repo name.
+        mode:
+          type: string
+          description: Requested create mode.
+        state:
+          type: string
+          enum: [running, done, failed]
+          description: |
+            `running` is the only non-terminal value. `failed` means the repo
+            does NOT exist — the partial database and registry row were rolled
+            back before the job became terminal.
         step:
           type: string
-          description: Machine-readable step identifier (e.g. "init", "clone", "index").
+          description: Machine-readable step identifier (e.g. "clone", "register").
         message:
           type: string
           description: Human-readable progress message.
         pct:
-          type: number
-          format: double
-          description: Completion percentage (0–100), present on progress events.
+          type: integer
+          description: Completion percentage (0–100) of the last recorded step.
         repo:
+          type: object
+          description: |
+            Present only when state is `done`. Absent while running (the repo
+            does not exist yet) and after a failure (it was rolled back), so
+            the link is never offered pointing at nothing.
+        error:
           type: string
-          description: Repo name, present on the final done event.
-        title:
-          type: string
-          description: Short summary, present on done/error events.
-        detail:
-          type: string
-          description: Extended detail or error description.
+          description: Failure description. Present only when state is `failed`.
+        timed_out:
+          type: boolean
+          description: |
+            Present only when state is `failed`. True when the failure was the
+            create's own deadline expiring rather than a create error — named
+            separately because the two call for different client behaviour.
 
     # Origin probe (pre-create)
     ProbeOriginRequest:

--- a/web/src/CreateProgress.tsx
+++ b/web/src/CreateProgress.tsx
@@ -1,20 +1,78 @@
-import type { CreateEvent } from './api';
+import type { RepoCreateStatus } from './api';
 
-// CreateProgress renders the NDJSON event stream from api.createRepo — the
-// same rendering CreateRepoForm did inline, pulled out so the wizard shell
-// can drop it under whichever step is showing (only ever 'review', but kept
-// presentational per the step-component convention).
-export function CreateProgress({ events }: { events: CreateEvent[] }) {
-  if (events.length === 0) return null;
+// CREATE_STEPS is the step list each create mode runs, in order, mirroring the
+// emit() calls in internal/repos/lifecycle.go. It exists because polling
+// reports a LATEST VALUE, not a stream: a local create finishes in
+// milliseconds and is typically polled once, so a component that rendered only
+// what it observed would flash "started → done" and show none of the work.
+//
+// Rendering the known list with the reported step as a CURSOR keeps the step
+// log on every mode, and is honest about what it is — these are the steps the
+// create WILL run, marked done/current/pending, not a claim that each one was
+// individually witnessed.
+//
+// It is a mirror, so it can drift. Drift is visible rather than silent: an
+// unknown reported step still renders (see cursor below), it simply does not
+// match a row — a step missing here shows as an unmatched current step, not as
+// a hang.
+const CREATE_STEPS: Record<string, string[]> = {
+  preset: ['validate', 'ontology', 'init-git', 'register', 'done'],
+  custom: ['validate', 'ontology', 'init-git', 'register', 'done'],
+  clone: ['validate', 'clone', 'persist-origin', 'register', 'sync', 'done'],
+  initialize: ['validate', 'probe', 'ontology', 'clone', 'ontology-write', 'push', 'persist-origin', 'register', 'sync', 'done'],
+};
+
+const LABELS: Record<string, string> = {
+  validate: 'Validating request',
+  probe: 'Checking the remote',
+  ontology: 'Resolving ontology',
+  clone: 'Reading the remote',
+  'init-git': 'Initialising git store',
+  'ontology-write': 'Writing ontology',
+  push: 'Pushing agent branch',
+  'persist-origin': 'Saving remote config',
+  register: 'Registering repo',
+  sync: 'Activating sync',
+  done: 'Repo ready',
+};
+
+// CreateProgress renders a create's progress — the same rendering
+// CreateRepoForm did inline, pulled out so the wizard shell can drop it under
+// whichever step is showing (only ever 'review', but kept presentational per
+// the step-component convention).
+export function CreateProgress({ status }: { status: RepoCreateStatus | null }) {
+  if (!status) return null;
+
+  if (status.state === 'failed') {
+    return (
+      <div data-testid="create-progress" style={box}>
+        <div style={{ color: '#f88' }}>{status.error || 'create failed'}</div>
+      </div>
+    );
+  }
+
+  const steps = CREATE_STEPS[status.mode] ?? CREATE_STEPS.preset;
+  // -1 for a step this list does not know: everything then reads as pending
+  // rather than as spuriously complete, which is the safe direction to drift.
+  const cursor = status.step ? steps.indexOf(status.step) : -1;
+
   return (
     <div data-testid="create-progress" style={box}>
-      {events.map((e, i) => (
-        <div key={i} style={{ color: e.type === 'error' ? '#f88' : '#9c9' }}>
-          {e.type === 'progress' ? `${e.pct ?? 0}% ${e.step ?? ''} — ${e.message ?? ''}` : e.type}
-        </div>
-      ))}
+      <div style={{ color: '#9c9', marginBottom: 6 }}>
+        {status.pct ?? 0}% {status.message || ''}
+      </div>
+      {steps.map((s, i) => {
+        const done = cursor > i || status.state === 'done';
+        const current = cursor === i && status.state !== 'done';
+        return (
+          <div key={s} data-testid={`create-step-${s}`}
+            style={{ color: done ? '#9c9' : current ? '#eee' : '#666' }}>
+            {done ? '\u2713' : current ? '\u2026' : '\u00b7'} {LABELS[s] ?? s}
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-const box: React.CSSProperties = { marginTop: 12, padding: 10, background: '#0c0c0c', borderRadius: 4, fontSize: 12, fontFamily: 'var(--k-font-mono)', maxHeight: 160, overflow: 'auto' };
+const box: React.CSSProperties = { marginTop: 12, padding: 10, background: '#0c0c0c', borderRadius: 4, fontSize: 12, fontFamily: 'var(--k-font-mono)', maxHeight: 220, overflow: 'auto' };

--- a/web/src/CreateRepoWizard.test.tsx
+++ b/web/src/CreateRepoWizard.test.tsx
@@ -7,10 +7,7 @@ vi.mock('./api', () => ({
   api: {
     probeOrigin: vi.fn(),
     probeInitialized: vi.fn(),
-    createRepo: vi.fn(async (_b: unknown, onEvent: (e: unknown) => void) => {
-      onEvent({ type: 'progress', step: 'init-git', pct: 50, message: 'x' });
-      onEvent({ type: 'done', repo: { name: 'kb' } });
-    }),
+    createRepo: vi.fn(),
     ontologyPresets: vi.fn(async () => [
       { name: 'default', id: 'general', title: 'General', description: 'd', topics: ['people'] },
       { name: 'code', id: 'source-code', title: 'Code', description: 'd', topics: ['invariants'] },
@@ -55,13 +52,33 @@ const passBranchStep = async () => {
   await waitFor(() => expect(screen.queryByTestId('step-branch')).not.toBeInTheDocument());
 };
 
-// The default createRepo: two events, ending in a repo named "kb". Restored
-// before every test rather than only cleared, because mockImplementation
-// installs an IMPLEMENTATION and clearAllMocks leaves it in place — so one
-// test's deliberate failure became the next test's createRepo.
-const okCreate = async (_b: unknown, onEvent: (e: unknown) => void) => {
-  onEvent({ type: 'progress', step: 'init-git', pct: 50, message: 'x' });
-  onEvent({ type: 'done', repo: { name: 'kb' } });
+// createRepo is a 202-then-poll OBSERVER now: it reports each status it sees
+// and RESOLVES with the terminal one. A failed create resolves with
+// state 'failed' rather than throwing — a failure is an outcome the wizard
+// renders, not an exception — so these mocks must RETURN their terminal
+// status, not merely announce it.
+const status = (over: Record<string, unknown> = {}) => ({
+  create_id: 'job1', name: 'kb', mode: 'initialize', state: 'running', ...over,
+});
+
+// A create that reaches `step` and then fails there.
+const failingCreate = (step: string, error: string) =>
+  async (_b: unknown, onStatus: (s: unknown) => void) => {
+    onStatus(status({ step, pct: 70, message: 'pushing agent/host' }));
+    const final = status({ step, state: 'failed', error });
+    onStatus(final);
+    return final;
+  };
+
+// The default createRepo: one progress report, then a repo named "kb".
+// Restored before every test rather than only cleared, because
+// mockImplementation installs an IMPLEMENTATION and clearAllMocks leaves it in
+// place — so one test's deliberate failure became the next test's createRepo.
+const okCreate = async (_b: unknown, onStatus: (s: unknown) => void) => {
+  onStatus(status({ mode: 'preset', step: 'init-git', pct: 50, message: 'x' }));
+  const final = status({ mode: 'preset', state: 'done', step: 'done', pct: 100, repo: { name: 'kb' } });
+  onStatus(final);
+  return final;
 };
 
 describe('CreateRepoWizard', () => {
@@ -268,10 +285,7 @@ describe('CreateRepoWizard', () => {
     (api.probeOrigin as ReturnType<typeof vi.fn>).mockResolvedValue(probed());
     initializedAs('no');
     (api.createRepo as ReturnType<typeof vi.fn>).mockImplementation(
-      async (_b: unknown, onEvent: (e: unknown) => void) => {
-        onEvent({ type: 'progress', step: 'push', pct: 70, message: 'pushing agent/host' });
-        onEvent({ type: 'error', detail: 'initialize: push agent/host: authorization failed: You are not allowed to push code to this project.' });
-      });
+      failingCreate('push', 'initialize: push agent/host: authorization failed: You are not allowed to push code to this project.'));
     render(<CreateRepoWizard onDone={() => {}} onCancel={() => {}} />);
 
     fireEvent.change(screen.getByTestId('create-url'), { target: { value: 'https://h/new.git' } });
@@ -302,10 +316,7 @@ describe('CreateRepoWizard', () => {
     (api.probeOrigin as ReturnType<typeof vi.fn>).mockResolvedValue(probed());
     initializedAs('no');
     (api.createRepo as ReturnType<typeof vi.fn>).mockImplementation(
-      async (_b: unknown, onEvent: (e: unknown) => void) => {
-        onEvent({ type: 'progress', step: 'push', pct: 70, message: 'pushing agent/host' });
-        onEvent({ type: 'error', detail: 'initialize: push agent/host: pre-receive hook declined' });
-      });
+      failingCreate('push', 'initialize: push agent/host: pre-receive hook declined'));
     render(<CreateRepoWizard onDone={() => {}} onCancel={() => {}} />);
 
     fireEvent.change(screen.getByTestId('create-url'), { target: { value: 'https://h/new.git' } });
@@ -339,9 +350,7 @@ describe('CreateRepoWizard', () => {
     (api.probeOrigin as ReturnType<typeof vi.fn>).mockResolvedValue(probed());
     initializedAs('no');
     (api.createRepo as ReturnType<typeof vi.fn>).mockImplementation(
-      async (_b: unknown, onEvent: (e: unknown) => void) => {
-        onEvent({ type: 'error', detail: 'initialize: push agent/host: pre-receive hook declined' });
-      });
+      failingCreate('push', 'initialize: push agent/host: pre-receive hook declined'));
     render(<CreateRepoWizard onDone={() => {}} onCancel={() => {}} />);
 
     fireEvent.change(screen.getByTestId('create-url'), { target: { value: 'https://h/new.git' } });

--- a/web/src/CreateRepoWizard.tsx
+++ b/web/src/CreateRepoWizard.tsx
@@ -1,5 +1,5 @@
 import { useReducer, useRef, useState } from 'react';
-import { api, type CreateEvent, type ProbeResult } from './api';
+import { api, type RepoCreateStatus, type ProbeResult } from './api';
 import { wizardReducer, initialWizardState, currentStep, stepsFor, branchCheckBlocked, probeIsCurrent, createBodyFor, authFor, isValidRepoName, type WizardAction } from './wizardState';
 import { WizardStepRail } from './WizardStepRail';
 import { StepSource } from './StepSource';
@@ -58,7 +58,11 @@ export function CreateRepoWizard({ onDone, onCancel }: { onDone: (name: string) 
   const [checkedOk, setCheckedOk] = useState(0);
   const [creating, setCreating] = useState(false);
   const [createErr, setCreateErr] = useState('');
-  const [events, setEvents] = useState<CreateEvent[]>([]);
+  // The latest reported create status, or null before a create starts.
+  // Polling reports a LATEST VALUE rather than a stream, so the progress
+  // component renders the mode's known step list with this as the cursor —
+  // see CreateProgress.
+  const [createStatus, setCreateStatus] = useState<RepoCreateStatus | null>(null);
   // Gates Next on the ontology step. Passed to StepOntology as setOntologyValid
   // directly (not a wrapping lambda) so its identity is stable across
   // renders — StepOntology's validity effects depend on it and a fresh
@@ -93,7 +97,7 @@ export function CreateRepoWizard({ onDone, onCancel }: { onDone: (name: string) 
     // probeError/probeFailure are deliberately NOT cleared: they belong to the
     // access step's own check, which is still true when you navigate back to it.
     setCreateErr('');
-    setEvents([]);
+    setCreateStatus(null);
     dispatch(a);
   };
 
@@ -238,17 +242,18 @@ export function CreateRepoWizard({ onDone, onCancel }: { onDone: (name: string) 
   };
 
   const handleCreate = async () => {
-    setCreateErr(''); setEvents([]); setCreating(true);
+    setCreateErr(''); setCreateStatus(null); setCreating(true);
     const body = createBodyFor(state);
-    let failed = false;
-    let doneName = state.name;
     try {
-      await api.createRepo(body, (e) => {
-        setEvents(prev => [...prev, e]);
-        if (e.type === 'done' && e.repo) doneName = e.repo.name;
-        if (e.type === 'error') { failed = true; setCreateErr(e.detail || e.title || 'create failed'); }
-      });
-      if (!failed) onDone(doneName);
+      // createRepo POSTs, gets a 202, and polls to a terminal state. A failed
+      // create RESOLVES with state 'failed' — it is an outcome to render, not
+      // an exception — so the catch below is for a REFUSED request only.
+      const final = await api.createRepo(body, setCreateStatus);
+      if (final.state === 'failed') {
+        setCreateErr(final.error || 'create failed');
+      } else {
+        onDone(final.repo?.name || state.name);
+      }
     } catch (e) {
       setCreateErr(e instanceof Error ? e.message : String(e));
     } finally {
@@ -337,7 +342,7 @@ export function CreateRepoWizard({ onDone, onCancel }: { onDone: (name: string) 
           <div style={errNote}>No repository was added. You can change something and try again.</div>
         </div>
       )}
-      {step === 'review' && <CreateProgress events={events} />}
+      {step === 'review' && <CreateProgress status={createStatus} />}
 
       <div style={footer}>
         {step !== 'source' && (

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parseSearchQuery, parseFilterQuery, parseNDJSONLine, api } from './api';
+import { parseSearchQuery, parseFilterQuery, api } from './api';
 
 describe('parseSearchQuery', () => {
   it('parses plain text', () => {
@@ -690,20 +690,64 @@ describe('api lens read surface', () => {
   });
 });
 
-describe('parseNDJSONLine', () => {
-  it('parses a progress line', () => {
-    const e = parseNDJSONLine('{"type":"progress","step":"clone","message":"x","pct":40}');
-    expect(e?.type).toBe('progress');
-    expect(e?.pct).toBe(40);
+describe('api.createRepo (202 + poll)', () => {
+  // POST /repos answers 202 and does NOT hold the work: the create runs on the
+  // server's own bounded context. createRepo is therefore an OBSERVER that
+  // polls to a terminal state — these pin that it actually polls, that it
+  // stops on each terminal state, and that a failed create RESOLVES rather
+  // than throwing (a failure is an outcome to render, not an exception).
+  const accepted = (over: Record<string, unknown> = {}) =>
+    ({ create_id: 'job1', name: 'work', mode: 'preset', state: 'running', step: 'validate', pct: 5, ...over });
+
+  it('polls the create job until it is done and reports each step', async () => {
+    const bodies = [
+      accepted(),
+      accepted({ state: 'running', step: 'register', pct: 85 }),
+      accepted({ state: 'done', step: 'done', pct: 100, repo: { name: 'work' } }),
+    ];
+    let call = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: call === 0 ? 202 : 200, statusText: '',
+      json: async () => bodies[call++],
+    })));
+
+    const seen: string[] = [];
+    const final = await api.createRepo(
+      { name: 'work', mode: 'preset', ontology_preset: 'default' },
+      s => { seen.push(s.step ?? ''); });
+
+    expect(final.state).toBe('done');
+    expect(final.repo?.name).toBe('work');
+    // Three fetches: the POST plus two polls. A createRepo that returned on
+    // the 202 would have made exactly one and seen exactly one step.
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(3);
+    expect(seen).toEqual(['validate', 'register', 'done']);
   });
-  it('parses a done line with repo', () => {
-    const e = parseNDJSONLine('{"type":"done","repo":{"name":"work"}}');
-    expect(e?.type).toBe('done');
-    expect(e?.repo?.name).toBe('work');
+
+  it('resolves (does not throw) when the create fails, carrying the reason', async () => {
+    const bodies = [
+      accepted(),
+      accepted({ state: 'failed', error: 'context deadline exceeded', timed_out: true }),
+    ];
+    let call = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true, status: call === 0 ? 202 : 200, statusText: '',
+      json: async () => bodies[call++],
+    })));
+
+    const final = await api.createRepo({ name: 'work', mode: 'preset' }, () => {});
+    expect(final.state).toBe('failed');
+    expect(final.error).toBe('context deadline exceeded');
+    expect(final.timed_out).toBe(true);
   });
-  it('returns null for blank/garbage lines', () => {
-    expect(parseNDJSONLine('   ')).toBeNull();
-    expect(parseNDJSONLine('not json')).toBeNull();
+
+  it('throws when the POST itself is refused', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false, status: 409, statusText: 'Conflict',
+      json: async () => ({ detail: 'repo already exists' }),
+    })));
+    await expect(api.createRepo({ name: 'work', mode: 'preset' }, () => {}))
+      .rejects.toThrow('repo already exists');
   });
 });
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -639,24 +639,28 @@ async function getAgentBranch(repo: string): Promise<string> {
   return (agent || main || branches[0])?.name || 'main';
 }
 
-export interface CreateEvent {
-  type: 'progress' | 'done' | 'error';
+// RepoCreateStatus is the state of one detached repo-create job — the body of
+// the 202 that POST /repos answers with, and of every poll of
+// /repo-creates/{id}. One shape for both, so the 202 IS the first poll result.
+//
+// step/message/pct are a LATEST-VALUE snapshot, not a stream: a poll landing
+// between two steps reports the earlier one, and no intermediate step is
+// guaranteed to be seen by anyone. Anything that needs every step must derive
+// it from the known pipeline, not from what it happened to observe.
+export interface RepoCreateStatus {
+  create_id: string;
+  name: string;
+  mode: string;
+  state: 'running' | 'done' | 'failed';
   step?: string;
   message?: string;
   pct?: number;
+  /** Present only when state is 'done'. */
   repo?: { name: string };
-  title?: string;
-  detail?: string;
-}
-
-export function parseNDJSONLine(line: string): CreateEvent | null {
-  const t = line.trim();
-  if (!t) return null;
-  try {
-    return JSON.parse(t) as CreateEvent;
-  } catch {
-    return null;
-  }
+  /** Present only when state is 'failed'. */
+  error?: string;
+  /** Present only when state is 'failed': the create's own deadline expired. */
+  timed_out?: boolean;
 }
 
 export interface CreateRepoBody {
@@ -784,9 +788,31 @@ export interface ArchivedRepo {
   sizeBytes?: number;
 }
 
-// createRepo POSTs and streams NDJSON progress, invoking onEvent per line.
-// Resolves when the stream ends. Throws on a pre-stream non-OK (problem+json).
-async function createRepo(body: CreateRepoBody, onEvent: (e: CreateEvent) => void): Promise<void> {
+// createRepoPollMs is how often createRepo asks how a create is going.
+//
+// It is a RESPONSIVENESS choice, not a correctness one: the create finishes
+// when it finishes regardless of whether anyone is asking. Short enough that a
+// clone's progress reads as live, long enough not to hammer the server for the
+// minutes a large clone can take.
+const createRepoPollMs = 400;
+
+// createRepo starts a repo create and follows it to its terminal state,
+// invoking onStatus each time the reported status changes.
+//
+// The POST answers 202 immediately and does NOT hold the work (issue #67):
+// the server runs the create on its own bounded context, so nothing here —
+// abandoning the poll, reloading the page, losing the network — can cancel a
+// create that is already under way. This function is an OBSERVER, and if it
+// stops observing the create still lands.
+//
+// Resolves with the terminal status (state 'done' or 'failed'); a failed
+// create resolves rather than throwing, because "the create failed" is an
+// outcome the caller renders, not an exception. It throws only when the
+// request itself was refused (problem+json) or the job became unreadable.
+async function createRepo(
+  body: CreateRepoBody,
+  onStatus: (s: RepoCreateStatus) => void,
+): Promise<RepoCreateStatus> {
   const r = await fetch(apiUrl('/api/v1/repos'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -800,22 +826,20 @@ async function createRepo(body: CreateRepoBody, onEvent: (e: CreateEvent) => voi
     } catch { /* ignore */ }
     throw new Error(`create → ${r.status} ${detail}`);
   }
-  const reader = r.body!.getReader();
-  const dec = new TextDecoder();
-  let buf = '';
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buf += dec.decode(value, { stream: true });
-    let nl: number;
-    while ((nl = buf.indexOf('\n')) >= 0) {
-      const e = parseNDJSONLine(buf.slice(0, nl));
-      buf = buf.slice(nl + 1);
-      if (e) onEvent(e);
-    }
+  let status = await r.json() as RepoCreateStatus;
+  onStatus(status);
+  while (status.state === 'running') {
+    await new Promise(res => setTimeout(res, createRepoPollMs));
+    // A poll that fails is NOT a create that failed — the create is on the
+    // server and unaffected. Surfacing it as a create failure would report a
+    // repo as broken that is very likely fine, so a lost poll just retries.
+    try {
+      status = await fetchJSON<RepoCreateStatus>(
+        apiUrl(`/api/v1/repo-creates/${status.create_id}`));
+      onStatus(status);
+    } catch { /* transient; poll again */ }
   }
-  const tail = parseNDJSONLine(buf);
-  if (tail) onEvent(tail);
+  return status;
 }
 
 async function archiveRepo(repo: string): Promise<ArchivedRepo> {


### PR DESCRIPTION
Closes #67.

Repo creation no longer runs on the HTTP request context — a client disconnect can no longer abort or limbo a create.

## Shape
- `POST /api/v1/repos` returns **202 + Location** and runs a **bounded background job** (own ctx parented to `m.ctx` + a timeout, never the request).
- `GET /api/v1/repo-creates/{id}` returns the job's progress + terminal state (TTL'd registry). Sibling collection, deliberately not `/repos/creates/{id}` — "creates" is a legal repo name and would shadow every `/repos/{repo}` route.
- Frontend polls the status endpoint; a per-mode `CREATE_STEPS` list (mirroring `lifecycle.go`) keeps the step log for fast local creates, with drift rendered visibly (unknown step → all pending, never spuriously complete).

## Safety
- The create's bounded ctx is a **sibling** of `indexCtx`, never an ancestor — a create deadline expiring cannot cancel a running index heal (the `clone-create-index-stuck-indexing` incident shape). `StartCreate` takes no ctx parameter by design.
- Timeout/failure lands a legible terminal state (`state:failed` + `timed_out:true`), rolls back via `cleanup()` (registry row gone, no `.db` on disk, name free to retry).

## Verification
Both suites green honest-captured (go 49 ok / vet proven-to-run; JS 1191 pass, zero lint delta). The incident oracle is falsifiable — sabotaging the ctx-into-builder reproduces the stuck-'indexing' pin, uniquely. MN13 clean (operational bounds). Cold-reviewed independently: MERGE-READY, no findings.