### PR TITLE
Structural cousin detection: fire when defunded + meet cousins in prune (#155, #149)

### DIFF
--- a/internal/store/abstraction.go
+++ b/internal/store/abstraction.go
@@ -615,6 +615,48 @@ func (ax *abstractionIndex) RestatementPairsByMatchKind(ctx context.Context, bra
 	return scanRestatementPairs(rows)
 }
 
+// RestatementPairsByMatchKindOldest sweeps a match-kind population in MINT
+// ORDER instead of ranking it.
+//
+// Same population as RestatementPairsByMatchKind, different question. That one
+// asks "which of these is most title-similar"; this asks "which have waited
+// longest". The sweep is the right shape for the structural routes because
+// their inflow far exceeds what any session can judge, so a cosine ranking
+// re-offers the same head forever and the tail is never reached.
+//
+// `rowid` is the mint order, with the caveat spelled out on the interface: the
+// cache is written with INSERT OR REPLACE, so a re-minted pair gets a fresh
+// rowid and moves to the BACK. That is the wanted behaviour (a re-minted pair
+// is revisited, not skipped) but it means the ordering is only age-EXACT once
+// the title axis is complete.
+//
+// Ties are broken on the paths, so two runs over one corpus agree even if the
+// rowids ever collide.
+func (ax *abstractionIndex) RestatementPairsByMatchKindOldest(ctx context.Context, branch string, kinds []string, limit int) ([]RestatementPair, error) {
+	if limit <= 0 || len(kinds) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(kinds)), ",")
+	args := make([]any, 0, len(kinds)+2)
+	args = append(args, branch)
+	for _, k := range kinds {
+		args = append(args, k)
+	}
+	args = append(args, limit)
+	rows, err := conn(ctx, ax.rh.db).QueryContext(ctx,
+		`SELECT p.a_path, p.b_path, p.a_fact_id, p.b_fact_id, p.title_cos, p.match_kind
+		   FROM restatement_pairs p
+		   JOIN branches b ON b.id = p.branch_id
+		  WHERE b.name = ? AND p.match_kind IN (`+placeholders+`)
+		  ORDER BY p.rowid ASC, p.a_path ASC, p.b_path ASC
+		  LIMIT ?`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("abstraction: sweep pairs by match kind: %w", err)
+	}
+	defer rows.Close()
+	return scanRestatementPairs(rows)
+}
+
 func scanRestatementPairs(rows *sql.Rows) ([]RestatementPair, error) {
 	var out []RestatementPair
 	for rows.Next() {

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -374,6 +374,29 @@ type AbstractionIndex interface {
 	// titles score, so they cannot be reached through the cosine ranking that
 	// serves the title-KNN population.
 	RestatementPairsByMatchKind(ctx context.Context, branch string, kinds []string, limit int) ([]RestatementPair, error)
+	// RestatementPairsByMatchKindOldest returns the `limit` OLDEST standing
+	// pairs of the named match kinds, by mint order rather than by cosine.
+	//
+	// The structural routes need a SWEEP, not a ranking. Inflow far exceeds
+	// outflow, so re-selecting the top of a cosine ranking every session
+	// starves the tail forever — and the ranking buys nothing here anyway,
+	// since a structurally matched pair is a near-certain duplicate whatever
+	// its cosine happens to be (see MatchKind).
+	//
+	// There is NO stored cursor, and deliberately so: consumption IS the
+	// cursor. A judged pair is deleted when its verdict lands, so "the oldest
+	// N standing" re-evaluated each session advances on its own.
+	//
+	// MINT ORDER IS `rowid`, and that is exact only while the axis is
+	// COMPLETE. ReplaceRestatementPairs writes with INSERT OR REPLACE, which
+	// in SQLite deletes the conflicting row and inserts a new one — assigning a
+	// FRESH rowid. So rowid means "least recently minted OR RE-minted": a
+	// re-minted pair goes to the BACK of the sweep (revisited, never skipped),
+	// and while the title axis is still filling every pair is rescanned each
+	// session, which churns every rowid and makes this ordering deterministic
+	// but not age-stable. Callers must SAY WHICH REGIME THEY ARE IN rather than
+	// claim an oldest-first guarantee they do not have.
+	RestatementPairsByMatchKindOldest(ctx context.Context, branch string, kinds []string, limit int) ([]RestatementPair, error)
 	// TitleVectorsByFactID returns STORED title-axis vectors, keyed by fact id.
 	// Symmetric with BodyVectorsByFactID; nothing is re-embedded.
 	TitleVectorsByFactID(ctx context.Context, ids []int64) (map[int64][]float32, error)

--- a/internal/synthesize/cousins.go
+++ b/internal/synthesize/cousins.go
@@ -1,0 +1,302 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+
+	"knomit/internal/store"
+)
+
+// Cousin-meeting inside prune (knomit#149).
+//
+// THE BLINDER. ScopedCluster expands each seed's neighbourhood with
+// `Path: categoryDir(seed.File)` (cluster.go), and that filter is a raw path
+// PREFIX — `AND f.path LIKE cat||'%'`. So:
+//
+//   - SIBLINGS (same directory) meet.
+//   - DESCENDANTS of a shallow-filed seed meet, which is why prune clusters
+//     look cross-category from outside: a fact filed at a shallow path acts as
+//     a hub joining the deep directories under it.
+//   - COUSINS — two facts in different directories under a shared ancestor,
+//     with no shallow-filed seed bridging them — are unreachable AT ANY COSINE.
+//
+// Measured on the live core corpus: six confirmed duplicate pairs at blended
+// cosine 0.83–0.97, each split across two freeform categories, none
+// co-clustered. `network-security/check-point-…` and
+// `network-appliances/23d98f38` surfaced in prune items repeatedly and never
+// once together. Six independent confirmations across four drain sessions.
+//
+// WHY THIS AUGMENTS RATHER THAN REPLACES. Removing the fence re-clusters the
+// whole corpus and moves what EffortNormal produces. It is also unnecessary:
+// the fence is on the neighbour EXPANSION only — `SubgraphEdges` (Step 2) reads
+// SIMILAR_TO unfenced — so a second, unfenced expansion whose result reaches
+// PRUNE ONLY buys the cousins without touching what anything else clusters.
+//
+// WHAT THIS DELIBERATELY DOES NOT TOUCH. `clusters` has FIVE consumers in
+// reviewStrategy.Plan: dedupCluster's mechanical merge, the prune items,
+// planRestatementShortlist's co-membership, distillGroups, and
+// clusterResultFromGroups (which feeds both bridge axes and discover). The
+// ruling scopes this to prune, so this function takes and returns a SEPARATE
+// prune-cluster slice and never mutates the one those other four read.
+//
+// AND IT RUNS AFTER dedupCluster, not before. Before it, a newly-met cousin
+// pair above the floor would be merged MECHANICALLY, with no judge — a strictly
+// larger change than the one ruled. The ruling is that cousins should MEET so
+// the prune JUDGE sees them.
+
+// maxCousinSearches is a RESOURCE BUDGET: how many unfenced neighbour searches
+// one session will spend looking for cousins.
+//
+// MN13 classification — it bounds WORK, and encodes no claim about how many
+// cousins a corpus has. Each search is one bounded KNN over a stored vector
+// (QueryByPath re-embeds nothing), the same unit ScopedCluster and dedupCluster
+// already spend per seed; this caps how many of them the cousin pass adds on
+// top. When the cap truncates the sweep the health line SAYS SO — a silent cap
+// reads as "covered everything" and is the failure this area keeps hitting.
+const maxCousinSearches = 64
+
+// maxConcurrentCousinSearches bounds in-flight searches, matching
+// maxConcurrentDedupSearches and maxConcurrentNeighborSearches. Same rationale:
+// each search is I/O-bound and independent.
+const maxConcurrentCousinSearches = 8
+
+// cousinHealth is what the pass reports about itself. Observability only — no
+// branch reads it.
+type cousinHealth struct {
+	Searched  int  // facts whose unfenced neighbourhood was actually read
+	Candidate int  // facts in prune clusters, i.e. what a complete sweep would be
+	Attached  int  // cousins pulled into an existing prune cluster
+	Joined    int  // pairs of prune clusters merged because a cousin linked them
+	Truncated bool // the budget cut the sweep short
+	Failure   string
+}
+
+// joinCousinsForPrune widens the PRUNE cluster set — and only that set — so
+// that facts the category fence kept apart are judged together.
+//
+// The search is deliberately the same one dedupCluster runs (QueryByPath, the
+// model's own dedup floor, no path filter) with the membership rule INVERTED:
+// dedupCluster keeps only hits already inside the cluster, and this keeps only
+// hits outside it. That symmetry is the point — the two halves of one
+// neighbourhood, one already handled and one previously discarded.
+//
+// Degrades to "no cousins" rather than failing the session: this is an addition
+// to consolidation, and a corpus whose search backend is unhappy should still
+// get its ordinary review. A failure becomes a health line, never silence.
+func joinCousinsForPrune(
+	ctx context.Context,
+	d Deps,
+	branch string,
+	pruneClusters [][]factForLLM,
+	threshold float64,
+) ([][]factForLLM, cousinHealth) {
+	var h cousinHealth
+	if len(pruneClusters) == 0 {
+		return pruneClusters, h
+	}
+
+	// Which prune cluster each fact currently sits in. A fact in no prune
+	// cluster is absent, which is exactly the "leftover" case the measured
+	// pairs took: one twin in a prune item, the other in the rest bucket.
+	clusterOf := make(map[string]int)
+	for i, c := range pruneClusters {
+		for _, f := range c {
+			clusterOf[f.File] = i
+		}
+	}
+
+	// The sweep order is fixed BY PATH before the budget is applied, so which
+	// facts get searched is a function of the SET of prune facts and nothing
+	// else — not of the order Louvain happened to emit its communities in.
+	//
+	// Collecting from a slice is already ordered, so this sort is not what makes
+	// a single run reproducible; it is what makes the truncated tail independent
+	// of CLUSTER ORDER. Without it, the same corpus clustered into the same
+	// groups in a different sequence sweeps a different subset and produces
+	// different prune items — a wobble of exactly the kind cluster.go's own
+	// sort.Strings exists to stop, one layer down.
+	var targets []string
+	for _, c := range pruneClusters {
+		for _, f := range c {
+			targets = append(targets, f.File)
+		}
+	}
+	sort.Strings(targets)
+	h.Candidate = len(targets)
+	if len(targets) > maxCousinSearches {
+		targets = targets[:maxCousinSearches]
+		h.Truncated = true
+	}
+	h.Searched = len(targets)
+
+	// A cousin edge: a fact in a prune cluster, and a neighbour outside it.
+	type cousinEdge struct {
+		from string // path in a prune cluster
+		hit  factForLLM
+	}
+	var edges []cousinEdge
+	var mu sync.Mutex
+	var searchErr error
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentCousinSearches)
+	for _, path := range targets {
+		g.Go(func() error {
+			// NO `Path` filter. That single omission IS the fix — everything
+			// else here is bookkeeping around it.
+			results, err := d.Search.Search(gctx, branch, store.SearchOptions{
+				QueryByPath:   path,
+				MinSimilarity: threshold,
+				Limit:         10,
+			})
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				// Record the first failure and carry on: one unhappy search
+				// must not cost the session its other cousins.
+				if searchErr == nil {
+					searchErr = err
+				}
+				return nil
+			}
+			for _, r := range results {
+				if r.Path == path {
+					continue // self-match
+				}
+				if other, ok := clusterOf[r.Path]; ok && other == clusterOf[path] {
+					continue // siblings: they already meet
+				}
+				// Kind is NOT filtered here, matching ScopedCluster's own
+				// neighbour expansion — a neighbour it pulls in is not
+				// kind-checked either. Introducing a filter on this path alone
+				// would make the two halves of one neighbourhood disagree.
+				edges = append(edges, cousinEdge{from: path, hit: factForLLM{
+					File: r.Path, Title: r.Title, Body: r.Body,
+					Type: r.Type, Domain: r.Domain, Entities: r.Entities,
+					Motifs: r.Motifs, Confidence: r.Confidence, Sources: r.Sources,
+				}})
+			}
+			return nil
+		})
+	}
+	// The goroutines swallow their own errors, so Wait is a barrier.
+	_ = g.Wait()
+
+	if searchErr != nil {
+		h.Failure = "cousin search failed"
+		log.Warn().Err(searchErr).Msg("review: cousin search failed; prune clusters keep their category-scoped membership")
+	}
+	if len(edges) == 0 {
+		return pruneClusters, h
+	}
+
+	// Deterministic application order, for the same reason cluster.go sorts its
+	// subgraph paths: the searches ran concurrently, so `edges` arrives in
+	// completion order. Union-find over an unsorted edge list can produce
+	// different cluster groupings for identical input.
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].from != edges[j].from {
+			return edges[i].from < edges[j].from
+		}
+		return edges[i].hit.File < edges[j].hit.File
+	})
+
+	// Union-find over prune-cluster indices. Two clusters merge when a cousin
+	// edge links them; a cousin in NO cluster is attached to the one that found
+	// it.
+	parent := make([]int, len(pruneClusters))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+
+	attached := make(map[int][]factForLLM)
+	attachedSeen := map[string]bool{}
+	for _, e := range edges {
+		src := find(clusterOf[e.from])
+		if dstIdx, inCluster := clusterOf[e.hit.File]; inCluster {
+			dst := find(dstIdx)
+			if src != dst {
+				parent[dst] = src
+				h.Joined++
+			}
+			continue
+		}
+		if attachedSeen[e.hit.File] {
+			continue
+		}
+		attachedSeen[e.hit.File] = true
+		attached[src] = append(attached[src], e.hit)
+		h.Attached++
+	}
+
+	// Rebuild. Iterating by index keeps the output order a function of the
+	// input order, so cluster keys stay stable for an unchanged corpus.
+	merged := make(map[int][]factForLLM)
+	var roots []int
+	for i, c := range pruneClusters {
+		root := find(i)
+		if _, seen := merged[root]; !seen {
+			roots = append(roots, root)
+		}
+		merged[root] = append(merged[root], c...)
+	}
+	for root, extra := range attached {
+		merged[find(root)] = append(merged[find(root)], extra...)
+	}
+
+	// NO de-duplication pass here, and that is a conclusion rather than an
+	// omission. A first draft ran the output through a dedupeByPath helper "in
+	// case a cousin is reached from two members of one cluster". Sabotage S16
+	// deleted it and every test stayed green, which sent me to check whether it
+	// could ever fire: it cannot. `attachedSeen` already admits each cousin
+	// exactly once across the whole pass, and the attach branch is reached only
+	// when `clusterOf` has no entry for the hit — so an attached fact is by
+	// construction in no cluster, and the union branch only ever re-parents
+	// disjoint Louvain communities. The only input that could produce a
+	// duplicate is one whose clusters already overlap, which is a malformed
+	// cluster set rather than something this function should paper over.
+	// An unreachable guard is worse than no guard: it invites a test that
+	// asserts nothing (fixture vacuity) and it implies a hazard that does not
+	// exist.
+	out := make([][]factForLLM, 0, len(roots))
+	for _, root := range roots {
+		out = append(out, merged[root])
+	}
+	return out, h
+}
+
+// cousinSignalLine reports what the cousin pass did.
+//
+// It reports even when it found nothing, on this area's standing rule: absence
+// of work must be STATED, never inferred. A pass that is silent when it finds
+// nothing is indistinguishable from a pass that did not run — which is exactly
+// how the category fence stayed invisible for as long as it did.
+func cousinSignalLine(h cousinHealth) string {
+	if h.Failure != "" {
+		return fmt.Sprintf("cross-category prune: %s; prune clusters keep their "+
+			"category-scoped membership this session", h.Failure)
+	}
+	line := fmt.Sprintf(
+		"cross-category prune: %d of %d prune facts swept for cousins, "+
+			"%d cousin(s) attached, %d cluster pair(s) joined",
+		h.Searched, h.Candidate, h.Attached, h.Joined)
+	if h.Truncated {
+		line += fmt.Sprintf(". SWEEP TRUNCATED at the %d-search budget — %d prune "+
+			"facts were not swept this session, so absence of cousins is NOT "+
+			"established for them", maxCousinSearches, h.Candidate-h.Searched)
+	}
+	return line
+}

