### PR TITLE
Discover reinforcement: cite the derivation-path seeds, not every offered seed (#151)

### DIFF
--- a/internal/synthesize/discovery.go
+++ b/internal/synthesize/discovery.go
@@ -253,7 +253,7 @@ func renderDiscoverPrompt(payload DiscoverWorkPayload, ontologyRoot string) stri
 		b.WriteString("  (b) The consequence is LOAD-BEARING — its falsity invalidates ≥2 of the cited facts.\n")
 	}
 	b.WriteString("  (c) Not already in the corpus — you QUERIED for it above and no existing fact states it. If one does, REINFORCE it instead of proposing (below).\n")
-	b.WriteString("  (d) You can cite every seed fact above in refs. An empty refs array indicates you did not engage with the inputs.\n\n")
+	b.WriteString("  (d) You can cite AT LEAST TWO of the seed facts above in refs, as the derivation path this claim actually rests on. Cite the seeds that genuinely support it and NO OTHERS — a seed that does not fit is simply not claimed as evidence, not forced in, and not a reason to abandon an otherwise valid derivation. Refs naming anything that is not a seed above are discarded. An empty refs array indicates you did not engage with the inputs.\n\n")
 	b.WriteString("If any condition fails, return an empty proposals array. Skipping is the expected outcome.\n\n")
 	// GATE rider 3 (designer, 2026-08-23): discovery's third outcome. On a
 	// recall hit the answer is neither propose nor decline — the seeds are an
@@ -267,10 +267,10 @@ func renderDiscoverPrompt(payload DiscoverWorkPayload, ontologyRoot string) stri
 	b.WriteString("Reinforce ONLY IF ALL of these hold:\n")
 	b.WriteString("  (a) The existing fact states the SAME claim, not a neighbouring one. Say why in one sentence; if you cannot write that sentence, they are not the same claim.\n")
 	b.WriteString("  (b) You would otherwise have proposed it here. Reinforcement replaces a proposal; it is never a note about something you happened to read.\n")
-	b.WriteString("  (c) You can cite every seed fact above in refs.\n")
+	b.WriteString("  (c) You can cite AT LEAST TWO of the seed facts above in refs, as the derivation path — the seeds that genuinely support the existing claim, and no others.\n")
 	b.WriteString("DEFAULT TO NO on sameness. When you are torn between \"the same claim\" and \"a claim near it\", PROPOSE AND LINK instead of reinforcing: a false link is recoverable, a false merge is not.\n\n")
 	b.WriteString("PERSISTENCE — origin reflects how this group was formed.\n")
-	b.WriteString("These facts were grouped by a cross-cluster BRIDGE, so any fact you persist from them is discovery-engine output (origin: discovered). Submit your proposals back via knomit_hypothesize/knomit_review to record them automatically. If you instead save one directly with knomit_learn after previewing, you MUST set origin: discovered and cite every seed fact above in refs.\n\n")
+	b.WriteString("These facts were grouped by a cross-cluster BRIDGE, so any fact you persist from them is discovery-engine output (origin: discovered). Submit your proposals back via knomit_hypothesize/knomit_review to record them automatically. If you instead save one directly with knomit_learn after previewing, you MUST set origin: discovered and cite at least two of the seed facts above in refs — the ones on the derivation path, and no facts other than the seeds.\n\n")
 	b.WriteString("RESPONSE SCHEMA: {\"proposals\":[{\"path\":\"" + ontologyRoot + "/.../slug.md\",\"title\":\"...\",\"body\":\"...\",\"type\":\"")
 	if payload.Direction == DiscoverBackward {
 		b.WriteString("hypothesis")
@@ -342,9 +342,38 @@ func applyDiscoveredProposals(
 			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("discovery %s rejected: %v", p.Path, err)})
 			continue
 		}
-		if !refsCoverSeeds(p.Refs, seedPaths) {
-			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("discovery rejected: %s refs does not cite every seed", p.Path)})
+		// ONE expression of the floor, both call sites. The proposal and
+		// reinforce paths ask the same question and must not drift into two
+		// spellings of it — the same reason the motif rank order has a single
+		// comparator. splitSeedRefs is called again here only for the message
+		// and the discard list; the DECISION is refsCiteSeedSubset's alone.
+		if !refsCiteSeedSubset(p.Refs, seedPaths, localRepoID) {
+			_, _, distinctSeeds := splitSeedRefs(p.Refs, seedPaths, localRepoID)
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf(
+				"discovery rejected: %s cites %d of the bridge's seeds as its derivation path, needs at least %d",
+				p.Path, distinctSeeds, minCitedSeeds)})
 			continue
