### PR TITLE
ci(tests): run ./... on the blocking job, and make the conformance check actually run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history, because the test step below now runs ./... and that
+          # includes internal/synthesize, whose TestConformance_BridgeFilesUntouched
+          # diffs the working tree against its merge base with dev.
+          #
+          # MEASURED, not assumed: on a pull_request the default shallow
+          # checkout fetches ONLY refs/pull/N/merge — the ref list in that tree
+          # is literally that one entry, no dev, no master — so the test's
+          # baseRefOrSkip finds no base ref and SKIPS ITSELF, announcing that it
+          # "is NOT being enforced". A conformance check that never runs is the
+          # same silent gap this job was widened to close, so the history it
+          # needs is fetched here. Cost is ~126 MiB per runner, the same order
+          # as the ~75 MiB of native libs `make setup` already pulls into this
+          # job.
+          #
+          # build-test only: the desktop, desktop-ui and embed-smoke jobs below
+          # never build internal/synthesize, so they keep the cheap checkout.
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -60,24 +78,60 @@ jobs:
       - name: Build (CGo) — proves libtokenizers.a links + cloud is Wails-free
         run: CGO_ENABLED=1 go build $(go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./...)
 
-      - name: Unit tests (no model download)
-        run: CGO_ENABLED=1 go test ./internal/embeddings/ ./internal/config/ ./internal/fact/
-
-      # Guard: the test harness (test/testenv, test/storytests) must
-      # never be linked into a shipped binary. Pure `go list` graph check, no
-      # native libs / no compile.
-      - name: Test-harness isolation guard
-        run: go test ./test/archtest/
-
-      # Store needs the runtime native libs; internal/web links them transitively
-      # (it constructs a store in tests) and the desktop helper packages
-      # (lockfile/netutil/paths/autostart/singleinstance) are plain Go but run
-      # here too so the build-test job actually exercises them. The desktop
-      # `//go:build desktop` packages are covered by the `desktop` job below.
-      - name: Store, web + desktop-helper tests (runtime native libs)
+      # ./... — EVERY test-bearing package (49 of them), replacing the named
+      # list this step used to carry, which reached 17. The 32 it never ran
+      # included internal/synthesize, internal/mcp, internal/repos,
+      # internal/refs, cmd and all of tools/ — so "CI green" was silent about
+      # most of the tree, and two real bugs (a teardown flake and a data race
+      # in internal/repos) sat on dev undetected because the only job that
+      # could see those packages was race.yml, which is post-merge and
+      # non-blocking. This is that gap closed on the job that actually gates.
+      #
+      # A named list is the wrong shape for this even when it is correct today:
+      # it goes stale silently, every new package is uncovered by default, and
+      # nothing fails when one is forgotten. ./... has no such failure mode —
+      # which is why race.yml was written this way from the start.
+      #
+      # The runtime native libs are exported for the WHOLE run now. The old
+      # three-step split (two steps deliberately without LD_LIBRARY_PATH, one
+      # with) documented which packages need them; ./... cannot express that,
+      # and the export is inert for the packages that do not. The two guards
+      # those steps called out still run here, just not by name: test/archtest
+      # keeps the test harness (test/testenv, test/storytests) out of shipped
+      # binaries, and tools/desktop/internal/... exercises the plain-Go desktop
+      # helpers, with the `//go:build desktop` packages covered by the desktop
+      # job below.
+      #
+      # TIMING IS MEASURED. The full run is 169s wall on an Apple-Silicon dev
+      # machine, of which internal/synthesize alone is 160s — it IS the
+      # critical path, everything else runs beside it. That leaves 3.75x of
+      # headroom under go test's 10-minute-PER-PACKAGE default, so no -timeout
+      # is set here and the job's ceiling is left alone. race.yml needs
+      # -timeout 30m because the SAME package takes 744s under -race, which is
+      # over the default; without -race it is not close. If some package ever
+      # does approach 10m, RE-MEASURE and set -timeout then — do not pre-raise
+      # it on a hunch.
+      #
+      # -skip ON PUSH ONLY. TestConformance_BridgeFilesUntouched asserts a
+      # NON-EMPTY diff against dev, so that a branch-scoped check cannot pass
+      # vacuously. On a push to dev/master the checkout IS that branch
+      # (actions/checkout runs `-B dev refs/remotes/origin/dev`, so `dev`
+      # resolves), the merge base is HEAD, the diff is empty by construction,
+      # and the test fails for a reason that has nothing to do with the commit.
+      # On a pull_request it is exactly where the check means something, so it
+      # runs — which is what the fetch-depth: 0 above buys. The condition is
+      # load-bearing rather than cosmetic: an unconditional -skip, as race.yml
+      # carries for its own push-only trigger, would silently defeat that.
+      # `github.event_name` in a called workflow is the CALLER's event (the
+      # same property embed-smoke below depends on), so a release tag counts as
+      # a push and is skipped too — correct, since a tag is not a branch under
+      # review.
+      - name: Tests — all packages
+        env:
+          CONFORMANCE_SKIP: ${{ github.event_name == 'push' && '-skip=TestConformance_BridgeFilesUntouched' || '' }}
         run: |
           export LD_LIBRARY_PATH="$LIBDIR" DYLD_LIBRARY_PATH="$LIBDIR"