--- a/internal/synthesize/cousins_test.go
+++ b/internal/synthesize/cousins_test.go
@@ -1,0 +1,468 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// Cousin-meeting inside prune (knomit#149).
+//
+// The fixture below is the measured shape, not an invented one: two facts about
+// ONE event, filed under two sibling freeform categories, with a blended cosine
+// ABOVE the model's mechanical dedup floor — and structurally unable to
+// co-cluster because ScopedCluster fences each seed's neighbour search to its
+// own directory.
+
+const (
+	cousinAPath = "kb/technology/security/vulnerabilities/network-security/check-point-cve-2026-16232.md"
+	cousinBPath = "kb/technology/security/vulnerabilities/network-appliances/23d98f38.md"
+	cousinTitle = "SmartConsole authentication bypass under active exploitation"
+	cousinBody  = "The same event, recorded twice under two freeform categories."
+	// A's SIBLING — same directory, close on the axis, so A lands in a
+	// multi-fact cluster and therefore in a prune item.
+	//
+	// This is not fixture padding, it is the MEASURED SHAPE. In every one of
+	// the six confirmed cousin pairs on the live corpus, one half was served in
+	// a prune item and the other sat in the leftover bucket; that asymmetry is
+	// what the sweep exploits, since it can only search outward from facts that
+	// are already in a prune cluster. See
+	// TestCousins_BothHalvesLeftoverIsNotReached for the case this does NOT
+	// cover.
+	cousinSiblingPath  = "kb/technology/security/vulnerabilities/network-security/smartconsole-followup.md"
+	cousinSiblingTitle = "SmartConsole bypass: vendor confirms exploitation in the wild"
+)
+
+// cousinEnv places the twins on the axis by hand so the test controls the
+// cosine exactly, and files them as COUSINS: `network-security` and
+// `network-appliances` are siblings, so neither path is a prefix of the other
+// and the fence makes them mutually unreachable.
+func cousinEnv(t *testing.T, filler int) *restatementEnv {
+	t.Helper()
+	titleB := cousinTitle + " (weekly recap)"
+	bodyB := cousinBody + " Filed a second time."
+	emb := &restatementEmbedder{vectorFor: func(text string) []float32 {
+		switch text {
+		case cousinTitle:
+			return axisVector(0)
+		case titleB:
+			return axisVector(0.02)
+		case cousinTitle + " " + cousinBody:
+			return axisVector(0.01)
+		case titleB + " " + bodyB:
+			return axisVector(0.03)
+		case cousinSiblingTitle:
+			return axisVector(0.04)
+		case cousinSiblingTitle + " " + cousinBody:
+			return axisVector(0.05)
+		}
+		return nil
+	}}
+	env := newRestatementEnvWith(t, 0, emb)
+	for i := range filler {
+		env.writeFact(
+			fmt.Sprintf("kb/technology/filler/topic%d/%08x.md", i, i+1),
+			fmt.Sprintf("Filler note 2026 about widget %d", 1000+i),
+			"an unrelated body")
+	}
+	env.writeFact(cousinAPath, cousinTitle, cousinBody)
+	env.writeFact(cousinSiblingPath, cousinSiblingTitle, cousinBody)
+	env.writeFact(cousinBPath, titleB, bodyB)
+	return env
+}
+
+// cousinFixtureIsSound asserts the two things the fixture CLAIMS, because a
+// fixture chosen to make a test discriminate is a claim and an unasserted claim
+// is how a test ends up measuring nothing (the campaign's fixture-vacuity
+// lesson).
+func cousinFixtureIsSound(t *testing.T, env *restatementEnv) {
+	t.Helper()
+	// (1) The pair really is above the mechanical dedup floor. Below it, the
+	// search in joinCousinsForPrune would not return the cousin at all and
+	// every test here would pass or fail for the wrong reason.
+	ids := env.liveFactIDs()
+	vecs, err := env.svc.Abstraction().BodyVectorsByFactID(context.Background(),
+		[]int64{ids[cousinAPath], ids[cousinBPath]})
+	require.NoError(t, err)
+	cos := store.CosineSim(vecs[ids[cousinAPath]], vecs[ids[cousinBPath]])
+	require.GreaterOrEqual(t, cos, env.dedupThreshold(),
+		"fixture must sit at or above the mechanical dedup floor")
+
+	// (2) They really are COUSINS — neither path is a prefix of the other, so
+	// the fence genuinely separates them. A fixture where one path happened to
+	// contain the other would be testing siblings, which already meet.
+	a, b := categoryDir(cousinAPath), categoryDir(cousinBPath)
+	require.False(t, strings.HasPrefix(a, b), "fixture paths must not nest")
+	require.False(t, strings.HasPrefix(b, a), "fixture paths must not nest")
+}
+
+// TestCousins_FenceKeepsANonSeedCousinOutOfTheSubgraph is the PREMISE of this
+// file, stated as the thing the fence provably does.
+//
+// It is deliberately NOT written as "run ScopedCluster over everything and
+// check the two are apart". That version passes VACUOUSLY here — at the
+// production resolution this fixture yields zero clusters, so "not together" is
+// trivially true and the assertion measures nothing. (It was written that way
+// first and passed for exactly that reason.)
+//
+// What the fence actually guarantees is narrower and checkable: a cousin that
+// is not itself a seed can never ENTER the subgraph, because the only way in is
+// some seed's neighbour search and every one of those is fenced to its own
+// category directory. Absent from the subgraph, absent from every cluster, at
+// any cosine.
+func TestCousins_FenceKeepsANonSeedCousinOutOfTheSubgraph(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, 20)
+	cousinFixtureIsSound(t, env)
+
+	// Seeds = everything EXCEPT the cousin. This is the measured shape: the
+	// second twin sat in the leftover bucket, not in the seed set that built
+	// any prune cluster.
+	var seeds []factForLLM
+	for _, f := range allFactsForLLM(t, env) {
+		if f.File != cousinBPath {
+			seeds = append(seeds, f)
+		}
+	}
+	require.NotEmpty(t, seeds)
+
+	clusters, err := ScopedCluster(ctx, seeds, env.svc.Search(),
+		env.ri.ClusterResolution(), env.ri.ClusterMinCommunitySize(), func(ProgressEvent) {}, env.branch)
+	require.NoError(t, err)
+	for _, c := range clusters {
+		for _, f := range c {
+			require.NotEqual(t, cousinBPath, f.File,
+				"PREMISE OF THIS FILE: a non-seed cousin cannot reach the subgraph, "+
+					"because every route in is a neighbour search fenced to the "+
+					"seed's own category directory. If this ever fails the blinder "+
+					"is gone, and these tests must be re-derived rather than deleted")
+		}
+	}
+
+	// And the unfenced search — the one this fix adds — DOES reach it. Without
+	// this half the test above is satisfied by a corpus where the cousin is
+	// simply not findable at all.
+	hits, err := env.svc.Search().Search(ctx, env.branch, store.SearchOptions{
+		QueryByPath:   cousinAPath,
+		MinSimilarity: env.dedupThreshold(),
+		Limit:         10,
+	})
+	require.NoError(t, err)
+	var reachable bool
+	for _, r := range hits {
+		if r.Path == cousinBPath {
+			reachable = true
+		}
+	}
+	require.True(t, reachable,
+		"the cousin must be reachable once the path fence is dropped — otherwise "+
+			"the fence is not what was hiding it")
+}
+
+// TestCousins_JoinBringsThemTogetherForPrune is the fix.
+func TestCousins_JoinBringsThemTogetherForPrune(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, 20)
+	cousinFixtureIsSound(t, env)
+	d := env.deps()
+
+	// The cousin sits OUTSIDE any prune cluster — the measured "leftover
+	// bucket" case: one twin served in a prune item, the other never served
+	// alongside it.
+	pruneClusters := [][]factForLLM{{
+		{File: cousinAPath, Title: cousinTitle},
+		{File: "kb/technology/filler/topic0/00000001.md", Title: "Filler note 2026 about widget 1000"},
+	}}
+	require.False(t, clustersHoldTogether(pruneClusters, cousinAPath, cousinBPath),
+		"fixture must START with the pair apart, or the join is credited for nothing")
+
+	joined, h := joinCousinsForPrune(ctx, d, env.branch, pruneClusters, env.dedupThreshold())
+	require.Empty(t, h.Failure)
+	require.True(t, clustersHoldTogether(joined, cousinAPath, cousinBPath),
+		"a near-certain duplicate the category fence hid must be put in front of "+
+			"the prune judge")
+	require.Positive(t, h.Attached, "the health must report the attachment it made")
+}
+
+// TestCousins_JoinUnionsTwoPruneClusters is the other arrangement, and it is a
+// separate code path.
+//
+// When BOTH cousins already sit in prune clusters — different ones — attaching
+// is not enough; the two clusters have to be merged, or the judge still sees
+// them in separate work items and can still never merge them.
+func TestCousins_JoinUnionsTwoPruneClusters(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, 20)
+	cousinFixtureIsSound(t, env)
+
+	pruneClusters := [][]factForLLM{
+		{{File: cousinAPath}, {File: "kb/technology/filler/topic0/00000001.md"}},
+		{{File: cousinBPath}, {File: "kb/technology/filler/topic1/00000002.md"}},
+	}
+	joined, h := joinCousinsForPrune(ctx, env.deps(), env.branch, pruneClusters, env.dedupThreshold())
+	require.Empty(t, h.Failure)
+	require.Positive(t, h.Joined, "two prune clusters linked by a cousin must be merged")
+	require.True(t, clustersHoldTogether(joined, cousinAPath, cousinBPath),
+		"a pair split across two prune ITEMS is as unjudgeable as one split across clusters")
+	require.Len(t, joined, 1, "the two clusters become one")
+}
+
+// TestCousins_ClustersAreNotMutated is the blast-radius guarantee, and it is
+// the load-bearing half of "augment, not replace".
+//
+// `clusters` is read by FOUR other consumers after this pass runs —
+// dedupCluster (already done), distillGroups, clusterResultFromGroups (both
+// bridge axes and discover), and planRestatementShortlist's co-membership. The
+// ruling scopes #149 to prune, so a cousin must never reach any of them.
+func TestCousins_ClustersAreNotMutated(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, 20)
+	cousinFixtureIsSound(t, env)
+
+	original := [][]factForLLM{{
+		{File: cousinAPath, Title: cousinTitle},
+		{File: "kb/technology/filler/topic0/00000001.md", Title: "Filler note 2026 about widget 1000"},
+	}}
+	before := renderClusters(original)
+
+	joined, h := joinCousinsForPrune(ctx, env.deps(), env.branch, original, env.dedupThreshold())
+	require.Positive(t, h.Attached, "fixture must actually attach something, or immutability is trivial")
+	require.True(t, clustersHoldTogether(joined, cousinAPath, cousinBPath))
+
+	require.Equal(t, before, renderClusters(original),
+		"the input cluster slice must be untouched — distill, both bridge axes "+
+			"and discover read it AFTER this runs, and the ruling scopes this "+
+			"fix to prune alone")
+}
+
+// TestCousins_SiblingsAreNotDoubleCounted — facts already in one cluster meet
+// by construction, and re-adding them would put the same fact in a prune item
+// twice, asking the judge to compare a fact with itself.
+func TestCousins_SiblingsAreNotDoubleCounted(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, 20)
+
+	// Both twins in ONE cluster already.
+	pruneClusters := [][]factForLLM{{{File: cousinAPath}, {File: cousinBPath}}}
+	joined, h := joinCousinsForPrune(ctx, env.deps(), env.branch, pruneClusters, env.dedupThreshold())
+	require.Zero(t, h.Joined, "a pair already in one cluster needs no join")
+	require.Len(t, joined, 1)
+	seen := map[string]int{}
+	for _, f := range joined[0] {
+		seen[f.File]++
+	}
+	for path, n := range seen {
+		require.Equal(t, 1, n, "fact %s appears %d times in one prune item", path, n)
+	}
+}
+
+// TestCousins_TruncatedSweepSaysSo — a cap that nothing reports reads as
+// "covered everything". The whole failure class this area keeps hitting is caps
+// that stay silent, so a truncated sweep must say which facts it did NOT reach.
+func TestCousins_TruncatedSweepSaysSo(t *testing.T) {
+	full := cousinHealth{Searched: maxCousinSearches, Candidate: maxCousinSearches + 7, Truncated: true}
+	line := cousinSignalLine(full)
+	require.Contains(t, line, "SWEEP TRUNCATED")
+	require.Contains(t, line, "7 prune facts were not swept",
+		"the line must name HOW MANY went unswept, or a reader cannot size the gap")
+
+	complete := cousinHealth{Searched: 12, Candidate: 12}
+	require.NotContains(t, cousinSignalLine(complete), "TRUNCATED")
+}
+
+// TestCousins_BudgetActuallyTruncates drives the real function, because the
+// test above asserts on a health struct the test itself built — which pins the
+// formatter and not the cap.
+func TestCousins_BudgetActuallyTruncates(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, maxCousinSearches+10)
+
+	// One cluster holding more facts than the search budget allows.
+	var big []factForLLM
+	for i := range maxCousinSearches + 5 {
+		big = append(big, factForLLM{File: fmt.Sprintf("kb/technology/filler/topic%d/%08x.md", i, i+1)})
+	}
+	require.Greater(t, len(big), maxCousinSearches,
+		"fixture must exceed the budget, or truncation is never reached")
+
+	_, h := joinCousinsForPrune(ctx, env.deps(), env.branch, [][]factForLLM{big}, env.dedupThreshold())
+	require.True(t, h.Truncated, "a sweep over more facts than the budget must report truncation")
+	require.Equal(t, maxCousinSearches, h.Searched, "and it must stop AT the budget")
+	require.Equal(t, len(big), h.Candidate, "and still report what a complete sweep would have been")
+}
+
+// TestCousins_TruncatedSweepIsIndependentOfClusterOrder pins what the sweep's
+// sort actually buys.
+//
+// A first version of this test just called the function repeatedly and compared
+// runs. That passes with the sort DELETED (sabotage S15): `targets` is
+// collected from a slice, so a single run is already reproducible without it.
+// Repetition alone cannot see the property.
+//
+// What the sort guarantees is that the truncated tail depends on the SET of
+// prune facts and not on the ORDER Louvain emitted its communities in. So the
+// test feeds the same facts grouped into the same clusters, PRESENTED IN
+// REVERSED ORDER, and requires the swept set to be identical. Without the sort
+// the two presentations sweep different subsets and the prune items differ for
+// one unchanged corpus.
+func TestCousins_TruncatedSweepIsIndependentOfClusterOrder(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, maxCousinSearches+10)
+
+	// The ONE cluster that can attach a cousin, plus enough filler clusters to
+	// blow the search budget. Filler paths (kb/technology/filler/…) sort BEFORE
+	// the cousin's (kb/technology/security/…), so under the sort the cousin
+	// falls outside the budget in BOTH presentations. Without the sort its fate
+	// depends purely on which end of the list its cluster sits at.
+	cousinCluster := []factForLLM{{File: cousinAPath}}
+	clusters := [][]factForLLM{cousinCluster}
+	for c := range 3 {
+		var cluster []factForLLM
+		for i := range maxCousinSearches / 2 {
+			n := c*(maxCousinSearches/2) + i
+			cluster = append(cluster, factForLLM{
+				File: fmt.Sprintf("kb/technology/filler/topic%d/%08x.md", n, n+1)})
+		}
+		clusters = append(clusters, cluster)
+	}
+	total := 0
+	for _, c := range clusters {
+		total += len(c)
+	}
+	require.Greater(t, total, maxCousinSearches,
+		"fixture must exceed the budget, or there is no tail to truncate and "+
+			"cluster order cannot matter")
+
+	// Fixture assertion: on its own — no budget pressure — that cluster DOES
+	// attach the cousin. Without this, "0 attached" below would be satisfied by
+	// a corpus that simply has no cousin to find, and the test would pass while
+	// measuring nothing.
+	_, solo := joinCousinsForPrune(ctx, env.deps(), env.branch, [][]factForLLM{cousinCluster}, env.dedupThreshold())
+	require.Positive(t, solo.Attached,
+		"fixture's cousin cluster must attach when the budget is not the constraint")
+
+	_, forward := joinCousinsForPrune(ctx, env.deps(), env.branch, clusters, env.dedupThreshold())
+	require.True(t, forward.Truncated, "fixture must truncate, or this measures nothing")
+
+	reversed := make([][]factForLLM, 0, len(clusters))
+	for i := len(clusters) - 1; i >= 0; i-- {
+		reversed = append(reversed, clusters[i])
+	}
+	_, backward := joinCousinsForPrune(ctx, env.deps(), env.branch, reversed, env.dedupThreshold())
+
+	require.Equal(t, forward.Searched, backward.Searched)
+	require.Equal(t, forward.Attached, backward.Attached,
+		"the same facts in a different cluster ORDER must sweep the same subset — "+
+			"otherwise one unchanged corpus produces different prune items "+
+			"depending only on the sequence Louvain emitted its communities in")
+}
+
+// TestCousins_PlanRunsTheSweepAndReportsIt is the WIRING half.
+//
+// Calling joinCousinsForPrune asserts joinCousinsForPrune works, not that
+// anything calls it (the campaign's path-vs-state rule). This drives the real
+// Plan through StartSession and reads what the session says about itself.
+//
+// It asserts the pass RAN and REPORTED — not that a cousin was attached —
+// because whether this fixture yields any prune cluster at all depends on the
+// production Louvain resolution, which is a property of the clusterer rather
+// than of this fix. The attachment itself is pinned by the unit tests above,
+// against prune clusters built the way Plan builds them.
+func TestCousins_PlanRunsTheSweepAndReportsIt(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, 20)
+	cousinFixtureIsSound(t, env)
+
+	p := NewPipeline(env.ri, func(ProgressEvent) {}, EffortNormal, ScopeFilter{}, reviewStrategy{})
+	res, err := p.StartSession(ctx)
+	require.NoError(t, err)
+
+	require.Contains(t, strings.Join(res.Health, "\n"), "cross-category prune:",
+		"the pass must report itself even when it finds nothing — silence is how "+
+			"the category fence stayed invisible for as long as it did, and an "+
+			"unreported pass is indistinguishable from one that never ran")
+}
+
+// TestCousins_BothHalvesLeftoverIsNotReached records a LIMIT of this fix, so it
+// is a known boundary rather than a surprise.
+//
+// The sweep searches outward from facts that are ALREADY in a prune cluster. A
+// cousin pair where NEITHER half is in one — both sitting in the leftover
+// bucket — has no origin to search from and is not reached.
+//
+// That is the ruled scope ("cousin-meeting INSIDE prune") and it covers the
+// measured population: in all six confirmed pairs on the live corpus, one half
+// was served in a prune item and the other was the leftover. Widening the sweep
+// origin to every seed would also CREATE prune items where there were none,
+// which is a larger behaviour change than the one ruled — so it is recorded
+// here rather than done quietly.
+//
+// If this test ever fails, the sweep origin was widened: that may be correct,
+// but it is a scope change and should be a decision, not a side effect.
+func TestCousins_BothHalvesLeftoverIsNotReached(t *testing.T) {
+	ctx := context.Background()
+	env := cousinEnv(t, 20)
+	cousinFixtureIsSound(t, env)
+
+	// A prune cluster made of two UNRELATED filler facts: neither cousin is in
+	// it, so neither is a sweep origin.
+	pruneClusters := [][]factForLLM{{
+		{File: "kb/technology/filler/topic0/00000001.md"},
+		{File: "kb/technology/filler/topic1/00000002.md"},
+	}}
+	joined, h := joinCousinsForPrune(ctx, env.deps(), env.branch, pruneClusters, env.dedupThreshold())
+	require.Empty(t, h.Failure)
+	require.False(t, clustersHoldTogether(joined, cousinAPath, cousinBPath),
+		"KNOWN LIMIT: with neither half in a prune cluster there is no origin to "+
+			"sweep from, so this pair is not reached. Widening the origin to every "+
+			"seed is a scope change, not a bug fix")
+}
+
+// allFactsForLLM reads every live fact as a seed, the way Plan does.
+func allFactsForLLM(t *testing.T, env *restatementEnv) []factForLLM {
+	t.Helper()
+	live, err := env.svc.Abstraction().LiveEpistemicFacts(context.Background(), env.branch)
+	require.NoError(t, err)
+	out := make([]factForLLM, 0, len(live))
+	for _, path := range live {
+		out = append(out, factForLLM{File: path})
+	}
+	return out
+}
+
+// clustersHoldTogether reports whether any one cluster contains both paths.
+func clustersHoldTogether(clusters [][]factForLLM, a, b string) bool {
+	for _, c := range clusters {
+		var hasA, hasB bool
+		for _, f := range c {
+			if f.File == a {
+				hasA = true
+			}
+			if f.File == b {
+				hasB = true
+			}
+		}
+		if hasA && hasB {
+			return true
+		}
+	}
+	return false
+}
+
+// renderClusters is a stable string form for equality assertions.
+func renderClusters(clusters [][]factForLLM) string {
+	var b strings.Builder
+	for _, c := range clusters {
+		for _, f := range c {
+			b.WriteString(f.File)
+			b.WriteString(",")
+		}
+		b.WriteString("|")
+	}
+	return b.String()
+}

