### PR TITLE
Port drain-earned judging discipline into shipped prompts (#136) — HELD for review

### DIFF
--- a/internal/synthesize/discovery.go
+++ b/internal/synthesize/discovery.go
@@ -234,6 +234,13 @@ func renderDiscoverPrompt(payload DiscoverWorkPayload, ontologyRoot string) stri
 			fmt.Fprintf(&b, "      %s\n", firstLine(m.Body))
 		}
 	}
+	// Source-monoculture guard (#136, MIRROR). A bridge earns its place by
+	// spanning COMMUNITIES; if every member's material traces to one origin,
+	// the shared thread is that origin, not a mechanism that recurs across the
+	// corpus. This is a judgment the prompt must carry because the mechanical
+	// qualify gate reasons over motif recurrence and subject-disjointness, not
+	// over where a fact's content came from.
+	b.WriteString("\nA bridge must span COMMUNITIES, not one source's own material. If the members' primary sources all trace to a single vendor, project, or author, the shared thread is that origin — not a mechanism that recurs across the corpus — and it is not a cross-community bridge. Default to NO.\n")
 	// GATE rider 2 (designer, 2026-08-23). The far-lane demo established that
 	// condition (c) below is not answerable from this prompt at all: novelty
 	// rests on the agent's default-skip rather than on the 0.92 dedup gate

--- a/internal/synthesize/prompts/large/distill_user.txt
+++ b/internal/synthesize/prompts/large/distill_user.txt
@@ -45,6 +45,20 @@ Consumers act on the summary they compress a fact into; synthesis is compression
 - Carry every scope qualifier ("only when…", "except…", "as of…") and every "WHAT THIS DOES NOT MEAN" clause from the inputs into the synthesis body. These clauses were added deliberately to block known misreadings — smoothing them away reopens the trap.
 - Only list an original fact in "retract" if the synthesis preserves ALL of its conditions and caveats. If preserving them would make the synthesis unwieldy, keep the original alongside the synthesis instead of subsuming it.
 
+## When NOT to distill
+
+A synthesis is not always there to be found, and the pressure to produce one is where false ones come from. Returning no synthesis is a valid, common outcome.
+
+- The synthesis you WANT to be true is the one to distrust. Wanting a clean pattern is not evidence for it. The classic error is merging two DIFFERENT mechanisms into one appealing headline because a single claim reads better than two — a claim that erases a real distinction is worse than no claim at all.
+- Do not launder a contradiction into corroboration. When the members genuinely disagree, the honest output is NO distill — not a smoothed headline that hides the disagreement under an average. A synthesis may claim only what its sources jointly support; where they conflict, they support nothing joint.
+- If the motif-carrying members share NO motif, skip. Facts that instantiate no common regularity will not yield a distillable pattern, and forcing one names a regularity that isn't there.
+
+## Motifs on the synthesized fact — what a motif is, and when not to add one
+
+A motif names a MECHANISM — what happens, the shape of a recurring cause-and-effect — independent of the fact's subject, so that two facts about unrelated systems can be linked by it. A motif is NOT a topic or subject area, NOT a heuristic or piece of advice ("check the…", "examine the…"), NOT a category or class of thing. If the name you reach for describes what someone should DO, or what an area is ABOUT, rather than what HAPPENS, it is not a motif.
+
+Most facts instantiate no nameable motif, and that is the normal case — leave the field empty. Do NOT invent one to fill it. A wrong motif is worse than none: it becomes evidence that unrelated facts describe the same mechanism, and nothing downstream can tell that it was guessed. Carry over a member's motif only if it is still true of the merged claim; author a new one only if the synthesized claim genuinely exemplifies a regularity no member named.
+
 ## Hypothesis handling
 
 - Do NOT use hypothesis-type facts as inputs for creating new synthesis facts. Hypotheses are unconfirmed predictions.

--- a/internal/synthesize/prompts/large/motif_alias_user.txt
+++ b/internal/synthesize/prompts/large/motif_alias_user.txt
@@ -12,6 +12,8 @@ READ THE CARRIER TITLES. They are the evidence, and the names alone are not. Two
 
 DEFAULT TO "different". Merge only when you can state, in one sentence, the mechanism both names describe. If you cannot write that sentence, the answer is "different" — including when the names look similar, and including when you are unsure. There is no cost to leaving two names separate: a later pass will see them again if evidence accumulates. There is a real cost to merging two mechanisms that are not the same, because nothing downstream can tell it happened.
 