-          CGO_ENABLED=1 go test ./internal/store/... ./test/storytests/ ./internal/web/... ./tools/desktop/internal/...
+          CGO_ENABLED=1 go test $CONFORMANCE_SKIP ./...
 
       # Origin-sync fault matrix: build-tagged contract cells drive the real
       # product clone/sync/push path over an in-process fault-injecting git

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,19 @@ name: Tests
 on:
   workflow_call:
 
+# THE SPLIT POINT, DEFINED ONCE. internal/synthesize is the long pole — 421s on
+# ubuntu-latest against 33s for the next-slowest package — so it runs as its own
+# job, in parallel with everything else, instead of making every other package
+# wait behind it.
+#
+# Both jobs read this same variable: build-test runs `go list ./...` MINUS this
+# package, the synthesize job runs exactly this package. That is what keeps the
+# two halves an exact partition of ./... — a coverage split that named its
+# packages in two places would drift apart silently, which is the failure this
+# workflow was just repaired for.
+env:
+  SPLIT_PKG: knomit/internal/synthesize
+
 jobs:
   build-test:
     strategy:
@@ -35,25 +48,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      # Shallow checkout, deliberately. This job briefly carried fetch-depth: 0
+      # because ./... included the diff-based conformance test; that test moved
+      # to the synthesize job below, and the full history moved with it rather
+      # than being left behind as cargo.
       - uses: actions/checkout@v4
-        with:
-          # Full history, because the test step below now runs ./... and that
-          # includes internal/synthesize, whose TestConformance_BridgeFilesUntouched
-          # diffs the working tree against its merge base with dev.
-          #
-          # MEASURED, not assumed: on a pull_request the default shallow
-          # checkout fetches ONLY refs/pull/N/merge — the ref list in that tree
-          # is literally that one entry, no dev, no master — so the test's
-          # baseRefOrSkip finds no base ref and SKIPS ITSELF, announcing that it
-          # "is NOT being enforced". A conformance check that never runs is the
-          # same silent gap this job was widened to close, so the history it
-          # needs is fetched here. Cost is ~126 MiB per runner, the same order
-          # as the ~75 MiB of native libs `make setup` already pulls into this
-          # job.
-          #
-          # build-test only: the desktop, desktop-ui and embed-smoke jobs below
-          # never build internal/synthesize, so they keep the cheap checkout.
-          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -78,74 +77,47 @@ jobs:
       - name: Build (CGo) — proves libtokenizers.a links + cloud is Wails-free
         run: CGO_ENABLED=1 go build $(go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./...)
 
-      # ./... — EVERY test-bearing package (49 of them), replacing the named
-      # list this step used to carry, which reached 17. The 32 it never ran
-      # included internal/synthesize, internal/mcp, internal/repos,
-      # internal/refs, cmd and all of tools/ — so "CI green" was silent about
-      # most of the tree, and two real bugs (a teardown flake and a data race
-      # in internal/repos) sat on dev undetected because the only job that
-      # could see those packages was race.yml, which is post-merge and
-      # non-blocking. This is that gap closed on the job that actually gates.
+      # EVERY test-bearing package EXCEPT the one the synthesize job owns.
+      # Together the two jobs are an exact partition of ./... — this one runs
+      # `go list ./...` minus $SPLIT_PKG, that one runs exactly $SPLIT_PKG, and
+      # neither side carries a hand-written package list. That matters: the
+      # named 17-package list this step used to have covered 17 of the repo's 49
+      # test-bearing packages, so a green CI said nothing about
+      # internal/synthesize, internal/mcp, internal/repos, internal/refs, cmd or
+      # any of tools/ — and two real bugs (a teardown flake and a data race in
+      # internal/repos) sat on dev undetected because the only job that could
+      # see those packages was race.yml, which is post-merge and non-blocking.
+      # A list goes stale in silence; a derived set does not.
       #