+		}
+		citedSeeds, extraRefs, _ := splitSeedRefs(p.Refs, seedPaths, localRepoID)
+		// SEEDS ONLY, discarded not rejected — the same treatment the reinforce
+		// path has always given surplus refs, so the two paths now agree.
+		//
+		// A derived fact's refs ARE its derivation path: every one becomes a
+		// permanent DERIVED_FROM edge and moves the fact's evidence weight, so a
+		// ref naming something the bridge never offered is a derivation nobody
+		// checked. Before #151 this path wrote them through unfiltered.
+		//
+		// Discarding rather than rejecting keeps the campaign's rule that a
+		// proposal costing a bridge enumeration and an LLM call is not thrown
+		// away over surplus (cf. DropInvalidMotifs) — and the warning is what
+		// stops the drop being silent. NOTE the consequence: this drops
+		// external refs too (an https:// source the model attached), because
+		// the discover prompt asks for a derivation path over the seeds, not a
+		// bibliography.
+		if len(extraRefs) > 0 {
+			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf(
+				"discovery %s: discarded %d ref(s) naming facts outside the bridge: %s",
+				p.Path, len(extraRefs), strings.Join(extraRefs, ", "))})
 		}
 		if p.Confidence < gates.ConfidenceThreshold {
 			log.Debug().Str("path", p.Path).Float64("confidence", p.Confidence).Float64("threshold", gates.ConfidenceThreshold).Msg("discovery gate: confidence below threshold")
@@ -379,7 +408,7 @@ func applyDiscoveredProposals(
 		// bridge proposal is a NEW claim over facts that stay alive — so there
 		// is no retraction list. A rejection warns and skips this one proposal,
 		// matching every other gate in this loop.
-		canonRefs, _, gerr := gate.Apply(ctx, f.Path(), p.Refs, nil)
+		canonRefs, _, gerr := gate.Apply(ctx, f.Path(), citedSeeds, nil)
 		if gerr != nil {
 			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf("discovery %s rejected: %v", f.Path(), gerr)})
 			continue
@@ -442,18 +471,82 @@ func applyDiscoveredProposals(
 	return written, nil
 }
 
-// refsCoverSeeds reports whether refs is a superset of the seed paths set.
-func refsCoverSeeds(refs []string, seedPaths map[string]struct{}) bool {
-	have := make(map[string]struct{}, len(refs))
-	for _, r := range refs {
-		have[r] = struct{}{}
-	}
+// minCitedSeeds is the floor on how many of a bridge's offered seeds a derived
+// fact must claim as its derivation path.
+//
+// TWO, because one is not a derivation. A bridge asserts that a claim follows
+// from the CONJUNCTION of facts that clustering kept apart; a fact citing a
+// single seed is not a weaker bridge, it is a different thing entirely — an
+// observation about one fact, which the bridge machinery is not the way to
+// record. This is a floor on ARGUMENT SHAPE, not a corpus property: it is two
+// because a conjunction needs two terms, and no measurement of any corpus
+// could move it (MN13).
+//
+// CONSEQUENCE WORTH STATING, because it is the first thing a reader will get
+// wrong: on a TWO-seed bridge this rule is identical to the all-seeds rule it
+// replaces. #151 relaxes nothing there, by design. The relaxation bites only
+// at three or more seeds — which is where it was measured to bite (s207's
+// discarded derivation was a five-seed item).
+const minCitedSeeds = 2
+
+// splitSeedRefs partitions a derived fact's refs into the OFFERED SEEDS it
+// claims and the EXTRAS it does not, comparing on canonical fact paths rather
+// than raw strings.
+//
+// THE NORMALISATION IS LOAD-BEARING, and the raw-string version it replaces was
+// a latent defect. Refs are STORED CANONICAL as kb://<own-id12>/<path>, so a
+// seed cited in the form the corpus itself writes matched NOTHING under a
+// literal string compare. Under the all-seeds rule that failed loudly (a valid
+// answer was rejected); under the subset rule it fails twice over — the
+// correctly-spelled seed does not COUNT toward minCitedSeeds and is then
+// discarded as an extra, so relaxing the gate without this would have thrown
+// away the very answers #151 exists to keep. Third live site of the same
+// stored-canonical trap (#125's lineage refs, #132's self-refs, this).
+//
+// Returns the cited seeds in their ORIGINAL spelling (callers canonicalise
+// deliberately, and the reinforce path must not rewrite authored strings), the
+// extras likewise, and the count of DISTINCT seeds cited — distinct, so a fact
+// naming one seed twice, in two spellings, does not buy itself a second term.
+func splitSeedRefs(refs []string, seedPaths map[string]struct{}, localRepoID string) (cited, extras []string, distinct int) {
+	canonSeed := make(map[string]struct{}, len(seedPaths))
 	for s := range seedPaths {
-		if _, ok := have[s]; !ok {
-			return false
-		}
+		canonSeed[fact.ClassifyRef(s, localRepoID).Path] = struct{}{}
 	}
-	return true
+	seen := make(map[string]struct{}, len(refs))
+	for _, r := range refs {
+		c := fact.ClassifyRef(r, localRepoID)
+		if _, isSeed := canonSeed[c.Path]; isSeed && c.Kind == fact.RefLocalFact {
+			cited = append(cited, r)
+			if _, dup := seen[c.Path]; !dup {
+				seen[c.Path] = struct{}{}
+				distinct++
+			}
+			continue
+		}
+		extras = append(extras, r)
+	}
+	return cited, extras, distinct
+}
+
+// refsCiteSeedSubset reports whether a derived fact's refs form an acceptable
+// derivation path over the bridge's offered seeds: a SUBSET of them, at least
+// minCitedSeeds distinct.
+//
+// This replaces the "cite EVERY offered seed" rule (designer ruling
+// 2026-08-26, #151). That rule PUNISHED JUDGE HONESTY: when four of five seeds
+// genuinely derived the target and the fifth did not, there was no subset
+// mechanism, so a valid independent derivation was discarded whole rather than
+// recorded at its true strength. It also FORCED the exact over-citation that
+// #125 (lineage) and #132 (self-reference) forbid, so the three rules were
+// fighting each other; this aligns them.
+//
+// WHAT IT DOES NOT LICENSE: inventing a citation. Only offered seeds count
+// toward the floor, and refs naming anything else are the caller's to discard —
+// a derived fact's refs are its derivation path, and a path through a fact the
+// bridge never offered is a claim nobody checked.
+func refsCiteSeedSubset(refs []string, seedPaths map[string]struct{}, localRepoID string) bool {
+	_, _, distinct := splitSeedRefs(refs, seedPaths, localRepoID)
+	return distinct >= minCitedSeeds
 }
 
 // isDuplicate computes the document embedding for the proposal and reports

--- a/internal/synthesize/discovery_citation_test.go
+++ b/internal/synthesize/discovery_citation_test.go
@@ -1,0 +1,358 @@
+package synthesize
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// citationRepoID is a well-formed 12-hex repo id. Most of this package's
+// discovery fixtures pass bareRefFixture ("") instead, which works only because
+// they spell every ref as a bare path — see
+// TestSeedSubset_EmptyRepoIDCannotSeeACanonicalSeed for why that is not a
+// harmless simplification here.
+const citationRepoID = "0123456789ab"
+
+func seedSet(paths ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		out[p] = struct{}{}
+	}
+	return out
+}
+
+// ── the relaxation itself ──
+
+// TestSeedSubset_ThreeSeedBridgeAcceptsTwo is #151 in one assertion, and the
+// only test in the package that can show the relaxation at all: a bridge
+// offering THREE seeds, a derived fact citing two.
+//
+// Under the all-seeds rule this was REJECTED, and that rejection is what the
+// issue measured — s207 lost a valid independent derivation because four of
+// five seeds supported the target and the fifth did not, with no subset
+// mechanism to record it at its true strength.
+func TestSeedSubset_ThreeSeedBridgeAcceptsTwo(t *testing.T) {
+	seeds := seedSet("kb/a.md", "kb/b.md", "kb/c.md")
+
+	require.True(t, refsCiteSeedSubset([]string{"kb/a.md", "kb/b.md"}, seeds, citationRepoID),
+		"two of three offered seeds IS a derivation path — this is the whole of #151")
+	require.True(t, refsCiteSeedSubset([]string{"kb/a.md", "kb/b.md", "kb/c.md"}, seeds, citationRepoID),
+		"citing all three is still fine; the rule was relaxed, not inverted")
+}
+
+// TestSeedSubset_OneCitedSeedIsNotADerivation pins the floor. One seed is not a
+// weaker bridge — it is a different claim shape, an observation about a single
+// fact, which the bridge machinery is not the way to record.
+func TestSeedSubset_OneCitedSeedIsNotADerivation(t *testing.T) {
+	seeds := seedSet("kb/a.md", "kb/b.md", "kb/c.md")
+
+	require.False(t, refsCiteSeedSubset([]string{"kb/a.md"}, seeds, citationRepoID))
+	require.False(t, refsCiteSeedSubset(nil, seeds, citationRepoID),
+		"an empty refs array means the inputs were not engaged with")
+}
+
+// TestSeedSubset_TwoSeedBridgeStillNeedsBoth states the consequence a reader is
+// most likely to get wrong, and states it deliberately rather than leaving it
+// to be discovered: on a TWO-seed bridge the new rule and the old one are
+// IDENTICAL. #151 relaxes nothing there.
+//
+// This is not a gap. A bridge asserts a claim follows from the conjunction of
+// facts clustering kept apart; with two seeds, both are the conjunction. The
+// relaxation exists for the three-and-more case, which is where it was
+// measured. If this test ever goes green on a single citation, the floor has
+// been lowered to one and the bridge contract has changed meaning.
+func TestSeedSubset_TwoSeedBridgeStillNeedsBoth(t *testing.T) {
+	seeds := seedSet("kb/a.md", "kb/b.md")
+
+	require.False(t, refsCiteSeedSubset([]string{"kb/a.md"}, seeds, citationRepoID),
+		"on a two-seed bridge, citing one is below the floor")
+	require.True(t, refsCiteSeedSubset([]string{"kb/a.md", "kb/b.md"}, seeds, citationRepoID))
+}
+
+// ── the stored-canonical spelling ──
+
+// TestSeedSubset_CanonicalSpellingCountsAsTheSeed is the load-bearing one.
+//
+// Refs are STORED CANONICAL as kb://<own-id12>/<path>. The predicate this
+// replaced compared raw strings, so a seed cited in the spelling the corpus
+// itself writes matched nothing. Under the all-seeds rule that failed loudly;
+// under the subset rule it fails twice — the correctly-spelled seed does not
+// COUNT toward the floor, and is then discarded as an extra, so relaxing the
+// gate without normalising would have thrown away the very answers #151 exists
+// to keep.
+func TestSeedSubset_CanonicalSpellingCountsAsTheSeed(t *testing.T) {
+	seeds := seedSet("kb/a.md", "kb/b.md", "kb/c.md")
+	refs := []string{
+		fact.QualifyKBPath(citationRepoID, "kb/a.md"),
+		"kb/b.md",
+	}
+	// Fixture check: the ref really is in the stored form. A bare path here
+	// would make this test pass with normalisation removed.
+	require.Contains(t, refs[0], "kb://",
+		"fixture must use the stored spelling or it does not exercise normalisation")
+
+	require.True(t, refsCiteSeedSubset(refs, seeds, citationRepoID),
+		"a canonically-spelled seed IS the seed and must count toward the floor")
+
+	cited, extras, distinct := splitSeedRefs(refs, seeds, citationRepoID)
+	require.Equal(t, 2, distinct)
+	require.Len(t, cited, 2)
+	require.Empty(t, extras, "a canonically-spelled seed must not be discarded as an extra")
+}
+
+// TestSeedSubset_EmptyRepoIDCannotSeeACanonicalSeed asserts a FAILURE MODE, not
+// a feature — the same shape as #125's EmptyRepoIDExcludesNothing.
+//
+// With an empty local repo id every kb:// ref classifies as FOREIGN, so a
+// correctly-cited seed is invisible: it does not count toward the floor and it
+// is discarded as an extra. The two arms below are the same input and differ
+// only in the repo id, so what they measure is the id and nothing else.
+//
+// If this ever flips, normalisation has stopped depending on the repo id and
+// the hazard is gone — DELETE this test rather than weakening its assertion.
+func TestSeedSubset_EmptyRepoIDCannotSeeACanonicalSeed(t *testing.T) {
+	seeds := seedSet("kb/a.md", "kb/b.md", "kb/c.md")
+	refs := []string{
+		fact.QualifyKBPath(citationRepoID, "kb/a.md"),
+		fact.QualifyKBPath(citationRepoID, "kb/b.md"),
+	}
+
+	require.True(t, refsCiteSeedSubset(refs, seeds, citationRepoID),
+		"with the real repo id both seeds are recognised")
+
+	require.False(t, refsCiteSeedSubset(refs, seeds, ""),
+		"with an empty repo id the SAME two seeds are invisible — this is the trap being pinned")
+	_, extras, distinct := splitSeedRefs(refs, seeds, "")
+	require.Zero(t, distinct)
+	require.Len(t, extras, 2, "and they are then thrown away as refs outside the bridge")
+}
+
+// TestSeedSubset_OneSeedTwoSpellingsCountsOnce stops a fact buying itself a
+// second term by naming one seed twice. Distinctness is what makes the floor a
+// claim about the ARGUMENT rather than about the length of the refs array.
+func TestSeedSubset_OneSeedTwoSpellingsCountsOnce(t *testing.T) {
+	seeds := seedSet("kb/a.md", "kb/b.md", "kb/c.md")
+	refs := []string{"kb/a.md", fact.QualifyKBPath(citationRepoID, "kb/a.md")}
+
+	_, _, distinct := splitSeedRefs(refs, seeds, citationRepoID)
+	require.Equal(t, 1, distinct, "one seed, spelled two ways, is one term")
+	require.False(t, refsCiteSeedSubset(refs, seeds, citationRepoID))
+}
+
+// TestSeedSubset_NonSeedRefsAreExtras covers the "nothing inventable" half:
+// only offered seeds count, and everything else is the caller's to discard.
+func TestSeedSubset_NonSeedRefsAreExtras(t *testing.T) {
+	seeds := seedSet("kb/a.md", "kb/b.md", "kb/c.md")
+	refs := []string{"kb/a.md", "kb/b.md", "kb/invented.md", "https://example.com/paper"}
+
+	cited, extras, distinct := splitSeedRefs(refs, seeds, citationRepoID)
+	require.Equal(t, 2, distinct, "an invented ref does not help reach the floor")
+	require.ElementsMatch(t, []string{"kb/a.md", "kb/b.md"}, cited)
+	require.ElementsMatch(t, []string{"kb/invented.md", "https://example.com/paper"}, extras,
+		"an external URL is an extra too — the discover prompt asks for a derivation path, not a bibliography")
+}
+
+// ── the proposal path, end to end ──
+
+// threeSeedProposalEnv is a real store with three seeds, for the cases the
+// package's two-member fixtures structurally cannot express.
+func threeSeedProposalEnv(t *testing.T) (*store.Service, string, DiscoverWorkPayload) {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+	branch := "agent/test"
+
+	for _, p := range []string{"kb/a.md", "kb/b.md", "kb/c.md"} {
+		seedSimpleFact(t, svc, branch, p)
+	}
+	return svc, branch, DiscoverWorkPayload{
+		Direction: DiscoverForward,
+		Bridge: BridgeSeedSet{
+			Token: "x", Kind: BridgeEntity,
+			Members: []factForLLM{
+				{File: "kb/a.md", Title: "A"},
+				{File: "kb/b.md", Title: "B"},
+				{File: "kb/c.md", Title: "C"},
+			},
+		},
+	}
+}
+
+// TestApplyDiscoveredProposals_AcceptsTwoOfThreeSeeds is the behavioural half
+// of the relaxation on the proposal path — the derivation that used to be
+// discarded whole is now written.
+func TestApplyDiscoveredProposals_AcceptsTwoOfThreeSeeds(t *testing.T) {
+	svc, branch, payload := threeSeedProposalEnv(t)
+
+	props := []DiscoveredFact{{
+		Path: "kb/kept.md", Title: "kept", Body: "kept", Type: "synthesis",
+		Domain: []string{"x"}, Confidence: 0.9,
+		Refs: []string{"kb/a.md", "kb/b.md"}, // kb/c.md genuinely does not fit
+	}}
+
+	written, err := applyDiscoveredProposals(context.Background(), svc.Facts(), svc.Search(),
+		nil, payload, props, DiscoveryGates{}, branch, bareRefFixture, "kb", nil)
+	require.NoError(t, err)
+	require.Len(t, written, 1, "a two-of-three derivation must be recorded, not discarded")
+
+	f := readFactForTest(t, svc, branch, written[0])
+	require.Len(t, f.Refs, 2, "and it records only the seeds it actually rests on")
+	require.NotContains(t, strings.Join(f.Refs, " "), "kb/c.md",
+		"the seed that did not fit must not be forced into the derivation path")
+}
+
+// TestApplyDiscoveredProposals_DiscardsRefsOutsideTheBridge covers the
+// offered-only half, which BEFORE #151 this path did not enforce at all: refs
+// went through to the written fact unfiltered, so an invented citation became a
+// permanent DERIVED_FROM edge on evidence nobody checked.
+//
+// Discard, not reject: the proposal survives with the invention removed. The
+// pair of assertions is the point — that it was written AND that the invention
+// is gone. Asserting only the first would pass on the pre-#151 behaviour.
+func TestApplyDiscoveredProposals_DiscardsRefsOutsideTheBridge(t *testing.T) {
+	svc, branch, payload := threeSeedProposalEnv(t)
+	seedSimpleFact(t, svc, branch, "kb/elsewhere.md")
+
+	props := []DiscoveredFact{{
+		Path: "kb/kept.md", Title: "kept", Body: "kept", Type: "synthesis",
+		Domain: []string{"x"}, Confidence: 0.9,
+		Refs: []string{"kb/a.md", "kb/b.md", "kb/elsewhere.md"},
+	}}
+
+	var warned []string
+	written, err := applyDiscoveredProposals(context.Background(), svc.Facts(), svc.Search(),
+		nil, payload, props, DiscoveryGates{}, branch, bareRefFixture, "kb",
+		func(e ProgressEvent) {
+			if e.Phase == "warn" {
+				warned = append(warned, e.Message)
+			}
+		})
+	require.NoError(t, err)
+	require.Len(t, written, 1, "surplus citation must not kill an otherwise valid proposal")
+
+	f := readFactForTest(t, svc, branch, written[0])
+	require.NotContains(t, strings.Join(f.Refs, " "), "kb/elsewhere.md",
+		"a ref the bridge never offered must not become a derivation path")
+	require.Contains(t, strings.Join(warned, "\n"), "outside the bridge",
+		"and the drop must be WARNED, never silent")
+}
+
+// TestApplyDiscoveredProposals_RejectsOneOfThreeSeeds is the floor on the
+// proposal path, on a fixture where it is NOT confounded with the old
+// all-seeds rule.
+func TestApplyDiscoveredProposals_RejectsOneOfThreeSeeds(t *testing.T) {
+	svc, branch, payload := threeSeedProposalEnv(t)
+
+	props := []DiscoveredFact{{
+		Path: "kb/thin.md", Title: "thin", Body: "thin", Type: "synthesis",
+		Domain: []string{"x"}, Confidence: 0.9, Refs: []string{"kb/a.md"},
+	}}
+
+	written, err := applyDiscoveredProposals(context.Background(), svc.Facts(), svc.Search(),
+		nil, payload, props, DiscoveryGates{}, branch, bareRefFixture, "kb", nil)
+	require.NoError(t, err)
+	require.Empty(t, written, "one citation is not a derivation path")
+}
+
+func readFactForTest(t *testing.T, svc *store.Service, branch, path string) fact.Fact {
+	t.Helper()
+	res, err := svc.Facts().ReadFact(context.Background(), branch, path, nil)
+	require.NoError(t, err)
+	f, err := fact.ParseFact(path, res.Content)
+	require.NoError(t, err)
+	return f
+}
+
+// ── the reinforce path, end to end ──
+
+const seedThreePath = "kb/gotchas/sandboxing/thirdseed.md"
+
+// threeSeedReinforceEnv extends the package's two-seed reinforce fixture with a
+// third seed, so the subset rule can be told apart from the all-seeds rule it
+// replaced. On the two-seed fixture the two rules coincide and no test built on
+// it is evidence about #151 either way.
+func threeSeedReinforceEnv(t *testing.T) *reinforceEnv {
+	t.Helper()
+	env := newReinforceEnv(t)
+
+	f := fact.NewFact(seedThreePath)
+	f.Title = "A third seed the target does not rest on"
+	f.Body = "Body of the third seed."
+	f.Type = fact.Observation
+	f.Confidence = 0.8
+	f.Sources = 1
+	content, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	_, err = env.svc.Facts().WriteFact(context.Background(), env.branch, seedThreePath,
+		content, "write third seed", "test")
+	require.NoError(t, err)
+
+	env.payload.Bridge.Members = append(env.payload.Bridge.Members,
+		factForLLM{File: seedThreePath})
+	return env
+}
+
+// TestApplyReinforcements_AcceptsTwoOfThreeSeeds is the relaxation on the
+// reinforce path — the case the issue named as blocker 1. Reinforcement was
+// near-unusable precisely because a bridge whose seeds do not ALL derive the
+// target had no way to record the derivation that genuinely holds.
+func TestApplyReinforcements_AcceptsTwoOfThreeSeeds(t *testing.T) {
+	env := threeSeedReinforceEnv(t)
+	before := env.read(reinforcePath)
+
+	r := goodReinforcement() // cites seedOne + seedTwo, not seedThree
+	require.Equal(t, []string{reinforcePath}, env.apply(r),
+		"two of three seeds IS an independent derivation and must be recorded")
+
+	after := env.read(reinforcePath)
+	require.Equal(t, before.Sources+1, after.Sources)
+	require.NotContains(t, strings.Join(after.Refs, " "), seedThreePath,
+		"the seed that does not fit must not be forced into the derivation path")
+}
+
+// TestApplyReinforcements_RejectsOneOfThreeSeeds is the floor, on the fixture
+// where it is not confounded with the old rule.
+func TestApplyReinforcements_RejectsOneOfThreeSeeds(t *testing.T) {
+	env := threeSeedReinforceEnv(t)
+	before := env.read(reinforcePath)
+
+	r := goodReinforcement()
+	r.Refs = flexStrings{seedOnePath}
+	require.Empty(t, env.apply(r))
+	require.Equal(t, before.Sources, env.read(reinforcePath).Sources,
+		"a rejected reinforcement must not move sources")
+}
+
+// TestApplyReinforcements_CanonicalSeedSpellingIsAccepted drives the real
+// reinforce path with seeds cited the way the corpus stores them.
+//
+// It is the wiring half of TestSeedSubset_CanonicalSpellingCountsAsTheSeed: the
+// predicate test proves the comparison normalises, this proves the CALLER hands
+// it a real repo id. Before #151 this input failed twice over — rejected by the
+// gate, and, had it passed, both seeds classified as extras and dropped, so the
+// reinforcement would have been a no-op with sources untouched.
+func TestApplyReinforcements_CanonicalSeedSpellingIsAccepted(t *testing.T) {
+	env := threeSeedReinforceEnv(t)
+	before := env.read(reinforcePath)
+
+	r := goodReinforcement()
+	r.Refs = flexStrings{
+		fact.QualifyKBPath(env.repoID, seedOnePath),
+		fact.QualifyKBPath(env.repoID, seedTwoPath),
+	}
+	require.Contains(t, string(r.Refs[0]), "kb://",
+		"fixture check: bare paths here would not exercise normalisation")
+
+	require.Equal(t, []string{reinforcePath}, env.apply(r),
+		"seeds cited in the stored canonical spelling must be recognised")
+	require.Equal(t, before.Sources+1, env.read(reinforcePath).Sources)
+}

--- a/internal/synthesize/discovery_reinforce.go
+++ b/internal/synthesize/discovery_reinforce.go
@@ -82,8 +82,14 @@ func applyReinforcements(
 			reject("%s is one of the seeds — a fact is not an independent derivation of itself", r.Path)
 			continue
 		}
-		if !refsCoverSeeds(r.Refs, seedPaths) {
-			reject("%s refs does not cite every seed", r.Path)
+		// The derivation-path floor (#151), replacing "cite every seed". See
+		// refsCiteSeedSubset. The split below is the same partition this check
+		// runs, recomputed after the fact is read so a rejection here costs no
+		// read — deliberate duplication of two cheap calls, not a seam.
+		if !refsCiteSeedSubset(r.Refs, seedPaths, localRepoID) {
+			_, _, distinct := splitSeedRefs(r.Refs, seedPaths, localRepoID)
+			reject("%s cites %d of the bridge's seeds as its derivation path, needs at least %d",
+				r.Path, distinct, minCitedSeeds)
 			continue
 		}
 
@@ -140,20 +146,21 @@ func applyReinforcements(
 		// write list is built from it and the two can diverge.
 		prior := append([]string(nil), f.Refs...)
 
-		// SEEDS ONLY (review H2). refsCoverSeeds is a superset check, so r.Refs
-		// may name anything the model happened to read while deciding — and
-		// rider 2 now instructs it to read. Every extra would become a permanent
+		// SEEDS ONLY (review H2). The subset check above bounds how FEW seeds
+		// may be cited; this bounds what else may ride along. r.Refs may name
+		// anything the model happened to read while deciding — and rider 2 now
+		// instructs it to read. Every extra would become a permanent
 		// DERIVED_FROM edge on a fact someone else authored, and would move its
 		// evidence weight. Surplus citation does not kill an otherwise valid
 		// reinforcement; the extras are dropped with a warning.
-		var extras, seeds []string
-		for _, ref := range r.Refs {
-			if _, isSeed := seedPaths[ref]; isSeed {
-				seeds = append(seeds, ref)
-			} else {
-				extras = append(extras, ref)
-			}
-		}
+		//
+		// The partition is by CANONICAL PATH (#151), not by raw string. It used
+		// to disagree with the dedup membership test twelve lines below, which
+		// has always canonicalised: a seed cited as kb://<own-id>/<path> — the
+		// spelling the corpus stores — was classified an EXTRA here and dropped,
+		// while the test below would have recognised it. One half of this
+		// function knew how refs are spelled and the other did not.
+		seeds, extras, _ := splitSeedRefs(r.Refs, seedPaths, localRepoID)
 		if len(extras) > 0 {
 			onProgress(ProgressEvent{Phase: "warn", Message: fmt.Sprintf(
 				"reinforce %s: discarded %d ref(s) naming facts outside the bridge: %s",

--- a/internal/synthesize/discovery_reinforce_test.go
+++ b/internal/synthesize/discovery_reinforce_test.go
@@ -201,8 +201,13 @@ func TestApplyReinforcements_RejectsAnUnreasonedEquivalence(t *testing.T) {
 	require.Equal(t, before.Sources, env.read(reinforcePath).Sources)
 }
 
-// The same engagement proof the proposal path demands: cite every seed.
-func TestApplyReinforcements_RejectsWhenRefsDoNotCoverEverySeed(t *testing.T) {
+// The same derivation-path floor the proposal path demands: at least two seeds.
+//
+// Retargeted by #151 (was ..._RejectsWhenRefsDoNotCoverEverySeed). This env's
+// bridge has two members, so citing one is both "not every seed" and "below the
+// floor" — the two rules coincide here and this test cannot tell them apart.
+// The three-seed cases that CAN are in discovery_citation_test.go.
+func TestApplyReinforcements_RejectsFewerThanTwoCitedSeeds(t *testing.T) {
 	env := newReinforceEnv(t)
 	before := env.read(reinforcePath)
 

--- a/internal/synthesize/discovery_test.go
+++ b/internal/synthesize/discovery_test.go
@@ -95,10 +95,17 @@ func TestApplyDiscoveredProposals_ConfidenceGate(t *testing.T) {
 	require.True(t, strings.HasPrefix(written[0], "kb/"), "wrote %q", written[0])
 }
 
-// TestApplyDiscoveredProposals_RefsMustCoverSeeds: a proposal that omits
-// one of the bridge members from refs is rejected (proves the agent
-// engaged with every input).
-func TestApplyDiscoveredProposals_RefsMustCoverSeeds(t *testing.T) {
+// TestApplyDiscoveredProposals_RefsMustCiteAtLeastTwoSeeds: a proposal citing
+// ONE seed is rejected — a single citation is not a derivation path.
+//
+// Retargeted by #151. It used to read "a proposal that omits one of the bridge
+// members is rejected", which is no longer the rule: on a THREE-seed bridge,
+// omitting one is now correct. What survives is the floor, and this fixture's
+// bridge has exactly two members, where the floor and the old all-seeds rule
+// happen to coincide. TestSeedSubset_TwoSeedBridgeStillNeedsBoth states that
+// coincidence deliberately; this test is not evidence of the relaxation either
+// way — discovery_citation_test.go carries that.
+func TestApplyDiscoveredProposals_RefsMustCiteAtLeastTwoSeeds(t *testing.T) {
 	dir := t.TempDir()
 	svc, err := store.Open(filepath.Join(dir, "k.db"))
 	require.NoError(t, err)
@@ -116,14 +123,14 @@ func TestApplyDiscoveredProposals_RefsMustCoverSeeds(t *testing.T) {
 			Members: []factForLLM{{File: "kb/a.md", Title: "A"}, {File: "kb/b.md", Title: "B"}},
 		},
 	}
-	// Refs missing kb/b.md → reject.
+	// Refs cite one seed of the two offered → below the floor, reject.
 	props := []DiscoveredFact{{
 		Path: "kb/skipped.md", Title: "x", Body: "x", Type: "synthesis",
 		Domain: []string{"x"}, Confidence: 0.9, Refs: []string{"kb/a.md"},
 	}}
 	written, err := applyDiscoveredProposals(context.Background(), svc.Facts(), svc.Search(), nil, payload, props, DiscoveryGates{}, branch, bareRefFixture, "kb", nil)
 	require.NoError(t, err)
-	require.Empty(t, written, "incomplete-refs proposal must be rejected")
+	require.Empty(t, written, "a proposal citing one seed of two must be rejected")
 }
 
 // TestApplyDiscoveredProposals_OriginDiscovered: the written fact carries
@@ -208,7 +215,7 @@ func TestRenderDiscoverPrompt_TokenPresent_ContainsBridgeTokenLine(t *testing.T)
 	out := renderDiscoverPrompt(payload, "kb")
 	require.Contains(t, out, `Bridge token:`, "token-present prompt must emit Bridge token: line")
 	require.Contains(t, out, `Members (1):`)
-	require.Contains(t, out, "(d) You can cite every seed fact above in refs")
+	require.Contains(t, out, "(d) You can cite AT LEAST TWO of the seed facts above in refs")
 
 	// extract RESPONSE SCHEMA line for comparison with token-optional variant
 	schemaLine := extractResponseSchemaLine(out)
@@ -240,7 +247,7 @@ func TestRenderDiscoverPrompt_TokenEmpty_Forward(t *testing.T) {
 	require.NotContains(t, out, "Bridge token:", "token-optional prompt must NOT emit Bridge token: line")
 	require.Contains(t, out, "auth", "scope label must appear in prompt")
 	require.Contains(t, out, "Members (2):")
-	require.Contains(t, out, "(d) You can cite every seed fact above in refs")
+	require.Contains(t, out, "(d) You can cite AT LEAST TWO of the seed facts above in refs")
 	require.Contains(t, out, "RESPONSE SCHEMA")
 	require.Contains(t, out, "strictly ENTAILED", "forward token-optional must keep entailment language")
 
@@ -278,7 +285,7 @@ func TestRenderDiscoverPrompt_MandatesDiscoveredOrigin(t *testing.T) {
 			out := renderDiscoverPrompt(v.payload, "kb")
 			require.Contains(t, out, "origin: discovered",
 				"discover prompt must name the discovered origin at proposal time")
-			require.Contains(t, out, "MUST set origin: discovered and cite every seed fact above in refs",
+			require.Contains(t, out, "MUST set origin: discovered and cite at least two of the seed facts above in refs",
 				"discover prompt must mandate origin + refs for the knomit_learn save path")
 			require.Contains(t, out, "BRIDGE",
 				"the instruction must tie origin to the bridge grouping method")
@@ -320,7 +327,7 @@ func TestRenderDiscoverPrompt_TokenEmpty_Backward(t *testing.T) {
 	require.NotContains(t, out, "Bridge token:", "backward token-optional prompt must NOT emit Bridge token: line")
 	require.Contains(t, out, "auth", "scope label must appear in backward token-optional prompt")
 	require.Contains(t, out, "Members (1):")
-	require.Contains(t, out, "(d) You can cite every seed fact above in refs")
+	require.Contains(t, out, "(d) You can cite AT LEAST TWO of the seed facts above in refs")
 	require.Contains(t, out, "strictly REQUIRED", "backward token-optional must keep required-by language")
 
 	// RESPONSE SCHEMA must match backward token-present.

--- a/internal/synthesize/hypothesize_engine_test.go
+++ b/internal/synthesize/hypothesize_engine_test.go
@@ -257,9 +257,35 @@ func TestHypothesizer_DiscoverParseFailure_NonFatal(t *testing.T) {
 }
 
 // discoverResponseOneProposal is a valid forward-discover response proposing
-// exactly one fact. With empty bridge members, refs=[] satisfies the
-// refs-cover-seeds check and confidence 0.9 clears the 0.5 gate.
-const discoverResponseOneProposal = `{"proposals":[{"path":"kb/x/p.md","title":"P","body":"B","type":"synthesis","domain":["auth"],"confidence":0.9,"entities":[],"refs":[]}]}`
+// exactly one fact, citing the two seeds insertSeededDiscoverItem offers.
+// Confidence 0.9 clears the 0.5 gate.
+//
+// It used to carry refs=[] against a bridge with NO members, where the
+// then-current "refs must cover every seed" check was vacuously satisfied by
+// the empty seed set. #151 replaced that with a floor of two cited seeds, and
+// the fixture stopped writing anything — correctly. A zero-member bridge cannot
+// occur (enumeration requires at least two members spanning two communities),
+// so the old fixture was asserting THROUGH an impossible state; the seeds below
+// make it a shape the engine can actually produce.
+const discoverResponseOneProposal = `{"proposals":[{"path":"kb/x/p.md","title":"P","body":"B","type":"synthesis","domain":["auth"],"confidence":0.9,"entities":[],"refs":["kb/seedone.md","kb/seedtwo.md"]}]}`
+
+// insertSeededDiscoverItem is insertManualDiscoverItem plus the two seed facts
+// its bridge offers, for tests that let apply RUN and need the proposal to
+// survive the citation gate. Tests asserting that nothing is written keep using
+// the bare helper, whose empty corpus is what makes "no facts" measurable.
+func insertSeededDiscoverItem(t *testing.T, svc *store.Service, sessionID string) {
+	t.Helper()
+	writeTestFact(t, svc, "kb/seedone.md", "Seed one", fact.Observation, "auth")
+	writeTestFact(t, svc, "kb/seedtwo.md", "Seed two", fact.Observation, "auth")
+	require.NoError(t, svc.Pipeline().InsertPipelineWorkItem(context.Background(), store.PipelineWorkItem{
+		SessionID:  sessionID,
+		StepType:   "discover",
+		ClusterKey: "discover-bwd-0",
+		FactsJSON: `{"direction":"forward","bridge":{"token":"auth","kind":"entity","members":` +
+			`[{"path":"kb/seedone.md"},{"path":"kb/seedtwo.md"}]}}`,
+		Priority: backwardDiscoverPriority(0),
+	}))
+}
 
 // TestHypothesizer_ConcurrentDiscoverSubmission_WritesOnce is the hypothesize
 // half of the P0.4 claim anchor (review_claim_test.go covers the review half):
@@ -281,7 +307,7 @@ func TestHypothesizer_ConcurrentDiscoverSubmission_WritesOnce(t *testing.T) {
 
 	sess, err := svc.Pipeline().CreatePipelineSession(ctx, "hypothesize", "agent/test", "")
 	require.NoError(t, err)
-	insertManualDiscoverItem(t, svc, sess.ID)
+	insertSeededDiscoverItem(t, svc, sess.ID)
 
 	p := NewHypothesizer(ri, nil, EffortHigh, ScopeFilter{})
 	var start, done sync.WaitGroup
@@ -300,9 +326,20 @@ func TestHypothesizer_ConcurrentDiscoverSubmission_WritesOnce(t *testing.T) {
 	start.Done()
 	done.Wait()
 
+	// Count only the PROPOSED fact. The two seeds are also on disk now, so a
+	// bare corpus count would no longer measure what this test is about.
+	// normalizeFactPath rewrites the basename to a uuid, so match on title.
 	results, err := svc.Search().Search(ctx, "agent/test", store.SearchOptions{Limit: 10})
 	require.NoError(t, err)
-	require.Len(t, results, 1, "a duplicated discover submission must not duplicate its proposals")
+	proposed := 0
+	for _, r := range results {
+		if r.Title == "P" {
+			proposed++
+		}
+	}
+	require.Equal(t, 1, proposed,
+		"a duplicated discover submission must not duplicate its proposals (corpus: %d facts)",
+		len(results))
 }
 
 // TestBackwardDiscoverPriority_StrictlyNegativeRanked is the regression guard


### PR DESCRIPTION
Closes #151 (blocker 1 fully, blocker 4 partially).

The "cite EVERY offered seed" rule discarded valid derivations — a judge honestly citing only the seeds on the derivation path was rejected. Relaxed to: cite a SUBSET of the offered seeds, minimum 2, only offered seeds permitted (nothing inventable); non-fitting seeds are simply not claimed.

- One predicate (`refsCiteSeedSubset`) at BOTH call sites (proposal + reinforce) — no two-spellings drift.
- Seed-match normalizes via `fact.ClassifyRef` (seeds are cited canonical `kb://<id>/<path>`), so a legitimately-spelled seed counts — a raw-string compare would ship the fix inert. Pinned by `CanonicalSpellingCountsAsTheSeed` / `EmptyRepoIDCannotSeeACanonicalSeed`.
- Invented refs on the proposal path are DISCARDED with a warning (mirroring the reinforce extras-discard), not silently kept — without the filter an invented ref becomes a permanent DERIVED_FROM edge.
- `minCitedSeeds=2` is an argument-shape floor (a conjunction needs two terms), not a corpus property (MN13).

Scope honesty: blocker 1 FIXED; blocker 4 PARTIAL (hypothesis-heavy items stay unanswerable-except-empty — residue for follow-up); blockers 2 & 3 untouched. Two-seed bridges unaffected by design. Cold-reviewed independently: MERGE-READY, no findings; merge result verified green against current dev by three independent runs.