### PR TITLE
Prune-then-distill progression: distill only what prune certified distinct (#135)

### DIFF
--- a/internal/synthesize/progression.go
+++ b/internal/synthesize/progression.go
@@ -1,0 +1,224 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"knomit/internal/store"
+)
+
+// Prune-then-distill progression (knomit#135).
+//
+// THE DEFECT. Distill items were planned ALONGSIDE prune at session start, so
+// every cluster was reasoned over twice in one session: once to decide whether
+// its facts overlap, and again to synthesize upward from them as though they
+// did not. When the prune verdict MERGED two facts, the distill item still held
+// the pre-merge grouping — which is how synthesis fabricated corroboration out
+// of one claim that had been recorded twice. Two facts saying the same thing
+// look like two independent sources to anything that does not know they were
+// just merged.
+//
+// THE FIX is an ordering, not a filter: every cluster goes to PRUNE first, and
+// its distill item exists only if the prune verdict earns it. The prune verdict
+// is a FREE CLASSIFIER, and that is the whole idea —
+//
+//   - acted on (merge / retract / update) → the facts overlapped. The cluster
+//     STOPS this session. The action dirties the changed facts, so survivors
+//     and merge outputs re-seed through the watermark and are re-clustered next
+//     session, on settled material.
+//   - all KEEP → the judge certified them distinct. That is synthesis's
+//     legitimate input, and it is promoted IN THE SAME SESSION.
+//
+// SAME-SESSION IS LOAD-BEARING. "Plan distill next session for KEEPed clusters"
+// silently never fires: an all-KEEP verdict changes nothing, so nothing is
+// dirty, so the watermark never re-seeds those facts and the promotion is a
+// promise the pipeline cannot keep.
+//
+// NO NEW MACHINERY. Enqueue-after-answer already exists and already ships:
+// Strategy.Apply runs after the claim CAS is won, NextPipelineWorkItem filters
+// on neither step type nor phase, and handlePhase advances only once the queue
+// returns nil — so an item inserted here is served before the session
+// completes. enqueueRaptorFollowups has been doing exactly this from the
+// distill arm since RAPTOR landed. No dependency column, no schema change, no
+// stored cursor.
+//
+// ORDERING IS FREE TOO. Prune items carry priority = cluster size (positive),
+// distill items carry 0.0, and the queue is `priority DESC`. A promoted item
+// therefore lands behind every prune item still queued, which is exactly the
+// "every cluster goes to prune first" the ruling asks for — no sequencing code.
+
+// promotedDistillKeyPrefix marks a distill item that a prune verdict promoted,
+// so the queue census can tell a promoted item from a planned one.
+const promotedDistillKeyPrefix = "distill-promoted-"
+
+// pruneVerdictCertifiesDistinct reports whether a prune answer is the explicit,
+// complete all-KEEP that earns promotion.
+//
+// FOUR CONDITIONS, and every one of them is load-bearing:
+//
+//  1. No merges. A merge is the judge saying these facts overlap.
+//  2. At least one decision. `{"decisions":[],"merges":[]}` is a NON-ANSWER,
+//     not an all-KEEP — promoting on it would manufacture synthesis work out of
+//     silence, which is this area's standing rule (absence must be STATED,
+//     never inferred) turned on its own promotion signal. It is also exactly
+//     what the EffortNormal regression fixture answers prune with, so reading
+//     empty as all-KEEP would make that fixture start producing distill items.
+//  3. Every decision is `keep`. `retract` and `update` both ACT: each rewrites
+//     or removes a fact, producing a new content-addressed row. The ruling
+//     names merge/retract, and `update` is included here because the ruling's
+//     own rationale — "the action dirties the changed facts, so they re-seed
+//     via the watermark" — covers it identically. Distilling over a fact that
+//     just changed underneath is the thing that rationale forbids.
+//  4. The decisions COVER every fact in the item. validatePrunePaths accepts a
+//     PARTIAL decision list — it checks that decisions reference known paths,
+//     not that known paths have decisions — so "all the decisions were keep" is
+//     satisfied by a judge that classified one fact out of five. Partial
+//     coverage is silence for the rest, which is condition 2 again at a
+//     different granularity.
+func pruneVerdictCertifiesDistinct(result PruneResult, inputPaths []string) bool {
+	if len(result.Merges) > 0 || len(result.Decisions) == 0 {
+		return false
+	}
+	decided := make(map[string]bool, len(result.Decisions))
+	for _, d := range result.Decisions {
+		if d.Action != "keep" {
+			return false
+		}
+		decided[d.Path] = true
+	}
+	for _, p := range inputPaths {
+		if !decided[p] {
+			return false
+		}
+	}
+	return true
+}
+
+// promotesToDistill reports whether this prune item is the CLUSTER-shaped kind
+// whose all-KEEP means "this group is worth synthesizing over".
+//
+// Shortlist items are excluded, and the distinction is a real one rather than
+// bookkeeping. A `restate-N` item is a two-fact cross-cluster PAIR: its
+// all-KEEP means "these two restatements are distinct", which is a judgement
+// about redundancy between two specific facts and NOT the claim that some
+// group is a coherent subject worth synthesizing upward from. Promoting one
+// would hand distill a pair the clusterer never grouped.
+func promotesToDistill(item *store.PipelineWorkItem) bool {
+	return item != nil &&
+		item.StepType == "prune" &&
+		!strings.HasPrefix(item.ClusterKey, restatementClusterKeyPrefix)
+}
+
+// promoteClusterToDistill enqueues the distill item a certified-distinct prune
+// cluster has earned, and reports what it did.
+//
+// THE PAYLOAD IS THE PRUNE ITEM'S OWN FACTS, and that is forced rather than
+// chosen. The plan-time distill grouping is seeds-only, but the seed set is a
+// plan-time value that no longer exists by the time Apply runs — and the only
+// session-scoped persistence is pipeline_work_items, which has no spare column
+// and no "blocked" flag (an unanswered row is servable by definition). So the
+// seeds-only payload cannot be reconstructed here without the schema change
+// this fix exists without. Two consequences, both deliberate and both reported
+// in the health line rather than left for an auditor to discover:
+//
+//   - Promoted payloads are WHOLE-CLUSTER: they include neighbours the seed
+//     scan never returned, and (post knomit#149) any cousin the cross-category
+//     sweep attached. Plan-time distill groups were seeds-only.
+//   - The population WIDENS slightly. A cluster with one seed and two pulled-in
+//     neighbours is a prune item today but was never a distill group; it now
+//     becomes one if the judge certifies it. This does not reintroduce the
+//     redundancy #135 removes — that was distill firing on prune-ACTED,
+//     overlapping clusters, which promotion-gating blocks outright.
+//
+// Every failure is logged and swallowed. The prune decisions are already
+// committed by the time this runs, so returning an error here would report a
+// failure for work that succeeded; losing a promotion costs one round of
+// synthesis, not correctness. That is enqueueRaptorFollowups' own contract, for
+// the same reason.
+func promoteClusterToDistill(
+	ctx context.Context,
+	d Deps,
+	sess *store.PipelineSession,
+	item *store.PipelineWorkItem,
+) {
+	var facts []factForLLM
+	if err := json.Unmarshal([]byte(item.FactsJSON), &facts); err != nil {
+		log.Warn().Err(err).Str("session", sess.ID).Str("cluster", item.ClusterKey).
+			Msg("review: certified-distinct cluster could not be decoded for promotion")
+		return
+	}
+	// One fact is not a group — there is no pattern to find across a single
+	// fact, which is the same floor distillGroups applies at plan time.
+	if len(facts) < 2 {
+		return
+	}
+
+	enqueued := 0
+	for ci, chunk := range chunkFacts(facts, maxItemBytes) {
+		payload, err := json.Marshal(chunk)
+		if err != nil {
+			log.Warn().Err(err).Str("session", sess.ID).Str("cluster", item.ClusterKey).
+				Msg("review: promoted distill chunk could not be marshalled")
+			continue
+		}
+		// Depth 0: this is a FIRST-round distill over corpus facts, not a
+		// RAPTOR follow-up over synthesis output. Handing it a deeper depth
+		// would spend the recursion budget the follow-ups need.
+		//
+		// Priority 0.0 matches every other depth-0 distill item, which is what
+		// puts it behind the prune items still queued.
+		if err := d.Pipeline.InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+			SessionID:  sess.ID,
+			StepType:   "distill",
+			ClusterKey: fmt.Sprintf("%s%s-%d", promotedDistillKeyPrefix, item.ClusterKey, ci),
+			FactsJSON:  string(payload),
+			Priority:   0.0,
+		}); err != nil {
+			log.Warn().Err(err).Str("session", sess.ID).Str("cluster", item.ClusterKey).
+				Msg("review: promoted distill item could not be enqueued")
+			continue
+		}
+		enqueued++
+	}
+	if enqueued == 0 {
+		return
+	}
+	sess.Health = append(sess.Health, fmt.Sprintf(
+		"prune→distill: %s came back all-KEEP, so the judge certified its %d facts "+
+			"distinct and %d distill item(s) were promoted for THIS session. The "+
+			"promoted payload is the WHOLE CLUSTER — it carries neighbours the seed "+
+			"scan did not return, and any cross-category cousin attached to it, "+
+			"which plan-time distill groups did not.",
+		item.ClusterKey, len(facts), enqueued))
+}
+
+// recordProgressionStop states that a cluster was NOT promoted, and why.
+//
+// Absence of work must be STATED, never inferred — the rule this area keeps
+// re-learning. Without this line a cluster that stopped because its judge acted
+// on it is indistinguishable from a cluster the progression forgot, and the
+// whole point of #135 is that distill NOT running is now a designed outcome
+// rather than an omission.
+func recordProgressionStop(sess *store.PipelineSession, item *store.PipelineWorkItem, stats *ReviewStats) {
+	if sess == nil || item == nil {
+		return
+	}
+	if stats != nil && (stats.Merged > 0 || stats.Pruned > 0 || stats.Updated > 0) {
+		sess.Health = append(sess.Health, fmt.Sprintf(
+			"prune→distill: %s was ACTED on (%d merged, %d retracted, %d updated), so it "+
+				"stops here this session. The changed facts are now dirty and re-seed "+
+				"through the watermark, so this cluster is re-clustered and considered "+
+				"for synthesis NEXT session, on settled material.",
+			item.ClusterKey, stats.Merged, stats.Pruned, stats.Updated))
+		return
+	}
+	sess.Health = append(sess.Health, fmt.Sprintf(
+		"prune→distill: %s was not promoted. The verdict was neither a complete "+
+			"all-KEEP nor an action — an empty or PARTIAL decision list leaves part of "+
+			"the cluster unclassified, and synthesis is not planned on silence.",
+		item.ClusterKey))
+}