-      # A named list is the wrong shape for this even when it is correct today:
-      # it goes stale silently, every new package is uncovered by default, and
-      # nothing fails when one is forgotten. ./... has no such failure mode —
-      # which is why race.yml was written this way from the start.
+      # `go list ./...` rather than the ./... wildcard because a package has to
+      # be REMOVED from the set. The two are not interchangeable for an explicit
+      # argument list — `go test ./tools/desktop` is a hard error ("build
+      # constraints exclude all Go files") for a package whose files are all
+      # behind //go:build desktop, where the wildcard skips it silently. go list
+      # applies the same constraints and never emits such a package, so the list
+      # it produces is safe to pass explicitly. Verified on both, not assumed.
       #
-      # The runtime native libs are exported for the WHOLE run now. The old
-      # three-step split (two steps deliberately without LD_LIBRARY_PATH, one
-      # with) documented which packages need them; ./... cannot express that,
-      # and the export is inert for the packages that do not. The two guards
-      # those steps called out still run here, just not by name: test/archtest
-      # keeps the test harness (test/testenv, test/storytests) out of shipped
-      # binaries, and tools/desktop/internal/... exercises the plain-Go desktop
-      # helpers, with the `//go:build desktop` packages covered by the desktop
-      # job below.
-      #
-      # TIMING IS MEASURED ON THE RUNNERS THAT ACTUALLY RUN IT.
-      # internal/synthesize is the critical path — everything else runs beside
-      # it — and it takes 385s on ubuntu-latest and 331s on macos-latest, from
-      # this workflow's own first run. The same package is 160s on an
-      # Apple-Silicon dev machine, so a LOCAL figure is a FLOOR, not a
-      # forecast: the runners are ~2.4x slower, and sizing this from the local
-      # number would have left 385s sitting under go test's 600s ceiling with
-      # 1.56x of headroom while a comment claimed 3.75x.
-      #
-      # That margin is too thin to leave alone. go test defaults to 10 minutes
-      # PER PACKAGE, and what happens at that boundary is `panic: test timed
-      # out after 10m0s` — a red that looks like a bug and is not. That is the
-      # wallpaper failure race.yml's own comment exists to avoid, and a single
-      # noisy runner or a handful of new synthesize tests reaches it from 385s.
-      # -timeout 20m is ~3.1x the measured ubuntu figure, the same discipline
-      # race.yml applies (its 30m is ~2.4x the 744s that package takes under
-      # -race). RE-MEASURE before changing this; do not move it on a hunch.
-      #
-      # No timeout-minutes on the job, deliberately: its default ceiling is far
-      # looser than this -timeout, which is the ordering race.yml documents —
-      # the go test timeout has to fire FIRST, because it prints a goroutine
-      # dump naming the stuck test, while a job timeout kills the runner and
-      # leaves a truncated log and no stack.
-      #
-      # -skip ON PUSH ONLY. TestConformance_BridgeFilesUntouched asserts a
-      # NON-EMPTY diff against dev, so that a branch-scoped check cannot pass
-      # vacuously. On a push to dev/master the checkout IS that branch
-      # (actions/checkout runs `-B dev refs/remotes/origin/dev`, so `dev`
-      # resolves), the merge base is HEAD, the diff is empty by construction,
-      # and the test fails for a reason that has nothing to do with the commit.
-      # On a pull_request it is exactly where the check means something, so it
-      # runs — which is what the fetch-depth: 0 above buys. The condition is
-      # load-bearing rather than cosmetic: an unconditional -skip, as race.yml
-      # carries for its own push-only trigger, would silently defeat that.
-      # `github.event_name` in a called workflow is the CALLER's event (the
-      # same property embed-smoke below depends on), so a release tag counts as
-      # a push and is skipped too — correct, since a tag is not a branch under
-      # review.
-      - name: Tests — all packages
-        env:
-          CONFORMANCE_SKIP: ${{ github.event_name == 'push' && '-skip=TestConformance_BridgeFilesUntouched' || '' }}
+      # The guard below is the load-bearing part. If $SPLIT_PKG is ever renamed
+      # or moved, `grep -vx` quietly excludes nothing and the package runs in
+      # both jobs (waste), while the synthesize job fails outright — but a
+      # LOOSER pattern would quietly exclude MORE than one package and nothing
+      # would fail at all. That silent omission is the exact class of gap this
+      # workflow was repaired for, so the count is asserted rather than trusted.
+      # set -o pipefail matters for the same reason: a failed `go list` must not
+      # collapse into an empty list that tests nothing and exits 0.
+      # (step names are not env-interpolated by Actions, so the long pole is
+      # named in prose here and identified only by $SPLIT_PKG in the command.)
+      - name: Tests — every package except the long pole
         run: |
