### PR TITLE
Manager.Close drains in-flight detached creates (CI flake + #67 follow-up)

### DIFF
--- a/internal/repos/create_job.go
+++ b/internal/repos/create_job.go
@@ -26,6 +26,21 @@ import (
 // legitimately slow but progressing create.
 const DefaultCreateTimeout = 30 * time.Minute
 
+// createDrainTimeout bounds how long Close waits for in-flight creates AFTER
+// cancelling them.
+//
+// CLASSIFICATION (MN13): an OPERATIONAL BOUND, not a corpus property. It is a
+// backstop on shutdown latency, not a measure of anything. The cancel above is
+// what makes the wait short in the normal case — a create notices at its next
+// step boundary — so this only fires when a create is wedged inside work that
+// does not observe cancellation, and there the right answer is to stop waiting
+// and let the process exit rather than hang shutdown forever.
+//
+// The cost of it firing is the hazard it exists to prevent, so it is generous
+// rather than tight: a create that outlives it may still touch a closing
+// handle, which is exactly the use-after-close being fixed.
+const createDrainTimeout = 30 * time.Second
+
 // CreateJobTTL is how long a FINISHED job stays readable before it is reaped.
 //
 // CLASSIFICATION (MN13): an OPERATIONAL BOUND on retention, not a corpus
@@ -275,10 +290,18 @@ func (m *Manager) StartCreate(spec CreateSpec) *CreateJob {
 
 	timeout := m.createTimeout()
 
+	// Registered with the drain BEFORE the goroutine starts. Adding inside the
+	// goroutine would race Close: a create could be started and not yet counted
+	// when Close reads the waitgroup, which is the very gap this closes.
+	m.createWg.Add(1)
+
 	go func() {
-		// Parented to the manager, never to a request; cancelled on the way
-		// out so the timer is released rather than left to fire.
-		ctx, cancel := context.WithTimeout(m.ctx, timeout)
+		defer m.createWg.Done()
+		// Parented to createsCtx, not m.ctx: same lifetime, plus a cancel that
+		// Close owns, so shutdown can wind an in-flight create down instead of
+		// waiting out its full deadline. Cancelled on the way out either way so
+		// the timer is released rather than left to fire.
+		ctx, cancel := context.WithTimeout(m.createsCtx, timeout)
 		defer cancel()
 
 		ri, err := m.Create(ctx, spec, j.record)
@@ -301,4 +324,29 @@ func (m *Manager) StartCreate(spec CreateSpec) *CreateJob {
 	}()
 
 	return j
+}
+
+// drainCreates cancels every in-flight detached create and waits for them,
+// bounded by createDrainTimeout. Called by Close BEFORE the control.db handles
+// are released, so a create still unwinding can complete its own rollback
+// against an open database.
+//
+// Reports whether the drain completed. A false return means at least one create
+// is still running and shutdown proceeded anyway — the caller logs it, because
+// the alternative is hanging forever on work that is not observing its context.
+func (m *Manager) drainCreates() bool {
+	if m.createsCancel != nil {
+		m.createsCancel()
+	}
+	done := make(chan struct{})
+	go func() {
+		m.createWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(createDrainTimeout):
+		return false
+	}
 }

--- a/internal/repos/create_job_test.go
+++ b/internal/repos/create_job_test.go
@@ -172,3 +172,101 @@ func TestStartCreate_JobDeadlineDoesNotPinTheIndexAtIndexing(t *testing.T) {
 	}, 30*time.Second, 50*time.Millisecond,
 		"the detached create's cancelled context must not stop the background index heal")
 }
+
+// TestManagerClose_DrainsInFlightCreate is the third instance of an invariant
+// Close already enforces twice: drain in-flight background work BEFORE touching
+// the handles it uses.
+//
+// TestManagerClose_WaitsForBackgroundIndex pinned it for the index heal (PR #82
+// review finding #1 — "Manager.Close ran svc.Close() while the heal was still
+// issuing SQL on the same *sql.DB — a use-after-close"), and
+// TestClose_WaitsForInFlightAcquire pins it for an outstanding Acquire. #67
+// introduced a THIRD background worker — the detached create — and never
+// registered it with the drain. The create runs on m.ctx, which Close neither
+// cancels nor waits for, so it keeps issuing SQL against a control.db that
+// Close has already closed (observed: "registry: sql: database is closed") and
+// keeps writing files into a directory the caller is about to remove. That is
+// the CI flake this fixes, and the Manager.Close edge deferred from #67.
+//
+// Close CANCELS before waiting rather than waiting the create out: a create is
+// bounded by CreateTimeout, and blocking shutdown for half an hour is the wrong
+// shutdown semantics. Cancelling makes the wait short AND makes the rollback
+// complete, because the create unwinds through its own boundary checks and
+// cleanup() while control.db is still open.
+// CLONE MODE IS THE FIXTURE so the create is slow enough to still be running
+// when Close arrives; the anti-vacuity assertion below checks that directly.
+//
+// WHAT MADE THIS TEST DETERMINISTIC WAS THE ASSERTION, NOT THE FIXTURE, and the
+// history is worth keeping because the obvious version does not work. The first
+// form asked a TIMING question — "was the job done when Close returned?" — and
+// measured, with the drain removed, 27/30 red on preset and 28/30 on a
+// one-fact clone. Scaling the remote to 200 facts did NOT help (20/30): the
+// margin was never the problem.
+//
+// The reason is that Close BREAKING the create is what makes the create finish
+// quickly, so the symptom partially masks itself — the timing check missed
+// precisely the runs where teardown won hardest. Asking about the create's
+// OUTCOME instead is 30/30 red without the drain and 0/20 with it, on the
+// CHEAPEST fixture. The 200-fact remote was built, measured, and thrown away.
+func TestManagerClose_DrainsInFlightCreate(t *testing.T) {
+	root := t.TempDir()
+	m := New(context.Background(), Deps{
+		Cfg:         config.Config{Home: t.TempDir(), LocalOriginRoot: root},
+		AgentBranch: "machine/test",
+		Embedder:    testEmbedder{},
+	})
+	require.NoError(t, m.Start())
+	url := seedBareRemoteWithFact(t, filepath.Join(root, "remote.git"))
+
+	job := m.StartCreate(CreateSpec{Name: "cloned", Mode: "clone",
+		Origin: &OriginSpec{URL: url, Branch: "main"}})
+
+	// ANTI-VACUITY. The test says something only if the create is STILL RUNNING
+	// when Close is called — if it had already finished, Close would have
+	// nothing to drain and would pass with no drain implemented at all.
+	require.Equal(t, CreateRunning, job.Status().State,
+		"the create must still be in flight when Close is called, or this test "+
+			"cannot detect whether Close drains it")
+
+	require.NoError(t, m.Close())
+
+	// THE PRIMARY PROPERTY, and it is about the create's OUTCOME rather than
+	// about timing: Close must not DESTROY an in-flight create. Measured, with
+	// the drain removed, the create is killed 12 times out of 12 — in two
+	// flavours, roughly evenly split:
+	//
+	//   "repo manager is not running"      (Close nilled the handles first)
+	//   "registry: sql: database is closed" (Close closed control.db under it)
+	//
+	// With the drain, 10 out of 10 report `context canceled` — a create that
+	// was asked to stop and stopped, which is the whole difference between an
+	// orderly shutdown and a use-after-close.
+	//
+	// This assertion replaced a timing one ("was the job done when Close
+	// returned?"), which looked reasonable and was only ~65% reliable. The
+	// reason is worth keeping: Close BREAKING the create is what makes the
+	// create finish quickly, so the symptom partially masks itself and the
+	// timing check missed exactly the runs where teardown won the race hardest.
+	_, cerr := job.Result()
+	if cerr != nil {
+		require.NotErrorIs(t, cerr, ErrManagerStopped,
+			"Close nilled the control handles while a create was still running")
+		require.NotContains(t, cerr.Error(), "database is closed",
+			"Close closed control.db while a create was still issuing SQL on it — "+
+				"the use-after-close this drain exists to prevent")
+	}
+
+	// SECONDARY, and strictly true whenever the drain is present: Close did not
+	// return until the create was terminal. Checked without blocking, because a
+	// receive that had to wait would be this test doing the draining Close is
+	// supposed to have done. Weaker than the outcome check above (it catches
+	// only about half the unfixed runs), kept because it can never fail while
+	// the drain is working.
+	select {
+	case <-job.Done():
+	default:
+		t.Fatal("Close returned while a detached create was still in flight")
+	}
+	require.NotEqual(t, CreateRunning, job.Status().State,
+		"a drained create must be terminal, not merely unobserved")
+}

--- a/internal/repos/manager.go
+++ b/internal/repos/manager.go
@@ -108,6 +108,23 @@ type Manager struct {
 	// job outlives the name reservation inflightMu guards.
 	createJobsMu sync.Mutex
 	createJobs   map[string]*CreateJob
+
+	// createsCtx/createsCancel/createWg own the DETACHED CREATE lifecycle, the
+	// third piece of background work Close must drain before it touches the
+	// handles that work uses — after the index heal (indexWg) and the reconcile
+	// loop (syncWg), and for the same reason: a create still running when
+	// control.db closes issues SQL on a closed *sql.DB and keeps writing into a
+	// directory the caller is now free to delete.
+	//
+	// SEPARATE from m.ctx, which Close cannot cancel because it belongs to
+	// whoever called New. Close cancels createsCancel and then waits createWg,
+	// so shutdown does not have to sit out a create's full CreateTimeout — and
+	// the cancelled create unwinds through its own step-boundary checks and
+	// cleanup() while control.db is STILL OPEN, which is what lets the rollback
+	// actually complete instead of logging "registry row not removed".
+	createsCtx    context.Context
+	createsCancel context.CancelFunc
+	createWg      sync.WaitGroup
 }
 
 // ResolveAuth resolves a transport.AuthMethod for the given config and remote
@@ -132,7 +149,10 @@ func (m *Manager) ResolveAuth(cfg config.RemoteAuthConfig, url string) (transpor
 
 // New returns an uninitialised Manager. Call Boot to open repos.
 func New(ctx context.Context, deps Deps) *Manager {
+	createsCtx, createsCancel := context.WithCancel(ctx)
 	return &Manager{
+		createsCtx:      createsCtx,
+		createsCancel:   createsCancel,
 		repos:           make(map[string]*RepoInstance),
 		byUID:           make(map[string]*RepoInstance),
 		unavailable:     make(map[string]Unavailable),
@@ -490,6 +510,23 @@ func (m *Manager) Close() error {
 	if m.sessionReaperStop != nil {
 		m.sessionReaperStop()
 		m.sessionReaperStop = nil
+	}
+
+	// Drain detached creates FIRST — before the control.db handles below are
+	// nilled and closed. This is the same invariant the indexWg/syncWg waits in
+	// pass 2 enforce for the index heal and the reconcile loop (see
+	// TestManagerClose_WaitsForBackgroundIndex, PR #82 review finding #1): no
+	// in-flight background SQL may race the handle closing. A detached create
+	// (#67) is the third such worker and was not registered with the drain,
+	// which is how it kept issuing SQL on a closed control.db and writing into
+	// a directory the caller was already deleting.
+	//
+	// It runs BEFORE the handles are released rather than beside pass 2 for a
+	// second reason: a cancelled create rolls itself back, and that rollback
+	// deletes a registry row. It needs the registry still open to do it.
+	if !m.drainCreates() {
+		log.Error().Dur("timeout", createDrainTimeout).
+			Msg("close: in-flight repo create did not finish after cancellation; closing anyway")
 	}
 
 	m.mu.Lock()


### PR DESCRIPTION
Fixes the dev-CI teardown flake (`TestPostRepos_BodyUnderTheCapIsNotRejectedAsOversize` on the macOS runner: `TempDir RemoveAll: directory not empty` + a nil deref at teardown) and resolves the deferred "create-in-flight during `Manager.Close`" edge from #67.

## What
#67 added a third background worker — the detached create from `StartCreate` — but `Manager.Close` was never taught to drain it, so a create running at Close kept issuing SQL against nilled/closed handles and wrote files into a `t.TempDir()` being `RemoveAll`'d. This COMPLETES an existing, tested invariant: `Close` already drains the index-heal and acquire workers (waits `indexWg`/`syncWg`, PR #82) before releasing handles.

`Close` now CANCELS in-flight detached creates (a manager-owned `createsCtx` derived from `m.ctx`, never a request) and bounded-waits (`createDrainTimeout` = 30s, an operational bound) BEFORE the control handles are released — so a cancelled create unwinds through its own `cleanup()` against an OPEN registry and actually completes its rollback instead of logging "registry row not removed". `createsCancel` cancels only `createsCtx`, not `m.ctx`, so it cannot cancel an in-flight index heal (no `clone-create-index-stuck-indexing` regression).

## Verification
Cold-reviewed independently: MERGE-READY, no findings. The pre-existing builder race (a SEPARATE ownership bug, being fixed on its own branch) was confirmed present on both this branch and base at equal rate — this fix neither causes nor worsens it. The outcome-based drain test is 20/20 deterministic (RED without the drain, GREEN with); the timing-based version it replaced was 10-35% inert because Close breaking the create is what makes the create finish fast — the symptom masked itself. MN13 clean; no `internal/synthesize`; `internal/web` untouched (the flaky test needs no change — the tell this is the root fix).