--- a/internal/synthesize/progression_test.go
+++ b/internal/synthesize/progression_test.go
@@ -1,0 +1,468 @@
+package synthesize
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/fact"
+	"knomit/internal/store"
+)
+
+// The prune→distill progression (knomit#135).
+//
+// Distill used to be planned ALONGSIDE prune at session start, so a cluster was
+// reasoned over twice in one session — and a cluster whose prune verdict MERGED
+// two facts was still distilled from the pre-merge grouping, which is how
+// synthesis fabricated corroboration out of one claim recorded twice.
+
+func pruneItem(clusterKey string, paths ...string) *store.PipelineWorkItem {
+	facts := make([]factForLLM, 0, len(paths))
+	for _, p := range paths {
+		facts = append(facts, factForLLM{File: p, Title: "t " + p, Body: "b " + p, Type: "observation"})
+	}
+	payload, err := json.Marshal(facts)
+	if err != nil {
+		panic(err)
+	}
+	return &store.PipelineWorkItem{
+		StepType: "prune", ClusterKey: clusterKey, FactsJSON: string(payload),
+	}
+}
+
+func keeps(paths ...string) PruneResult {
+	d := make([]PruneDecision, 0, len(paths))
+	for _, p := range paths {
+		d = append(d, PruneDecision{Path: p, Action: "keep"})
+	}
+	return PruneResult{Decisions: d}
+}
+
+// TestProgression_ExplicitCompleteAllKeepCertifies is the promotion signal.
+func TestProgression_ExplicitCompleteAllKeepCertifies(t *testing.T) {
+	paths := []string{"kb/a.md", "kb/b.md", "kb/c.md"}
+	require.True(t, pruneVerdictCertifiesDistinct(keeps(paths...), paths),
+		"an explicit keep for every fact in the item is the judge certifying the "+
+			"cluster distinct — synthesis's legitimate input")
+}
+
+// TestProgression_EmptyDecisionsIsNotAllKeep is the one that protects MN5.
+//
+// `{"decisions":[],"merges":[]}` is a NON-ANSWER, not an all-KEEP. Promoting on
+// it manufactures synthesis work out of silence — and it is exactly what the
+// EffortNormal regression fixture answers prune with, so reading empty as
+// all-KEEP would make that fixture start producing distill items.
+func TestProgression_EmptyDecisionsIsNotAllKeep(t *testing.T) {
+	paths := []string{"kb/a.md", "kb/b.md"}
+	require.False(t, pruneVerdictCertifiesDistinct(PruneResult{}, paths),
+		"an empty decision list is silence, and synthesis is never planned on silence")
+	require.False(t, pruneVerdictCertifiesDistinct(PruneResult{Decisions: []PruneDecision{}}, paths),
+		"an explicitly empty list is the same non-answer as a missing one")
+
+	// AND with no input paths either. This is the case that separates the
+	// explicit empty-decisions guard from the coverage loop below it: with a
+	// non-empty item the coverage loop already rejects an empty answer, so
+	// deleting the guard leaves every other assertion here green (sabotage S2).
+	// Only a zero-fact item tells the two apart — both loops run zero times, and
+	// without the guard the predicate returns TRUE, certifying nothing at all as
+	// distinct.
+	//
+	// The downstream `len(facts) < 2` check in promoteClusterToDistill means
+	// that would not actually enqueue anything today. The guard stays anyway:
+	// a predicate that is correct only because of what its caller happens to do
+	// next is a trap for the next caller.
+	require.False(t, pruneVerdictCertifiesDistinct(PruneResult{}, nil),
+		"a verdict over NO facts certifies nothing — vacuous truth is not a "+
+			"judge's classification")
+}
+
+// TestProgression_PartialCoverageIsNotAllKeep — validatePrunePaths accepts a
+// PARTIAL decision list (it checks that decisions name known paths, never that
+// known paths have decisions), so "every decision was keep" is satisfied by a
+// judge that classified one fact out of three. Partial coverage is silence for
+// the rest.
+func TestProgression_PartialCoverageIsNotAllKeep(t *testing.T) {
+	paths := []string{"kb/a.md", "kb/b.md", "kb/c.md"}
+	partial := keeps("kb/a.md", "kb/b.md")
+
+	// Fixture assertion: the partial answer is genuinely VALID input, or this
+	// test is asserting against something the pipeline would have rejected
+	// upstream and the coverage check is being credited for the validator's work.
+	require.NoError(t, validatePrunePaths(partial, paths),
+		"fixture must be a verdict the validator ACCEPTS, or the coverage check "+
+			"under test is unreachable in production")
+
+	require.False(t, pruneVerdictCertifiesDistinct(partial, paths),
+		"a cluster with an unclassified fact has not been certified distinct")
+}
+
+// TestProgression_AnyActionStopsTheCluster — merge, retract and update all ACT.
+// Each produces a new content-addressed row, so the facts re-seed through the
+// watermark and the cluster belongs to NEXT session, on settled material.
+func TestProgression_AnyActionStopsTheCluster(t *testing.T) {
+	paths := []string{"kb/a.md", "kb/b.md"}
+
+	retract := keeps(paths...)
+	retract.Decisions[1].Action = "retract"
+	require.False(t, pruneVerdictCertifiesDistinct(retract, paths),
+		"a retract removes a fact; the cluster stops here")
+
+	update := keeps(paths...)
+	update.Decisions[1].Action = "update"
+	require.False(t, pruneVerdictCertifiesDistinct(update, paths),
+		"an UPDATE rewrites a fact into a new row, so it dirties exactly as a "+
+			"retract does — distilling over a fact that just changed underneath is "+
+			"what the progression exists to prevent")
+
+	merged := keeps(paths...)
+	merged.Merges = []MergeEntry{{Paths: paths}}
+	require.False(t, pruneVerdictCertifiesDistinct(merged, paths),
+		"a merge is the judge saying these facts overlap — the exact case that "+
+			"fabricated corroboration when distill ran anyway")
+}
+
+// TestProgression_ShortlistItemsDoNotPromote — a `restate-N` item is a two-fact
+// cross-cluster PAIR. Its all-KEEP means "these two restatements are distinct",
+// which is a judgement about redundancy between two specific facts, NOT the
+// claim that some group is a coherent subject worth synthesizing upward from.
+func TestProgression_ShortlistItemsDoNotPromote(t *testing.T) {
+	cluster := pruneItem("cluster-3", "kb/a.md", "kb/b.md")
+	require.True(t, promotesToDistill(cluster),
+		"a cluster-shaped prune item is the promotable kind")
+
+	shortlist := pruneItem(restatementClusterKeyPrefix+"0", "kb/a.md", "kb/b.md")
+	require.False(t, promotesToDistill(shortlist),
+		"a shortlist pair's all-KEEP says the two are distinct, not that a group "+
+			"is worth synthesizing")
+
+	// Fixture assertion: the two differ ONLY in cluster key, so the exclusion is
+	// credited to the key and not to some other difference.
+	require.Equal(t, cluster.StepType, shortlist.StepType)
+	require.Equal(t, cluster.FactsJSON, shortlist.FactsJSON)
+}
+
+// TestProgression_NonPruneItemsDoNotPromote — the hook is scoped to the prune
+// arm, but the predicate states it too, so a future caller cannot widen it by
+// accident.
+func TestProgression_NonPruneItemsDoNotPromote(t *testing.T) {
+	require.False(t, promotesToDistill(&store.PipelineWorkItem{StepType: "distill", ClusterKey: "distill-c0"}))
+	require.False(t, promotesToDistill(&store.PipelineWorkItem{StepType: "discover", ClusterKey: "discover-0"}))
+	require.False(t, promotesToDistill(nil))
+}
+
+// TestProgression_RemainderIsPlannedAtSessionStart pins ruling 1, and it is the
+// coverage the naive reading of #135 silently drops.
+//
+// distillGroups' remainder is the seeds that landed in no multi-seed cluster.
+// They never become a prune item, so they have NO verdict to be classified by —
+// gating them on promotion would gate them on nothing. They were never part of
+// the double-reasoning #135 removes: that was distill firing on prune's OWN
+// clusters.
+func TestProgression_RemainderIsPlannedAtSessionStart(t *testing.T) {
+	seeds := []factForLLM{
+		{File: "kb/x/1.md"}, {File: "kb/x/2.md"}, // one clustered pair
+		{File: "kb/lonely.md"}, // in no cluster at all
+	}
+	clusters := [][]factForLLM{{seeds[0], seeds[1]}}
+
+	groups := distillGroups(seeds, clusters)
+
+	var clustered, remainder []distillGroup
+	for _, g := range groups {
+		if g.Remainder {
+			remainder = append(remainder, g)
+		} else {
+			clustered = append(clustered, g)
+		}
+	}
+
+	// Fixture assertion: BOTH kinds must exist, or the split is not being tested.
+	require.Len(t, clustered, 1, "fixture must produce a clustered group")
+	require.Len(t, remainder, 1, "fixture must produce a remainder group")
+
+	require.Equal(t, "kb/lonely.md", remainder[0].Facts[0].File,
+		"the unclustered seed belongs to the remainder, which is NOT promotion-gated "+
+			"— it has no prune verdict to be gated on")
+}
+
+// TestProgression_PromotedKeyIsDistinguishable — a promoted item must be
+// tellable from a planned one in the queue census, or an auditor cannot see the
+// progression working.
+func TestProgression_PromotedKeyIsDistinguishable(t *testing.T) {
+	require.True(t, strings.HasPrefix(promotedDistillKeyPrefix, "distill-"),
+		"a promoted item is still a distill item and should read as one")
+	require.NotEqual(t, "distill-rest", promotedDistillKeyPrefix)
+	require.False(t, strings.HasPrefix("distill-c0", promotedDistillKeyPrefix),
+		"a plan-time clustered key must not be mistaken for a promoted one")
+	require.False(t, strings.HasPrefix("distill-rest", promotedDistillKeyPrefix),
+		"the remainder key must not be mistaken for a promoted one")
+}
+
+// TestProgression_StopIsStatedNotInferred — absence of work must be STATED. A
+// cluster that stopped because its judge acted on it must not be
+// indistinguishable from a cluster the progression forgot.
+func TestProgression_StopIsStatedNotInferred(t *testing.T) {
+	item := pruneItem("cluster-1", "kb/a.md", "kb/b.md")
+
+	acted := &store.PipelineSession{}
+	recordProgressionStop(acted, item, &ReviewStats{Merged: 1})
+	require.Len(t, acted.Health, 1)
+	require.Contains(t, acted.Health[0], "ACTED on")
+	require.Contains(t, acted.Health[0], "NEXT session",
+		"the line must say where the cluster went, not merely that it stopped")
+
+	silent := &store.PipelineSession{}
+	recordProgressionStop(silent, item, &ReviewStats{})
+	require.Len(t, silent.Health, 1)
+	require.Contains(t, silent.Health[0], "not promoted")
+	require.NotContains(t, silent.Health[0], "ACTED on",
+		"an incomplete verdict is a different outcome from an action and must not "+
+			"be reported as one")
+}
+
+// ── the call site ─────────────────────────────────────────────────────────
+//
+// Everything above tests the PREDICATE. A predicate that works proves the
+// predicate works, not that anything calls it — the campaign's standing check
+// #3. These drive the real ContinueSession → Decode → Apply path and read the
+// resulting queue.
+
+// progressionEnv seeds two real facts and puts a prune item in front of the
+// judge, without going through Plan.
+//
+// Deliberately NOT via Plan: at the production Louvain resolution no cluster
+// forms in this harness (the same wall knomit#149 hit), so a Plan-driven
+// fixture would produce no prune item and every assertion below would pass
+// vacuously against an empty queue.
+func progressionEnv(t *testing.T, clusterKey string) (*restatementEnv, *Pipeline, *store.PipelineSession) {
+	t.Helper()
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	env.writeFact("kb/prog/alpha.md", "alpha", "body of alpha")
+	env.writeFact("kb/prog/beta.md", "beta", "body of beta")
+
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
+	require.NoError(t, err)
+
+	facts := []factForLLM{
+		{File: "kb/prog/alpha.md", Title: "alpha", Body: "body of alpha", Type: "observation"},
+		{File: "kb/prog/beta.md", Title: "beta", Body: "body of beta", Type: "observation"},
+	}
+	payload, err := json.Marshal(facts)
+	require.NoError(t, err)
+	require.NoError(t, env.svc.Pipeline().InsertPipelineWorkItem(ctx, store.PipelineWorkItem{
+		SessionID: sess.ID, StepType: "prune", ClusterKey: clusterKey,
+		FactsJSON: string(payload), Priority: 2,
+	}))
+
+	p := NewPipeline(env.ri, func(ProgressEvent) {}, EffortNormal, ScopeFilter{}, reviewStrategy{})
+	return env, p, sess
+}
+
+func promotedItems(t *testing.T, env *restatementEnv, sessionID string) []store.PipelineWorkItem {
+	t.Helper()
+	items, err := env.svc.Pipeline().PendingPipelineWorkItems(context.Background(), sessionID)
+	require.NoError(t, err)
+	var out []store.PipelineWorkItem
+	for _, it := range items {
+		if strings.HasPrefix(it.ClusterKey, promotedDistillKeyPrefix) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+const allKeepAnswer = `{"decisions":[{"path":"kb/prog/alpha.md","action":"keep"},` +
+	`{"path":"kb/prog/beta.md","action":"keep"}],"merges":[]}`
+
+// TestProgression_AllKeepPromotesThroughTheRealApplyPath is the whole fix,
+// end to end.
+func TestProgression_AllKeepPromotesThroughTheRealApplyPath(t *testing.T) {
+	ctx := context.Background()
+	env, p, sess := progressionEnv(t, "cluster-0")
+
+	res, err := p.ContinueSession(ctx, sess.ID, allKeepAnswer)
+	require.NoError(t, err)
+
+	promoted := promotedItems(t, env, sess.ID)
+	require.Len(t, promoted, 1,
+		"an all-KEEP cluster must get its distill item IN THIS SESSION — a "+
+			"'next session' promise never fires, because an all-KEEP dirties "+
+			"nothing and the watermark never re-seeds it")
+	require.Equal(t, "distill", promoted[0].StepType)
+	require.Contains(t, promoted[0].FactsJSON, "kb/prog/alpha.md")
+	require.Contains(t, promoted[0].FactsJSON, "kb/prog/beta.md")
+
+	require.Contains(t, strings.Join(res.Health, "\n"), "came back all-KEEP",
+		"the promotion must ride the turn that produced it")
+	require.Contains(t, strings.Join(res.Health, "\n"), "WHOLE CLUSTER",
+		"the payload widening is a designed consequence and must be legible to "+
+			"an auditor reading distill output, not left to be discovered")
+}
+
+// TestProgression_ActedVerdictPromotesNothing — the acted-on case is the one
+// that fabricated corroboration when distill ran anyway.
+func TestProgression_ActedVerdictPromotesNothing(t *testing.T) {
+	ctx := context.Background()
+	env, p, sess := progressionEnv(t, "cluster-0")
+
+	retract := `{"decisions":[{"path":"kb/prog/alpha.md","action":"keep"},` +
+		`{"path":"kb/prog/beta.md","action":"retract"}],"merges":[]}`
+	res, err := p.ContinueSession(ctx, sess.ID, retract)
+	require.NoError(t, err)
+
+	require.Empty(t, promotedItems(t, env, sess.ID),
+		"an acted-on cluster STOPS this session; its facts are now dirty and it "+
+			"is reconsidered next session on settled material")
+	require.Contains(t, strings.Join(res.Health, "\n"), "ACTED on",
+		"and the stop must be STATED — a cluster that stopped by design must not "+
+			"read the same as one the progression forgot")
+}
+
+// TestProgression_EmptyAnswerPromotesNothingThroughApply is MN5's own answer
+// shape, driven through the real path.
+func TestProgression_EmptyAnswerPromotesNothingThroughApply(t *testing.T) {
+	ctx := context.Background()
+	env, p, sess := progressionEnv(t, "cluster-0")
+
+	res, err := p.ContinueSession(ctx, sess.ID, `{"decisions":[],"merges":[]}`)
+	require.NoError(t, err)
+
+	require.Empty(t, promotedItems(t, env, sess.ID),
+		"an empty decision list is silence, not an all-KEEP — promoting on it "+
+			"would manufacture synthesis work from a non-answer, and would make "+
+			"the EffortNormal fixture start producing distill items")
+	require.Contains(t, strings.Join(res.Health, "\n"), "not promoted")
+}
+
+// TestProgression_ShortlistItemPromotesNothingThroughApply — same all-KEEP
+// answer, same facts, only the cluster key differs.
+func TestProgression_ShortlistItemPromotesNothingThroughApply(t *testing.T) {
+	ctx := context.Background()
+	env, p, sess := progressionEnv(t, restatementClusterKeyPrefix+"0")
+
+	_, err := p.ContinueSession(ctx, sess.ID, allKeepAnswer)
+	require.NoError(t, err)
+
+	require.Empty(t, promotedItems(t, env, sess.ID),
+		"a shortlist pair's all-KEEP means 'these two restatements are distinct', "+
+			"which is not 'this group is worth synthesizing over'")
+}
+
+// ── the plan side, driven through the real Plan ───────────────────────────
+
+// edgeReadFails forces ScopedCluster onto its DOCUMENTED category-grouping
+// fallback, which is the only way to get a real cluster out of this harness.
+//
+// At the production Louvain resolution no community survives
+// filterSmallClusters on a test-sized corpus — measured at 4, 8, 15 and 30
+// tightly-grouped facts, all yielding zero clusters, which is the same wall
+// knomit#149 hit. Without a cluster there is no clustered distill group, so a
+// test of the promotion GATE would pass against a queue that never had a
+// `distill-c*` item to suppress: vacuous, and it stayed green under the
+// sabotage that removed the gate entirely (S1).
+//
+// Failing the edge read is not a contrivance — it is a path ScopedCluster
+// documents and handles, and it groups the subgraph by category directory,
+// which for a single-directory fixture is exactly one cluster.
+type edgeReadFails struct{ SearchQuery }
+
+func (edgeReadFails) SubgraphEdges(context.Context, []string) ([][2]string, error) {
+	return nil, errors.New("test: forced subgraph edge-read failure")
+}
+
+// planFixture seeds n facts in ONE directory and plans a session over them with
+// clustering forced through the fallback.
+func planFixture(t *testing.T, n int) (*restatementEnv, *store.PipelineSession, []store.PipelineWorkItem) {
+	t.Helper()
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	var seeds []fact.Fact
+	for i := range n {
+		path := fmt.Sprintf("kb/topic/f%d.md", i)
+		env.writeFact(path, fmt.Sprintf("note %d", i), "body")
+		r, err := env.svc.Facts().ReadFact(ctx, env.branch, path, nil)
+		require.NoError(t, err)
+		f, err := fact.ParseFact(path, r.Content)
+		require.NoError(t, err)
+		seeds = append(seeds, f)
+	}
+
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
+	require.NoError(t, err)
+	d := env.deps()
+	d.Search = edgeReadFails{env.svc.Search()}
+	require.NoError(t, reviewStrategy{}.Plan(ctx, d, sess, seeds))
+
+	items, err := env.svc.Pipeline().PendingPipelineWorkItems(ctx, sess.ID)
+	require.NoError(t, err)
+	return env, sess, items
+}
+
+func keysWithPrefix(items []store.PipelineWorkItem, prefix string) []string {
+	var out []string
+	for _, it := range items {
+		if strings.HasPrefix(it.ClusterKey, prefix) {
+			out = append(out, it.ClusterKey)
+		}
+	}
+	return out
+}
+
+// TestProgression_PlanDoesNotEnqueueClusteredDistillUpFront is the plan half of
+// #135, driven through the real Plan.
+//
+// The fixture is asserted to produce BOTH a prune item and (before the fix) a
+// clustered distill group, so "no distill-c* in the queue" is a statement about
+// suppression rather than about an empty queue.
+func TestProgression_PlanDoesNotEnqueueClusteredDistillUpFront(t *testing.T) {
+	_, _, items := planFixture(t, 4)
+
+	// Fixture assertion: a cluster REALLY formed, or there was never a
+	// clustered distill group to suppress and this test measures nothing.
+	require.NotEmpty(t, keysWithPrefix(items, "cluster-"),
+		"fixture must produce a prune item, or no cluster formed and the gate "+
+			"under test is unreachable")
+
+	require.Empty(t, keysWithPrefix(items, "distill-c"),
+		"a clustered distill item must NOT be planned at session start — the "+
+			"cluster is reasoned over by prune first, and its distill item exists "+
+			"only if the verdict earns it")
+}
+
+// TestProgression_PlanStillEnqueuesTheRemainder — ruling 1, at the call site.
+// The remainder has no prune item to be gated on, so gating it would be gating
+// it on nothing.
+func TestProgression_PlanStillEnqueuesTheRemainder(t *testing.T) {
+	ctx := context.Background()
+	env := newRestatementEnv(t, 0)
+	// Two facts in one directory (they cluster via the fallback) plus one
+	// filed alone, which the category grouping cannot pair with anything.
+	paths := []string{"kb/topic/a.md", "kb/topic/b.md", "kb/alone/c.md"}
+	var seeds []fact.Fact
+	for _, p := range paths {
+		env.writeFact(p, "note "+p, "body")
+		r, err := env.svc.Facts().ReadFact(ctx, env.branch, p, nil)
+		require.NoError(t, err)
+		f, err := fact.ParseFact(p, r.Content)
+		require.NoError(t, err)
+		seeds = append(seeds, f)
+	}
+	sess, err := env.svc.Pipeline().CreatePipelineSession(ctx, reviewTool, env.branch, "")
+	require.NoError(t, err)
+	d := env.deps()
+	d.Search = edgeReadFails{env.svc.Search()}
+	require.NoError(t, reviewStrategy{}.Plan(ctx, d, sess, seeds))
+
+	items, err := env.svc.Pipeline().PendingPipelineWorkItems(ctx, sess.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, keysWithPrefix(items, "distill-rest"),
+		"the remainder is NOT promotion-gated: those seeds never become a prune "+
+			"item, so there is no verdict to gate them on and gating them would "+
+			"drop them silently")
+}

--- a/internal/synthesize/review_strategy.go
+++ b/internal/synthesize/review_strategy.go
@@ -349,8 +349,39 @@ func (reviewStrategy) Plan(ctx context.Context, d Deps, sess *store.PipelineSess
 	// prune's positive cluster-size priorities and above the negative
 	// discover/reflect band (see forwardDiscoverPriority). Equal-priority items
 	// are served in insertion order by NextPipelineWorkItem's `id ASC` tiebreak.
+	//
+	// PROGRESSION, NOT MIRROR (knomit#135). Only the REMAINDER group is
+	// enqueued here. A clustered group is held back and enqueued only if its
+	// prune verdict comes back all-KEEP — see promoteClusterToDistill.
+	//
+	// The defect: distill was planned ALONGSIDE prune at session start, so
+	// every cluster was reasoned over twice in one session — once to decide
+	// whether its facts overlap, then again to synthesize upward from them as
+	// though they did not. Worse, a cluster whose prune verdict MERGED two
+	// facts was still distilled from the pre-merge grouping, which is how
+	// synthesis ended up fabricating corroboration out of what was one claim
+	// recorded twice.
+	//
+	// The prune verdict is a free classifier and this is the whole idea:
+	// acted-on (merge / retract / update) means the facts overlapped, so the
+	// cluster STOPS this session and re-seeds through the watermark once the
+	// changed facts settle; all-KEEP means the judge certified them distinct,
+	// which is synthesis's legitimate input.
+	//
+	// THE REMAINDER IS NOT GATED, and that is deliberate rather than an
+	// oversight. distillGroups' remainder is the seeds that landed in no
+	// multi-seed cluster; those never become a prune item at all, so they have
+	// no verdict to be classified by. Gating them on promotion would gate them
+	// on nothing and silently drop them — the population is substantial on real
+	// corpora. They were never part of the double-reasoning #135 removes: that
+	// was distill firing on prune's OWN clusters.
 	if len(llmSeeds) > 1 {
 		for _, group := range distillGroups(llmSeeds, clusters) {
+			if !group.Remainder {
+				// Held for promotion. Enqueued from the prune Apply arm if and
+				// only if the judge certifies the cluster distinct.
+				continue
+			}
 			for ci, chunk := range chunkFacts(group.Facts, maxItemBytes) {
 				factsJSON, err := json.Marshal(chunk)
 				if err != nil {
@@ -544,6 +575,13 @@ func (reviewStrategy) RenderPayload(item *store.PipelineWorkItem) (string, error
 type distillGroup struct {
 	Key   string
 	Facts []factForLLM
+	// Remainder marks the group of seeds that landed in NO multi-seed cluster.
+	//
+	// It is the one group with no corresponding prune item, so it is the one
+	// group that cannot be promotion-gated: there is no verdict to classify it
+	// by (knomit#135). Everything else here is a cluster, and a cluster is held
+	// until its prune verdict says it is worth synthesizing over.
+	Remainder bool
 }
 
 // distillGroups partitions the seed pool into the groups depth-0 distill
@@ -608,7 +646,7 @@ func distillGroups(seeds []factForLLM, clusters [][]factForLLM) []distillGroup {
 		}
 	}
 	if len(remainder) > 0 {
-		groups = append(groups, distillGroup{Key: "distill-rest", Facts: remainder})
+		groups = append(groups, distillGroup{Key: "distill-rest", Facts: remainder, Remainder: true})
 	}
 	return groups
 }
@@ -917,6 +955,28 @@ func (reviewStrategy) Apply(ctx context.Context, d Deps, sess *store.PipelineSes
 		// shortlist is earning its slots, and counting them would keep a
 		// useless shortlist funded forever on any healthy corpus.
 		recordShortlistVerdict(ctx, d, sess, judged, dec.prune)
+
+		// The prune→distill progression (knomit#135). The verdict just applied
+		// is a free classifier: all-KEEP means the judge certified this cluster
+		// distinct, which is synthesis's legitimate input, so its distill item
+		// is enqueued NOW — same session, because an all-KEEP dirties nothing
+		// and a "next session" promise would never fire.
+		//
+		// AFTER the apply, deliberately. The promotion is a statement about a
+		// verdict that has LANDED; enqueueing before the mutations committed
+		// would promote on an answer that could still fail to apply.
+		if promotesToDistill(item) {
+			inputPaths, perr := itemInputPaths(item)
+			switch {
+			case perr != nil:
+				log.Warn().Err(perr).Str("session", sess.ID).Str("cluster", item.ClusterKey).
+					Msg("review: prune item paths unreadable; cluster not considered for promotion")
+			case pruneVerdictCertifiesDistinct(*dec.prune, inputPaths):
+				promoteClusterToDistill(ctx, d, sess, item)
+			default:
+				recordProgressionStop(sess, item, stats)
+			}
+		}
 
 	case "distill":
 		stats, writtenFacts, err := ApplyDistillDecisions(ctx, d.Facts, d.Search, dec.distill.Synthesize, dec.distill.Retract, reviewTool, d.OnProgress, branch, fact.ID12(d.RI.ID()), d.RI.OntologyRoot())


### PR DESCRIPTION
Closes #135.

Distill and discover could offer the identical member set consecutively in one session — redundant work items manufacturing redundant facts, and reinforcement on identical seeds fabricating corroboration. Fixed as a PROGRESSION gated on the prune verdict as a free classifier.

## What
- Clustered distill groups are no longer planned at session start. Every cluster goes to PRUNE first.
- If the prune verdict ACTS (merge/retract/**update**) → the cluster STOPS this session (its change dirties the facts, so it re-seeds via the watermark next session — synthesis over settled material).
- If prune is a strict all-KEEP → the cluster is PROMOTED to distill in the SAME session, enqueued at Apply time (the enqueue-after-answer machinery already exists — `enqueueRaptorFollowups` is the precedent). Priority ordering puts the distill item behind remaining prune items for free.
- **Strict all-KEEP** = no merges + at least one decision + every decision `keep` + decisions covering every fact in the item. An empty or partial answer is a non-answer and does NOT promote — which also keeps MN5's empty-prune-answer from manufacturing a distill item.
- The `distill-rest-*` remainder bucket stays planned at session start (a remainder seed never gets a prune item, so it has no verdict to be promoted from). Shortlist/restate pairs do not promote (a pair's "distinct" ≠ a cluster's "judge-certified distinct worth synthesising").
- Promoted payloads are the whole judge-certified-distinct cluster (neighbours + post-#149 cousins), stated in the health line; the population widens to certified-distinct clusters that were prune items but not distill groups — both made legible.

## Verification
MN5 byte-identical + `TestReviewer_NormalEffort_DefaultPath` green; MN13 clean (only a string const); 3 files. Seven sabotages, two of which initially escaped and were closed (the plan-side fixture needs an errored-`SubgraphEdges` double to force the category fallback, because production Louvain forms zero clusters — the #149 wall; and the empty-decisions guard was kept because it's genuinely reachable on a zero-fact item). Cold-reviewed independently: MERGE-READY, no findings.