+          set -euo pipefail
           export LD_LIBRARY_PATH="$LIBDIR" DYLD_LIBRARY_PATH="$LIBDIR"
-          CGO_ENABLED=1 go test $CONFORMANCE_SKIP -timeout 20m ./...
+          all=$(go list ./...)
+          n=$(printf '%s\n' "$all" | grep -cx "$SPLIT_PKG" || true)
+          if [ "$n" -ne 1 ]; then
+            echo "::error::$SPLIT_PKG must name exactly one package in ./..., found $n — the build-test/synthesize split is no longer a partition of the tree" >&2
+            exit 1
+          fi
+          CGO_ENABLED=1 go test $(printf '%s\n' "$all" | grep -vx "$SPLIT_PKG")
 
       # Origin-sync fault matrix: build-tagged contract cells drive the real
       # product clone/sync/push path over an in-process fault-injecting git
@@ -157,6 +129,91 @@ jobs:
         run: |
           export LD_LIBRARY_PATH="$LIBDIR" DYLD_LIBRARY_PATH="$LIBDIR"
           CGO_ENABLED=1 go test -tags contract ./test/storytests/ -count=1 -timeout 300s
+
+  # internal/synthesize on its own runner, in parallel with build-test.
+  #
+  # WHY IT IS SPLIT OUT, measured: inside a single ./... step the package times
+  # SUM to 600s on ubuntu but the step takes 441s, because `go test` already
+  # runs packages concurrently. synthesize alone is 421s of that — the other 47
+  # packages finish beside it and add ~20s. So synthesize was not merely the
+  # slowest package, it WAS the step, and everything serially after it in
+  # build-test (the 82s CGo build and the 59s contract cells on macOS) was
+  # queued behind work it did not depend on.
+  #
+  # WHAT THE SPLIT BUYS, and what it does not: it takes ~141s off the PR's
+  # critical path (~10m0s to ~7.7m). It cannot do better, because synthesize
+  # plus its own setup IS the critical path now — you cannot parallelise the
+  # long pole with itself. Going below ~7.7m means making synthesize's own
+  # suite faster, not moving it around. Duplicating the setup is cheap enough
+  # not to eat the gain: `make setup` measures 3-5s, not the minutes its
+  # payload size suggests.
+  #
+  # Both OSes, deliberately. Dropping this to one runner would halve the job's
+  # cost and reduce coverage on the other platform — build-test's set plus this
+  # job's set has to remain ./... on EVERY runner in the matrix, or the split
+  # reintroduces exactly the silent gap it was built alongside.
+  synthesize:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # fetch-depth: 0 lives HERE, with the test that needs it.
+      # TestConformance_BridgeFilesUntouched diffs the working tree against its
+      # merge base with dev, and its baseRefOrSkip helper skips when no base ref
+      # RESOLVES — which is not the same as "no diff". MEASURED: a default
+      # depth-1 pull_request checkout fetches only refs/pull/N/merge, so that
+      # tree's entire ref list is that one entry, no dev and no master, and the
+      # test SKIPS ITSELF while announcing it "is NOT being enforced". Full
+      # history is what makes origin/dev resolve and the check actually run.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Resolve native lib dir
+        run: echo "LIBDIR=$(pwd)/dist/$(go env GOOS)-$(go env GOARCH)/lib" >> "$GITHUB_ENV"
+
+      - name: Fetch native libs (ONNX Runtime, libtokenizers.a)
+        run: make setup
+
+      # -timeout 20m IS MEASURED ON THE RUNNERS, and the local figure is a
+      # FLOOR rather than a forecast: this package is 160s on an Apple-Silicon
+      # dev machine but 385s then 421s on ubuntu-latest across two runs, and
+      # 331s then 387s on macos — the runners are ~2.4x slower AND vary by
+      # ~10-17% run to run. Sizing a ceiling from one sample of a noisy
+      # quantity is the same error as sizing it from the wrong machine: the
+      # observed peak of 421s sits at only 1.42x under go test's 600s
+      # PER-PACKAGE default, so a single unlucky run panics with `test timed
+      # out after 10m0s` — a red that looks like a bug in the code under review
+      # and is not. 20m is ~3.1x the measured peak, the same discipline
+      # race.yml applies (its 30m is ~2.4x the 744s this package takes under
+      # -race). RE-MEASURE before moving it.
+      #
+      # -skip ON PUSH ONLY. The conformance test asserts a NON-EMPTY diff so it
+      # cannot pass vacuously. On a push to dev/master the checkout IS that
+      # branch (actions/checkout runs `-B dev refs/remotes/origin/dev`), the
+      # merge base is HEAD, the diff is empty by construction, and it fails for
+      # a reason that has nothing to do with the commit. On a pull_request it
+      # is exactly where the check means something, so it runs.
+      # `github.event_name` in a called workflow is the CALLER's event — the
+      # property embed-smoke below also depends on — so a release tag counts as
+      # a push and is skipped too, which is right: a tag is not a branch under
+      # review.
+      #
+      # $SPLIT_PKG is passed explicitly, so a rename fails this job loudly
+      # instead of leaving the package untested on both sides of the split.
+      - name: Tests — the long pole, parallel with build-test
+        env:
+          CONFORMANCE_SKIP: ${{ github.event_name == 'push' && '-skip=TestConformance_BridgeFilesUntouched' || '' }}
+        run: |
+          set -euo pipefail
+          export LD_LIBRARY_PATH="$LIBDIR" DYLD_LIBRARY_PATH="$LIBDIR"
+          CGO_ENABLED=1 go test $CONFORMANCE_SKIP -timeout 20m "$SPLIT_PKG"
 
   # Build + test the Wails v3 desktop app. It lives behind `//go:build desktop`
   # and links the OS-native webview toolkit (Cocoa/WebKit on macOS), so the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,15 +102,29 @@ jobs:
       # helpers, with the `//go:build desktop` packages covered by the desktop
       # job below.
       #