+Beware the mislabelled carrier. Two correct but DISTINCT names can end up on one fact because that fact was given a motif it should not carry. Their co-occurrence there is not evidence that they name the same mechanism — it is evidence of one mislabelling. Do not let a single shared carrier become merge pressure: the harm of a wrong motif is exactly that it becomes evidence in a later merge that cannot be undone.
+
 Merge when:
 - the two names describe the same underlying mechanism in different words, and the carriers on both sides are instances of it
 
@@ -20,6 +22,7 @@ Do NOT merge when:
 - one name is a PROBLEM and the other its REMEDY. Carriers routinely discuss both, so the two read as one topic — but a mechanism and the thing that prevents it are opposites, not synonyms.
 - one name is broader than the other
 - the carriers on one side would not be described by the other name
+- a single fact carries BOTH names, on two different clauses of itself. If the two were phrasings of one regularity, one clause could not need both — a fact that states them separately is proving they are distinct, not that they belong together.
 - you are relying on the names alone because the carriers are unclear
 
 Respond as JSON (no markdown wrapping):

--- a/internal/synthesize/prompts/large/motif_define_user.txt
+++ b/internal/synthesize/prompts/large/motif_define_user.txt
@@ -21,6 +21,10 @@ Do not write:
 - advice, a judgement about whether the mechanism is good or bad, or how to avoid it
 - anything you would have to see a specific system to know
 
+The test for a definable motif: it must name a CAUSAL ENGINE — what happens, a mechanism or the shape of a failure. A name that is really a heuristic ("check the…", "examine the…", "verify…") is an instruction, not a mechanism, and cannot be defined as one. Neither can a topic, a class of vulnerability, or a choice or trend — those name what a fact is ABOUT or what someone decided, not what happens. The absence of a control is not itself a mechanism; the mechanism is what that absence lets happen.
+
+Define what the mechanism's SUBJECT does, not what a fact about it does. A name read as "the source's own word replacing independent inspection" describes a mechanism; a fact that carefully attributes a claim to its source is the opposite of that, not an instance of it. Read the name as the general thing that happens in the world, and describe that.
+
 If a name is too vague to define without inventing a meaning for it, return an empty definition for that name rather than guessing. A wrong definition is worse than a missing one: it will be used to decide whether unrelated facts describe the same mechanism.
 
 Respond as JSON (no markdown wrapping):

--- a/internal/synthesize/prompts/large/prune_user.txt
+++ b/internal/synthesize/prompts/large/prune_user.txt
@@ -39,6 +39,14 @@ Merge output requirements (mandatory):
 Merge fidelity (mandatory):
 - Facts are duplicates only if their conditions and scopes match. Same subject with different qualifiers ("only when…", "except…", different thresholds) is NOT a duplicate — keep both.
 - The merged body must preserve every component of compound conditions, every scope qualifier, and every "WHAT THIS DOES NOT MEAN" clause present in ANY input fact. Never collapse a multi-part condition into a catchier summary — the dropped component is how a true fact becomes a false slogan.
+- Do NOT merge two facts written to PRESERVE a distinction. When one fact carries a clause whose purpose is to warn against conflating it with the other — a "this is not the same as…", a significance note flagging that a neighbouring analysis would miss it — that clause exists precisely to keep the two apart, and merging is what silently destroys the warning. A pair kept separate on purpose reads like a duplicate; it is not one.
+- Same topic, different event is not a duplicate. Two facts about the same subject that record DIFFERENT occurrences, measurements, or moments each stand alone — keep both. And declining to merge is itself a verdict you are accountable for, not a free pass: an all-keep on a small cluster must be a decision you would defend after reading it, not a default reached by not looking.
+
+## Verdict discipline — keep, retract, update
+
+- A confidence DOWNGRADE does not correct a false claim. A fact left at reduced confidence still asserts its claim at full voice to anyone who reads it; lowering the number says "trust this less", never "this is wrong". If the BODY is wrong, correct the body or retract — do not quietly lower confidence and leave the wrong words standing.
+- Set confidence from the EVIDENCE BASE — how many independent sources support the fact, and of what kind — not from how confident the claim's wording sounds. A boldly-worded fact with one source is not more certain than a hedged one with five.
+- Do not retract a correctly-dated snapshot merely because a newer fact has overtaken it. A fact that was true as of its date and says so is history, not error; retracting it deletes the trail that makes the later correction legible. Supersession is recorded by the newer fact existing, not by erasing the older one.
 
 ## Hypothesis handling
 

