### PR TITLE
Self-reference: exclude a candidate from its own cluster + remove self-refs at the source (#132)

### DIFF
--- a/internal/mcp/learn.go
+++ b/internal/mcp/learn.go
@@ -19,8 +19,7 @@ import (
 
 // localEvidenceRefs returns the subset of a fact's refs that are genuinely-local
 // fact edges eligible to contribute evidence weight. It drops:
-//   - the fact's own resulting path (a dedup-merge appends it as lineage; a fact
-//     is never its own evidence source), and
+//   - the fact's own path (a fact is never its own evidence source), and
 //   - everything ClassifyRef does not call a local fact: a FOREIGN kb:// ref
 //     points into another repo, and a source citation is not a fact edge even
 //     when the file it cites is markdown (src://…/plans/x.md ends in ".md").
@@ -31,9 +30,12 @@ import (
 // them as foreign and silently compute the weight from nothing.
 func localEvidenceRefs(f fact.Fact, localRepoID string) []string {
 	var localRefs []string
-	// The self-path may be stored either bare (as the merge appended it) or
-	// canonical (as it was written), so compare on the classified path rather
-	// than the raw string.
+	// KEPT after #132 stopped the merge writing a self-ref, because facts
+	// written BEFORE that change still carry one on disk, in BOTH forms —
+	// measured: kb://<id>/…/69694fd7.md canonical, …/f1d14b64.md bare. A
+	// read-side drop is what keeps those legacy rows from inflating a weight,
+	// and it costs one comparison. Compare on the CLASSIFIED path, never the
+	// raw string, precisely because the two stored forms differ.
 	self := fact.ClassifyRef(f.Path(), localRepoID).Path
 	for _, r := range f.Refs {
 		c := fact.ClassifyRef(r, localRepoID)
@@ -354,16 +356,39 @@ func newFactWins(newFact, existing fact.Fact) bool {
 // one field that unions WINNER-first, because they are capped and so their
 // order decides what survives — see the call site. Pure.
 //
-// existingPath is the existing fact's RAW on-disk path and is deliberately
-// distinct from existing.Path(). The two differ in case: existing came from
-// ParseFact(existingPath, …), whose final step is NewFact(existingPath) =
-// strings.ToLower(existingPath). The merged fact's IDENTITY uses the
-// normalized form (that is what identity means here, and lowercasing is
-// idempotent, so this matches the pre-refactor behaviour exactly), but the
-// lineage REF must use the raw path — a ref is a pointer to a file, and for a
-// mixed-case fact file like "kb/Tech/Foo.md" the normalized "kb/tech/foo.md"
-// names nothing on disk, so every provenance walk through that edge dangles.
-func mergeFacts(newFact, existing fact.Fact, existingPath string) fact.Fact {
+// THE MERGE EMITS NO SELF-REFERENCE, and that is the point of #132. Two
+// separate ways one used to arise, and BOTH have to be closed — removing only
+// the first leaves the second producing them:
+//
+//  1. The merge APPENDED the existing fact's path as lineage. Because the merge
+//     RETARGETS onto that path, the appended path is the merged fact's OWN
+//     path, by construction. That append is gone: the retarget preserves the
+//     file, so git history for it already records that this version subsumed a
+//     duplicate, and the ref added nothing a reader could not get from
+//     `git log`.
+//
+//  2. The union can CONVERT a legitimate ref into a self-reference. An incoming
+//     fact may cite the very fact it then dedup-merges into — a perfectly
+//     ordinary "B cites A" that becomes "A cites A" the moment B is retargeted
+//     onto A. Nothing was appended; the ref was already there and only its
+//     meaning changed. So the union is FILTERED against the merged path rather
+//     than merely not added to. (Found by the suite, not by reading: it is
+//     exactly what TestLearnHandler_OriginDefaultsAuthored does.)
+//
+// Nothing downstream loses information. localEvidenceRefs already dropped the
+// self-path so it could not inflate evidence weight, and the recursive ref
+// walks in internal/synthesize/weight.go absorb it as a back-edge — the ref was
+// discarded by every consumer that read it.
+//
+// localRepoID is needed to CLASSIFY, not to decorate: refs arrive bare from the
+// caller and canonical from storage, and ClassifyRef with an empty id reads
+// every kb://<id>/… ref as FOREIGN — so a filter without it would silently miss
+// every canonical self-ref, which is the majority form on disk.
+//
+// Note what is NOT affected: refs to OTHER facts, including retired ones, are
+// unioned as before. Citing a retired predecessor at a DIFFERENT path is
+// genuine lineage and stays.
+func mergeFacts(newFact, existing fact.Fact, localRepoID string) fact.Fact {
 	merged := fact.NewFact(existing.Path())
 	winner, loser := existing, newFact
 	if newFactWins(newFact, existing) {
@@ -417,8 +442,18 @@ func mergeFacts(newFact, existing fact.Fact, existingPath string) fact.Fact {
 	// is a hybrid, since a naive recompute mishandles a DERIVED existing fact
 	// whose lineage-composed weight max preserves better.
 	merged.EvidenceWeight = max(newFact.EvidenceWeight, existing.EvidenceWeight)
-	// Raw path, not existing.Path(): see the doc comment above.
-	merged.Refs = fact.AppendUnique(fact.UnionStrings(newFact.Refs, existing.Refs), existingPath)
+	// Union, then drop any ref that names the merged fact itself — in either
+	// stored form. See the doc comment above (#132).
+	self := fact.ClassifyRef(merged.Path(), localRepoID).Path
+	union := fact.UnionStrings(newFact.Refs, existing.Refs)
+	kept := make([]string, 0, len(union))
+	for _, r := range union {
+		if c := fact.ClassifyRef(r, localRepoID); c.Kind == fact.RefLocalFact && c.Path == self {
+			continue
+		}
+		kept = append(kept, r)
+	}
+	merged.Refs = kept
 	return merged
 }
 
@@ -481,6 +516,7 @@ func applyDedupMerge(
 	topicCategories []string,
 	paths []string,
 	files map[string]string,
+	localRepoID string,
 ) (map[string][]float32, []string, map[string][]string, error) {
 	// The near-duplicate cosine floor is model-dependent (see internal/embeddings/params).
 	dedupThreshold := store.EmbedderThresholds(batchEmb).Dedup
@@ -584,7 +620,7 @@ func applyDedupMerge(
 			continue
 		}
 
-		merged := mergeFacts(f, existingFact, match.Path)
+		merged := mergeFacts(f, existingFact, localRepoID)
 		if newFactWins(f, existingFact) {
 			// dedup vector still describes the merged content (same title+body
 			// as the new fact); just retarget to the existing path it now lives at.
@@ -765,7 +801,7 @@ func LearnHandler(embedders ...store.BatchEmbedder) func(context.Context, mcpgo.
 		// matches in its own category directory, if any. Mutates facts and
 		// files in place; hands back the embedding donations and the subsumed
 		// hypotheses to retract alongside the write.
-		embByPath, retract, priorRefs, err := applyDedupMerge(ctx, s, agentBranch, ontology, batchEmb, facts, topicCategories, paths, files)
+		embByPath, retract, priorRefs, err := applyDedupMerge(ctx, s, agentBranch, ontology, batchEmb, facts, topicCategories, paths, files, gate.LocalRepoID())
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/learn_defaults_test.go
+++ b/internal/mcp/learn_defaults_test.go
@@ -8,6 +8,12 @@ import (
 	"knomit/internal/fact"
 )
 
+// testLocalID is a stand-in repo id for mergeFacts unit tests. It must be
+// non-empty: ClassifyRef reads every kb://<id>/… ref as FOREIGN when the local
+// id is empty, so an empty value here would silently disable the self-ref
+// filter the merge now applies.
+const testLocalID = "3ec012f5b4d2"
+
 // knomit_learn's input schema advertises `"sources": {"default": 1}` and
 // `"confidence": {"default": 0.7}`, but a JSON Schema `default` is
 // documentation for the client, not server-side coercion. learnFactInput held
@@ -89,7 +95,7 @@ func TestMergeFacts_TransfersLoserSources(t *testing.T) {
 	incoming.Title, incoming.Body, incoming.Type = "N", "nb", fact.Observation
 	incoming.Confidence, incoming.Sources = 0.5, 3
 
-	merged := mergeFacts(incoming, existing, "kb/tech/foo.md")
+	merged := mergeFacts(incoming, existing, testLocalID)
 	require.Equal(t, 5, merged.Sources,
 		"a dedup merge leaves one file, so both facts' corroborations must pool into it")
 }

--- a/internal/mcp/learn_motif_test.go
+++ b/internal/mcp/learn_motif_test.go
@@ -46,7 +46,7 @@ func motifMergeFixture(t *testing.T, newMotifs, existingMotifs []string, newWins
 		nf.Confidence, ex.Confidence = 0.5, 0.9
 	}
 	require.Equal(t, newWins, newFactWins(nf, ex), "fixture must produce the intended winner")
-	return mergeFacts(nf, ex, "kb/alpha/existing.md")
+	return mergeFacts(nf, ex, testLocalID)
 }
 
 // TestMergeFacts_MotifsWinnerFirstTrimAtCap is the roadmap's conformance case,
@@ -90,7 +90,7 @@ func TestMergeFacts_DomainAndEntitiesStayIncomingFirst(t *testing.T) {
 	ex.Entities = []string{"OldEntity"}
 
 	require.False(t, newFactWins(nf, ex))
-	merged := mergeFacts(nf, ex, "kb/alpha/existing.md")
+	merged := mergeFacts(nf, ex, testLocalID)
 
 	require.Equal(t, []string{"new-domain", "old-domain"}, merged.Domain,
 		"domain stays incoming-first even when the incoming fact loses")

--- a/internal/mcp/learn_origin_test.go
+++ b/internal/mcp/learn_origin_test.go
@@ -213,12 +213,17 @@ func TestLearnHandler_AllowsDiscoveredHypothesis(t *testing.T) {
 	require.Equal(t, fact.Discovered, got.Origin)
 }
 
-// TestLearnHandler_DedupMergeWeightExcludesSelfCitation is a regression test:
-// when a discovered fact dedup-merges against an existing fact, the merge
-// appends the fact's own resulting path to refs as lineage. The evidence_weight
-// computation must NOT count that self-path as a source — otherwise a merged
-// derived fact inflates its own weight by citing its predecessor as evidence.
-func TestLearnHandler_DedupMergeWeightExcludesSelfCitation(t *testing.T) {
+// TestLearnHandler_DedupMergeEmitsNoSelfCitation inverts what this test used to
+// assert. It pinned that the merge APPENDS the fact's own resulting path as
+// lineage, and that evidence_weight excludes it. #132 removed the append: a
+// fact citing itself is not lineage, because the retarget preserves the file
+// and git history already records the subsumption.
+//
+// The WEIGHT assertion is kept unchanged and is the more important half — it
+// held before via the read-side exclusion in localEvidenceRefs and must still
+// hold now that the ref is not written at all. Two independent reasons for one
+// number, which is why the merge change cannot quietly alter it.
+func TestLearnHandler_DedupMergeEmitsNoSelfCitation(t *testing.T) {
 	svc, ctx, emb := newOriginTestRepo(t)
 
 	// Seed the only legitimate source. weight must derive from THIS alone.
@@ -270,8 +275,15 @@ func TestLearnHandler_DedupMergeWeightExcludesSelfCitation(t *testing.T) {
 	require.NoError(t, berr)
 	root, rerr := svc.RootCommit(context.Background(), br)
 	require.NoError(t, rerr)
-	require.Contains(t, merged.Refs, fact.QualifyKBPath(fact.ID12(root), firstPath),
-		"merge appends the fact's own path to refs (lineage) — the condition under test")
+	require.NotContains(t, merged.Refs, fact.QualifyKBPath(fact.ID12(root), firstPath),
+		"the merge must not write the fact's own path as a ref (#132)")
+	require.NotContains(t, merged.Refs, firstPath,
+		"nor the bare spelling of it — both forms occur in stored corpora")
+	// The genuine source SURVIVES: this is the boundary. #132 removes the
+	// self-reference, not lineage — a merged fact keeps every ref naming some
+	// OTHER fact.
+	require.Contains(t, merged.Refs, fact.QualifyKBPath(fact.ID12(root), sourcePath),
+		"the real source citation must survive the merge")
 	require.Equal(t, fact.Discovered, merged.Origin, "merged fact must stay discovered")
 	require.InDelta(t, baseline, merged.EvidenceWeight, 1e-9,
 		"weight must derive from the genuine source only, not inflate by counting the fact's own predecessor path as evidence")
@@ -283,7 +295,8 @@ func TestLearnHandler_DedupMergeWeightExcludesSelfCitation(t *testing.T) {
 // A cross-repo kb:// ref is excluded even though it ends in ".md", and a
 // SOURCE citation is excluded even when the file it cites is markdown — which
 // the previous ".md suffix" rule got wrong, counting src://…/plans/x.md as
-// local evidence. The fact's own path is excluded as dedup-merge lineage.
+// local evidence. The fact's own path is excluded — the merge no longer
+// writes one (#132), but facts written before that change still carry one.
 //
 // A schemeless ref like "docs/x.txt" IS a repo-relative fact path — that is
 // what schemeless means — so it is kept here. It cannot reach this function in
@@ -299,7 +312,7 @@ func TestLocalEvidenceRefs(t *testing.T) {
 	f.Refs = []string{
 		localRef,       // genuinely local: kept
 		kbRef,          // cross-repo kb:// (ends in .md): dropped
-		f.Path(),       // the fact's own path (dedup-merge lineage): dropped
+		f.Path(),       // the fact's own path (legacy, pre-#132): dropped
 		srcMarkdownRef, // markdown SOURCE citation (ends in .md): dropped
 		"https://example.com/paper",
 	}
@@ -324,7 +337,7 @@ func TestLocalEvidenceRefs_CanonicalStoredForm(t *testing.T) {
 	f := fact.NewFact("kb/observations/ai/derived.md")
 	f.Refs = []string{
 		fact.QualifyKBPath(localID, "kb/observations/ai/source.md"), // evidence
-		fact.QualifyKBPath(localID, f.Path()),                       // own path: lineage, not evidence
+		fact.QualifyKBPath(localID, f.Path()),                       // own path (legacy): never evidence
 		fact.QualifyKBPath("7b4887ce51d9", "kb/elsewhere.md"),       // foreign: excluded
 	}
 

--- a/internal/mcp/learn_paths_test.go
+++ b/internal/mcp/learn_paths_test.go
@@ -50,16 +50,18 @@ func TestValidateAndBuildFacts_UppercaseOntologyRoot(t *testing.T) {
 	require.Equal(t, strings.ToLower(paths[0]), facts[0].Path())
 }
 
-// TestMergeFacts_LineageRefUsesRawPath pins that the lineage ref a dedup-merge
-// appends points at a file that exists on disk.
+// TestMergeFacts_AppendsNoSelfLineageRef replaces TestMergeFacts_LineageRefUsesRawPath,
+// which pinned that the appended lineage ref used the RAW on-disk path so a
+// provenance walk through it would not dangle. That whole concern is gone with
+// the ref: #132 stopped the merge appending its own path at all, because the
+// merge RETARGETS onto that path, so the "lineage" ref pointed at the merged
+// fact itself.
 //
-// The merged fact's IDENTITY is the normalized (lowercased) path — that is
-// what identity means, and ToLower is idempotent. But the REF is a pointer to
-// a file. `existing` is produced by ParseFact(rawPath, …), whose last step
-// lowercases the whole path, so existing.Path() for "kb/Tech/Foo.md" is
-// "kb/tech/foo.md" — a path with no file behind it. Using it as the lineage
-// ref makes every provenance walk through that edge dangle.
-func TestMergeFacts_LineageRefUsesRawPath(t *testing.T) {
+// The mixed-case fixture is KEPT deliberately. Raw vs normalized was the reason
+// the old ref existed, so it is the case most likely to be reintroduced by
+// someone restoring the append "correctly" — a merge that emits EITHER spelling
+// of its own path fails here.
+func TestMergeFacts_AppendsNoSelfLineageRef(t *testing.T) {
 	const rawPath = "kb/Tech/Foo.md"
 
 	existing := fact.NewFact(rawPath) // mirrors ParseFact: lowercases
@@ -72,14 +74,60 @@ func TestMergeFacts_LineageRefUsesRawPath(t *testing.T) {
 	incoming.Confidence, incoming.Sources = 0.5, 1
 	incoming.Domain, incoming.Entities, incoming.Refs = []string{"d"}, []string{}, []string{}
 
-	merged := mergeFacts(incoming, existing, rawPath)
+	merged := mergeFacts(incoming, existing, testLocalID)
 
-	require.Contains(t, merged.Refs, rawPath,
-		"lineage ref must be the raw on-disk path so provenance walks resolve")
+	require.NotContains(t, merged.Refs, rawPath,
+		"the merge must not append its own path as lineage (#132)")
 	require.NotContains(t, merged.Refs, strings.ToLower(rawPath),
-		"lowercased path names no file on disk; a ref to it dangles")
-	// Identity stays normalized — unchanged from the pre-refactor behaviour.
+		"nor the normalized spelling of it")
+	require.Empty(t, merged.Refs,
+		"neither operand carried a ref, so the merge must produce none")
+	// Identity stays normalized — unchanged.
 	require.Equal(t, strings.ToLower(rawPath), merged.Path())
+}
+
+// TestMergeFacts_DropsARefThatBecomesSelfReferential is the SECOND way a merge
+// used to emit a self-ref, and the one removing the append does not close: the
+// incoming fact legitimately cites the fact it then merges INTO. Nothing is
+// appended — the ref was already there, and the retarget is what changes its
+// meaning from "B cites A" to "A cites A".
+//
+// Both stored spellings are exercised, because refs arrive bare from a caller
+// and canonical from storage, and a filter that classified with an empty repo
+// id would read the canonical one as foreign and keep it.
+func TestMergeFacts_DropsARefThatBecomesSelfReferential(t *testing.T) {
+	const existingPath = "kb/tech/foo.md"
+	const otherPath = "kb/tech/other.md"
+
+	for _, tc := range []struct {
+		name    string
+		selfRef string
+	}{
+		{"bare", existingPath},
+		{"canonical", fact.QualifyKBPath(testLocalID, existingPath)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			existing := fact.NewFact(existingPath)
+			existing.Title, existing.Body, existing.Type = "E", "eb", fact.Observation
+			existing.Confidence, existing.Sources = 0.9, 2
+			existing.Domain, existing.Entities = []string{"d"}, []string{}
+			existing.Refs = []string{}
+
+			incoming := fact.NewFact("kb/tech/new.md")
+			incoming.Title, incoming.Body, incoming.Type = "N", "nb", fact.Observation
+			incoming.Confidence, incoming.Sources = 0.5, 1
+			incoming.Domain, incoming.Entities = []string{"d"}, []string{}
+			// Cites the fact it is about to be merged into, plus an unrelated one.
+			incoming.Refs = []string{tc.selfRef, otherPath}
+
+			merged := mergeFacts(incoming, existing, testLocalID)
+
+			require.NotContains(t, merged.Refs, tc.selfRef,
+				"a ref the retarget turned into a self-reference must be dropped")
+			require.Contains(t, merged.Refs, otherPath,
+				"refs to OTHER facts must survive — dropping those would destroy lineage")
+		})
+	}
 }
 
 // knomit_learn must refuse exactly what the REST create path refuses: the two

--- a/internal/refs/refs.go
+++ b/internal/refs/refs.go
@@ -150,10 +150,43 @@ func (g Gate) CheckBatch(ctx context.Context, batch, prior map[string][]string) 
 	}
 	sort.Strings(sources)
 
+	var selfRefs []problem
 	for _, from := range sources {
 		carried := g.pathSet(prior[from])
+		self := fact.ClassifyRef(from, g.localRepoID).Path
 		for _, raw := range batch[from] {
 			r := fact.ClassifyRef(raw, g.localRepoID)
+
+			// SELF-REFERENCE (#132) — checked FIRST, and the order is
+			// load-bearing. A self-ref is by definition in inBatch (the fact
+			// is the thing being written), so any check placed after the skip
+			// below is unreachable and would ship as a green no-op.
+			//
+			// Compared on the CLASSIFIED path, never the raw string: a
+			// self-ref reaches here bare ("kb/x/y.md") or canonical
+			// ("kb://<own-id>/kb/x/y.md") and both forms exist in stored
+			// corpora today, so a string test would match roughly none of them.
+			//
+			// NEWLY-ADDED refs only — a self-ref the fact already CARRIED is
+			// let through, deliberately. Facts written before #132 carry one
+			// on disk, and some of them live in repos a given deployment
+			// mounts READ-ONLY, so they cannot be repaired from everywhere
+			// they can be read. Rejecting a carried self-ref would make those
+			// facts uneditable — bricking a record nobody in reach can fix, to
+			// prevent a state that no longer has a producer.
+			//
+			// Safe because the producer is gone: mergeFacts no longer emits a
+			// self-ref by either route (append, or a union entry the retarget
+			// turns self-referential), so nothing legitimate introduces a NEW
+			// one and this check is defence in depth. And the legacy rows are
+			// inert on read — localEvidenceRefs drops the self-path before it
+			// can reach a weight, and the recursive walks absorb it as a
+			// back-edge.
+			if r.Kind == fact.RefLocalFact && r.Path == self && !carried[r.Path] {
+				selfRefs = append(selfRefs, problem{from, raw})
+				continue
+			}
+
 			if r.Kind != fact.RefLocalFact || inBatch[r.Path] || carried[r.Path] {
 				continue
 			}
@@ -172,6 +205,24 @@ func (g Gate) CheckBatch(ctx context.Context, batch, prior map[string][]string) 
 				problems = append(problems, problem{from, raw})
 			}
 		}
+	}
+
+	// Reported separately from unresolvable refs, and FIRST, because the two
+	// need opposite fixes: an unresolvable ref means "write the target"; a
+	// self-ref means "delete this ref, there is nothing to write". Folding
+	// them into one list would tell an agent to create a fact that already
+	// exists — it is the one being written.
+	if len(selfRefs) > 0 {
+		var b strings.Builder
+		b.WriteString("a fact may not reference itself — nothing was written:\n")
+		for _, p := range selfRefs {
+			fmt.Fprintf(&b, "  %s cites its own path as %s\n", p.from, p.ref)
+		}
+		b.WriteString("\nRemove the ref. A fact is not evidence for itself, and its own " +
+			"history is already recorded by the commit that writes it.\nRefs to OTHER " +
+			"facts are unaffected, including facts this one supersedes or that have " +
+			"since been retracted — citing those is lineage and stays valid.")
+		return fmt.Errorf("%s", b.String())
 	}
 
 	if len(problems) == 0 {

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -408,3 +408,32 @@ func TestApply_RefToAnotherFactIsNotSelfReference(t *testing.T) {
 		t.Fatalf("citing a different fact must be allowed, got %v", err)
 	}
 }
+
+// The shape #151's reinforce path actually writes: a fact that ALREADY carries
+// a legacy self-ref gains a NEW ref to a different fact. Both halves must hold
+// at once — the carried self-ref is grandfathered, and the newly-added seed is
+// checked normally.
+//
+// This is a cross-package interaction, pinned here because it is where the rule
+// lives. discovery_reinforce.go builds newRefs from the fact's existing refs
+// plus the cited seeds and passes a prior SNAPSHOT to CheckBatch; if a carried
+// self-ref were rejected, reinforce would fail outright on any of the legacy
+// facts that carry one — and those cannot currently be repaired, because they
+// live in a read-only mount. That is the concrete reason the carried case is
+// grandfathered rather than rejected.
+func TestGate_CarriedSelfRefPlusNewRef_ReinforceShape(t *testing.T) {
+	g := New(gateRepoID, existsIn("kb/seed.md"))
+	self := "kb/legacy.md"
+	batch := map[string][]string{self: {self, "kb/seed.md"}}
+	prior := map[string][]string{self: {self}}
+	if err := g.CheckBatch(context.Background(), batch, prior); err != nil {
+		t.Fatalf("a legacy self-ref carrier gaining a real seed ref must be accepted, got %v", err)
+	}
+
+	// And the new-ref check is NOT weakened by the carried self-ref sitting
+	// beside it: an unresolvable addition is still rejected.
+	batch[self] = []string{self, "kb/typo.md"}
+	if err := g.CheckBatch(context.Background(), batch, prior); err == nil {
+		t.Fatal("an unresolvable NEW ref must still be rejected alongside a carried self-ref")
+	}
+}

--- a/internal/refs/refs_test.go
+++ b/internal/refs/refs_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"knomit/internal/fact"
 )
 
 const gateRepoID = "3ec012f5b4d2"
@@ -85,13 +87,19 @@ func TestGate_ReportsAllProblems(t *testing.T) {
 }
 
 // Canonical form must behave exactly like the bare form.
-func TestGate_AcceptsQualifiedSelfReference(t *testing.T) {
+//
+// RENAMED from TestGate_AcceptsQualifiedSelfReference. "Self" there meant own
+// REPO — this is kb/y/new.md citing a DIFFERENT fact, written canonically. Once
+// #132 gave "self-reference" a precise and opposite meaning (a ref to the
+// fact's OWN PATH, now rejected), the old name read as the direct contradiction
+// of TestApply_SelfReferenceIsRejectedInCanonicalForm sitting a few lines away.
+func TestGate_AcceptsQualifiedRefToAnotherFactInThisRepo(t *testing.T) {
 	g := newGate("kb/decisions/x/abc.md")
 	batch := map[string][]string{
 		"kb/y/new.md": {"kb://3ec012f5b4d2/kb/decisions/x/abc.md"},
 	}
 	if err := g.CheckBatch(context.Background(), batch, nil); err != nil {
-		t.Fatalf("qualified self-reference must be accepted, got %v", err)
+		t.Fatalf("a canonical ref to another fact in this repo must be accepted, got %v", err)
 	}
 }
 
@@ -320,13 +328,83 @@ func TestApply_ChecksThenCanonicalizes(t *testing.T) {
 	}
 }
 
-// A fact may cite ITSELF (dedup-merge appends its own path as lineage) — the
-// single-fact batch satisfies that without a resolution lookup.
-func TestApply_SelfReferenceIsSatisfiedByTheBatch(t *testing.T) {
+// A fact may NOT cite itself (#132). This inverts the previous assertion, which
+// said the single-fact batch SATISFIED a self-citation — true of the resolution
+// question, and beside the point: a self-ref is not an unresolvable pointer, it
+// is a malformed one. The merge that used to produce these no longer does.
+//
+// The resolver must not be consulted: rejection is decided on the ref's shape
+// alone, so no corpus lookup can be part of the answer.
+func TestApply_SelfReferenceIsRejected(t *testing.T) {
 	g := New(gateRepoID, func(context.Context, string) (bool, error) {
 		return false, errors.New("resolver must not be consulted")
 	})
-	if _, _, err := g.Apply(context.Background(), "kb/self.md", []string{"kb/self.md"}, nil); err != nil {
-		t.Fatalf("a self-citation must be satisfied by its own batch entry, got %v", err)
+	_, _, err := g.Apply(context.Background(), "kb/self.md", []string{"kb/self.md"}, nil)
+	if err == nil {
+		t.Fatal("a fact citing its own path must be rejected")
+	}
+	if !strings.Contains(err.Error(), "may not reference itself") {
+		t.Fatalf("error must name the self-reference, got %v", err)
+	}
+}
+
+// The self-ref check compares CLASSIFIED paths, so it catches the canonical
+// form too. This is the form the corpus actually stores (bare paths are
+// qualified on write), so a check that only caught the bare spelling would miss
+// most real instances — both forms exist in stored corpora today.
+func TestApply_SelfReferenceIsRejectedInCanonicalForm(t *testing.T) {
+	g := New(gateRepoID, func(context.Context, string) (bool, error) {
+		return true, nil
+	})
+	canon := fact.QualifyKBPath(gateRepoID, "kb/self.md")
+	if _, _, err := g.Apply(context.Background(), "kb/self.md", []string{canon}, nil); err == nil {
+		t.Fatalf("a self-citation in canonical form (%s) must be rejected", canon)
+	}
+}
+
+// A self-ref the fact ALREADY CARRIED is GRANDFATHERED, and that asymmetry is
+// deliberate rather than an oversight. Facts written before #132 carry one on
+// disk, and some live in repos a deployment mounts READ-ONLY — rejecting a
+// carried self-ref would make those uneditable by anyone who can reach them,
+// bricking records nobody can repair in order to forbid a state that no longer
+// has a producer. They are inert on read (localEvidenceRefs drops the
+// self-path; the recursive walks absorb it as a back-edge), so letting an edit
+// through costs nothing.
+//
+// The NEW-ref rejection above is what actually closes the hole; this is the
+// bound on its blast radius.
+func TestApply_CarriedSelfReferenceIsGrandfathered(t *testing.T) {
+	g := New(gateRepoID, func(context.Context, string) (bool, error) {
+		return true, nil
+	})
+	prior := []string{"kb/self.md"}
+	if _, _, err := g.Apply(context.Background(), "kb/self.md", []string{"kb/self.md"}, prior); err != nil {
+		t.Fatalf("a carried self-citation must be let through so legacy facts stay editable, got %v", err)
+	}
+}
+
+// The grandfathering is matched on the CLASSIFIED path, so a fact whose stored
+// self-ref is canonical stays editable when the caller resends it bare (or the
+// other way round) — the two spellings are one edge, and both occur on disk.
+func TestApply_CarriedSelfReferenceGrandfatheredAcrossForms(t *testing.T) {
+	g := New(gateRepoID, func(context.Context, string) (bool, error) {
+		return true, nil
+	})
+	canon := fact.QualifyKBPath(gateRepoID, "kb/self.md")
+	if _, _, err := g.Apply(context.Background(), "kb/self.md", []string{"kb/self.md"}, []string{canon}); err != nil {
+		t.Fatalf("a carried canonical self-ref resent bare must be let through, got %v", err)
+	}
+}
+
+// Refs to OTHER facts are untouched by the self-check — including a retired
+// predecessor at a DIFFERENT path, which is genuine lineage. This is the
+// boundary #132 draws: reject a ref equal to the fact's OWN path, keep
+// everything else.
+func TestApply_RefToAnotherFactIsNotSelfReference(t *testing.T) {
+	g := New(gateRepoID, func(_ context.Context, p string) (bool, error) {
+		return p == "kb/other.md", nil
+	})
+	if _, _, err := g.Apply(context.Background(), "kb/self.md", []string{"kb/other.md"}, nil); err != nil {
+		t.Fatalf("citing a different fact must be allowed, got %v", err)
 	}
 }

--- a/internal/store/methodology.go
+++ b/internal/store/methodology.go
@@ -74,12 +74,29 @@ func (mm *methodologyMatcher) RelevantMethodologyForFact(
 	}
 
 	// Load methodology candidate set visible on this branch.
+	//
+	// The source fact is EXCLUDED from its own candidate set (#132). A source
+	// fact may itself be a methodology fact — that is not a corner case but the
+	// observed one: a distill cluster whose input facts include a methodology
+	// fact retrieved kb/meta/reasoning/substrate-layer-dominance.md at 0.90 as
+	// guidance for synthesizing that very fact. The score is genuine, because a
+	// fact matches itself perfectly, and that is exactly what makes it
+	// worthless: a perfect methodology score is a self-membership red flag, not
+	// a strong recommendation, and here it cleared the 0.50 mandatory-read
+	// threshold on nothing but its own identity.
+	//
+	// Excluded HERE, in the candidate set, rather than filtered from the
+	// results: this query is the single authoritative definition of what is
+	// being scored, so a later filter would leave the self-match to consume a
+	// top-k slot before being dropped. The KNN query below is deliberately left
+	// alone — it only populates similarity scores keyed by fact id, and an
+	// entry for a fact absent from cands is never read.
 	rows, err := conn(ctx, mm.rh.db).QueryContext(ctx, `
 		SELECT f.path, f.title, f.id, f.blob_hash, f.domain, f.entities
 		FROM facts f
 		JOIN branch_facts bf ON bf.fact_id = f.id AND bf.branch_id = ?
-		WHERE f.type = 'methodology'
-	`, branchID)
+		WHERE f.type = 'methodology' AND f.path <> ?
+	`, branchID, factPath)
 	if err != nil {
 		return nil, fmt.Errorf("RelevantMethodologyForFact: query candidates: %w", err)
 	}

--- a/internal/store/methodology_test.go
+++ b/internal/store/methodology_test.go
@@ -627,3 +627,84 @@ func TestRelevantMethodologyForFact_VectorCoverage_WithNoiseInIndex(t *testing.T
 			"methodology candidate %s has VectorScore=0 — KNN window did not cover it", m.Path)
 	}
 }
+
+// TestRelevantMethodologyForFact_ExcludesTheSourceFactItself pins #132(b)(2):
+// a candidate scored against a set must not BE a member of that set.
+//
+// Live exhibit (core drain s213): the methodology retriever returned
+// kb/meta/reasoning/substrate-layer-dominance.md at 0.90 for a distill item
+// where that fact was itself one of the cluster's input facts — a self-match
+// pushing it past the 0.50 mandatory-read threshold. The score is genuine (a
+// fact matches itself perfectly) and meaningless: the prompt then tells the
+// judge to read, as guidance for synthesizing a fact, that very fact.
+//
+// A source fact can be a methodology fact — that is exactly the live case —
+// so the candidate query has to exclude the source path rather than relying on
+// the type filter to separate them.
+//
+// ANTI-VACUITY: assertion 1 is the control and it is what makes assertion 2
+// mean anything. If self were absent merely because it never entered the
+// candidate pool — wrong type, wrong branch, below threshold — assertion 2
+// would pass under any implementation, including one with no exclusion at all.
+// Assertion 1 proves self IS retrievable, with a high score, from a DIFFERENT
+// source on the same branch. Only then does its absence in assertion 2 pin the
+// exclusion.
+func TestRelevantMethodologyForFact_ExcludesTheSourceFactItself(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	defer svc.Close()
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/a"))
+	svc.SetEmbedder(&stub768Embedder{})
+
+	ctx := context.Background()
+	branch := "agent/a"
+
+	// Two methodology facts sharing tags, so each is a strong candidate for
+	// the other and neither is filtered out by tag overlap.
+	const selfPath = "kb/meta/reasoning/self.md"
+	const otherPath = "kb/meta/reasoning/other.md"
+	doms := []string{"meta", "reasoning", "methodology"}
+	ents := []string{"Anthropic"}
+
+	_, err = svc.Facts().WriteFact(ctx, branch, selfPath,
+		methFactBody("Self", "a lesson about layers", doms, ents), "add self", "")
+	require.NoError(t, err)
+	_, err = svc.Facts().WriteFact(ctx, branch, otherPath,
+		methFactBody("Other", "a lesson about layers", doms, ents), "add other", "")
+	require.NoError(t, err)
+
+	// 1. CONTROL — self is a genuine, high-scoring candidate when the source
+	//    is someone else. Without this the test below proves nothing.
+	fromOther, err := svc.Search().RelevantMethodologyForFact(ctx, branch,
+		otherPath, doms, ents, 10, 0.0)
+	require.NoError(t, err)
+	var selfScore float64
+	var selfSeen bool
+	for _, m := range fromOther {
+		if m.Path == selfPath {
+			selfSeen, selfScore = true, m.Score
+		}
+		require.NotEqual(t, otherPath, m.Path,
+			"the source fact must be excluded from its own candidate set")
+	}
+	require.True(t, selfSeen,
+		"fixture is inert: %s must be retrievable as a candidate for another fact, "+
+			"or its absence below says nothing about self-exclusion", selfPath)
+	require.Greater(t, selfScore, 0.50,
+		"fixture is inert: %s must score above the 0.50 mandatory-read threshold "+
+			"as a candidate, or excluding it changes nothing that mattered", selfPath)
+
+	// 2. THE PROPERTY — asking on behalf of self must not return self, even
+	//    though self is the highest-scoring candidate in the pool.
+	fromSelf, err := svc.Search().RelevantMethodologyForFact(ctx, branch,
+		selfPath, doms, ents, 10, 0.0)
+	require.NoError(t, err)
+	for _, m := range fromSelf {
+		require.NotEqual(t, selfPath, m.Path,
+			"a fact must never be offered as methodology for synthesizing itself "+
+				"(scored %.2f as a member of its own candidate set)", m.Score)
+	}
+	// And the retrieval still works — excluding self must not empty the result.
+	require.NotEmpty(t, fromSelf, "excluding self must not suppress the other candidates")
+}


### PR DESCRIPTION
Closes #132 (code fix — prevention; the legacy-data repair, item 3, is deferred, see below).

Two halves of "self-reference is unchecked across passes":

## Item 2 — a candidate scored against a cluster containing itself
`RelevantMethodologyForFact` (`internal/store/methodology.go`) now excludes the source fact (`AND f.path <> ?`), so a fact can no longer self-match at 0.90 past the 0.50 mandatory-read threshold. All three retrieval callers funnel through this one query.

## Items 1 — self-refs removed at the source (designer G4 ruling: remove, don't tolerate)
The dedup-merge produced self-refs; since the retarget PRESERVES the fact's path, git history already carries the lineage, so the appended self-ref was redundant. TWO producers, both handled (the second found only by running the suite): (a) the explicit append of the own-path, removed; (b) the union CONVERTING a legitimate "B cites A" into "A cites A" when B retargets onto A — now filtered against the merged path (`mergeFacts` keeps `localRepoID` to classify bare-vs-canonical refs correctly). Plus a defence-in-depth write-gate rejection with a **grandfather rule**: a NEWLY-added self-ref is rejected, a CARRIED one (in `prior`) is let through — which keeps 6 legacy self-ref facts (in a read-only mount) editable and keeps discover-reinforce working on them.

## Deferred — item 3 (data repair)
The 6 already-stored self-ref facts live in the `core` repo, which every campaign session mounts read-only; they cannot be repaired from here. They are harmless (weight already excludes them on read; the grandfather rule keeps them editable). Tracked as a deferred cleanup for when a `core`-writable session is available.

## Verification
Both producers sabotage-proven RED; the grandfather + gate placement load-bearing (self-check before the in-batch skip); the #151 reinforce interaction pinned both ways; item 2's exclusion has an anti-vacuity control. No `internal/synthesize` edits (MN5 not in play), MN13 clean. Cold-reviewed independently: MERGE-READY, no findings; merge result green against current dev.