-      # TIMING IS MEASURED. The full run is 169s wall on an Apple-Silicon dev
-      # machine, of which internal/synthesize alone is 160s — it IS the
-      # critical path, everything else runs beside it. That leaves 3.75x of
-      # headroom under go test's 10-minute-PER-PACKAGE default, so no -timeout
-      # is set here and the job's ceiling is left alone. race.yml needs
-      # -timeout 30m because the SAME package takes 744s under -race, which is
-      # over the default; without -race it is not close. If some package ever
-      # does approach 10m, RE-MEASURE and set -timeout then — do not pre-raise
-      # it on a hunch.
+      # TIMING IS MEASURED ON THE RUNNERS THAT ACTUALLY RUN IT.
+      # internal/synthesize is the critical path — everything else runs beside
+      # it — and it takes 385s on ubuntu-latest and 331s on macos-latest, from
+      # this workflow's own first run. The same package is 160s on an
+      # Apple-Silicon dev machine, so a LOCAL figure is a FLOOR, not a
+      # forecast: the runners are ~2.4x slower, and sizing this from the local
+      # number would have left 385s sitting under go test's 600s ceiling with
+      # 1.56x of headroom while a comment claimed 3.75x.
+      #
+      # That margin is too thin to leave alone. go test defaults to 10 minutes
+      # PER PACKAGE, and what happens at that boundary is `panic: test timed
+      # out after 10m0s` — a red that looks like a bug and is not. That is the
+      # wallpaper failure race.yml's own comment exists to avoid, and a single
+      # noisy runner or a handful of new synthesize tests reaches it from 385s.
+      # -timeout 20m is ~3.1x the measured ubuntu figure, the same discipline
+      # race.yml applies (its 30m is ~2.4x the 744s that package takes under
+      # -race). RE-MEASURE before changing this; do not move it on a hunch.
+      #
+      # No timeout-minutes on the job, deliberately: its default ceiling is far
+      # looser than this -timeout, which is the ordering race.yml documents —
+      # the go test timeout has to fire FIRST, because it prints a goroutine
+      # dump naming the stuck test, while a job timeout kills the runner and
+      # leaves a truncated log and no stack.
       #
       # -skip ON PUSH ONLY. TestConformance_BridgeFilesUntouched asserts a
       # NON-EMPTY diff against dev, so that a branch-scoped check cannot pass