--- a/internal/synthesize/prompts/large/reflect_user.txt
+++ b/internal/synthesize/prompts/large/reflect_user.txt
@@ -8,6 +8,27 @@ those transitions reinforce or expose as gaps. The default action is
 methodologies. Proposing a new methodology is rare and the server rejects
 proposals too similar to anything already in the corpus.
 
+Discipline for this judgment — these are themselves methodology lessons,
+and they apply to the reflection you are making right now:
+
+  - Query before declaring a gap. Deciding a transition REINFORCES an
+    existing methodology is safe on the evidence in front of you; declaring
+    the lesson NEW and proposing is not — the methodology you are sure does
+    not exist is the one you would misremember. Read the candidates below
+    before concluding none fit.
+  - Pre-register the check. Name the methodology you expect a transition to
+    reinforce, and what would confirm it, BEFORE you read the transition's
+    outcome. A lesson that turns out to fit after you already assumed it is
+    not the same as one you checked.
+  - A moving rate is not a finding. No per-session metric is independent of
+    that session's input mix; a rate that rose or fell tracks what came in,
+    not a change in method, until something rules the input out. Do not read
+    a number's movement as a methodology lesson on its own.
+  - Widen a claim only on evidence that moves a LEG of its argument. A
+    methodology improves when evidence contradicts part of it and forces a
+    revision; it merely bloats when evidence that already agrees is piled on
+    as more support. Reinforce on genuine load, not on agreement.
+
 {{if .ExistingMethodology}}Existing methodology candidates (the retrieval
 system thinks these may overlap with the lesson):
 


### PR DESCRIPTION
Addresses #136. **HELD — do not merge.** Opened for the designer to review the full scope before any merge decision; an independent cold review is running in parallel.

Ports the earned JUDGMENT from the corpus-judging drain into six prompt surfaces — targeted additions in each prompt's own voice, not a rewrite (the prompts already carry strong rails). +57 lines across 6 files. Generic throughout (no drain-specific examples in the prompt text). Full port-list spec: `.claude/plans/motif/2026-08-26-136-port-list.md`.

## Per surface
- **prune** — complementary-by-design guard (don't merge two facts whose clauses exist to preserve a distinction); same-topic/different-event ≠ duplicate + declining-to-merge is an accountable verdict; a confidence downgrade doesn't correct a false claim (fix the body); set confidence from the evidence base; don't retract a correctly-dated snapshot.
- **distill** — distrust the synthesis you *want* true; don't launder a contradiction into corroboration; skip a cluster whose motif-carriers share no motif; + the motif block (option A below).
- **motif_alias** — a discriminator on two clauses of one fact proves the names distinct; one shared (possibly mislabelled) carrier is not evidence of sameness.
- **motif_define** — the causal-engine test (a motif names a mechanism, not a heuristic/topic/vuln-class); define what the subject does, not what the fact does.
- **reflect** — query before declaring a gap; pre-register the check; a moving rate is not a finding; widen only on evidence that moves a leg of the argument.
- **discover** — source-monoculture guard (single-vendor members ≠ a cross-community bridge).

## Decisions applied (all marked for your review)
- **Structural = option A:** the "what a motif is / when not to add one" judgment went into **distill + discover** (the surfaces that write motif-carrying facts). `knomit_learn` tool guidance left untouched — the MCP surface is unchanged.
- **Deferred:** the prune "re-judge motifs on merge" port was **left out** — it conflicts with MN11 (mechanical merge unions motifs to avoid data loss). Pending an MN11 reconciliation.
- **Bare-entity discover guard omitted** because #125 already rejects bare-entity bridges mechanically (`BridgeKind.Qualifies` = motif-only; entity is rank-tiebreaker) — verified; a prompt line would be redundant.

## Verification
`go test ./... -count=1` green (49 ok); `go vet ./...` clean; MN5 blob unchanged; MN1 conformance passes (the discover edit introduces no vocabulary token). **NOTE:** the ruling's per-surface **shakedown against a real-corpus copy** was NOT run (prompt-only edits, no corpus run) — flagged for your decision on whether it's wanted before merge.