--- a/internal/synthesize/identity_test.go
+++ b/internal/synthesize/identity_test.go
@@ -214,11 +214,20 @@ func TestStructural_ReachesTheJudge(t *testing.T) {
 		"a structurally matched pair must be offered to the judge, not merely detected")
 }
 
-// TestStructural_ReservationSurvivesAFullOrdinaryBand — the reservation is only
-// meaningful when the ordinary band could have taken every slot. A widener that
+// TestStructural_AllowanceSurvivesAFullOrdinaryBand — the allowance is only
+// meaningful when the ordinary band could have taken every slot. A route that
 // fires only on underfill is decorative (the designer's Q10 ruling on the motif
-// signal, which this reservation copies).
-func TestStructural_ReservationSurvivesAFullOrdinaryBand(t *testing.T) {
+// signal).
+//
+// CHANGED BY knomit#155, and the change is the point. This used to end
+// `require.Len(pairs, budget)` — "the reservation reallocates a slot, it does
+// not add one" — because the structural route was a reservation INSIDE the
+// budget. It is now a separate allowance spent outside the budget, so the
+// correct assertion is the opposite one: the ordinary band keeps its full
+// budget AND the structural pairs are added on top. The old assertion is not
+// merely obsolete; keeping it would re-impose the coupling the fix removed,
+// since the only way to satisfy it is to take a slot from the ordinary band.
+func TestStructural_AllowanceSurvivesAFullOrdinaryBand(t *testing.T) {
 	ctx := context.Background()
 	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
 	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
@@ -238,10 +247,14 @@ func TestStructural_ReservationSurvivesAFullOrdinaryBand(t *testing.T) {
 
 	pairs, h, err := selectRestatementCandidates(ctx, d, env.branch, nil, structuralFiller+2)
 	require.NoError(t, err)
-	require.Equal(t, 1, h.StructuralOffered,
-		"the reserved slot must be spent even when the ordinary band could have filled the budget")
+	require.Positive(t, h.StructuralOffered,
+		"the allowance must be spent even when the ordinary band could have filled the budget")
+	require.LessOrEqual(t, h.StructuralOffered, structuralAllowance,
+		"the allowance bounds the route; an unbounded sweep would drown the session")
 	require.True(t, containsPair(pairs, a, b))
-	require.Len(t, pairs, budget, "the reservation reallocates a slot, it does not add one")
+	require.Len(t, pairs, budget+h.StructuralOffered,
+		"the allowance ADDS to the budget, it does not spend from it — the ordinary "+
+			"band must still get every slot the throttle funded")
 }
 
 // TestStructural_NoTitleVectorIsDroppedNotScored — the ranking column means

--- a/internal/synthesize/pipeline.go
+++ b/internal/synthesize/pipeline.go
@@ -186,7 +186,36 @@ func (p *Pipeline) StartSession(ctx context.Context) (*PipelineResult, error) {
 	// A pass whose trigger is corpus state cannot be planned from an
 	// edge-triggered seed scan, and this early return is where it would be
 	// silently starved again.
+	//
+	// ONE WAS ADDED BACK, and this is it (knomit#155). The structural
+	// duplicate sweep drains STANDING pairs — corpus state — so left inside
+	// the edge-triggered Plan it would advance only while the corpus kept
+	// changing, and never on the caught-up corpus whose backlog it exists to
+	// drain. The hook below is that pass's, and NOT a general resurrection of
+	// the removed level-triggered trio: it plans the standing sweep and
+	// nothing else, so a quiet corpus does the sweep and goes home rather than
+	// running the whole edge-triggered plan over an empty seed set.
 	if len(seeds) == 0 {
+		planned, standingHealth, serr := p.planStandingWork(ctx, d, sess, branch, scan)
+		if serr != nil {
+			return nil, serr
+		}
+		if planned {
+			log.Info().Str("tool", tool).Str("session", sess.ID).
+				Msg("pipeline: dirty set empty but the corpus's own state has standing work; planning it")
+			res, err := p.nextItem(ctx, sess)
+			if err != nil {
+				return nil, err
+			}
+			// The same health contract the planned path below keeps: the
+			// descriptors ride the FIRST result. emptySeedHealth still goes on,
+			// because "nothing has CHANGED" remains true and is the sentence
+			// that explains why this session is only doing standing work.
+			res.Health = append(res.Health, emptySeedHealth(scan)...)
+			res.Health = append(res.Health, sess.Health...)
+			p.stampIdentity(res, sess)
+			return res, nil
+		}
 		res, cerr := p.completeSession(ctx, sess)
 		if cerr != nil {
 			return nil, cerr
@@ -194,6 +223,11 @@ func (p *Pipeline) StartSession(ctx context.Context) (*PipelineResult, error) {
 		// #122(c): an empty return that says nothing cannot be told from a
 		// finished corpus, which is how #121's wall read as completion.
 		res.Health = append(res.Health, emptySeedHealth(scan)...)
+		// And say what the STANDING channel found, on the same principle. An
+		// empty seed pool with a silent standing pass is the #121 wall's shape
+		// exactly: "nothing to do" indistinguishable from "the pass that would
+		// have found something never ran".
+		res.Health = append(res.Health, standingHealth...)
 		// Identity on THIS path too: an empty return is exactly when an
 		// operator most needs to know which corpus reported nothing, since
 		// "nothing to do" and "wrong repo" look identical otherwise.
@@ -479,6 +513,51 @@ func (p *Pipeline) RunAll(ctx context.Context, adapter llm.LLMAdapter) error {
 }
 
 // ── seed scan ─────────────────────────────────────────────────────────────
+
+// planStandingWork asks the strategy whether the corpus's own state gives it
+// work the empty dirty set would otherwise hide (knomit#115, knomit#155).
+//
+// Degrades to "nothing planned" in both failure modes — a strategy that does
+// not implement standingWorkStrategy, and one whose planning errors — so the
+// behaviour when this cannot answer is exactly the behaviour before it existed.
+// A standing pass must never fail a session that was about to complete
+// successfully; it is an ADDITION to the session, not a precondition for one.
+// The error is not swallowed silently, though: it becomes a health line, on the
+// same rule as every other failure in this area.
+func (p *Pipeline) planStandingWork(ctx context.Context, d Deps, sess *store.PipelineSession, branch string, scan seedScan) (bool, []string, error) {
+	// A SCOPED session never plans standing work (knomit#128 review, MEDIUM-2,
+	// reinstated here verbatim in intent).
+	//
+	// The standing pools are corpus-wide BY CONSTRUCTION — the restatement
+	// shortlist does not know what scope the caller named, and the structural
+	// route deliberately ignores the scope filter even when it does — so
+	// consulting them on a scoped run turns a scope that matched nothing into a
+	// whole-corpus session the operator never asked for. That is the #122
+	// family's own rule: a scope must never silently widen.
+	//
+	// The pass is not lost. It is reached by any UNSCOPED session, which is the
+	// shape that legitimately speaks for the whole corpus.
+	if scan.Scoped {
+		return false, []string{
+			"standing work not planned: this session is SCOPED, and the standing " +
+				"pools are corpus-wide. Re-run without a scope to drain them.",
+		}, nil
+	}
+	sw, ok := p.strategy.(standingWorkStrategy)
+	if !ok {
+		return false, nil, nil
+	}
+	planned, health, err := sw.PlanStandingWork(ctx, d, sess, branch)
+	if err != nil {
+		log.Warn().Err(err).Str("tool", p.strategy.Tool()).Str("session", sess.ID).
+			Msg("pipeline: standing-work planning failed; completing as before")
+		return false, []string{
+			"standing work could not be planned this session: " + err.Error() +
+				". This is NOT a statement that the corpus has no standing work.",
+		}, nil
+	}
+	return planned, health, nil
+}
 
 // emptySeedHealth explains an empty seed pool to the agent that asked for one
 // (knomit#122 fix c, closing knomit#115's user-visible half).

--- a/internal/synthesize/restatement.go
+++ b/internal/synthesize/restatement.go
@@ -371,6 +371,27 @@ const shortlistOverfetch = 4
 // A SELECTION-POLICY constant, the same class as judgePairPermille (MN13).
 const shortlistMotifWiden = 3
 
+// structuralAllowance is how many judge slots ONE SESSION may spend on the
+// structural detection route, and it is spent WHATEVER THE THROTTLE SAYS.
+//
+// MN13 classification: a RESOURCE BUDGET, the same class as shortlistOverfetch
+// and pairNeighbourK — how much one session is willing to spend on this route.
+// It is NOT a claim about how many structural duplicates a corpus contains, and
+// nothing here is gated on a "≥N standing" floor, which would be exactly that
+// claim.
+//
+// WHY IT IS NOT THE THROTTLE'S TO WITHHOLD (knomit#155). The structural route
+// used to sit behind the ordinary band's `budget >= 2`, which made it
+// unreachable in the one state it was built for: a defunded corpus probes with
+// budget 1, one below the gate, so a corpus whose judge had resolved nothing
+// could never be shown the evidence that might change its mind. That is a
+// self-defunding latch — the penalty blocking its own recovery — and the fix is
+// to stop expressing this route's cost in the ordinary band's currency at all.
+// The throttle governs how much a corpus spends on TITLE-RANKED candidates,
+// which is what its verdict history is evidence about; it has never judged a
+// structural pair, so it has no evidence to withhold one on.
+const structuralAllowance = 5
+
 // Throttle states, reported in health output.
 //
 // RESOLVED, not merged: a verdict counts when the judge merged the pair OR
@@ -437,6 +458,18 @@ type restatementHealth struct {
 	// StandingStructural is how many structurally matched pairs the cache
 	// holds at all, whatever this session's scope and clusters made eligible.
 	StandingStructural int
+	// StructuralOutOfScope counts structural pairs offered to a SCOPED session
+	// whose halves both sit outside that scope. The structural route ignores
+	// the scope filter by design, which is a widening — and a widening the
+	// operator is not told about is the defect the #122 family exists to end.
+	StructuralOutOfScope int
+	// SweepOrderStable reports whether the sweep's oldest-first order currently
+	// means what it says. It is true only once the title axis is COMPLETE:
+	// while the axis is filling, every pair is rescanned and re-minted each
+	// session, which reassigns every rowid (see
+	// RestatementPairsByMatchKindOldest). Reported rather than assumed —
+	// a degenerated sweep order looks exactly like a working one from outside.
+	SweepOrderStable bool
 	// Probing is true when a defunded corpus spent its periodic probe slot —
 	// the one path by which its own evidence can change.
 	Probing bool
@@ -523,8 +556,37 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	h.ResolutionRate, h.ThrottleState = throttleState(verdicts)
 	h.Judged = len(verdicts)
 
+	// The structural sweep is decided BEFORE the throttle and independently of
+	// it (knomit#155). Ordering matters: every early return below is a
+	// throttle decision about the ordinary band, and the whole point of the
+	// dedicated allowance is that those decisions do not reach this route.
+	coGrouped := clusterCoMembership(clusters)
+	structural, err := selectStructuralSweep(ctx, d, branch, coGrouped)
+	if err != nil {
+		return nil, h, err
+	}
+	h.StructuralAvailable = len(structural)
+	// Whether "oldest-first" currently means what it says — see
+	// RestatementPairsByMatchKindOldest. Reported rather than assumed, because
+	// a sweep whose order has silently degenerated looks exactly like one that
+	// has not.
+	h.SweepOrderStable = h.Coverage >= 1
+	if !d.Scope.IsEmpty() {
+		// The structural route deliberately ignores the scope filter: a
+		// cross-category structural pair is corpus-wide evidence by
+		// construction. That is a SCOPE WIDENING, and a widening nobody is
+		// told about is the #122 family's own defect. Count them so the health
+		// line can say so.
+		for _, p := range structural {
+			if !pairTouchesScope(ctx, d, branch, p) {
+				h.StructuralOutOfScope++
+			}
+		}
+	}
+
 	budget := shortlistBudget(n)
 	probing := false
+	throttleClosed := false
 	if h.ThrottleState == throttleDefunded {
 		// Defunded corpora still probe, or they could never recover.
 		allowed, err := probeAllowed(ctx, d, branch)
@@ -532,17 +594,24 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 			return nil, h, err
 		}
 		if !allowed {
-			return nil, h, nil
+			throttleClosed = true
+		} else {
+			probing = true
+			budget = 1
 		}
-		probing = true
-		budget = 1
 	} else if err := d.Abstraction.SetProbeSessionsWaited(ctx, branch, 0); err != nil {
 		// A funded corpus owes no probe; reset so a later defunding starts its
 		// wait from now rather than inheriting an ancient count.
 		return nil, h, wrapf(reviewTool, err, "shortlist: reset probe wait")
 	}
 	if budget == 0 {
-		return nil, h, nil
+		throttleClosed = true
+	}
+	if throttleClosed {
+		// The ordinary band is shut. The structural allowance is not — this is
+		// the latch break, and it is the only path by which a defunded corpus
+		// is shown evidence its own verdict history says nothing about.
+		return emitStructuralOnly(structural, &h), h, nil
 	}
 
 	// Over-fetch: the exclusions below are decided per candidate, and cutting to
@@ -569,7 +638,6 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	// band underfilled. That made the signal contribute nothing in exactly the
 	// case it exists for: pairs the title axis UNDER-RANKS (designer ruling
 	// Q10).
-	coGrouped := clusterCoMembership(clusters)
 	eligible := func(p store.RestatementPair) bool {
 		if _, ok := coGrouped[pathPairKey(p.APath, p.BPath)]; ok {
 			return false
@@ -599,33 +667,6 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 		}
 	}
 
-	// RESERVE one slot for a STRUCTURAL pair when one exists (#127).
-	//
-	// Same shape as the motif widener below, and for the same reason: a pair
-	// found by path identity or a shared rare identifier is evidence the title
-	// ranking cannot see, so it sits below the title-ranked band by definition.
-	// Without a reserved slot the detection would be real and inert — a
-	// duplicate correctly identified and never offered, which is this issue's
-	// own failure mode arriving one layer later.
-	//
-	// A BUDGET ALLOCATION, not a threshold (MN13): it changes what may be
-	// considered, never how much is spent, and the corpus's own throttle still
-	// decides whether anything is spent at all.
-	var structural []store.RestatementPair
-	if budget >= 2 {
-		sp, serr := d.Abstraction.RestatementPairsByMatchKind(ctx, branch,
-			[]string{store.MatchPathIdentity, store.MatchRareToken}, budget*shortlistOverfetch)
-		if serr != nil {
-			return nil, h, wrapf(reviewTool, serr, "shortlist: structural rank")
-		}
-		for _, p := range sp {
-			if eligible(p) {
-				structural = append(structural, p)
-			}
-		}
-	}
-	h.StructuralAvailable = len(structural)
-
 	// RESERVE one slot for a widened pair when one exists. A shared canonical
 	// motif is evidence ORTHOGONAL to title similarity — evidence the title
 	// axis cannot see — so the pairs it identifies are below the title-ranked
@@ -639,24 +680,14 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	// a corpus that can afford one judgment should spend it on its
 	// best-evidenced candidate rather than on orthogonal evidence about a
 	// lower-ranked one.
-	// Two reservations, one slot each, and neither may take the last slot: a
-	// corpus that can afford two judgements should still spend one on its
-	// best-evidenced ordinary candidate.
-	structuralReserved, motifReserved := 0, 0
-	if budget >= 2 {
-		if len(structural) > 0 {
-			structuralReserved = 1
-		}
-		if len(motifPairs) > 0 {
-			motifReserved = 1
-		}
-		for structuralReserved+motifReserved >= budget {
-			if motifReserved > 0 {
-				motifReserved--
-				continue
-			}
-			structuralReserved--
-		}
+	//
+	// The structural route USED TO SHARE this arithmetic, as a second
+	// one-slot reservation. It no longer does: it has its own allowance, spent
+	// outside the budget entirely (knomit#155). So the only thing left to
+	// arbitrate here is the motif slot against the ordinary band.
+	motifReserved := 0
+	if budget >= 2 && len(motifPairs) > 0 {
+		motifReserved = 1
 	}
 
 	var out []store.RestatementPair
@@ -671,33 +702,35 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 		return true
 	}
 
-	// Structural first, within its own reservation. It is the only route by
-	// which a pair the title ranking places nowhere can be judged at all, and a
-	// route that fires only on underfill is decorative (the Q10 ruling on the
-	// motif widener, which this reservation copies).
-	used := 0
+	// Structural first, on its OWN allowance — it is not competing for the
+	// budget any more, so nothing it takes is taken from the ordinary band.
+	// It goes first only so the ordinary band's cosine stays the LAST thing
+	// added, which is what the operating point below reads.
 	for _, p := range structural {
-		if used >= structuralReserved {
-			break
-		}
 		if add(p) {
-			used++
 			h.StructuralOffered++
 		}
 	}
-	// The ordinary band takes everything the motif reservation does not hold —
-	// including any structural slot that went unused.
+	// The budget-funded bands. `budgeted` counts only what the BUDGET paid
+	// for: `len(out)` would now include the structural allowance and would
+	// shrink the ordinary band by however many structural pairs happened to
+	// stand — the allowance silently becoming a tax on the very band it was
+	// separated from.
+	budgeted := 0
 	for _, p := range ordinary {
-		if len(out) >= budget-motifReserved {
-			break
-		}
-		add(p)
-	}
-	for _, p := range motifPairs {
-		if len(out) >= budget {
+		if budgeted >= budget-motifReserved {
 			break
 		}
 		if add(p) {
+			budgeted++
+		}
+	}
+	for _, p := range motifPairs {
+		if budgeted >= budget {
+			break
+		}
+		if add(p) {
+			budgeted++
 			h.MotifWidened++
 		}
 	}
@@ -716,16 +749,77 @@ func selectRestatementCandidates(ctx context.Context, d Deps, branch string, clu
 	// knomit#117a: a probe whose one pair fails to load at item creation put
 	// NOTHING in front of the judge, yet bought a full interval of silence.
 	// That is the self-defunding latch re-introduced at a slower rate.
-	h.Probing = probing && len(out) > 0
-	if len(out) > 0 {
+	h.Probing = probing && budgeted > 0
+	if budgeted > 0 {
 		// The operating point is not a threshold anyone chose: it is whatever
 		// absolute cosine the last funded pair happens to sit at in THIS repo.
 		// Reported because it is a corpus fingerprint — the same code on
 		// another corpus prints a different number.
+		//
+		// FUNDED is the operative word, and it is why this reads `budgeted`
+		// rather than `len(out)`. The structural allowance is not funded by the
+		// budget, so its cosine is not this corpus's operating point — and on a
+		// defunded corpus, where the allowance is the ONLY thing emitted, using
+		// the last element would print a structural cosine as though the
+		// throttle had chosen it.
 		h.OperatingPoint = out[len(out)-1].TitleCos
 	}
 	h.Emitted = len(out)
 	return out, h, nil
+}
+
+// selectStructuralSweep is the structural route's whole selection: the oldest
+// standing path-identity pairs this session's clusters do not already hold.
+//
+// PATH-IDENTITY ONLY, for now. The rare-token route is the wider, weaker net
+// (store.MatchRareToken), and its merge rate is unmeasured because the route it
+// shares was inert — so it stays closed until the path-identity sample says
+// what a structural offer is actually worth. Opening both at once would spend
+// the sample on a population that cannot be told apart afterwards.
+//
+// The SCOPE filter is deliberately absent. `eligible` applies it to the
+// title-ranked band, where it belongs — a session asked to work on one area
+// should not spend its funded slots elsewhere. A structural pair is not that:
+// its evidence is the corpus's own filing, which is corpus-wide by
+// construction, and there is no scoped view that would ever co-present the two
+// halves. The widening is real, so it is COUNTED and reported rather than done
+// quietly (h.StructuralOutOfScope).
+func selectStructuralSweep(ctx context.Context, d Deps, branch string, coGrouped map[string]struct{}) ([]store.RestatementPair, error) {
+	// Over-fetch for the same reason the ordinary band does: the exclusion
+	// below is decided per candidate, so cutting to the allowance first would
+	// let one co-clustered pair silently shrink the sweep.
+	sp, err := d.Abstraction.RestatementPairsByMatchKindOldest(ctx, branch,
+		[]string{store.MatchPathIdentity}, structuralAllowance*shortlistOverfetch)
+	if err != nil {
+		return nil, wrapf(reviewTool, err, "shortlist: structural sweep")
+	}
+	var out []store.RestatementPair
+	for _, p := range sp {
+		if len(out) >= structuralAllowance {
+			break
+		}
+		// The one exclusion that survives on this route: prune already sees
+		// this pair in one cluster, so a shortlist slot would buy a second
+		// judgement of the same question.
+		if _, ok := coGrouped[pathPairKey(p.APath, p.BPath)]; ok {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// emitStructuralOnly is the return the throttle-closed paths take.
+//
+// A defunded corpus that is not probing, and a corpus whose budget rounds to
+// zero, both used to return NOTHING here. That is what made the structural
+// detection inert exactly where it mattered: the corpus with the least evidence
+// that consolidation is worth anything is the corpus most in need of being
+// shown a near-certain duplicate. The allowance is spent; the budget is not.
+func emitStructuralOnly(structural []store.RestatementPair, h *restatementHealth) []store.RestatementPair {
+	h.StructuralOffered = len(structural)
+	h.Emitted = len(structural)
+	return structural
 }
 
 // clusterCoMembership is the set of pairs this session's own dedupCluster
@@ -1016,9 +1110,29 @@ func structuralSignalLine(h restatementHealth) string {
 	if h.StandingStructural == 0 {
 		return "structural duplicate detection: no path-identity or rare-token pairs stand in this corpus"
 	}
-	return fmt.Sprintf(
-		"structural duplicate detection: %d standing, %d eligible this session, %d offered",
-		h.StandingStructural, h.StructuralAvailable, h.StructuralOffered)
+	line := fmt.Sprintf(
+		"structural duplicate detection: %d standing, %d eligible this session, %d offered "+
+			"(allowance %d/session, path-identity only — rare-token stays closed until the "+
+			"path-identity merge rate justifies it)",
+		h.StandingStructural, h.StructuralAvailable, h.StructuralOffered, structuralAllowance)
+	// Say which order the sweep is actually in. "Oldest-first" is exact only on
+	// a complete axis; while the axis fills, every pair is re-minted each
+	// session and the order is deterministic but not age-stable. A sweep that
+	// has silently degenerated reads identically to one that has not, so the
+	// regime is stated rather than implied (see
+	// RestatementPairsByMatchKindOldest).
+	if h.SweepOrderStable {
+		line += ". Sweep order: oldest-first (axis complete)"
+	} else {
+		line += ". Sweep order: NOT yet age-stable — the title axis is still filling, so " +
+			"pairs are re-minted each session and mint order churns"
+	}
+	if h.StructuralOutOfScope > 0 {
+		line += fmt.Sprintf(". %d structural pair(s) offered from OUTSIDE this session's scope "+
+			"— structural evidence is corpus-wide by construction, so this route ignores the "+
+			"scope filter on purpose", h.StructuralOutOfScope)
+	}
+	return line
 }
 
 // motifSignalLine reports what the §7 motif widener contributed this session.

--- a/internal/synthesize/restatement_standing_work_test.go
+++ b/internal/synthesize/restatement_standing_work_test.go
@@ -1,0 +1,262 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// The corpus-state channel (knomit#155, second half).
+//
+// The structural sweep drains STANDING pairs — corpus state — but it was
+// planned from inside `reviewStrategy.Plan`, which `StartSession` only reaches
+// when the dirty set is NON-EMPTY. So the sweep advanced only while the corpus
+// kept changing, and never on the caught-up corpus whose backlog it exists to
+// drain: the population and the trigger were exact opposites.
+//
+// This is knomit#115's shape returning with the pass that has it, exactly as
+// the rip-out's comment at the empty-seed early return predicted.
+
+// standingEnv is a corpus with standing structural pairs whose review watermark
+// has already been advanced past everything — a QUIET corpus, which is the one
+// state the old code could not serve.
+//
+// The watermark is advanced by running a real session to completion rather than
+// by writing the watermark row directly: the starvation is a COMPOSITION of the
+// seed scan and the completion, and a test that fakes either half cannot see it.
+func standingEnv(t *testing.T) (*restatementEnv, *Pipeline) {
+	t.Helper()
+	ctx := context.Background()
+	env := manyTwinsEnvWithFiller(t, structuralAllowance+3, 40)
+	env.seedShortlist()
+
+	p := NewPipeline(env.ri, func(ProgressEvent) {}, EffortNormal, ScopeFilter{}, reviewStrategy{})
+
+	// Drain one full session so the watermark reaches HEAD and the corpus goes
+	// quiet. Answers are empty no-ops; nothing here is about what the judge
+	// decides, only about the corpus having nothing left to CHANGE.
+	res, err := p.StartSession(ctx)
+	require.NoError(t, err)
+	for steps := 0; res.Item != nil && steps < 200; steps++ {
+		res, err = p.ContinueSession(ctx, res.SessionID, noopAnswerFor(t, res.Item.Type))
+		require.NoError(t, err)
+	}
+	return env, p
+}
+
+func noopAnswerFor(t *testing.T, stepType string) string {
+	t.Helper()
+	switch stepType {
+	case "prune":
+		return `{"decisions":[],"merges":[]}`
+	case "distill":
+		return `{"synthesize":[],"retract":[]}`
+	case "reflect":
+		return `{"methodologies":[]}`
+	}
+	t.Fatalf("unexpected step type %q", stepType)
+	return ""
+}
+
+// TestStanding_QuietCorpusStillDrainsItsStandingPairs is the whole of the
+// second half of knomit#155.
+//
+// A corpus with nothing dirty and a backlog of standing structural pairs must
+// still be handed those pairs. Before the hook, StartSession short-circuited to
+// completeSession before `Plan` ran, so the standing channel never executed at
+// all on exactly this corpus.
+func TestStanding_QuietCorpusStillDrainsItsStandingPairs(t *testing.T) {
+	ctx := context.Background()
+	env, p := standingEnv(t)
+
+	// Fixture assertions FIRST. Both are load-bearing: a corpus that is not
+	// actually quiet would reach the ordinary Plan and prove nothing, and a
+	// corpus with no standing pairs would give the sweep nothing to find.
+	seeds, scan, err := p.dirtyFacts(ctx, env.branch, env.svc.Facts(), env.svc.Search(), env.svc.Pipeline())
+	require.NoError(t, err)
+	require.Empty(t, seeds,
+		"fixture must be QUIET — with a non-empty dirty set this exercises the "+
+			"ordinary planned path and says nothing about the early return")
+	require.False(t, scan.Scoped, "fixture must be unscoped, or the scope guard short-circuits it")
+	standing, err := env.svc.Abstraction().RestatementPairsByMatchKindOldest(ctx, env.branch,
+		[]string{store.MatchPathIdentity}, 100_000)
+	require.NoError(t, err)
+	require.NotEmpty(t, standing, "fixture must hold standing structural pairs")
+
+	res, err := p.StartSession(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res.Item,
+		"a quiet corpus with standing structural pairs must still be handed work — "+
+			"a pass whose trigger is corpus state cannot be planned from an "+
+			"edge-triggered seed scan")
+	require.Equal(t, "prune", res.Item.Type,
+		"the standing channel reaches the judge as an ordinary prune item")
+	require.False(t, res.Done, "a session that just planned work is not done")
+}
+
+// TestStanding_QuietCorpusSaysWhatItDidWhenItPlansNothing is the legibility
+// half, and it is not decoration.
+//
+// #121's wall was a session returning `done:true` with no health block while
+// ~288 facts sat unreachable — "nothing to do" and "the pass that would have
+// found something never ran" are indistinguishable from outside. Adding a
+// standing channel that can silently find nothing would rebuild that ambiguity
+// one layer in.
+func TestStanding_QuietCorpusSaysWhatItDidWhenItPlansNothing(t *testing.T) {
+	ctx := context.Background()
+	// A quiet corpus with NO structural pairs at all: the standing channel runs
+	// and legitimately finds nothing.
+	env := newRestatementEnv(t, 6)
+	p := NewPipeline(env.ri, func(ProgressEvent) {}, EffortNormal, ScopeFilter{}, reviewStrategy{})
+	res, err := p.StartSession(ctx)
+	require.NoError(t, err)
+	for steps := 0; res.Item != nil && steps < 200; steps++ {
+		res, err = p.ContinueSession(ctx, res.SessionID, noopAnswerFor(t, res.Item.Type))
+		require.NoError(t, err)
+	}
+
+	res, err = p.StartSession(ctx)
+	require.NoError(t, err)
+	require.True(t, res.Done, "fixture must actually be finished, or this is not the empty path")
+
+	joined := strings.Join(res.Health, "\n")
+	require.Contains(t, joined, "nothing has changed since the review watermark",
+		"the edge-triggered channel must still explain itself")
+	require.Contains(t, joined, "standing work",
+		"the standing channel must say it RAN — silence here is #121's wall, "+
+			"where 'nothing to do' and 'never ran' read identically")
+}
+
+// TestStanding_ScopedQuietSessionDoesNotDrainTheWholeCorpus reinstates
+// knomit#128 review MEDIUM-2, on the pass that brought the hazard back.
+//
+// The standing pools are corpus-wide by construction — and the structural route
+// deliberately ignores the scope filter even when one is set — so consulting
+// them from a scoped session turns a scope that matched nothing into a
+// whole-corpus session nobody asked for. Measured before the original guard: a
+// scoped run matching no facts planned work over three facts, all outside the
+// scope, and printed no scoped sentence at all.
+func TestStanding_ScopedQuietSessionDoesNotDrainTheWholeCorpus(t *testing.T) {
+	ctx := context.Background()
+	env, _ := standingEnv(t)
+
+	// Fixture assertion: an UNSCOPED pipeline on this same corpus DOES plan
+	// standing work. Without this the test below passes against a corpus where
+	// the standing channel finds nothing for reasons unrelated to the scope.
+	unscoped := NewPipeline(env.ri, func(ProgressEvent) {}, EffortNormal, ScopeFilter{}, reviewStrategy{})
+	open, err := unscoped.StartSession(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, open.Item,
+		"fixture must plan standing work when UNSCOPED, or the scope guard is "+
+			"being credited for an empty corpus")
+
+	scoped := NewPipeline(env.ri, func(ProgressEvent) {}, EffortNormal,
+		ScopeFilter{Domain: []string{"a-domain-no-fact-here-carries"}}, reviewStrategy{})
+	res, err := scoped.StartSession(ctx)
+	require.NoError(t, err)
+	require.Nil(t, res.Item,
+		"a SCOPED session whose scope matched nothing must not drain the whole "+
+			"corpus's standing backlog — a scope must never silently widen")
+	require.True(t, res.Done)
+	require.Contains(t, strings.Join(res.Health, "\n"), "SCOPED",
+		"and it must SAY why it did not, or the guard is indistinguishable from an empty corpus")
+}
+
+// TestStanding_HypothesizeStrategyIsUnaffected pins the optionality.
+//
+// The hook is an interface a strategy may implement. A strategy that does not
+// must behave exactly as it did before the hook existed — the engine must not
+// have acquired a new failure mode for every tool that has no standing channel.
+func TestStanding_HypothesizeStrategyIsUnaffected(t *testing.T) {
+	var s any = hypothesizeStrategy{}
+	_, implements := s.(standingWorkStrategy)
+	require.False(t, implements,
+		"hypothesize owns no corpus-state channel; if it grows one, this test "+
+			"should be replaced by one that exercises it, not deleted")
+}
+
+// TestStanding_PlanStandingWorkPlansOnlyTheStandingChannel pins the ruling that
+// the quiet path calls the shortlist DIRECTLY rather than falling through into
+// the full edge-triggered Plan.
+//
+// IT RUNS AT EFFORT MEDIUM, and that is the whole reason it can tell the two
+// apart. At EffortNormal with a nil seed pool the two are behaviourally
+// IDENTICAL — ScopedCluster returns nothing, there are no prune clusters, the
+// distill block needs len(seeds) > 1, and bridge seeding is off — so a test
+// written at normal effort passes whichever is called. It was written that way
+// first, and the sabotage that swapped in the full Plan walked straight through
+// it (S12). At medium, Plan additionally runs the motif vocabulary passes:
+// RebuildAliases, planMotifAliasWork, planMotifDefineWork. Those are
+// edge-triggered maintenance that a quiet standing sweep has no business
+// firing, and they are the observable difference.
+func TestStanding_PlanStandingWorkPlansOnlyTheStandingChannel(t *testing.T) {
+	ctx := context.Background()
+	env, _ := standingEnv(t)
+
+	d := env.deps()
+	d.Effort = EffortMedium
+	// Fixture assertion: the effort dial must actually be the one that opens the
+	// vocabulary block, or this test is back to the indistinguishable case.
+	require.True(t, d.Effort.MaintainsVocabulary(),
+		"fixture must run at an effort where Plan does MORE than the shortlist, "+
+			"or the two paths cannot be told apart")
+
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
+	require.NoError(t, err)
+	planned, health, err := reviewStrategy{}.PlanStandingWork(ctx, d, sess, env.branch)
+	require.NoError(t, err)
+	require.True(t, planned, "fixture must plan something, or the census below is over an empty queue")
+	require.NotEmpty(t, health, "the standing channel always reports, planned or not")
+
+	// The DISCRIMINATING assertion, and the one S12 was caught by. The
+	// vocabulary passes enqueue an item only when they find judge pairs, but
+	// they record a health line UNCONDITIONALLY — so the health block, not the
+	// queue, is where "did the full edge-triggered Plan run here?" is actually
+	// answerable on a quiet corpus.
+	require.NotContains(t, strings.Join(health, "\n"), "motif aliases:",
+		"the standing channel must NOT run the motif vocabulary passes — they are "+
+			"edge-triggered maintenance, and their health line is the tell that "+
+			"the full Plan was called instead of the shortlist")
+
+	items, err := env.svc.Pipeline().PendingPipelineWorkItems(ctx, sess.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+	for _, it := range items {
+		require.Equal(t, "prune", it.StepType,
+			"the standing channel enqueues shortlist prune items and NOTHING else — "+
+				"no distill chunks, no discover items, no motif vocabulary work")
+		require.True(t, strings.HasPrefix(it.ClusterKey, restatementClusterKeyPrefix),
+			fmt.Sprintf("every item must come from the shortlist; got cluster key %q", it.ClusterKey))
+	}
+}
+
+// TestStanding_QuietSessionDoesNotRunTheVocabularyPasses is the same ruling
+// stated as the negative, on the engine path rather than the strategy method.
+//
+// A quiet corpus at medium effort must not acquire the motif vocabulary work
+// that only an edge-triggered plan owns. Asserting it here as well as above is
+// not duplication: the test above calls PlanStandingWork directly, which proves
+// the method is right and says nothing about what StartSession calls.
+func TestStanding_QuietSessionDoesNotRunTheVocabularyPasses(t *testing.T) {
+	ctx := context.Background()
+	env, _ := standingEnv(t)
+
+	p := NewPipeline(env.ri, func(ProgressEvent) {}, EffortMedium, ScopeFilter{}, reviewStrategy{})
+	res, err := p.StartSession(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res.Item, "fixture must plan standing work, or there is nothing to census")
+
+	items, err := env.svc.Pipeline().PendingPipelineWorkItems(ctx, res.SessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+	for _, it := range items {
+		require.Equal(t, "prune", it.StepType,
+			"a quiet session runs the STANDING channel only; motif_alias / "+
+				"motif_define are edge-triggered maintenance and must not fire here")
+	}
+}

--- a/internal/synthesize/restatement_structural_allowance_test.go
+++ b/internal/synthesize/restatement_structural_allowance_test.go
@@ -358,9 +358,24 @@ func TestStructural_AllowanceCapsTheSweep(t *testing.T) {
 			"a whole session's judge budget to one route")
 }
 
-// manyTwinsEnv builds a corpus with n path-identity twin pairs, each on its own
-// discriminating subject token so no pair can match across pairs.
+// manyTwinsEnv builds a corpus with n path-identity twin pairs on the standard
+// filler, for tests about SELECTION (which is corpus-scaled).
 func manyTwinsEnv(t *testing.T, n int) *restatementEnv {
+	t.Helper()
+	return manyTwinsEnvWithFiller(t, n, structuralFiller)
+}
+
+// manyTwinsEnvWithFiller is manyTwinsEnv with the filler size chosen by the
+// caller.
+//
+// The filler exists for ONE reason — both rarity cuts are read off the corpus's
+// own token distribution, so a corpus with no distribution has nothing rare in
+// it — and the standard 404 is sized for `shortlistBudget`, which is a
+// SELECTION concern. Tests about the standing channel do not need it: the
+// allowance fires whatever the budget is, and 404 facts make the distill item
+// span six pages, which turns an unrelated paging contract into a fixture
+// problem. So they pass a smaller number and assert the detection still fires.
+func manyTwinsEnvWithFiller(t *testing.T, n, filler int) *restatementEnv {
 	t.Helper()
 	// Subject tokens chosen to be rare in this corpus and unrelated to each
 	// other; the prefix-EXTENSION shape (subject vs vendor/subject) is the one
@@ -372,7 +387,7 @@ func manyTwinsEnv(t *testing.T, n int) *restatementEnv {
 	require.LessOrEqual(t, n, len(subjects), "manyTwinsEnv has only %d subjects", len(subjects))
 
 	env := newRestatementEnv(t, 0)
-	for i := range structuralFiller {
+	for i := range filler {
 		env.writeFact(
 			fmt.Sprintf("kb/technology/filler/topic%d/%08x.md", i, i+1),
 			fmt.Sprintf("Filler note 2026 about widget %d", 1000+i),

--- a/internal/synthesize/restatement_structural_allowance_test.go
+++ b/internal/synthesize/restatement_structural_allowance_test.go
@@ -1,0 +1,487 @@
+package synthesize
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/store"
+)
+
+// The structural allowance (knomit#155).
+//
+// The route existed and was inert. Detection minted thousands of path-identity
+// pairs and offered zero, on every corpus that most needed them, because the
+// route's cost was expressed in the ordinary band's currency: it sat behind
+// `budget >= 2`, and a defunded corpus probes with budget 1. The corpus whose
+// judge had resolved nothing could never be shown the evidence that might
+// change its mind — the penalty blocking its own recovery.
+//
+// These tests pin the four properties that break the latch. Each is written to
+// fail for one reason only; the sabotage that catches each is named in the
+// commit.
+
+// structuralDefundedEnv is a corpus with one path-identity pair, driven to the
+// DEFUNDED throttle state by an all-keep verdict history.
+//
+// Defunding is done through the real verdict path rather than by poking the
+// throttle, because the latch is a composition of two mechanisms and a test
+// that fakes one of them cannot see it.
+func structuralDefundedEnv(t *testing.T, a, b string) (*restatementEnv, Deps) {
+	t.Helper()
+	ctx := context.Background()
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "Cisco patches nine flaws across Crosswork and Secure Workload"),
+		namedFact(b, "Nine Cisco advisories cover Crosswork and Secure Workload"),
+	})
+	env.seedShortlist()
+	d := env.deps()
+
+	// The fixture MUST reach the defunded state, and MUST still hold the
+	// structural pair when it gets there. Both are asserted below rather than
+	// assumed: a fixture chosen to make a test discriminate is a claim, and an
+	// unasserted claim is how a test ends up comparing zero against zero.
+	for range throttleMinVerdicts {
+		pairs, _, err := selectRestatementCandidates(ctx, d, env.branch, nil, structuralFiller+2)
+		require.NoError(t, err)
+		require.NotEmpty(t, pairs, "the corpus must still be spending while it is being defunded")
+		// Decline an ORDINARY pair. Declining the structural pair would retire
+		// the very thing under test.
+		var declined bool
+		for _, p := range pairs {
+			if p.MatchKind == store.MatchTitleKNN {
+				env.recordVerdict(p.APath, p.BPath, false)
+				declined = true
+				break
+			}
+		}
+		require.True(t, declined, "fixture must offer an ordinary pair to decline")
+	}
+	return env, d
+}
+
+// TestStructural_AllowanceFiresOnADefundedCorpus is the latch break, and it is
+// the whole of knomit#155.
+//
+// A defunded corpus that is NOT probing used to return nothing at all — the
+// early return happened before the structural fetch was even reached, so the
+// route was unreachable in exactly the state it was built for. The throttle
+// governs spend on TITLE-RANKED candidates, which is what its verdict history
+// is evidence about; it has never judged a structural pair, so it has no
+// evidence on which to withhold one.
+func TestStructural_AllowanceFiresOnADefundedCorpus(t *testing.T) {
+	ctx := context.Background()
+	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
+	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
+	env, d := structuralDefundedEnv(t, a, b)
+
+	pairs, h, err := selectRestatementCandidates(ctx, d, env.branch, nil, structuralFiller+2)
+	require.NoError(t, err)
+
+	// Fixture assertions FIRST — without these, every assertion below could
+	// pass against an empty population.
+	require.Equal(t, throttleDefunded, h.ThrottleState,
+		"fixture must actually be defunded, or this test measures the funded path")
+	require.False(t, h.Probing,
+		"fixture must be in the SILENT defunded state, not on a probe session — "+
+			"the probe path was never the one that was latched shut")
+	require.Positive(t, h.StandingStructural,
+		"fixture must hold standing structural pairs, or 'offered' is compared against nothing")
+
+	require.Positive(t, h.StructuralOffered,
+		"a defunded corpus must still be shown structural evidence — its verdict "+
+			"history is about title-ranked pairs and says nothing about this route")
+	require.True(t, containsPair(pairs, a, b),
+		"the structurally matched pair is what must reach the judge, not merely a count")
+}
+
+// TestStructural_AllowanceIsBoundedOnADefundedCorpus is the other half of the
+// latch break, and the reason the allowance is a number rather than a flag.
+//
+// "Fires even when defunded" without a bound is not a fix, it is a corpus that
+// ignores its own throttle. The allowance is a RESOURCE BUDGET (MN13): the
+// route is reachable, and it is bounded, and the two are independent claims.
+func TestStructural_AllowanceIsBoundedOnADefundedCorpus(t *testing.T) {
+	ctx := context.Background()
+	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
+	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
+	env, d := structuralDefundedEnv(t, a, b)
+
+	pairs, h, err := selectRestatementCandidates(ctx, d, env.branch, nil, structuralFiller+2)
+	require.NoError(t, err)
+	require.Equal(t, throttleDefunded, h.ThrottleState)
+	// Fixture assertion, and it is not ceremony: `0 <= structuralAllowance` is
+	// true, so without this the bound below is satisfied by a route that offers
+	// NOTHING — which is precisely the bug this whole commit removes. Caught by
+	// sabotage S1, which nulled the sweep on the throttle-closed path and left
+	// this test green.
+	require.Positive(t, h.StructuralOffered,
+		"fixture must actually offer structural pairs, or the bound is asserted against zero")
+	require.LessOrEqual(t, len(pairs), structuralAllowance,
+		"a defunded corpus spends the allowance and NOTHING else — the ordinary "+
+			"band stays shut, which is what the throttle actually decided")
+	require.Equal(t, h.StructuralOffered, len(pairs),
+		"every pair a defunded corpus emits comes from the allowance")
+}
+
+// TestStructural_SweepIsOldestFirstNotHighestCosine pins the sweep order.
+//
+// Inflow far exceeds what any session can judge, so re-selecting the top of a
+// cosine ranking every session starves the tail forever — and the ranking buys
+// nothing on this route anyway, since a structurally matched pair is a
+// near-certain duplicate whatever its cosine happens to be.
+//
+// The test is written as a DISAGREEMENT between the two orderings: it asserts
+// the sweep returns something the cosine ranking does not put first. An
+// assertion that merely checked "the sweep returned pairs" would pass under a
+// sabotage that swapped the ORDER BY back to `title_cos DESC`.
+func TestStructural_SweepIsOldestFirstNotHighestCosine(t *testing.T) {
+	ctx := context.Background()
+	env := sweepOrderEnv(t)
+	env.seedShortlist()
+	ax := env.svc.Abstraction()
+
+	byCos, err := ax.RestatementPairsByMatchKind(ctx, env.branch,
+		[]string{store.MatchPathIdentity}, 100_000)
+	require.NoError(t, err)
+	byAge, err := ax.RestatementPairsByMatchKindOldest(ctx, env.branch,
+		[]string{store.MatchPathIdentity}, 100_000)
+	require.NoError(t, err)
+
+	// Fixture assertion: the two orderings can only DISAGREE if the population
+	// is big enough to have an order at all, and if cosine is not already
+	// monotone in mint order.
+	require.Equal(t, len(byCos), len(byAge),
+		"both readers must see the same population; only the order may differ")
+	require.Greater(t, len(byAge), 1,
+		"fixture must hold more than one structural pair, or 'order' is meaningless")
+	require.NotEqual(t, orderOf(byCos), orderOf(byAge),
+		"fixture must be one where mint order and cosine rank actually disagree, "+
+			"or this test cannot tell the two readers apart")
+
+	// And the sweep is NOT sorted by descending cosine — that is the property
+	// under test, stated directly.
+	require.False(t, isDescendingByCos(byAge),
+		"the sweep must drain in mint order; a cosine-ranked sweep re-offers the "+
+			"same head every session and never reaches the tail")
+}
+
+// TestStructural_RareTokenStaysClosed pins the sampling stage.
+//
+// Path-identity's merge rate is UNMEASURED — the route it shares was inert, so
+// zero structural pairs have ever been judged. Offering both routes at once
+// would spend that sample on a mixed population whose halves cannot be told
+// apart afterwards, which is the one thing the staging exists to prevent.
+func TestStructural_RareTokenStaysClosed(t *testing.T) {
+	ctx := context.Background()
+	// A shared rare identifier, and NOT a path identity: neither path's token
+	// set contains the other's (`hardware` vs `policy`), so the only evidence
+	// joining them is the CVE in both titles.
+	a := "kb/technology/hardware/storage/aaaaaab1.md"
+	b := "kb/technology/policy/procurement/aaaaaab2.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "CVE-2026-16232 forces an emergency storage firmware recall"),
+		namedFact(b, "Procurement halts after CVE-2026-16232 lands in the catalogue"),
+	})
+	env.seedShortlist()
+
+	// Fixture assertion: the pair must actually have been DETECTED as
+	// rare-token, or "not offered" says nothing about the gate under test.
+	require.Equal(t, store.MatchRareToken, pairKindIn(t, env, a, b),
+		"fixture must produce a rare-token match, or the gate is not being tested")
+
+	sweep, err := selectStructuralSweep(ctx, env.deps(), env.branch, map[string]struct{}{})
+	require.NoError(t, err)
+	require.False(t, containsPair(sweep, a, b),
+		"rare-token is the weaker, wider net and stays closed until the "+
+			"path-identity sample says what a structural offer is worth")
+	for _, p := range sweep {
+		require.Equal(t, store.MatchPathIdentity, p.MatchKind,
+			"the sweep offers path-identity only while the sample is running")
+	}
+}
+
+// TestStructural_CoClusteredPairIsStillExcluded pins the ONE exclusion that
+// survives on this route.
+//
+// Dropping the scope filter is deliberate; dropping this would not be. "Prune
+// already sees this pair in one cluster" means a shortlist slot buys a second
+// judgement of the same question — true whatever route found the pair.
+func TestStructural_CoClusteredPairIsStillExcluded(t *testing.T) {
+	ctx := context.Background()
+	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
+	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "Cisco patches nine flaws across Crosswork and Secure Workload"),
+		namedFact(b, "Nine Cisco advisories cover Crosswork and Secure Workload"),
+	})
+	env.seedShortlist()
+	d := env.deps()
+
+	// Fixture assertion: unclustered, the pair IS offered. Without this the
+	// test below passes against a route that offers nothing at all.
+	free, err := selectStructuralSweep(ctx, d, env.branch, map[string]struct{}{})
+	require.NoError(t, err)
+	require.True(t, containsPair(free, a, b),
+		"fixture must offer the pair when it is NOT co-clustered, or the "+
+			"exclusion is being credited for a route that was already empty")
+
+	coGrouped := clusterCoMembership([][]factForLLM{{{File: a}, {File: b}}})
+	held, err := selectStructuralSweep(ctx, d, env.branch, coGrouped)
+	require.NoError(t, err)
+	require.False(t, containsPair(held, a, b),
+		"a pair prune already sees in one cluster must not also cost a shortlist slot")
+}
+
+// TestStructural_ScopedSessionIsOfferedOutOfScopePairsAndToldSo is the
+// scope-widening half, and BOTH assertions are load-bearing.
+//
+// The designer ruled the structural route ignores the scope filter: a
+// structural pair's evidence is the corpus's own filing, which is corpus-wide
+// by construction, and no scoped view would ever co-present the two halves. A
+// scope that silently widens is nonetheless the #122 family's own defect — so
+// the widening is announced. Testing the widening without the announcement
+// would pin exactly half of what was ruled.
+func TestStructural_ScopedSessionIsOfferedOutOfScopePairsAndToldSo(t *testing.T) {
+	ctx := context.Background()
+	a := "kb/technology/security/vulnerabilities/cisco/1e8287a2.md"
+	b := "kb/technology/security/vulnerabilities/networking/cisco/bfbb31b8.md"
+	env := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact(a, "Cisco patches nine flaws across Crosswork and Secure Workload"),
+		namedFact(b, "Nine Cisco advisories cover Crosswork and Secure Workload"),
+	})
+	env.seedShortlist()
+
+	scoped := env.deps()
+	// A domain no fact in this corpus carries, so EVERY structural pair the
+	// sweep returns is out of scope by construction.
+	scoped.Scope = ScopeFilter{Domain: []string{"a-domain-no-fact-here-carries"}}
+
+	pairs, h, err := selectRestatementCandidates(ctx, scoped, env.branch, nil, structuralFiller+2)
+	require.NoError(t, err)
+
+	require.Positive(t, h.StructuralOffered,
+		"the structural route does not answer to the scope filter — a cross-category "+
+			"structural pair is corpus-wide evidence by construction")
+	require.True(t, containsPair(pairs, a, b))
+	require.Equal(t, h.StructuralOffered, h.StructuralOutOfScope,
+		"every pair offered here is outside the scope, and the count must say so")
+	require.Contains(t, structuralSignalLine(h), "OUTSIDE this session's scope",
+		"a scope that widens without saying so is the defect #122 exists to end")
+}
+
+// TestStructural_HealthNamesTheSweepRegime — "oldest-first" is exact only once
+// the title axis is complete. While it fills, every pair is re-minted each
+// session and mint order churns, so the sweep is deterministic but not
+// age-stable. A degenerated sweep order reads identically to a working one from
+// outside, which is why the regime is stated rather than implied.
+func TestStructural_HealthNamesTheSweepRegime(t *testing.T) {
+	full := restatementHealth{StandingStructural: 3, Coverage: 1, SweepOrderStable: true}
+	require.Contains(t, structuralSignalLine(full), "oldest-first (axis complete)")
+
+	filling := restatementHealth{StandingStructural: 3, Coverage: 0.4, SweepOrderStable: false}
+	require.Contains(t, structuralSignalLine(filling), "NOT yet age-stable")
+	require.NotContains(t, structuralSignalLine(filling), "oldest-first (axis complete)",
+		"a filling axis must not be described as if its sweep order were age-stable")
+}
+
+// TestStructural_SweepRegimeIsDerivedNotDeclared is the other half of the
+// regime report, and it exists because the test above is not enough.
+//
+// The one above hands `structuralSignalLine` a health struct built by hand, so
+// it pins the RENDERING and nothing else — a sabotage that hardcodes
+// `SweepOrderStable = true` at the point of derivation walks straight through
+// it (it did: sabotage S7). Asserting on a value a test supplied is asserting
+// that the formatter works. This drives the real derivation instead, which is
+// the campaign's path-vs-state rule applied to a health line.
+func TestStructural_SweepRegimeIsDerivedNotDeclared(t *testing.T) {
+	ctx := context.Background()
+
+	// A corpus with NO embedder never puts a fact on the title axis, so
+	// coverage is zero and the sweep order cannot be age-stable.
+	bare := newRestatementEnvWithoutEmbedder(t, 12)
+	_, hBare, err := selectRestatementCandidates(ctx, bare.deps(), bare.branch, nil, 12)
+	require.NoError(t, err)
+	require.Zero(t, hBare.Coverage, "fixture must have an EMPTY axis, or it is not the filling regime")
+	require.False(t, hBare.SweepOrderStable,
+		"an axis with no coverage cannot have an age-stable sweep order — every "+
+			"pair is re-minted the moment the axis starts filling")
+
+	// A corpus whose axis is fully backfilled reports the stable regime.
+	full := structuralEnv(t, [2]struct{ Path, Title string }{
+		namedFact("kb/technology/security/vulnerabilities/cisco/aaaaaa07.md",
+			"Cisco patches nine flaws across Crosswork and Secure Workload"),
+		namedFact("kb/technology/security/vulnerabilities/networking/cisco/aaaaaa08.md",
+			"Nine Cisco advisories cover Crosswork and Secure Workload"),
+	})
+	full.seedShortlist()
+	_, hFull, err := selectRestatementCandidates(ctx, full.deps(), full.branch, nil, structuralFiller+2)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, hFull.Coverage,
+		"fixture must have a COMPLETE axis, or it is not the stable regime")
+	require.True(t, hFull.SweepOrderStable,
+		"a complete axis is exactly when mint order stops churning and oldest-first "+
+			"means what it says")
+}
+
+// TestStructural_AllowanceCapsTheSweep pins the BOUND, on a corpus that can
+// actually exceed it.
+//
+// This test exists because the bound was unguarded and nothing noticed: every
+// other fixture here holds fewer standing path-identity pairs than the
+// allowance, so deleting the cap left them all green (sabotage S8). A cap can
+// only be tested by a population large enough to hit it — otherwise the
+// over-fetch limit does the capping and the test credits the wrong line.
+func TestStructural_AllowanceCapsTheSweep(t *testing.T) {
+	ctx := context.Background()
+	const pairs = structuralAllowance + 3
+	env := manyTwinsEnv(t, pairs)
+	env.seedShortlist()
+	d := env.deps()
+
+	// Fixture assertion: the corpus must hold MORE structural pairs than the
+	// allowance, or the cap is never reached and this measures nothing.
+	standing, err := env.svc.Abstraction().RestatementPairsByMatchKindOldest(ctx, env.branch,
+		[]string{store.MatchPathIdentity}, 100_000)
+	require.NoError(t, err)
+	require.Greater(t, len(standing), structuralAllowance,
+		"fixture must hold more standing path-identity pairs than the allowance, "+
+			"or the cap under test is never reached")
+
+	sweep, err := selectStructuralSweep(ctx, d, env.branch, map[string]struct{}{})
+	require.NoError(t, err)
+	require.Len(t, sweep, structuralAllowance,
+		"the sweep spends the allowance and stops — an unbounded sweep would hand "+
+			"a whole session's judge budget to one route")
+}
+
+// manyTwinsEnv builds a corpus with n path-identity twin pairs, each on its own
+// discriminating subject token so no pair can match across pairs.
+func manyTwinsEnv(t *testing.T, n int) *restatementEnv {
+	t.Helper()
+	// Subject tokens chosen to be rare in this corpus and unrelated to each
+	// other; the prefix-EXTENSION shape (subject vs vendor/subject) is the one
+	// measured on the live corpus.
+	subjects := []string{
+		"cisco", "gitlab", "geoserver", "sharepoint", "ivanti",
+		"sonicwall", "fortinet", "confluence", "jenkins", "grafana",
+	}
+	require.LessOrEqual(t, n, len(subjects), "manyTwinsEnv has only %d subjects", len(subjects))
+
+	env := newRestatementEnv(t, 0)
+	for i := range structuralFiller {
+		env.writeFact(
+			fmt.Sprintf("kb/technology/filler/topic%d/%08x.md", i, i+1),
+			fmt.Sprintf("Filler note 2026 about widget %d", 1000+i),
+			"an unrelated body")
+	}
+	for i, s := range subjects[:n] {
+		env.writeFact(
+			fmt.Sprintf("kb/technology/security/vulnerabilities/%s/%08x.md", s, 0xAA0000+i*2),
+			fmt.Sprintf("%s advisory covers a remote code execution flaw", s),
+			"a body about the event")
+		env.writeFact(
+			fmt.Sprintf("kb/technology/security/vulnerabilities/vendor/%s/%08x.md", s, 0xAA0001+i*2),
+			fmt.Sprintf("Remote code execution flaw disclosed in %s", s),
+			"the same event, filed again")
+	}
+	return env
+}
+
+// sweepOrderEnv builds a corpus where MINT ORDER and COSINE RANK are exact
+// reverses of each other, so the two readers cannot agree by accident.
+//
+// Three path-identity twin pairs are written in sequence — mint order is write
+// order, since the refresh rescans in fact-id order and fact ids are assigned
+// at write time — and their title cosines INCREASE down that sequence. So the
+// cosine ranking reads P3, P2, P1 and the sweep reads P1, P2, P3.
+//
+// The twins are placed by hand on the axis rather than left to the hash
+// embedder: with hashed vectors the two orderings would probably differ, and
+// "probably" is not a fixture. Each pair sits at its own base angle, far from
+// the others, so no cross-pair title-KNN pair can crowd the population under
+// test; and each carries its own discriminating path token, so no cross-pair
+// PATH-IDENTITY match can form either.
+func sweepOrderEnv(t *testing.T) *restatementEnv {
+	t.Helper()
+	type twin struct {
+		aPath, bPath   string
+		aTitle, bTitle string
+		base, delta    float64
+	}
+	// delta DECREASES down the list, so cos(delta) — the pair's title cosine —
+	// increases: 0.83, 0.92, 0.98. Mint order is therefore ascending cosine,
+	// the exact reverse of the ranking.
+	twins := []twin{
+		{
+			aPath:  "kb/technology/security/vulnerabilities/cisco/aaaaaa01.md",
+			bPath:  "kb/technology/security/vulnerabilities/networking/cisco/aaaaaa02.md",
+			aTitle: "Cisco patches nine flaws across Crosswork and Secure Workload",
+			bTitle: "Nine Cisco advisories cover Crosswork and Secure Workload",
+			base:   0.0, delta: 0.6,
+		},
+		{
+			aPath:  "kb/technology/security/vulnerabilities/gitlab/aaaaaa03.md",
+			bPath:  "kb/technology/security/vulnerabilities/devops/gitlab/aaaaaa04.md",
+			aTitle: "GitLab directive flaw exploited within days of disclosure",
+			bTitle: "Attackers reach GitLab through a directive flaw",
+			base:   2.0, delta: 0.4,
+		},
+		{
+			aPath:  "kb/technology/security/vulnerabilities/geoserver/aaaaaa05.md",
+			bPath:  "kb/technology/security/vulnerabilities/geospatial/geoserver/aaaaaa06.md",
+			aTitle: "GeoServer property expression flaw under active exploitation",
+			bTitle: "Active exploitation of a GeoServer property expression flaw",
+			base:   4.0, delta: 0.2,
+		},
+	}
+
+	placed := map[string][]float32{}
+	for _, tw := range twins {
+		placed[tw.aTitle] = axisVector(tw.base)
+		placed[tw.bTitle] = axisVector(tw.base + tw.delta)
+	}
+	emb := &restatementEmbedder{vectorFor: func(text string) []float32 {
+		return placed[text] // nil for anything else — the hash vector is used
+	}}
+
+	env := newRestatementEnvWith(t, 0, emb)
+	// The filler first, and it is not decoration: both rarity cuts are read off
+	// the corpus's own token distribution, so a corpus with no distribution has
+	// nothing rare in it and no pair is ever classified.
+	for i := range structuralFiller {
+		env.writeFact(
+			fmt.Sprintf("kb/technology/filler/topic%d/%08x.md", i, i+1),
+			fmt.Sprintf("Filler note 2026 about widget %d", 1000+i),
+			"an unrelated body")
+	}
+	// Then the twins, IN ORDER. This sequence is the mint order under test.
+	for _, tw := range twins {
+		env.writeFact(tw.aPath, tw.aTitle, "a body about the event")
+		env.writeFact(tw.bPath, tw.bTitle, "the same event, filed again")
+	}
+	return env
+}
+
+// orderOf renders a pair list as a comparable order key.
+func orderOf(pairs []store.RestatementPair) string {
+	keys := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		keys = append(keys, pathPairKey(p.APath, p.BPath))
+	}
+	return strings.Join(keys, "|")
+}
+
+// isDescendingByCos reports whether a pair list is sorted by descending title
+// cosine — i.e. whether it is the RANKING rather than the sweep.
+func isDescendingByCos(pairs []store.RestatementPair) bool {
+	for i := 1; i < len(pairs); i++ {
+		if pairs[i].TitleCos > pairs[i-1].TitleCos {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -103,6 +103,53 @@ func recordVocabularySkipHealth(sess *store.PipelineSession, effort Effort) {
 		effort))
 }
 
+// PlanStandingWork plans the review's CORPUS-STATE channel on a session whose
+// dirty set is empty (knomit#155).
+//
+// ONLY the restatement shortlist runs here, and that is the whole design. The
+// rest of Plan is edge-triggered — clustering, dedup, prune items, distill
+// chunks, bridge seeding — and on an empty seed pool every one of them is
+// correctly empty. Running them anyway would widen the blast radius of a quiet
+// session for nothing. A caught-up corpus does its standing sweep and goes
+// home.
+//
+// Note what is NOT re-created here: the removed level-triggered trio asked
+// "does the corpus have work?" and then, separately, planned it — two
+// statements that could drift apart. This plans, then reports what it planned,
+// so the health line and the queue cannot disagree.
+func (reviewStrategy) PlanStandingWork(ctx context.Context, d Deps, sess *store.PipelineSession, branch string) (bool, []string, error) {
+	before := len(sess.Health)
+	// nil clusters: an empty dirty set clusters to nothing, so there is no
+	// co-membership to exclude against. That is not a degradation — the
+	// exclusion means "prune already sees this pair THIS SESSION", and this
+	// session's prune sees nothing at all.
+	if err := planRestatementShortlist(ctx, d, sess, branch, nil); err != nil {
+		return false, nil, err
+	}
+	// Whether anything reached the queue is read from the QUEUE, not inferred
+	// from the selection's own count. selected != served has been the source of
+	// two separate defects in this area (knomit#117a, #130): a pair that fails
+	// to load at item creation is selected and never served, and a session that
+	// reported the selection count over an empty queue is exactly the
+	// dishonesty this whole campaign is about.
+	items, err := d.Pipeline.PendingPipelineWorkItems(ctx, sess.ID)
+	if err != nil {
+		return false, nil, wrapf(reviewTool, err, "standing work: read pending items")
+	}
+	pending := len(items)
+	// The shortlist's own health lines were hung on the session by
+	// planRestatementShortlist; hand back only what it added, so the caller can
+	// place them without duplicating what it already holds.
+	health := append([]string(nil), sess.Health[before:]...)
+	if pending == 0 {
+		health = append(health,
+			"standing work: the corpus-state channel ran and enqueued nothing this "+
+				"session. This IS a finding — it means no standing pair was eligible, "+
+				"not that the channel was skipped.")
+	}
+	return pending > 0, health, nil
+}
+
 // Plan builds the review work queue over a non-empty seed pool: cluster, dedup,
 // then enqueue prune items per surviving multi-fact cluster, distill items over
 // the (chunked) seed pool, and — at effort >= medium — discover items per

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -191,6 +191,28 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 		}
 	}
 
+	// Cousin-meeting (knomit#149). ScopedCluster's neighbour expansion is
+	// fenced to each seed's own category directory, so two facts in DIFFERENT
+	// directories under a shared ancestor never co-cluster at any cosine. This
+	// widens the PRUNE cluster set — and nothing else — so the judge sees them.
+	//
+	// TWO PROPERTIES OF THIS CALL SITE ARE LOAD-BEARING, and both are about
+	// where it sits rather than what it does:
+	//
+	//  1. AFTER dedupCluster. Before it, a newly-met cousin above the floor
+	//     would be merged mechanically with no judge — a strictly larger change
+	//     than the one ruled, and one that spends the judge's authority without
+	//     asking it.
+	//  2. On `pruneClusters`, NOT on `clusters`. The latter is read by
+	//     distillGroups and clusterResultFromGroups (both bridge axes and
+	//     discover) further down this function; the ruling scopes the fix to
+	//     prune, so those four consumers must see exactly what they saw before.
+	pruneClusters, cousins := joinCousinsForPrune(ctx, d, branch, pruneClusters, dedupThreshold)
+	sess.Health = append(sess.Health, cousinSignalLine(cousins))
+	log.Info().Str("session", sess.ID).Int("attached", cousins.Attached).
+		Int("joined", cousins.Joined).Int("searched", cousins.Searched).
+		Msg("review: cousin sweep done")
+
 	// Store prune work items — priority = cluster size (bigger = more urgent).
 	//
 	// Prune clusters are deliberately NOT chunked, unlike the distill items
@@ -238,7 +260,18 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	// Every step degrades to "no candidates" rather than failing the session:
 	// this is an addition to consolidation, and a corpus that cannot embed its
 	// titles or read its own cache should still get its ordinary review.
-	if err := planRestatementShortlist(ctx, d, sess, branch, clusters); err != nil {
+	//
+	// The co-membership input is `clusters` PLUS the cousin-joined prune
+	// clusters, and the union is the point. The exclusion means "prune already
+	// sees this pair", so it has to be read off the clusters prune is ACTUALLY
+	// given — otherwise the shortlist would spend a judge slot on a pair the
+	// cousin sweep had just put in front of the same judge, which is the
+	// double-spend the exclusion exists to prevent. `clusters` stays in the
+	// list because it also carries the single-fact clusters, which contribute
+	// no pairs but cost nothing to pass; clusterCoMembership unions pairs, so
+	// the overlap between the two slices is harmless.
+	if err := planRestatementShortlist(ctx, d, sess, branch,
+		append(append([][]factForLLM{}, clusters...), pruneClusters...)); err != nil {
 		return err
 	}
 

--- a/internal/synthesize/strategy.go
+++ b/internal/synthesize/strategy.go
@@ -256,6 +256,36 @@ type Strategy interface {
 	Render(ctx context.Context, d Deps, sess *store.PipelineSession, item *store.PipelineWorkItem) (*WorkItemView, error)
 }
 
+// standingWorkStrategy is implemented by a strategy that owns work triggered by
+// CORPUS STATE rather than by the seed scan.
+//
+// The seed scan is EDGE-triggered: it asks what has CHANGED since the
+// watermark. A standing-state pass asks what the corpus IS, and that question
+// still has an answer when nothing has changed — so composing the two starves
+// the standing pass on exactly the corpora it exists for, the quiet ones that
+// have caught up. That composition is knomit#115, and the empty-seed early
+// return in StartSession is where it is reintroduced every time.
+//
+// The backfill pass was the last holder of this shape, and it was removed as a
+// one-off migration wrongly built as permanent machinery. This interface is
+// deliberately NARROWER than the `levelTriggeredStrategy` trio it replaces —
+// one hook, plan-or-don't, no separate "has work?" probe to fall out of step
+// with the planning it gates.
+//
+// Optional: a strategy that does not implement it behaves exactly as it did
+// before this existed.
+type standingWorkStrategy interface {
+	// PlanStandingWork enqueues work the corpus's own state calls for, on a
+	// session whose dirty set is EMPTY. It returns whether anything was
+	// enqueued, plus health lines to attach — which must be non-empty even
+	// when nothing was planned, because "no standing work" and "the standing
+	// pass never ran" are the two states an operator most needs to tell apart
+	// (knomit#122c).
+	//
+	// It is called ONLY on unscoped sessions; see planStandingWork.
+	PlanStandingWork(ctx context.Context, d Deps, sess *store.PipelineSession, branch string) (planned bool, health []string, err error)
+}
+
 // ── shared "discover" step ────────────────────────────────────────────────
 //
 // The discover step is the one step type both the review (forward) and


### PR DESCRIPTION
Closes #155. Closes #149.

Two coupled halves of the cousins-not-caught problem — #155 catches path-identity structural duplicates, #149 catches the rare-token/no-token cousin population; neither is measured by the other's targets.

## #155 — structural allowance, spent whatever the throttle says
A dedicated per-session structural allowance (~5 pairs) that fires EVEN WHEN THE CORPUS IS DEFUNDED, breaking the `budget>=2` latch that made the structural route inert. Path-identity first (rare-token gated on measured merge-rate), drained OLDEST-FIRST (rowid ASC, no stored cursor — consumption via delete-on-verdict is the cursor). Critically, the sweep is **corpus-state-triggered**: it is planned even on an EMPTY-SEED (quiet/caught-up) session, because it drains standing pairs, not dirty facts — a pass whose trigger is corpus state cannot be planned from an edge-triggered seed scan. Scoped quiet sessions don't sweep; a scoped session offered corpus-wide pairs says so in its health line.

## #149 — cousins meet inside prune, nothing else re-clusters
`ScopedCluster`'s category fence is on neighbour EXPANSION, so cross-category cousins don't co-cluster. This AUGMENTS prune (only) with a cousin-join that runs AFTER `dedupCluster`, on a SEPARATE prune-cluster set (the shared `clusters`, read by 5 consumers, is never mutated). It attaches a leftover cousin or unions two prune clusters — a pair with neither half already in a prune cluster is deliberately not reached (widening would manufacture prune items).

## Verification
MN5 byte-identical at all three commits AND `TestReviewer_NormalEffort_DefaultPath` green (collision avoided, not merely blob-frozen); MN13 three budgets (no corpus property); MN1 unaffected (the sweep offers, writes no facts). Cold-reviewed independently: every load-bearing guard sabotage-confirmed RED, MERGE-READY, no findings. Branch rebased onto current dev, so the reviewed tree is the merge result.