@@ -131,7 +145,7 @@ jobs:
           CONFORMANCE_SKIP: ${{ github.event_name == 'push' && '-skip=TestConformance_BridgeFilesUntouched' || '' }}
         run: |
           export LD_LIBRARY_PATH="$LIBDIR" DYLD_LIBRARY_PATH="$LIBDIR"
-          CGO_ENABLED=1 go test $CONFORMANCE_SKIP ./...
+          CGO_ENABLED=1 go test $CONFORMANCE_SKIP -timeout 20m ./...
 
       # Origin-sync fault matrix: build-tagged contract cells drive the real
       # product clone/sync/push path over an in-process fault-injecting git


### PR DESCRIPTION
## The gap

`tests.yml`'s test step named **17 packages**. The repo has **49 test-bearing** ones.

The 32 that never ran include `internal/synthesize`, `internal/mcp`, `internal/repos`, `internal/refs`, `cmd`, and all of `tools/…`. A green CI therefore said nothing about most of the tree, and two real bugs on dev (a teardown flake and a data race in `internal/repos`) went undetected because the only job that could see those packages was `race.yml`, which is post-merge and deliberately non-blocking.

A named list is the wrong shape even when it is correct today: it goes stale silently, every new package is uncovered by default, and nothing fails when one is forgotten.

## What this PR does

Three commits:

1. **`c84b6b92`** — the gating job runs every package instead of 17, and the diff-based conformance test is made to actually run.
2. **`7bf35fdc`** — `-timeout 20m`, sized from the runner-measured figure after the first CI run showed the local one was misleading.
3. **`c2b7a1d0`** — `internal/synthesize` split into its own parallel job, taking it off the critical path.

## The conformance-test problem, measured

`TestConformance_BridgeFilesUntouched` asserts a **non-empty** diff against dev so a branch-scoped check cannot pass vacuously. Its `baseRefOrSkip` helper skips only when **no base ref resolves** — which is not the same as "no diff". Replicating `actions/checkout@v4`'s exact fetch and checkout per trigger, then running the test in the result:

| Trigger | Ref state | Verdict |
|---|---|---|
| push to dev | checkout runs `-B dev refs/remotes/origin/dev`, so `dev` resolves; merge base **is** HEAD; diff is 0 files | **FAIL** — `"0" is not positive` |
| pull_request (default depth 1) | the tree's entire ref list is `refs/remotes/pull/N/merge` — no dev, no master | **SKIP** — "is NOT being enforced" |

So the obvious fix — skip on push, run on PR — produces a test that runs in **neither** trigger. That is the same silent-gap shape this PR exists to close. Hence both halves, each load-bearing:

- **`fetch-depth: 0`** gives the PR case a base ref, so the check enforces MN5 in CI for the first time. It now lives on the `synthesize` job, with the test that needs it; `build-test` is back to a shallow checkout rather than keeping full history as cargo. Measured cost on the runner: **5–8s**.
- **`-skip` conditional on `github.event_name == 'push'`**, not unconditional as in `race.yml` (correct there, since that workflow is push-only). An unconditional skip would silently defeat the `fetch-depth` change. `github.event_name` in a called workflow is the *caller's* event, so a release tag counts as a push and is skipped too — right, since a tag is not a branch under review.

## The split, and why it was measured first

Inside one `./...` step on ubuntu the package times **sum to 600s while the step takes 441s** — `go test` already runs packages concurrently. `internal/synthesize` alone was 421s of that; the other 47 finish beside it and add ~20s. So synthesize was not merely the slowest package, it *was* the step, and the work sitting serially after it (the 82s CGo build and 59s contract cells on macOS) was queued behind something it does not depend on.

Fixed overhead is small — `make setup` measures **3–5s**, not the minutes its ~75 MiB payload suggests — so a second job re-paying it does not eat the gain.

**Result, measured:** overall PR wall-clock **606s → 461s** (10m06s → 7m41s), a 24% reduction.

