### PR TITLE
Bridge lineage exclusion + mechanism-qualifies signal (#125)

### DIFF
--- a/internal/fact/motif_conformance_test.go
+++ b/internal/fact/motif_conformance_test.go
@@ -207,10 +207,20 @@ var mechanicsPaths = map[string][]string{
 	// What no entry here licenses: a motif term reaching dedup, clustering or
 	// search ranking. Those files stay nil below and this list does not touch
 	// them.
-	// laneOf, scoreMotifCandidate, rankAndCap, disjointMembers and
-	// copyMembers are deliberately NOT listed: their bodies name no motif
-	// identifier (they work on canonical ids, paths and scores), and this list
-	// rejects a permission nothing uses.
+	// laneOf, scoreMotifCandidate, disjointMembers and copyMembers are
+	// deliberately NOT listed: their bodies name no motif identifier (they work
+	// on canonical ids, paths and scores), and this list rejects a permission
+	// nothing uses.
+	//
+	// rankAndCap WAS in that sentence until #125 and no longer is. Nothing
+	// about what it does changed — it ranked motif bridge candidates before and
+	// ranks them now — but its inline sort literal became a call to the shared
+	// motifRankLess comparator, which names a motif identifier where the
+	// literal named none. That is the check working as designed rather than a
+	// false positive: MN6's register is of which functions READ motifs, and
+	// this one always did through the values it sorts. The alternative — naming
+	// the comparator so the word does not appear — is the fail-OPEN this test's
+	// own BasicLit case was added to close, so it was not taken.
 	//
 	// The names in this paragraph are prose, and the bidirectional machinery
 	// checks the allow-LIST rather than the reasoning beside it — so a rename
@@ -230,9 +240,29 @@ var mechanicsPaths = map[string][]string{
 	// session's health output. Reporting is not deciding — the no-branch
 	// property is what MN6 is about, and it holds: nothing in this package
 	// reads a health line.
+	// #125: the rank order gained an entity-overlap TIEBREAKER, and both rank
+	// paths now share one comparator (motifRankLess) so the served order and the
+	// measured order cannot drift. The two CALLERS name a motif identifier and
+	// are listed; motifRankLess itself is not, and deliberately so — its body
+	// reads only Q, the overlap and the token, so it mentions nothing, and the
+	// bidirectional half of this check refuses a permission nothing uses.
+	//
+	// What this licenses is ORDERING WITHIN THE AXIS, which is the §4/§5 path
+	// MN6 designs motifs into. What it does not license is the inverse — an
+	// entity term deciding whether a candidate EXISTS. The tiebreaker sits
+	// strictly below Q for exactly that reason, and is a sort term rather than
+	// a weight so no constant has to be invented to mean "small" (MN13).
 	"internal/synthesize/bridge_motif.go": {
 		"buildMotifBridges", "enumerateMotifCandidates", "sharedMotifSpecificity", "anyMotifs",
 		"motifResolverFor", "motifBridgeHealthLines", "verbatimGroups", "token2Families",
+		"rankAndCap", "rankAndCapRows",
+		// #125's qualify predicate. It is DECLARED here rather than beside
+		// BridgeKindFromString in bridge.go precisely so that file's nil entry
+		// above stays nil: a method whose body names BridgeMotif would have
+		// forced the entity/domain engine's "blind to motifs" declaration into
+		// a one-entry allow-list, to hold a predicate whose whole subject is
+		// the other axis. Moving the method preserved the stronger statement.
+		"Qualifies",
 		// Phase 4: buildMotifBridges' own loop, extracted so the measurement
 		// instrument and production drive the SAME enumeration and scoring
 		// rather than two implementations that agree until they do not. It IS

--- a/internal/synthesize/bridge.go
+++ b/internal/synthesize/bridge.go
@@ -71,6 +71,14 @@ const (
 // Enumeration for this kind lives entirely in bridge_motif.go, which is why no
 // function in THIS file mentions motifs — this file's mechanicsPaths entry
 // stays nil, and the MN6 declaration it makes stays true.
+//
+// #125 added a second member to that arrangement: BridgeKind.Qualifies, the
+// predicate that says only a shared MECHANISM qualifies a bridge, is declared
+// in bridge_motif.go rather than beside BridgeKindFromString here. Its body
+// names BridgeMotif, and putting it in this file would have turned the nil
+// entry above into a one-entry allow-list — eroding a documented property of
+// the entity/domain engine to hold a method whose entire subject is the OTHER
+// axis. Same rationale as the enumeration split, applied to a method.
 const BridgeMotif BridgeKind = "motif"
 
 // DefaultBridgeKind is the historical default — bridge on either axis.
@@ -86,6 +94,20 @@ func BridgeKindFromString(s string) BridgeKind {
 		return BridgeKind(s)
 	}
 	return DefaultBridgeKind
+}
+
+// entityAxisRankOnlyLine is the health line every surface that USED to serve
+// entity/domain bridges emits in their place.
+//
+// It exists because "0 bridges" and "this axis no longer qualifies" are the same
+// number, and a later auditor reading a session with no discover items has no
+// way to tell an axis that found nothing from one that cannot qualify — the
+// saturated-vs-broken confusion #147 was re-ruled over, one surface across.
+// The sentence names the state, not a count: there is no count to give.
+func entityAxisRankOnlyLine() string {
+	return "bridge axis: entity/domain is RANK-ONLY — a shared name no longer qualifies a " +
+		"bridge, only a shared mechanism does (#125). Zero entity bridges here is the " +
+		"designed state, not a stall."
 }
 
 // effortBudget is the maximum number of bridge seed sets a pool is truncated

--- a/internal/synthesize/bridge.go
+++ b/internal/synthesize/bridge.go
@@ -275,6 +275,11 @@ func enumerateBridgeCandidates(seeds []factForLLM, clusters ClusterResult, kind 
 		for _, f := range pathMap {
 			members = append(members, f)
 		}
+		// One-hop lineage exclusion (#125). Applied BEFORE the community-span
+		// check because dropping a member can collapse the span: a group whose
+		// two communities were "a synthesis" and "the fact it was distilled
+		// from" is not a bridge once the parent leaves. See bridge_lineage.go.
+		members, _ = lineageDisjointMembers(members)
 		if len(members) < 2 {
 			continue
 		}
@@ -424,6 +429,7 @@ func BuildBackwardBridges(
 	idx SearchQuery,
 	synthFacts []fact.Fact,
 	branch string,
+	localRepoID string,
 	effort Effort,
 	kind BridgeKind,
 	resolution float64,
@@ -439,15 +445,16 @@ func BuildBackwardBridges(
 	seeds := make([]factForLLM, 0, len(synthFacts))
 	for _, f := range synthFacts {
 		seeds = append(seeds, factForLLM{
-			File:       f.Path(),
-			Title:      f.Title,
-			Body:       f.Body,
-			Type:       string(f.Type),
-			Domain:     f.Domain,
-			Entities:   f.Entities,
-			Confidence: f.Confidence,
-			Sources:    f.Sources,
-			Origin:     string(f.Origin),
+			File:        f.Path(),
+			Title:       f.Title,
+			Body:        f.Body,
+			Type:        string(f.Type),
+			Domain:      f.Domain,
+			Entities:    f.Entities,
+			Confidence:  f.Confidence,
+			Sources:     f.Sources,
+			Origin:      string(f.Origin),
+			LineageRefs: localFactRefPaths(f.Refs, localRepoID),
 		})
 	}
 	groups, err := ScopedCluster(ctx, seeds, idx, resolution, minCommunitySize, func(ProgressEvent) {}, branch)

--- a/internal/synthesize/bridge_filtered.go
+++ b/internal/synthesize/bridge_filtered.go
@@ -307,6 +307,37 @@ func buildFilteredBridges(
 			}
 		}
 
+		// One-hop lineage exclusion (#125). The subset arrives cross-community
+		// by construction (reshapeCohesiveSubset), but a subset whose seam WAS
+		// a synthesis and its own source stops being a bridge once the parent
+		// leaves — so scoring runs over the survivors, and the Sep >= 2 gate in
+		// bridgeQ is what turns a collapsed span into a drop.
+		//
+		// `sub` itself is deliberately NOT narrowed: it is also the bookkeeping
+		// slice removed from `remaining` below, and shrinking it would leave the
+		// dropped parent in the pool to be re-extracted next iteration.
+		members, _ = lineageDisjointMembers(members)
+		if len(members) < 2 {
+			// Nothing scoreable left; fall through to the removal bookkeeping
+			// so the loop still makes progress on `remaining`.
+			subSet := make(map[string]bool, len(sub))
+			for _, p := range sub {
+				subSet[p] = true
+			}
+			next := remaining[:0:0]
+			for _, p := range remaining {
+				if !subSet[p] {
+					next = append(next, p)
+				}
+			}
+			remaining = next
+			continue
+		}
+		scored := make([]string, 0, len(members))
+		for _, m := range members {
+			scored = append(scored, m.File)
+		}
+
 		tok, tkind, spec := sharedSubToken(members, DefaultBridgeKind, seeds)
 		if tok != "" {
 			// Check whether tok canonically matches the scope along its own axis
@@ -333,16 +364,16 @@ func buildFilteredBridges(
 			}
 		}
 
-		gap, err := derivationGap(ctx, sub, idx)
+		gap, err := derivationGap(ctx, scored, idx)
 		if err != nil {
 			return nil, err
 		}
 		comp := BridgeComponents{
-			Coh:     cohesion(sub, g),
-			Sep:     separation(sub, clusterOf),
+			Coh:     cohesion(scored, g),
+			Sep:     separation(scored, clusterOf),
 			Gap:     gap,
 			Spec:    spec,
-			Members: len(sub),
+			Members: len(scored),
 		}
 		q, kept := bridgeQ(comp, cfg)
 		if kept {

--- a/internal/synthesize/bridge_lineage.go
+++ b/internal/synthesize/bridge_lineage.go
@@ -1,0 +1,126 @@
+package synthesize
+
+import (
+	"sort"
+
+	"knomit/internal/fact"
+)
+
+// One-hop lineage exclusion for bridge candidates (#125).
+//
+// A bridge is supposed to connect facts that nothing already connects. A
+// synthesis inherits its members' domain tags, so a token bridge can always
+// reconnect it to the very facts it was distilled from — measured on core
+// (2026-08-25): 4 of 4 discover items paired a synthesis with its own sources,
+// one of them a 5-seed item holding a synthesis plus THREE of its parents.
+// Reinforcing such a group raises `sources` using the evidence the fact was
+// already built from, which is a false ledger, not a confirmation.
+//
+// The exclusion is deliberately ONE HOP in either direction: a pair is dropped
+// when one member's refs name the other. Transitive (grandparent and deeper)
+// lineage is NOT excluded here and that is a decision, not an omission — it
+// would need a refs index or a graph walk, and neither is built speculatively
+// (designer ruling 2026-08-26). Deeper lineage is still felt at RANK, by
+// derivationGap's DERIVED_FROM term, which is why that term stays.
+
+// canonFactPath renders a fact's own path in the same canonical spelling
+// fact.ClassifyRef gives a ref's Path, so a member's path and another member's
+// stored refs can be compared as strings.
+//
+// A member path is always SCHEMELESS — it is the repo-relative path of a fact
+// in this repo, never a kb:// wire form — and ClassifyRef's schemeless branch
+// ignores localRepoID entirely when computing Path. Passing "" here is
+// therefore exact rather than a lossy shortcut; it is the stored REFS, not the
+// paths, that need the real repo id (see factForLLM.LineageRefs).
+func canonFactPath(p string) string {
+	return fact.ClassifyRef(p, "").Path
+}
+
+// lineagePair reports whether a and b stand in a direct citation relation —
+// b's path is among a's local refs, or a's among b's. Either direction counts:
+// a parent seeded beside its child is the same circularity as a child seeded
+// beside its parent.
+func lineagePair(a, b factForLLM) bool {
+	return cites(a, b) || cites(b, a)
+}
+
+// cites reports whether src's local refs name dst's path.
+func cites(src, dst factForLLM) bool {
+	want := canonFactPath(dst.File)
+	if want == "" {
+		return false
+	}
+	for _, r := range src.LineageRefs {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}
+
+// lineageDisjointMembers applies the one-hop lineage exclusion pairwise,
+// keeping a member only when it is lineage-disjoint from every member already
+// kept. It returns the survivors and how many members it dropped.
+//
+// Greedy rather than all-or-nothing, mirroring disjointMembers: one parent
+// sitting among four otherwise-unrelated facts must cost the group that one
+// member, not the whole bridge. Members are path-sorted first, so which member
+// survives a collision is deterministic rather than a function of map
+// iteration order.
+//
+// Callers must run this BEFORE any separation (community-span) check: dropping
+// a member can collapse the span, and a group that only spanned two
+// communities via the parent it just lost is not a bridge.
+func lineageDisjointMembers(members []factForLLM) ([]factForLLM, int) {
+	if len(members) < 2 {
+		return members, 0
+	}
+	ordered := make([]factForLLM, len(members))
+	copy(ordered, members)
+	sortByPath(ordered)
+
+	kept := make([]factForLLM, 0, len(ordered))
+	for _, cand := range ordered {
+		ok := true
+		for _, k := range kept {
+			if lineagePair(cand, k) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			kept = append(kept, cand)
+		}
+	}
+	return kept, len(ordered) - len(kept)
+}
+
+// sortByPath orders members by their fact path, in place. Every gate in the
+// bridge engine that drops members greedily needs the same deterministic
+// starting order, or which member survives a collision becomes a function of
+// map iteration order.
+func sortByPath(in []factForLLM) {
+	sort.SliceStable(in, func(i, j int) bool { return in[i].File < in[j].File })
+}
+
+// lineageDisjointMembersMap is lineageDisjointMembers over the path→fact map
+// shape the motif enumerator carries its groups in, returning the same shape so
+// the gates downstream of it are unchanged.
+func lineageDisjointMembersMap(members map[string]factForLLM) map[string]factForLLM {
+	if len(members) < 2 {
+		return members
+	}
+	all := make([]factForLLM, 0, len(members))
+	for _, f := range members {
+		all = append(all, f)
+	}
+	kept, dropped := lineageDisjointMembers(all)
+	if dropped == 0 {
+		return members
+	}
+	out := make(map[string]factForLLM, len(kept))
+	for _, f := range kept {
+		out[f.File] = f
+	}
+	return out
+}

--- a/internal/synthesize/bridge_lineage_test.go
+++ b/internal/synthesize/bridge_lineage_test.go
@@ -1,0 +1,422 @@
+package synthesize
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// testLocalRepoID is a well-formed 12-hex repo id. It is a REAL id shape, not
+// "", because "" is the configuration under which the lineage exclusion does
+// nothing at all (see TestBridgeLineage_EmptyRepoIDExcludesNothing) — a suite
+// that passed "" everywhere would be asserting the gate's behaviour with the
+// gate switched off.
+const testLocalRepoID = "abcdef012345"
+
+// storedRef renders a ref the way the corpus actually stores one: canonical
+// kb://<own-id12>/<path>, NOT a bare path. Every lineage test that means to
+// exercise production spelling uses this rather than writing the path raw.
+func storedRef(path string) string { return fact.QualifyKBPath(testLocalRepoID, path) }
+
+// lineageSeed is a two-community fixture member: it carries the shared token
+// the bridge would form on, plus whatever refs the test wants it to cite.
+func lineageSeed(path string, refs ...string) factForLLM {
+	return factForLLM{
+		File:        path,
+		Title:       path,
+		Body:        path + " body",
+		Type:        "observation",
+		Domain:      []string{"auth"},
+		Origin:      "authored",
+		LineageRefs: localFactRefPaths(refs, testLocalRepoID),
+	}
+}
+
+// ── the control: the fixture must produce a bridge when lineage is absent ──
+
+// TestBridgeLineage_ControlUnrelatedPairIsABridge is the falsifiability anchor
+// for every exclusion test below. The same two facts, in the same two
+// communities, on the same shared token, with NO citation between them, MUST
+// bridge. Without this, an exclusion test cannot tell "the gate dropped it"
+// from "the fixture never formed a candidate in the first place" — the
+// unreachable-branch shape that has cost this campaign three fixtures.
+func TestBridgeLineage_ControlUnrelatedPairIsABridge(t *testing.T) {
+	parent := lineageSeed("kb/synthesis/parent.md")
+	child := lineageSeed("kb/observations/child.md")
+
+	got := enumerateBridgeCandidates(
+		[]factForLLM{parent, child},
+		twoCommunities("kb/synthesis/parent.md", "kb/observations/child.md"),
+		BridgeDomain, ScopeFilter{})
+
+	set, found := containsToken(got, "auth")
+	require.True(t, found, "control: an uncited cross-community pair on a shared domain MUST bridge")
+	require.Len(t, set.Members, 2)
+}
+
+// TestBridgeLineage_ChildCitingParentIsNotABridge is #125's measured case: a
+// synthesis inherits its members' domain tags, so the domain token reconnects
+// it to the very facts it was distilled from. Reinforcing that group raises
+// `sources` on evidence the fact was already built from.
+func TestBridgeLineage_ChildCitingParentIsNotABridge(t *testing.T) {
+	parent := lineageSeed("kb/synthesis/parent.md")
+	child := lineageSeed("kb/observations/child.md", storedRef("kb/synthesis/parent.md"))
+
+	got := enumerateBridgeCandidates(
+		[]factForLLM{parent, child},
+		twoCommunities("kb/synthesis/parent.md", "kb/observations/child.md"),
+		BridgeDomain, ScopeFilter{})
+
+	_, found := containsToken(got, "auth")
+	require.False(t, found,
+		"a pair whose one member CITES the other is lineage, not a bridge: %+v", got)
+}
+
+// TestBridgeLineage_ParentCitingChildIsNotABridge pins the OTHER direction.
+// It is not symmetry for its own sake: the two directions arise from different
+// mechanisms — a distilled fact cites its sources (child→parent), and a merged
+// fact cites the predecessors it absorbed (parent→child) — so a one-directional
+// gate would silently pass a whole class.
+func TestBridgeLineage_ParentCitingChildIsNotABridge(t *testing.T) {
+	parent := lineageSeed("kb/synthesis/parent.md", storedRef("kb/observations/child.md"))
+	child := lineageSeed("kb/observations/child.md")
+
+	got := enumerateBridgeCandidates(
+		[]factForLLM{parent, child},
+		twoCommunities("kb/synthesis/parent.md", "kb/observations/child.md"),
+		BridgeDomain, ScopeFilter{})
+
+	_, found := containsToken(got, "auth")
+	require.False(t, found, "citation in EITHER direction is lineage: %+v", got)
+}
+
+// TestBridgeLineage_EmptyRepoIDExcludesNothing is the load-bearing test of this
+// file, and it asserts a FAILURE MODE rather than a feature.
+//
+// Refs are STORED CANONICAL as kb://<own-id12>/<path>. Classified with an empty
+// local repo id, every one of them reads as a FOREIGN fact ref, localFactRefPaths
+// returns nothing, and the exclusion has an empty set to test membership
+// against — so it excludes zero pairs while every other test in the suite still
+// passes. That is a whole fix shipping green and doing nothing.
+//
+// The two arms below are the SAME fixture and differ only in the repo id, so
+// what they measure is the id and nothing else.
+func TestBridgeLineage_EmptyRepoIDExcludesNothing(t *testing.T) {
+	raw := []string{storedRef("kb/synthesis/parent.md")}
+	clusters := twoCommunities("kb/synthesis/parent.md", "kb/observations/child.md")
+
+	withID := []factForLLM{
+		{File: "kb/synthesis/parent.md", Domain: []string{"auth"}, Origin: "authored"},
+		{File: "kb/observations/child.md", Domain: []string{"auth"}, Origin: "authored",
+			LineageRefs: localFactRefPaths(raw, testLocalRepoID)},
+	}
+	require.NotEmpty(t, withID[1].LineageRefs,
+		"fixture check: with the real repo id the stored ref MUST reduce to a local path")
+	_, found := containsToken(
+		enumerateBridgeCandidates(withID, clusters, BridgeDomain, ScopeFilter{}), "auth")
+	require.False(t, found, "with the repo id the lineage pair is excluded")
+
+	withoutID := []factForLLM{
+		{File: "kb/synthesis/parent.md", Domain: []string{"auth"}, Origin: "authored"},
+		{File: "kb/observations/child.md", Domain: []string{"auth"}, Origin: "authored",
+			LineageRefs: localFactRefPaths(raw, "")},
+	}
+	require.Empty(t, withoutID[1].LineageRefs,
+		"an empty repo id reads every stored ref as foreign — this is the trap being pinned")
+	_, found = containsToken(
+		enumerateBridgeCandidates(withoutID, clusters, BridgeDomain, ScopeFilter{}), "auth")
+	require.True(t, found,
+		"with an empty repo id the SAME lineage pair sails through — if this ever goes false, "+
+			"normalization has moved and the empty-id hazard is gone; delete this test rather than weaken it")
+}
+
+// TestBridgeLineage_BareRefSpellingAlsoExcludes covers the other spelling a ref
+// can legitimately carry: a schemeless repo-relative path. Both spellings mean
+// the same citation, so both must exclude.
+func TestBridgeLineage_BareRefSpellingAlsoExcludes(t *testing.T) {
+	parent := lineageSeed("kb/synthesis/parent.md")
+	child := lineageSeed("kb/observations/child.md", "kb/synthesis/parent.md")
+
+	got := enumerateBridgeCandidates(
+		[]factForLLM{parent, child},
+		twoCommunities("kb/synthesis/parent.md", "kb/observations/child.md"),
+		BridgeDomain, ScopeFilter{})
+
+	_, found := containsToken(got, "auth")
+	require.False(t, found, "a schemeless ref names the same fact and must exclude too: %+v", got)
+}
+
+// ── greedy drop, and what the drop does to the span ──
+
+// TestBridgeLineage_DropsOnlyTheLineageMember is the issue's 5-seed shape: a
+// synthesis seeded beside its own source AND an unrelated fact. The unrelated
+// member is a legitimate bridge partner and must survive; only the colliding
+// member goes.
+//
+// WHICH member goes is pinned here because a later test depends on it: the
+// greedy pass walks members in PATH ORDER and keeps the first of any colliding
+// pair, exactly as disjointMembers does. So the path-first member survives and
+// the one that cites it is dropped — deterministic, and deliberately not a
+// judgement about which of a parent and a child is worth more.
+func TestBridgeLineage_DropsOnlyTheLineageMember(t *testing.T) {
+	parent := lineageSeed("kb/a-synthesis.md")
+	child := lineageSeed("kb/b-child.md", storedRef("kb/a-synthesis.md"))
+	stranger := lineageSeed("kb/c-stranger.md")
+
+	// Three communities, so the survivors still span two after the drop.
+	clusters := ClusterResult{Clusters: map[int][]string{
+		0: {"kb/a-synthesis.md"}, 1: {"kb/b-child.md"}, 2: {"kb/c-stranger.md"},
+	}}
+
+	got := enumerateBridgeCandidates(
+		[]factForLLM{parent, child, stranger}, clusters, BridgeDomain, ScopeFilter{})
+
+	set, found := containsToken(got, "auth")
+	require.True(t, found, "the group must survive with its non-lineage members: %+v", got)
+	require.Len(t, set.Members, 2, "exactly one member — the colliding one — is dropped")
+	require.True(t, setHasMember(set, "kb/a-synthesis.md"),
+		"path-first member survives the collision")
+	require.False(t, setHasMember(set, "kb/b-child.md"),
+		"the member that cites an already-kept member is the one dropped")
+	require.True(t, setHasMember(set, "kb/c-stranger.md"),
+		"an unrelated member is not collateral damage")
+}
+
+// TestBridgeLineage_CollapsedSpanDropsTheGroup pins the ORDER of the gates:
+// the lineage drop runs BEFORE the community-span check. The dropped member is
+// the only thing that made this group cross-community, so once it leaves both
+// survivors sit in one community and there is no bridge left.
+//
+// Under the reversed order (span first) this group would be emitted, because
+// the span was still 2 when it was measured. That is the sabotage this test
+// exists to catch, and no other test in this file catches it: every other
+// exclusion case collapses to fewer than two members instead, which the
+// len(members) < 2 guard would reject under either ordering.
+func TestBridgeLineage_CollapsedSpanDropsTheGroup(t *testing.T) {
+	parent := lineageSeed("kb/a-parent.md")
+	child := lineageSeed("kb/b-child.md", storedRef("kb/a-parent.md"))
+	sibling := lineageSeed("kb/c-sibling.md")
+
+	// The CHILD — the member the greedy pass drops — is alone in community 1.
+	// Both survivors sit in community 0.
+	clusters := ClusterResult{Clusters: map[int][]string{
+		0: {"kb/a-parent.md", "kb/c-sibling.md"},
+		1: {"kb/b-child.md"},
+	}}
+
+	// Fixture check: before the drop this group really does span two
+	// communities, so the span check it must not reach would have passed.
+	require.Len(t, []factForLLM{parent, child, sibling}, 3)
+
+	got := enumerateBridgeCandidates(
+		[]factForLLM{parent, child, sibling}, clusters, BridgeDomain, ScopeFilter{})
+
+	_, found := containsToken(got, "auth")
+	require.False(t, found,
+		"the span was only 2 BECAUSE of the dropped member; after the drop the "+
+			"survivors are in one community and this is not a bridge: %+v", got)
+}
+
+// ── the motif axis ──
+
+// TestBridgeLineage_MotifSignalExcludesParentAndOwnSource is s175: the shared-
+// motif signal's first live firing offered a parent and its own source as a
+// reason to synthesize, because the parent had INHERITED the child's motif. A
+// motif shared BY CITATION is not a recurrence, and the signal cannot be
+// trusted until such pairs are gone.
+func TestBridgeLineage_MotifSignalExcludesParentAndOwnSource(t *testing.T) {
+	clusters := twoCommunities("kb/synthesis/parent.md", "kb/observations/child.md")
+	labels := labelsWith(200, map[string]int{"alpha": 2, "beta": 3})
+
+	control := []factForLLM{
+		{File: "kb/synthesis/parent.md", Motifs: []string{"legitimate-tool-hides-intent"},
+			Entities: []string{"Alpha"}},
+		{File: "kb/observations/child.md", Motifs: []string{"legitimate-tool-hides-intent"},
+			Entities: []string{"Beta"}},
+	}
+	got, _ := enumerateMotifCandidates(control, clusters, identityResolver, constDF(2), labels, tierExact)
+	require.Len(t, got, 1,
+		"control: two independently-assigned carriers of one motif ARE a candidate")
+
+	lineage := []factForLLM{
+		control[0],
+		{File: "kb/observations/child.md", Motifs: []string{"legitimate-tool-hides-intent"},
+			Entities: []string{"Beta"},
+			LineageRefs: localFactRefPaths(
+				[]string{storedRef("kb/synthesis/parent.md")}, testLocalRepoID)},
+	}
+	got, _ = enumerateMotifCandidates(lineage, clusters, identityResolver, constDF(2), labels, tierExact)
+	require.Empty(t, got,
+		"the SAME pair, with the child citing the parent, is a motif manufactured by "+
+			"citation and must not be enumerated: %+v", got)
+}
+
+// ── the scoped (token-optional) path ──
+
+// TestBridgeLineage_FilteredPathExcludesLineagePair covers the third
+// enumeration path — the one scoped sessions use. It does not share
+// enumerateBridgeCandidates with the other two, so an exclusion that only
+// landed there would leave every scoped session unprotected.
+func TestBridgeLineage_FilteredPathExcludesLineagePair(t *testing.T) {
+	run := func(t *testing.T, childRefs []string) []BridgeSeedSet {
+		t.Helper()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		seeds := []factForLLM{
+			{File: "a.md", Domain: []string{"billing"}, Entities: []string{"Invoice"}},
+			{File: "b.md", Domain: []string{"billing"}, Entities: []string{"Payment"},
+				LineageRefs: localFactRefPaths(childRefs, testLocalRepoID)},
+		}
+		g := store.NewSimilarityGraph([][2]string{{"a.md", "b.md"}})
+		clusters := ClusterResult{Clusters: map[int][]string{0: {"a.md"}, 1: {"b.md"}}}
+
+		idx := NewMockSearchIndex(ctrl)
+		idx.EXPECT().SimilarityAdjacency(gomock.Any(), gomock.InAnyOrder([]string{"a.md", "b.md"})).
+			Return(g, nil).AnyTimes()
+		idx.EXPECT().ReverseDependentPaths(gomock.Any(), gomock.Any()).
+			Return(map[string]struct{}{}, nil).AnyTimes()
+
+		out, err := buildFilteredBridges(context.Background(), idx, "main", seeds, clusters,
+			ScopeFilter{Domain: []string{"auth"}}, EffortHigh, filteredCfg)
+		require.NoError(t, err)
+		return out
+	}
+
+	require.Len(t, run(t, nil), 1,
+		"control: the scoped extractor DOES produce a bridge for this pair when nothing cites")
+	require.Empty(t, run(t, []string{storedRef("a.md")}),
+		"the same pair, with b citing a, must not reach an agent")
+}
+
+// TestBridgeLineage_TransitiveIsDELIBERATELYNotExcluded records the boundary of
+// this fix so a later reader does not file the gap as a bug.
+//
+// A grandparent/grandchild pair — a cites b, b cites c, nothing links a and c —
+// still bridges. Excluding it needs a refs index or a graph walk, and the
+// ruling (2026-08-26) defers building either until a drain shows grandparent
+// loops actually occurring. Deeper lineage is still FELT, at rank, through
+// derivationGap's DERIVED_FROM term.
+//
+// If a future change makes this pair excluded, this test failing is the correct
+// signal: the deferral was lifted, and that is a decision worth being told about.
+func TestBridgeLineage_TransitiveIsDELIBERATELYNotExcluded(t *testing.T) {
+	a := lineageSeed("kb/a-top.md", storedRef("kb/b-mid.md"))
+	b := lineageSeed("kb/b-mid.md", storedRef("kb/c-bottom.md"))
+	c := lineageSeed("kb/c-bottom.md")
+
+	// Only a and c are offered, so nothing in hand links them.
+	got := enumerateBridgeCandidates(
+		[]factForLLM{a, c},
+		twoCommunities("kb/a-top.md", "kb/c-bottom.md"),
+		BridgeDomain, ScopeFilter{})
+
+	set, found := containsToken(got, "auth")
+	require.True(t, found, "one-hop only: a grandparent pair is NOT excluded today")
+	require.Len(t, set.Members, 2)
+	require.NotEmpty(t, b.LineageRefs, "fixture check: the middle fact really does carry the hop")
+}
+
+// ── the WIRING: the projection sites, not the gate ──
+//
+// Every test above builds factForLLM by hand and therefore asserts that the
+// GATE works. None of them asserts that anything POPULATES LineageRefs
+// correctly, which is the half that actually meets production spelling — and a
+// sabotage replacing localFactRefPaths(f.Refs, id) with a bare f.Refs at the
+// projection sites passed all of them (the #117a shape: a test that calls the
+// helper is not a test of the wiring). The two below drive the real projections.
+
+// TestBridgeLineage_ReviewProjectionNormalizesStoredRefs pins the forward
+// (review) projection: a fact.Fact carrying a ref in the CANONICAL STORED
+// spelling must arrive at the scorer as the bare local path the gate compares.
+func TestBridgeLineage_ReviewProjectionNormalizesStoredRefs(t *testing.T) {
+	parentPath := "kb/synthesis/parent.md"
+
+	parent := fact.NewFact(parentPath)
+	parent.Title, parent.Body, parent.Type = "parent", "parent body", fact.Synthesis
+	parent.Domain = []string{"auth"}
+
+	child := fact.NewFact("kb/observations/child.md")
+	child.Title, child.Body, child.Type = "child", "child body", fact.Observation
+	child.Domain = []string{"auth"}
+	child.Refs = []string{storedRef(parentPath)}
+
+	// Fixture check: the ref really is in the kb:// stored form, not a bare
+	// path — otherwise this test would pass with normalization removed.
+	require.Contains(t, child.Refs[0], "kb://",
+		"fixture must use the stored spelling; a bare path would not exercise normalization")
+
+	seeds := factsForLLM([]fact.Fact{parent, child}, testLocalRepoID)
+	require.Len(t, seeds, 2)
+
+	var childSeed factForLLM
+	for _, s := range seeds {
+		if s.File == child.Path() {
+			childSeed = s
+		}
+	}
+	require.Equal(t, []string{parentPath}, childSeed.LineageRefs,
+		"the projection must reduce the stored kb:// ref to the local path the gate compares")
+
+	// And end to end through the gate, so the wiring is pinned by behaviour and
+	// not only by a field value.
+	_, found := containsToken(
+		enumerateBridgeCandidates(seeds, twoCommunities(parent.Path(), child.Path()),
+			BridgeDomain, ScopeFilter{}),
+		"auth")
+	require.False(t, found, "projected seeds must carry enough for the gate to fire")
+}
+
+// TestBridgeLineage_BackwardProjectionExcludesLineagePair pins the SECOND
+// projection — the hypothesize path's own factForLLM construction, which does
+// not go through factsForLLM and so could regress independently.
+func TestBridgeLineage_BackwardProjectionExcludesLineagePair(t *testing.T) {
+	ctx := context.Background()
+
+	mk := func(path string, refs ...string) fact.Fact {
+		f := fact.NewFact(path)
+		f.Title, f.Body, f.Type = path, path, fact.Synthesis
+		f.Domain, f.Entities = []string{"auth"}, []string{"shared"}
+		f.Refs = refs
+		return f
+	}
+
+	run := func(t *testing.T, facts []fact.Fact) []BridgeSeedSet {
+		t.Helper()
+		m := NewMockSearchIndex(gomock.NewController(t))
+		expectScopedClusterPartition(m, nil, [][]string{{"kb/a.md"}, {"kb/b.md"}})
+		m.EXPECT().SimilarityAdjacency(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, paths []string) (store.SimilarityGraph, error) {
+				pairs := make([][2]string, 0)
+				for i := 0; i < len(paths); i++ {
+					for j := i + 1; j < len(paths); j++ {
+						pairs = append(pairs, [2]string{paths[i], paths[j]})
+					}
+				}
+				return store.NewSimilarityGraph(pairs), nil
+			}).AnyTimes()
+		m.EXPECT().ReverseDependentPaths(gomock.Any(), gomock.Any()).
+			Return(map[string]struct{}{}, nil).AnyTimes()
+		m.EXPECT().TokenDF(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(1, nil).AnyTimes()
+
+		out, err := BuildBackwardBridges(ctx, m, facts, "agent/test", testLocalRepoID,
+			EffortHigh, BridgeDomain, 2.0, 2, testCfg, ScopeFilter{})
+		require.NoError(t, err)
+		return out
+	}
+
+	control := run(t, []fact.Fact{mk("kb/a.md"), mk("kb/b.md")})
+	_, found := containsToken(control, "auth")
+	require.True(t, found, "control: the backward path DOES bridge this pair when nothing cites")
+
+	lineage := run(t, []fact.Fact{mk("kb/a.md"), mk("kb/b.md", storedRef("kb/a.md"))})
+	_, found = containsToken(lineage, "auth")
+	require.False(t, found,
+		"the same pair, with b citing a in the stored spelling, must not reach an agent")
+}

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -240,6 +240,21 @@ func enumerateMotifCandidates(
 			continue
 		}
 
+		// GATE 2.5 — one-hop lineage exclusion (#125), pairwise (see
+		// lineageDisjointMembers). Ordered BEFORE subject-disjointness because
+		// it is the cheap one — set membership over refs already in hand, no
+		// index and no walk — and before separation because dropping a member
+		// can change the community span.
+		//
+		// This gate is why the shared-motif signal can be trusted at all: the
+		// signal's first-ever live firing (s175) offered a parent and its own
+		// source as a reason to synthesize, because the parent had INHERITED
+		// the child's motif. A motif shared by citation is not a recurrence.
+		members = lineageDisjointMembersMap(members)
+		if len(members) < 2 {
+			continue
+		}
+
 		// GATE 3 — subject-disjointness, applied pairwise (see disjointMembers).
 		// Ordered after the df band because it is the expensive one, and before
 		// separation because dropping a member can change the community span.

--- a/internal/synthesize/bridge_motif.go
+++ b/internal/synthesize/bridge_motif.go
@@ -157,7 +157,45 @@ type enumeratedMotif struct {
 	// family reports that this group came from the token-2 tier — a fold of
 	// several canonical ids — rather than from one id's own carriers.
 	family bool
+	// entOverlap is the group's mean pairwise entity-set overlap
+	// (NoveltySignals.EntityJaccard), carried here for ONE purpose: to break
+	// ties in the rank order (#125). Entity overlap never qualifies a bridge
+	// and never enters Q — a pair earns its place on the MECHANISM it shares,
+	// and shared names only decide which of two otherwise-equal groups an agent
+	// sees first. Zero when unset, which simply means no tiebreak.
+	entOverlap float64
 }
+
+// Qualifies reports whether a shared token of this kind can QUALIFY a pair as a
+// bridge — that is, whether it is enough on its own to put a candidate in front
+// of an agent.
+//
+// ONLY A SHARED MECHANISM QUALIFIES (designer ruling 2026-08-26, #125). Entity
+// and domain overlap never do; they enter only at RANK, deciding which of two
+// groups that already share a mechanism an agent sees first (motifRankLess).
+//
+// This is a measured verdict, not a preference. Across the whole drain the
+// shared-signal tally reached six firings — three manufactured by lineage, one
+// redundant with entity overlap, one redundant with a cross-reference the author
+// had already written in prose, one entity-overlap-by-mention — and ZERO that
+// cleared the axis's four success clauses (no shared entity after
+// normalisation, no common synthesis, different subject areas, not
+// near-duplicates). Session 206 measured the mechanism directly: every
+// entity/domain bridge that session produced nothing, because a token like
+// domain="ai" is degenerate in an AI corpus and preferentially selects DIGEST
+// facts, whose broad tags make the corpus's lowest-quality records its most
+// attractive seeds.
+//
+// The accepted consequence is SILENCE, not a fallback: a corpus or scope whose
+// motif axis is inactive gets no discover bridges at all rather than
+// entity-only ones. No entity-only bridge has ever been shown to be worth an
+// agent's time, so the silence costs nothing that was demonstrated.
+//
+// Note the asymmetry with the degenerate-token problem: the surviving axis
+// already fences it, with a df ceiling DERIVED from the corpus
+// (max(12, 2%*LiveFacts), bridge_motif.go). The entity axis never had one and
+// now needs none.
+func (k BridgeKind) Qualifies() bool { return k == BridgeMotif }
 
 // enumerateMotifCandidates is the §4 enumeration loop, with the gates applied
 // in §4 order: df band, then Louvain separation, then subject-disjointness.
@@ -846,6 +884,7 @@ func buildMotifBridgesWithRows(
 		}
 		cand := r.cand
 		cand.Q = r.q
+		cand.entOverlap = r.comp.Novelty.EntityJaccard
 		if r.lane == LaneNear {
 			near = append(near, cand)
 		} else {
@@ -881,12 +920,7 @@ func rankAndCapRows(in []enumeratedMotif, budget int, rows []scoredMotifRow, row
 			rows[i].cause = cause
 		}
 	}
-	sort.SliceStable(kept, func(i, j int) bool {
-		if kept[i].Q != kept[j].Q {
-			return kept[i].Q > kept[j].Q
-		}
-		return kept[i].Token < kept[j].Token
-	})
+	sort.SliceStable(kept, motifRankLess(kept))
 	if len(kept) > budget {
 		kept = kept[:budget]
 	}
@@ -1200,19 +1234,46 @@ func anyMotifs(seeds []factForLLM) bool {
 	return false
 }
 
-// rankAndCap orders by Q descending, Token ascending, and truncates to the
-// lane's own budget. A zero budget means the lane is closed at this effort.
+// motifRankLess is the ONE rank order for motif bridges: Q descending, then
+// entity overlap descending, then Token ascending.
+//
+// The middle term is #125's "entities are TIEBREAKER-ONLY" half, and its
+// POSITION is the whole of its semantics. Sitting BELOW Q, it can only choose
+// between groups the mechanism signal already scored equally; it can never lift
+// a group with a weaker mechanism above a stronger one, which is what a weight
+// inside Q would do.
+//
+// It is a tiebreaker rather than a weight for a second reason: a weight needs a
+// DEFAULT, and there is no measured distribution to derive one from. Its three
+// siblings (WCoh, WGap, WSpec) all default to 1.0, which here would make entity
+// overlap a co-equal term — "entities partly qualify", the thing the ruling
+// forbids — and any smaller value would be a number invented to mean "small".
+// That is the shape anti-patterns/corpus-property-constants exists to refuse.
+// A continuous entity nudge, if one is ever wanted, is a calibration item with
+// a measured default, not this fix.
+//
+// Shared by both rank paths so the served order and the measured order cannot
+// drift apart.
+func motifRankLess(in []enumeratedMotif) func(i, j int) bool {
+	return func(i, j int) bool {
+		if in[i].Q != in[j].Q {
+			return in[i].Q > in[j].Q
+		}
+		if in[i].entOverlap != in[j].entOverlap {
+			return in[i].entOverlap > in[j].entOverlap
+		}
+		return in[i].Token < in[j].Token
+	}
+}
+
+// rankAndCap orders by motifRankLess and truncates to the lane's own budget.
+// A zero budget means the lane is closed at this effort.
 func rankAndCap(in []enumeratedMotif, budget int) ([]BridgeSeedSet, int) {
 	if budget == 0 {
 		return nil, 0
 	}
 	in, crossTier := suppressContained(in)
-	sort.SliceStable(in, func(i, j int) bool {
-		if in[i].Q != in[j].Q {
-			return in[i].Q > in[j].Q
-		}
-		return in[i].Token < in[j].Token
-	})
+	sort.SliceStable(in, motifRankLess(in))
 	if len(in) > budget {
 		in = in[:budget]
 	}

--- a/internal/synthesize/bridge_motif_report.go
+++ b/internal/synthesize/bridge_motif_report.go
@@ -196,6 +196,7 @@ func MotifComponentReport(
 	motifs store.MotifIndex,
 	abstraction store.AbstractionIndex,
 	branch string,
+	localRepoID string,
 	eff Effort,
 	resolution float64,
 	minCommunitySize int,
@@ -218,7 +219,7 @@ func MotifComponentReport(
 		if !strat.AcceptSeed(f) {
 			continue
 		}
-		seeds = append(seeds, factsForLLM([]fact.Fact{f})...)
+		seeds = append(seeds, factsForLLM([]fact.Fact{f}, localRepoID)...)
 	}
 	rep.Seeds = len(seeds)
 	for _, s := range seeds {

--- a/internal/synthesize/bridge_qualify_test.go
+++ b/internal/synthesize/bridge_qualify_test.go
@@ -1,0 +1,367 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// TestBridgeKind_OnlyMechanismQualifies is the ruling in one assertion: a shared
+// MECHANISM qualifies a bridge; a shared NAME does not.
+func TestBridgeKind_OnlyMechanismQualifies(t *testing.T) {
+	require.True(t, BridgeMotif.Qualifies(), "a shared mechanism qualifies")
+	require.False(t, BridgeEntity.Qualifies(), "a shared entity name never qualifies")
+	require.False(t, BridgeDomain.Qualifies(), "a shared domain tag never qualifies")
+	require.False(t, BridgeBoth.Qualifies(), "neither does 'both' — it is the two non-qualifying axes")
+	require.False(t, BridgeKind("").Qualifies(), "an unset kind qualifies nothing")
+}
+
+// TestBridgeKind_NoConfigValueCanRequalifyTheEntityAxis pins the OTHER half of
+// why the entity axis is now silent, which is not in Qualifies() at all: the
+// per-repo `discovery.bridge` knob cannot name the motif axis. BridgeMotif is
+// deliberately absent from BridgeKindFromString, because motif bridging is
+// bound to the effort dial rather than to config.
+//
+// Without this, a reader could conclude the silence is a misconfiguration a
+// repo can fix by setting discovery.bridge = "motif". It cannot.
+func TestBridgeKind_NoConfigValueCanRequalifyTheEntityAxis(t *testing.T) {
+	for _, in := range []string{"", "domain", "entity", "both", "motif", "nonsense"} {
+		require.Falsef(t, BridgeKindFromString(in).Qualifies(),
+			"discovery.bridge = %q must not be able to make the token axis qualify", in)
+	}
+}
+
+// ── the review surface ──
+
+// TestReviewQualifyGate_EntityBridgesAreNotEnqueued is the behavioural half,
+// and it is built as a PAIR of assertions on ONE fixture so it cannot pass
+// vacuously:
+//
+//  1. the builder, run over the same seeds, DOES produce an entity/domain
+//     bridge — so the corpus provably would have served discover items before
+//     this change, and a green result is not "the fixture never bridged";
+//  2. the session nevertheless enqueues NO discover item, and says why.
+//
+// Assertion 1 is the load-bearing one. Without it this test would stay green if
+// the seeds stopped bridging for any unrelated reason — the fixture-vacuity
+// shape that has cost this campaign four fixtures.
+func TestReviewQualifyGate_EntityBridgesAreNotEnqueued(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+	branch := "agent/test"
+
+	// Four facts on one shared domain token, no motifs anywhere — the exact
+	// shape #125 measured on core, and a corpus the motif axis cannot serve.
+	paths := []string{"kb/alpha/one.md", "kb/beta/two.md", "kb/gamma/three.md", "kb/delta/four.md"}
+	seeds := make([]fact.Fact, 0, len(paths))
+	for i, p := range paths {
+		f := fact.NewFact(p)
+		f.Title, f.Body, f.Type = p, "body of "+p, fact.Observation
+		f.Domain, f.Confidence, f.Sources = []string{"auth"}, 0.5, 1
+		f.Entities = []string{[]string{"Alpha", "Beta", "Gamma", "Delta"}[i]}
+		body, serr := fact.SerializeFact(f)
+		require.NoError(t, serr)
+		_, werr := svc.Facts().WriteFact(ctx, branch, f.Path(), body, "seed", "")
+		require.NoError(t, werr)
+		seeds = append(seeds, f)
+	}
+
+	// (1) FIXTURE CHECK — these seeds really do form an entity/domain bridge.
+	llm := factsForLLM(seeds, testLocalRepoID)
+	clusters := ClusterResult{Clusters: map[int][]string{
+		0: {paths[0], paths[1]}, 1: {paths[2], paths[3]},
+	}}
+	cands := enumerateBridgeCandidates(llm, clusters, BridgeBoth, ScopeFilter{})
+	_, wouldBridge := containsToken(cands, "auth")
+	require.True(t, wouldBridge,
+		"fixture check: this corpus DOES produce a domain bridge — without this, "+
+			"the absence asserted below would prove nothing")
+
+	// (2) BEHAVIOUR — a real high-effort session serves none of it.
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name: "test", AgentBranch: branch, Svc: svc, OntologyRoot: "kb",
+	})
+	r := NewReviewerWithEffort(ri, nil, EffortHigh)
+
+	res, err := r.StartSession(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.SessionID)
+
+	items, err := svc.Pipeline().PendingPipelineWorkItems(ctx, res.SessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, items,
+		"the session must have queued its grounded work — an empty queue would make "+
+			"the discover-absence below meaningless")
+	for _, it := range items {
+		require.NotEqualf(t, "discover", it.StepType,
+			"no discover item may be enqueued from a mechanism-free corpus (%s)", it.ClusterKey)
+	}
+
+	// (3) AND IT SAYS WHY. A zero that does not explain itself is the
+	// saturated-vs-broken confusion this campaign already paid for once.
+	require.Contains(t, strings.Join(res.Health, "\n"), "RANK-ONLY",
+		"the session must state that the entity/domain axis cannot qualify, so a "+
+			"later auditor does not read zero discover items as a stall")
+}
+
+// TestReviewQualifyGate_HealthLineNamesTheDesignedState guards the CONTENT of
+// the line rather than only its presence. The line exists to stop a reader
+// diagnosing a stall, so it has to say both halves: what still qualifies, and
+// that zero is designed.
+func TestReviewQualifyGate_HealthLineNamesTheDesignedState(t *testing.T) {
+	line := entityAxisRankOnlyLine()
+	require.Contains(t, line, "mechanism", "it must name what DOES qualify")
+	require.Contains(t, strings.ToLower(line), "not a stall",
+		"it must rule out the reading it exists to prevent")
+	require.Contains(t, line, "#125", "it must be traceable to the ruling")
+}
+
+// ── the tiebreaker ──
+
+// TestMotifRankLess_EntityOverlapBreaksTiesButNeverOutranks is a two-arm test
+// and the SECOND arm is the load-bearing one.
+//
+// Arm 1 shows entity overlap doing its job among equals. Arm 2 shows it failing
+// to do anything when Q differs — which is the whole difference between a
+// tiebreaker and a weight, and the property that makes "entities never qualify"
+// true of the rank order too. Under a WEnt weight in Q, arm 2 flips.
+func TestMotifRankLess_EntityOverlapBreaksTiesButNeverOutranks(t *testing.T) {
+	mk := func(token string, q, ent float64) enumeratedMotif {
+		return enumeratedMotif{
+			BridgeSeedSet: BridgeSeedSet{Token: token, Kind: BridgeMotif, Q: q},
+			entOverlap:    ent,
+		}
+	}
+
+	t.Run("equal Q: more entity overlap ranks first", func(t *testing.T) {
+		// "a-token" sorts before "b-token", so Token-asc alone would put it
+		// first — the tiebreaker has to actively reverse that to be visible.
+		in := []enumeratedMotif{mk("a-token", 0.5, 0.1), mk("b-token", 0.5, 0.9)}
+		sortMotifsForTest(in)
+		require.Equal(t, "b-token", in[0].Token,
+			"among equal-Q groups the one whose members share more entities is seen first")
+	})
+
+	t.Run("higher Q wins even with zero entity overlap", func(t *testing.T) {
+		in := []enumeratedMotif{mk("a-token", 0.4, 1.0), mk("b-token", 0.5, 0.0)}
+		sortMotifsForTest(in)
+		require.Equal(t, "b-token", in[0].Token,
+			"entity overlap must NEVER lift a weaker mechanism above a stronger one — "+
+				"if this flips, the tiebreaker has become a weight and entities qualify again")
+	})
+
+	t.Run("equal Q and equal overlap falls back to Token asc", func(t *testing.T) {
+		in := []enumeratedMotif{mk("b-token", 0.5, 0.5), mk("a-token", 0.5, 0.5)}
+		sortMotifsForTest(in)
+		require.Equal(t, "a-token", in[0].Token,
+			"the determinism the rank order had before must survive the new term")
+	})
+}
+
+// TestMotifRankLess_IsSharedByBothRankPaths pins that the served order and the
+// measured order use ONE comparator. They drifted before (review finding M-4
+// was the same class: a measurement surface reporting a disposition production
+// never applied), and two sort literals is exactly how that recurs.
+func TestMotifRankLess_IsSharedByBothRankPaths(t *testing.T) {
+	mk := func(token string, q, ent float64) enumeratedMotif {
+		return enumeratedMotif{
+			BridgeSeedSet: BridgeSeedSet{Token: token, Kind: BridgeMotif, Q: q,
+				Members: []factForLLM{{File: token + "-x.md"}, {File: token + "-y.md"}}},
+			entOverlap: ent,
+		}
+	}
+	in := []enumeratedMotif{mk("a-token", 0.5, 0.1), mk("b-token", 0.5, 0.9)}
+
+	viaRankAndCap, _ := rankAndCap(append([]enumeratedMotif{}, in...), 8)
+
+	rows := make([]scoredMotifRow, 0, len(in))
+	rowOf := map[string]int{}
+	for i, c := range in {
+		rows = append(rows, scoredMotifRow{cand: c, lane: LaneNear, q: c.Q, kept: true})
+		rowOf[memberKey(c)] = i
+	}
+	viaRankAndCapRows, _ := rankAndCapRows(append([]enumeratedMotif{}, in...), 8, rows, rowOf)
+
+	require.Len(t, viaRankAndCap, 2)
+	require.Len(t, viaRankAndCapRows, 2)
+	require.Equal(t, "b-token", viaRankAndCap[0].Token)
+	require.Equal(t, viaRankAndCapRows[0].Token, viaRankAndCap[0].Token,
+		"both rank paths must order identically — one comparator, no second literal")
+}
+
+// sortMotifsForTest applies the production comparator, so a test can never
+// assert against a re-implementation of the order it is checking.
+func sortMotifsForTest(in []enumeratedMotif) {
+	sort.SliceStable(in, motifRankLess(in))
+}
+
+// TestDiscoverPayloadShapeUnchanged is a cheap guard on the one thing the
+// qualify gate must NOT have changed: a discover item's payload. The gate
+// decides WHETHER an item is made, never what is in it.
+func TestDiscoverPayloadShapeUnchanged(t *testing.T) {
+	b, err := json.Marshal(DiscoverWorkPayload{
+		Direction: DiscoverForward,
+		Bridge:    BridgeSeedSet{Token: "x", Kind: BridgeMotif},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"kind":"motif"`)
+}
+
+// TestMotifRankLess_EntityOverlapIsPopulatedByTheBuilder closes the gap the
+// rank tests above cannot see.
+//
+// Those tests set entOverlap by hand, so they assert the COMPARATOR. Nothing in
+// them asserts that production ever fills the field — and a sabotage deleting
+// the single assignment in buildMotifBridgesWithRows passed every one of them,
+// leaving the tiebreaker permanently inert at zero. Same shape as the lineage
+// half's projection gap: a test that hands the value in is not a test of the
+// wiring that produces it.
+//
+// This drives the real builder. Two candidates that tie on Q, one whose members
+// share a high-df entity (so the subject-disjointness gate lets them stand —
+// an umbrella label is ignored there, which is precisely the s183 shape where
+// the motif signal was redundant with entity overlap) and one whose members
+// share none.
+func TestMotifRankLess_EntityOverlapIsPopulatedByTheBuilder(t *testing.T) {
+	// "gartner" is carried by 100 of 200 live facts: far above the umbrella
+	// cut, so the disjointness gate ignores it and both members survive.
+	labels := labelsWith(200, map[string]int{"gartner": 100})
+
+	seeds := []factForLLM{
+		// Group "a-shared": both members carry the umbrella entity.
+		{File: "kb/alpha/1.md", Motifs: []string{"a-shared-shape"}, Entities: []string{"Gartner"}},
+		{File: "kb/beta/2.md", Motifs: []string{"a-shared-shape"}, Entities: []string{"Gartner"}},
+		// Group "b-disjoint": entity lists share nothing.
+		{File: "kb/gamma/3.md", Motifs: []string{"b-disjoint-shape"}, Entities: []string{"Hapax1"}},
+		{File: "kb/delta/4.md", Motifs: []string{"b-disjoint-shape"}, Entities: []string{"Hapax2"}},
+		// A third recurring motif, needed only to clear the per-corpus
+		// activation floor (3 recurring motifs). Both carriers sit in ONE
+		// community, so the separation gate drops the group and it never
+		// reaches the ranking this test is about — it pays the entry fee
+		// without joining the race.
+		{File: "kb/eps/5.md", Motifs: []string{"c-filler-shape"}, Entities: []string{"Hapax3"}},
+		{File: "kb/zeta/6.md", Motifs: []string{"c-filler-shape"}, Entities: []string{"Hapax4"}},
+	}
+	clusters := ClusterResult{Clusters: map[int][]string{
+		0: {"kb/alpha/1.md"}, 1: {"kb/beta/2.md"},
+		2: {"kb/gamma/3.md"}, 3: {"kb/delta/4.md"},
+		4: {"kb/eps/5.md", "kb/zeta/6.md"},
+	}}
+
+	near, far, health, err := buildMotifBridges(context.Background(), &countingSearchIndex{},
+		"main", seeds, clusters, EffortHigh, motifQualityConfig(),
+		identityResolver, labels, nil)
+	require.NoError(t, err)
+
+	served := append(append([]BridgeSeedSet{}, near...), far...)
+	require.Lenf(t, served, 2,
+		"fixture check: BOTH groups must survive every gate, or the ordering below "+
+			"is not an ordering (candidates=%d)", health.Candidates)
+
+	// Both groups score identically — same df, same (empty) adjacency, same
+	// derivation gap — so Q cannot be what separates them.
+	require.Equal(t, served[0].Q, served[1].Q,
+		"fixture check: the two groups must TIE on Q, or this test would pass "+
+			"on the Q term and never exercise the tiebreaker at all")
+
+	// Token-ascending alone would put "a-shared-shape" first regardless, so the
+	// assertion is made on the group that Token order already favours — which
+	// means it can only be evidence together with the reverse check below.
+	require.Equal(t, "a-shared-shape", served[0].Token,
+		"the group whose members share an entity is served first among equals")
+
+	// THE REVERSE CHECK: rename so Token order fights the tiebreaker. If
+	// entOverlap is never populated, Token asc decides and "a-disjoint-shape"
+	// wins; only a populated overlap can put the shared-entity group first.
+	for i := range seeds {
+		switch seeds[i].Motifs[0] {
+		case "a-shared-shape":
+			seeds[i].Motifs = []string{"z-shared-shape"}
+		case "b-disjoint-shape":
+			seeds[i].Motifs = []string{"a-disjoint-shape"}
+		}
+	}
+	near, far, _, err = buildMotifBridges(context.Background(), &countingSearchIndex{},
+		"main", seeds, clusters, EffortHigh, motifQualityConfig(),
+		identityResolver, labels, nil)
+	require.NoError(t, err)
+	served = append(append([]BridgeSeedSet{}, near...), far...)
+	require.Len(t, served, 2)
+	require.Equal(t, "z-shared-shape", served[0].Token,
+		"with Token order pointing the other way, only a populated entity overlap can "+
+			"still rank the shared-entity group first — if this fails, the builder is "+
+			"not filling entOverlap and the tiebreaker is inert")
+}
+
+// TestHypothesizeQualifyGate_BackwardBridgesAreNotEnqueued covers the SECOND
+// surface the qualify gate darkens, and it is the one a reader is most likely
+// to misdiagnose.
+//
+// The hypothesize tool's own discovery is entity/domain-ONLY: the motif axis is
+// enumerated in review, over the ordinary seed pool where the motif-carrying
+// facts live, and its far lane already routes backward from there. So unlike
+// the review surface — which still serves motif bridges on a motif-rich corpus
+// — this one now yields nothing on EVERY corpus at EVERY effort. Backward
+// discovery is not lost; this path to it is.
+//
+// Built as a pair, same discipline as the review test: prove the pool would
+// have bridged, then prove nothing was served, then prove the session says why.
+func TestHypothesizeQualifyGate_BackwardBridgesAreNotEnqueued(t *testing.T) {
+	ctx := context.Background()
+	svc, ri := newHypothesizeTestRepo(t)
+
+	// Four synthesis facts sharing one domain token across two communities —
+	// the pool BuildBackwardBridges is built to bridge.
+	paths := []string{"kb/alpha/s1.md", "kb/beta/s2.md", "kb/gamma/s3.md", "kb/delta/s4.md"}
+	for _, p := range paths {
+		writeTestFact(t, svc, p, p, fact.Synthesis, "auth")
+	}
+
+	// FIXTURE CHECK — the same pool really does enumerate a domain bridge.
+	// Without it, "no discover items" would be indistinguishable from "these
+	// four facts never formed a candidate".
+	llm := make([]factForLLM, 0, len(paths))
+	for _, p := range paths {
+		llm = append(llm, factForLLM{File: p, Domain: []string{"auth"}, Origin: "authored"})
+	}
+	cands := enumerateBridgeCandidates(llm, ClusterResult{Clusters: map[int][]string{
+		0: {paths[0], paths[1]}, 1: {paths[2], paths[3]},
+	}}, BridgeBoth, ScopeFilter{})
+	_, wouldBridge := containsToken(cands, "auth")
+	require.True(t, wouldBridge,
+		"fixture check: this synthesis pool DOES enumerate a domain bridge")
+
+	p := NewHypothesizer(ri, nil, EffortHigh, ScopeFilter{})
+	res, err := p.StartSession(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.SessionID)
+
+	items, err := svc.Pipeline().PendingPipelineWorkItems(ctx, res.SessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, items,
+		"the session must have queued its per-fact work — an empty queue would make "+
+			"the discover-absence below meaningless")
+	for _, it := range items {
+		require.NotEqualf(t, "discover", it.StepType,
+			"the hypothesize surface can no longer qualify a bridge (%s)", it.ClusterKey)
+	}
+
+	// Health is IN-MEMORY ONLY on the session and rides the FIRST result, so
+	// it is read from res rather than from the stored row.
+	require.Contains(t, strings.Join(res.Health, "\n"), "RANK-ONLY",
+		"this surface is dark on EVERY corpus, so it must say so — a reader who "+
+			"finds zero discover items here has no other way to tell design from stall")
+}

--- a/internal/synthesize/bridge_report.go
+++ b/internal/synthesize/bridge_report.go
@@ -38,10 +38,18 @@ type ScoredBridge struct {
 //
 // Errors from Search, ScopedCluster, SimilarityAdjacency, derivationGap,
 // or specificity are propagated immediately.
+//
+// localRepoID is this repo's 12-hex id, threaded for the same reason the
+// production path threads it: it is what reduces stored refs to the local fact
+// paths the one-hop lineage exclusion compares. A report run with "" would
+// enumerate candidates production excludes, and a measurement surface that
+// scores a different population than the engine serves is the failure this
+// file's POPULATION-first convention exists to prevent.
 func BridgeComponentReport(
 	ctx context.Context,
 	idx SearchQuery,
 	branch string,
+	localRepoID string,
 	kind BridgeKind,
 	eff Effort,
 	resolution float64,
@@ -59,15 +67,16 @@ func BridgeComponentReport(
 	seeds := make([]factForLLM, 0, len(results))
 	for _, r := range results {
 		seeds = append(seeds, factForLLM{
-			File:       r.Path,
-			Title:      r.Title,
-			Body:       r.Body,
-			Type:       r.Type,
-			Domain:     r.Domain,
-			Entities:   r.Entities,
-			Confidence: r.Confidence,
-			Sources:    r.Sources,
-			Origin:     r.Origin,
+			File:        r.Path,
+			Title:       r.Title,
+			Body:        r.Body,
+			Type:        r.Type,
+			Domain:      r.Domain,
+			Entities:    r.Entities,
+			Confidence:  r.Confidence,
+			Sources:     r.Sources,
+			Origin:      r.Origin,
+			LineageRefs: localFactRefPaths(r.Refs, localRepoID),
 		})
 	}
 

--- a/internal/synthesize/bridge_report_test.go
+++ b/internal/synthesize/bridge_report_test.go
@@ -92,7 +92,7 @@ func TestBridgeComponentReport_CrossCommunity_Kept(t *testing.T) {
 		MaxMembers:   10,
 	}
 
-	results, err := BridgeComponentReport(ctx, idx, branch, BridgeEntity, EffortHigh, 1.0, 1, cfg)
+	results, err := BridgeComponentReport(ctx, idx, branch, testLocalRepoID, BridgeEntity, EffortHigh, 1.0, 1, cfg)
 	require.NoError(t, err)
 
 	// At least one result: bridgeTok bridge should be kept
@@ -148,7 +148,7 @@ func TestBridgeComponentReport_SameCommunityToken_ProducesNoCandidates(t *testin
 		MaxMembers:   10,
 	}
 
-	results, err := BridgeComponentReport(ctx, idx, branch, BridgeEntity, EffortHigh, 1.0, 1, cfg)
+	results, err := BridgeComponentReport(ctx, idx, branch, testLocalRepoID, BridgeEntity, EffortHigh, 1.0, 1, cfg)
 	require.NoError(t, err)
 	require.Empty(t, results, "same-community token yields no bridge candidates")
 }
@@ -196,7 +196,7 @@ func TestBridgeComponentReport_CrossCommunityLowCohesion_GatedNotKept(t *testing
 		MaxMembers:   10,
 	}
 
-	results, err := BridgeComponentReport(ctx, idx, branch, BridgeEntity, EffortHigh, 1.0, 1, cfg)
+	results, err := BridgeComponentReport(ctx, idx, branch, testLocalRepoID, BridgeEntity, EffortHigh, 1.0, 1, cfg)
 	require.NoError(t, err)
 
 	// The candidate IS produced (cross-community) but gated by CohFloor.
@@ -261,7 +261,7 @@ func TestBridgeComponentReport_QDescOrdering(t *testing.T) {
 		MaxMembers:   10,
 	}
 
-	results, err := BridgeComponentReport(ctx, idx, branch, BridgeEntity, EffortHigh, 1.0, 1, cfg)
+	results, err := BridgeComponentReport(ctx, idx, branch, testLocalRepoID, BridgeEntity, EffortHigh, 1.0, 1, cfg)
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
 
@@ -302,7 +302,7 @@ func TestBridgeComponentReport_ErrorPropagation_SimilarityAdjacency(t *testing.T
 
 	cfg := QualityConfig{CohFloor: 0.0, MaxMembers: 10, QualityFloor: 0.0, WCoh: 1, WGap: 1, WSpec: 1}
 
-	_, err := BridgeComponentReport(ctx, idx, branch, BridgeEntity, EffortHigh, 1.0, 1, cfg)
+	_, err := BridgeComponentReport(ctx, idx, branch, testLocalRepoID, BridgeEntity, EffortHigh, 1.0, 1, cfg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, boom)
 }
@@ -329,7 +329,7 @@ func TestBridgeComponentReport_NormalEffort_Empty(t *testing.T) {
 	})
 
 	cfg := QualityConfig{CohFloor: 0.5, MaxMembers: 10, QualityFloor: 0.0, WCoh: 1, WGap: 1, WSpec: 1}
-	results, err := BridgeComponentReport(ctx, idx, branch, BridgeEntity, EffortNormal, 1.0, 1, cfg)
+	results, err := BridgeComponentReport(ctx, idx, branch, testLocalRepoID, BridgeEntity, EffortNormal, 1.0, 1, cfg)
 	require.NoError(t, err)
 	require.Empty(t, results, "EffortNormal must return empty results (effort gate returns early)")
 }

--- a/internal/synthesize/bridge_test.go
+++ b/internal/synthesize/bridge_test.go
@@ -317,7 +317,7 @@ func TestBuildBackwardBridges_HonorsBridgeKind(t *testing.T) {
 		Return(1, nil).AnyTimes()
 
 	// Entity kind: only the shared ENTITY token bridges.
-	ent, err := BuildBackwardBridges(ctx, m, synthFacts, "agent/test", EffortHigh, BridgeEntity, 2.0, 2, testCfg, ScopeFilter{})
+	ent, err := BuildBackwardBridges(ctx, m, synthFacts, "agent/test", testLocalRepoID, EffortHigh, BridgeEntity, 2.0, 2, testCfg, ScopeFilter{})
 	require.NoError(t, err)
 	if _, ok := containsToken(ent, "shared"); !ok {
 		t.Errorf("BridgeEntity must surface entity token 'shared': %v", ent)
@@ -327,7 +327,7 @@ func TestBuildBackwardBridges_HonorsBridgeKind(t *testing.T) {
 	}
 
 	// Domain kind: only the shared DOMAIN token bridges.
-	dom, err := BuildBackwardBridges(ctx, m, synthFacts, "agent/test", EffortHigh, BridgeDomain, 2.0, 2, testCfg, ScopeFilter{})
+	dom, err := BuildBackwardBridges(ctx, m, synthFacts, "agent/test", testLocalRepoID, EffortHigh, BridgeDomain, 2.0, 2, testCfg, ScopeFilter{})
 	require.NoError(t, err)
 	if _, ok := containsToken(dom, "auth"); !ok {
 		t.Errorf("BridgeDomain must surface domain token 'auth': %v", dom)
@@ -457,7 +457,7 @@ func TestBuildBackwardBridges_UsesConfiguredResolution(t *testing.T) {
 	m.EXPECT().TokenDF(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(1, nil).AnyTimes()
 
-	_, err := BuildBackwardBridges(ctx, m, synthFacts, "agent/test", EffortHigh, BridgeBoth, wantResolution, wantMinCommunity, testCfg, ScopeFilter{})
+	_, err := BuildBackwardBridges(ctx, m, synthFacts, "agent/test", testLocalRepoID, EffortHigh, BridgeBoth, wantResolution, wantMinCommunity, testCfg, ScopeFilter{})
 	require.NoError(t, err)
 }
 

--- a/internal/synthesize/hypothesize_strategy.go
+++ b/internal/synthesize/hypothesize_strategy.go
@@ -117,7 +117,22 @@ func (hypothesizeStrategy) Plan(ctx context.Context, d Deps, sess *store.Pipelin
 	// bridged facts. A single seed cannot bridge to anything, hence the >= 2
 	// guard. Skipped entirely at EffortNormal — that is the zero-discovery-spend
 	// contract of invariants/synthesize/effort-normal-byte-identical.
+	//
+	// SINCE #125 THIS ARM IS UNREACHABLE IN PRACTICE. Backward bridging here is
+	// entity/domain-only — the motif axis is enumerated in REVIEW, over the
+	// ordinary seed pool where the motif-carrying facts are, and its far lane
+	// already routes backward from there (designer ruling 2026-08-23,
+	// phase3-rulings-1 Q2). With entity/domain now rank-only, no candidate this
+	// builder can produce qualifies, so it returns empty on every corpus at
+	// every effort rather than only on motif-poor ones. Backward DISCOVERY is
+	// not lost — review's far lane carries it — but this surface is dark, and
+	// the first arm below is what tells a reader that, instead of leaving them
+	// to read zero items as a stall. The enqueue path is left in place:
+	// removing it is a rip-out decision for its own ticket, not part of this
+	// fix, and BuildBackwardBridges is still what the calibrate tools measure.
 	switch {
+	case d.Effort.Discovers() && !BridgeKindFromString(d.RI.DiscoveryBridge()).Qualifies():
+		sess.Health = append(sess.Health, entityAxisRankOnlyLine())
 	case d.Effort.Discovers() && len(seeds) >= 2:
 		if err := enqueueBackwardBridgeItems(ctx, d, sess.ID, seeds, branch); err != nil {
 			// Non-fatal: discovery is enrichment, not a blocker on the standard

--- a/internal/synthesize/hypothesize_strategy.go
+++ b/internal/synthesize/hypothesize_strategy.go
@@ -183,7 +183,7 @@ func backwardDiscoverPriority(rank int) float64 {
 // forward (review) path uses, so both discovery directions honour the same axis
 // selection AND the same community partition, with nothing hardcoded.
 func enqueueBackwardBridgeItems(ctx context.Context, d Deps, sessionID string, seeds []fact.Fact, branch string) error {
-	bridges, err := BuildBackwardBridges(ctx, d.Search, seeds, branch, d.Effort,
+	bridges, err := BuildBackwardBridges(ctx, d.Search, seeds, branch, fact.ID12(d.RI.ID()), d.Effort,
 		BridgeKindFromString(d.RI.DiscoveryBridge()), d.RI.ClusterResolution(),
 		d.RI.ClusterMinCommunitySize(), QualityConfigFromRepo(d.RI), d.Scope)
 	if err != nil {

--- a/internal/synthesize/review.go
+++ b/internal/synthesize/review.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"knomit/internal/fact"
+
 	"knomit/internal/llm"
 	"knomit/internal/repos"
 	"knomit/internal/store"
@@ -278,7 +280,7 @@ func (r *Reviewer) dirtyFacts(ctx context.Context, branch string, gs store.FactI
 	if seeds == nil {
 		return nil, nil
 	}
-	return factsForLLM(seeds), nil
+	return factsForLLM(seeds, fact.ID12(r.ri.ID())), nil
 }
 
 // nextItem dispatches on the session's persistent phase and returns the

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -112,7 +112,7 @@ func recordVocabularySkipHealth(sess *store.PipelineSession, effort Effort) {
 // already bound to the branch it was created against.
 func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSession, seeds []fact.Fact) error {
 	branch := sess.Branch
-	llmSeeds := factsForLLM(seeds)
+	llmSeeds := factsForLLM(seeds, fact.ID12(d.RI.ID()))
 
 	// Build scoped clusters.
 	t := time.Now()
@@ -519,20 +519,27 @@ func distillGroups(seeds []factForLLM, clusters [][]factForLLM) []distillGroup {
 // fact.Fact's. Origin in particular is carried through — bridge seeding
 // excludes origin=discovered facts, and dropping it here would let a
 // discovered fact seed its own discovery.
-func factsForLLM(seeds []fact.Fact) []factForLLM {
+//
+// localRepoID is this repo's 12-hex id and is threaded rather than defaulted:
+// it is what reduces the stored refs to LineageRefs, and refs are stored
+// canonical (kb://<own-id>/<path>), so classifying them with an empty id reads
+// every local citation as foreign and hands the lineage exclusion an empty set
+// to work from.
+func factsForLLM(seeds []fact.Fact, localRepoID string) []factForLLM {
 	out := make([]factForLLM, 0, len(seeds))
 	for _, f := range seeds {
 		out = append(out, factForLLM{
-			File:       f.Path(),
-			Title:      f.Title,
-			Body:       f.Body,
-			Type:       string(f.Type),
-			Domain:     f.Domain,
-			Entities:   f.Entities,
-			Motifs:     f.Motifs,
-			Confidence: f.Confidence,
-			Sources:    f.Sources,
-			Origin:     string(f.Origin),
+			File:        f.Path(),
+			Title:       f.Title,
+			Body:        f.Body,
+			Type:        string(f.Type),
+			Domain:      f.Domain,
+			Entities:    f.Entities,
+			Motifs:      f.Motifs,
+			Confidence:  f.Confidence,
+			Sources:     f.Sources,
+			Origin:      string(f.Origin),
+			LineageRefs: localFactRefPaths(f.Refs, localRepoID),
 		})
 	}
 	return out

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -302,11 +302,32 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	// Dispatch: scoped sessions use the token-optional filtered generator;
 	// unscoped sessions use the token-anchored scored generator. The scope is
 	// empty in the unscoped case, so passing it to buildScoredBridges is a no-op.
+	//
+	// THE QUALIFY GATE (#125). Only a shared MECHANISM qualifies a bridge; a
+	// shared entity or domain name does not, and enters only at rank. Both
+	// generators below are token-anchored on entity/domain — the scoped one
+	// labels its subsets with whatever entity/domain token they happen to
+	// share — so neither can produce a qualifying candidate, and the gate skips
+	// the BUILD rather than filtering its output: the axis costs no index call
+	// to discover it has nothing to offer.
+	//
+	// The builders themselves are deliberately untouched. They remain the
+	// population BridgeComponentReport measures, and removing them is a
+	// rip-out decision for its own ticket, not part of this fix.
+	bridgeKind := BridgeKindFromString(d.RI.DiscoveryBridge())
 	var bridges []BridgeSeedSet
-	if !d.Scope.IsEmpty() {
+	switch {
+	case !bridgeKind.Qualifies():
+		// Say WHY there are none. "0 bridges" and "this axis cannot qualify"
+		// are the same number, and only the health line separates a designed
+		// silence from a stall (the #147 lesson, one surface over).
+		if d.Effort.Discovers() {
+			sess.Health = append(sess.Health, entityAxisRankOnlyLine())
+		}
+	case !d.Scope.IsEmpty():
 		bridges, err = buildFilteredBridges(ctx, d.Search, branch, llmSeeds, cr, d.Scope, d.Effort, cfg)
-	} else {
-		bridges, err = buildScoredBridges(ctx, d.Search, branch, llmSeeds, cr, BridgeKindFromString(d.RI.DiscoveryBridge()), d.Effort, cfg, d.Scope)
+	default:
+		bridges, err = buildScoredBridges(ctx, d.Search, branch, llmSeeds, cr, bridgeKind, d.Effort, cfg, d.Scope)
 	}
 	if err != nil {
 		return wrapf(reviewTool, err, "build bridges")

--- a/internal/synthesize/types.go
+++ b/internal/synthesize/types.go
@@ -101,6 +101,21 @@ type factForLLM struct {
 	Confidence float64  `json:"confidence"`
 	Sources    int      `json:"sources"`
 	Origin     string   `json:"origin,omitempty"`
+	// LineageRefs holds this fact's refs REDUCED TO THE LOCAL FACT PATHS THEY
+	// NAME, canonicalized — not the raw ref strings. It exists for the one-hop
+	// lineage exclusion in bridge candidate scoring (#125), which needs to ask
+	// "does this member cite that member?" without an index or a graph walk.
+	//
+	// Normalization happens at the projection sites, not here, because it needs
+	// this repo's own 12-hex id: refs are STORED CANONICAL as
+	// kb://<own-id12>/<path>, so a raw ref string never equals a member's path
+	// and a lineage test over unnormalized refs excludes NOTHING while looking
+	// like it works. Populate it only via localFactRefPaths(f.Refs, localRepoID).
+	//
+	// json:"-" deliberately: this is scoring data, never prompt data. The LLM
+	// payload's bytes are unchanged by its presence, so no prompt, golden, or
+	// paging expectation moves.
+	LineageRefs []string `json:"-"`
 }
 
 // extractJSON strips optional markdown code fences from LLM output.

--- a/tools/calibrate/bridges.go
+++ b/tools/calibrate/bridges.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"knomit/internal/config"
 	"knomit/internal/embeddings"
+	"knomit/internal/fact"
 	"knomit/internal/store"
 	"knomit/internal/synthesize"
 )
@@ -81,7 +82,12 @@ paths, and token frequencies — no embedding model is loaded or needed.`,
 			idx := svc.Search()
 			ctx := context.Background()
 
-			report, err := synthesize.BridgeComponentReport(ctx, idx, branch, kind, eff, resolution, minCommunity, cfg)
+			localRepoID, err := localRepoIDFor(ctx, svc, branch)
+			if err != nil {
+				return err
+			}
+
+			report, err := synthesize.BridgeComponentReport(ctx, idx, branch, localRepoID, kind, eff, resolution, minCommunity, cfg)
 			if err != nil {
 				return fmt.Errorf("bridge component report: %w", err)
 			}
@@ -250,8 +256,13 @@ func runMotifReport(cmd *cobra.Command, dbPath, branch, effortStr string,
 	idx := motifThresholdIndex{SearchQuery: svc.Search()}
 	idx.dedup, idx.known = corpusDedupThreshold(dbPath)
 
+	localRepoID, err := localRepoIDFor(cmd.Context(), svc, branch)
+	if err != nil {
+		return err
+	}
+
 	rep, err := synthesize.MotifComponentReport(cmd.Context(), idx, svc.Motifs(),
-		svc.Abstraction(), branch, eff, resolution, minCommunity, cfg)
+		svc.Abstraction(), branch, localRepoID, eff, resolution, minCommunity, cfg)
 	if err != nil {
 		return fmt.Errorf("motif component report: %w", err)
 	}
@@ -351,4 +362,21 @@ func corpusDedupThreshold(dbPath string) (float64, bool) {
 		return 0, false
 	}
 	return m.Thresholds.Dedup, true
+}
+
+// localRepoIDFor resolves the corpus's own 12-hex repo identity, which the
+// bridge reports need to reduce stored refs (kb://<own-id>/<path>) to the local
+// fact paths the one-hop lineage exclusion compares.
+//
+// It is an ERROR, not a fallback to "": with an empty id every stored ref reads
+// as foreign, the lineage exclusion has nothing to exclude on, and the report
+// would silently score a LARGER candidate population than production serves.
+// A calibration number computed over the wrong population is exactly the class
+// of mistake the POPULATION-first headers in this file exist to prevent.
+func localRepoIDFor(ctx context.Context, svc *store.Service, branch string) (string, error) {
+	root, err := svc.RootCommit(ctx, branch)
+	if err != nil {
+		return "", fmt.Errorf("resolve repo identity on %q: %w", branch, err)
+	}
+	return fact.ID12(root), nil
 }

--- a/tools/motifannex/bridges.go
+++ b/tools/motifannex/bridges.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"knomit/internal/fact"
 	"knomit/internal/synthesize"
 )
 
@@ -32,7 +33,7 @@ func bridges(ctx context.Context, corpus, scratch, effortStr string) error {
 	defer closeAll()
 
 	rep, err := synthesize.MotifComponentReport(ctx, svc.Search(), svc.Motifs(), svc.Abstraction(),
-		branch, eff, ri.ClusterResolution(), ri.ClusterMinCommunitySize(),
+		branch, fact.ID12(ri.ID()), eff, ri.ClusterResolution(), ri.ClusterMinCommunitySize(),
 		synthesize.QualityConfigFromRepo(ri))
 	if err != nil {
 		return fmt.Errorf("motif component report: %w", err)

--- a/tools/motifannex/harnesspack.go
+++ b/tools/motifannex/harnesspack.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"knomit/internal/fact"
 	"knomit/internal/store"
 	"knomit/internal/synthesize"
 )
@@ -97,7 +98,7 @@ func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 		}
 		cfg := synthesize.QualityConfigFromRepo(ri)
 		rep, err := synthesize.MotifComponentReport(ctx, svc.Search(), svc.Motifs(),
-			svc.Abstraction(), branch, synthesize.EffortHigh,
+			svc.Abstraction(), branch, fact.ID12(ri.ID()), synthesize.EffortHigh,
 			ri.ClusterResolution(), ri.ClusterMinCommunitySize(), cfg)
 		if err != nil {
 			closeAll()
@@ -146,7 +147,7 @@ func harnesspack(ctx context.Context, scratch string, corpora []string) error {
 
 		// TOKEN — the shipped entity/domain report, kept bridges only.
 		tk, err := synthesize.BridgeComponentReport(ctx, svc.Search(), branch,
-			synthesize.BridgeKindFromString("both"), synthesize.EffortHigh,
+			fact.ID12(ri.ID()), synthesize.BridgeKindFromString("both"), synthesize.EffortHigh,
 			ri.ClusterResolution(), ri.ClusterMinCommunitySize(), cfg)
 		if err != nil {
 			closeAll()


### PR DESCRIPTION
Closes #125.

Two independent halves, both in `internal/synthesize` bridge scoring.

## Part 1 — one-hop lineage exclusion
When scoring a candidate bridge pair (X,Y), exclude it if `Y.path ∈ X.refs` or `X.path ∈ Y.refs` (direct parent/child, either direction) — a synthesis no longer bridges to its own source (circular REINFORCE evidence). Set-membership on refs already in hand, no index, no graph walk. Applied on all three enumeration paths. **Refs are stored canonical (`kb://<id>/<path>`)**, so the exclusion normalizes via `localFactRefPaths` — a bare-path test would match nothing and ship inert (pinned by `TestBridgeLineage_EmptyRepoIDExcludesNothing`).

## Part 2 — mechanism qualifies, entity is tiebreaker-only
Mechanism/motif qualifies a bridge; entity/domain overlap never qualifies, it only breaks rank ties (a sort term, not a weight — no invented constant). The qualify gate lives at the two production dispatch sites (spend-free: the build is skipped, not filtered). When the motif axis is inactive for a pool the entity axis yields no bridges — `entityAxisRankOnlyLine()` makes that silence legible on both surfaces. Quantity axis deferred (no detector exists).

## Verification
MN5 byte-identical both commits; MN6 (which tripped, caught by shape) resolved with four sound decisions; MN13 clean; 49 ok honest-captured; 13 sabotages each shown RED. Cold-reviewed independently: MERGE-READY, no findings. Merge result pre-verified green against current dev.