| Job | before | after |
|---|---|---|
| build-test (ubuntu) | 505s | **125s** |
| build-test (macos) | 601s | **259s** |
| synthesize (ubuntu) | — | 421s |
| synthesize (macos) | — | **454s** ← critical path |

It cannot do better. The synthesize job is 430s of test inside a 454s job: the long pole cannot be parallelised with itself. Going below ~7m41s means making that suite faster, not moving it around.

## Keeping the split an exact partition

A coverage split that dropped a package would reintroduce exactly the gap this PR closes, so neither side names packages. `SPLIT_PKG` is defined **once** at workflow level; `build-test` runs `go list ./...` minus it; the `synthesize` job runs exactly it; and `build-test` **fails the step unless `SPLIT_PKG` matches exactly one package** before testing anything. A rename fails loudly instead of letting a looser pattern quietly exclude more than one package.

`go list ./...` rather than the `./...` wildcard, because a package must be *removed* and the two are not interchangeable as an explicit argument list: `go test ./tools/desktop` is a hard error ("build constraints exclude all Go files") for a package whose files are all behind `//go:build desktop`, where the wildcard skips it silently. `go list` applies the same constraints and never emits such a package. Verified both ways.

**Completeness verified against the same runners, before and after the split:**

| | pre-split `./...` | post-split union | dropped | added |
|---|---|---|---|---|
| ubuntu-latest | 53 | 53 | **0** | **0** |
| macos-latest | 53 | 53 | **0** | **0** |

Zero overlap between the two jobs on both runners. Locally the partition also holds (54 + 1 = 55); the local set is two larger than CI's because `go list ./...` picks up `web/node_modules/flatted/golang/pkg/flatted` when `web/`'s npm deps are installed, and CI only ever runs `npm install` in `tools/desktop/ui`.

## Timing, and a correction

The first version set no `-timeout`, reasoning from a local measurement: 160s against Go's 600s per-package default, so 3.75× headroom. That was arithmetically fine and **epistemically wrong** — it reasoned from a dev machine about a ceiling that only applies on the runner.

| `internal/synthesize` | ubuntu | macos |
|---|---|---|
| local (Apple Silicon) | 160s | — |
| CI run 1 | 385.2s | 331.4s |
| CI run 2 | **421.2s** | 387.1s |
| CI run 3 (split) | 398.7s | 337.4s |

Run 2 changed only the `-timeout` flag, which cannot affect runtime — so that spread is pure runner variance (+9% / +17%). The observed peak, 421s against a 600s wall, is **1.42× headroom, not 3.75×**; run 2 would have been the unlucky one, and the failure there is `panic: test timed out after 10m0s` — a red that looks like a bug in the code under review and is not.

`-timeout 20m` is ~3.1× the measured peak, the same discipline `race.yml` applies (its 30m is ~2.4× the 744s this package takes under `-race`). **Caveat stated plainly: n=3.** That is a spread, not a characterised tail — sized to survive variance observed, not proven sufficient forever, which is why the comment says RE-MEASURE rather than offering a formula.

No `timeout-minutes` on the jobs, deliberately: the default ceiling stays looser than the `-timeout`, preserving the ordering `race.yml` documents — the `go test` timeout must fire first, because it prints a goroutine dump naming the stuck test, while a job timeout leaves a truncated log and no stack.

## Scope and notes for review

`race.yml` and `ci.yml` are untouched.

- **MN5 is gated in CI for the first time**, confirmed across three runs: the `synthesize` job's checkout logs `+refs/heads/*:refs/remotes/origin/*`, so `origin/dev` resolves and the conformance test genuinely runs on `pull_request` with no skip flag.
- **New job names.** `tests / synthesize (ubuntu-latest|macos-latest)` are new contexts. `dev` has no branch protection and the one active ruleset covering `dev`/`master` contains no rules, so no required-status-check list needs updating — and equally, nothing currently requires any of these jobs to pass before merge. Flagging that as an observation, not something this PR changes.
- **The lever below 7m41s**, if wall-clock matters further: `internal/synthesize` is entirely serial — **0 of its 91 test files call `t.Parallel()`** — and ~20 `TestStructural_*` tests each build their own env at 5.6–6.1s, roughly 104s of the 160s local runtime. That is a test-suite change with real risk in a package that has race history, so it is reported here rather than attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)