### PR TITLE
Serve the web UI under a reverse-proxy path prefix

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,17 +25,34 @@
       No redirect loop: the replacement path always ends in `/`, so the second
       load returns early.
 
-      Both guards below hold the desktop shell harmless, and either alone would
-      do it. tools/desktop/app.go calls window.SetURL("/"), so the pathname ends
-      in `/` on every platform; and on macOS the shell is served over the custom
+      Two guards hold the desktop shell harmless, and either alone would do it.
+      tools/desktop/app.go calls window.SetURL("/"), so the pathname ends in `/`
+      on every platform; and on macOS the shell is served over the custom
       `wails://localhost` scheme, which the protocol check excludes outright
       rather than reasoning about how a non-special scheme stringifies.
+
+      A third refuses a '//' pathname outright — see the comment on it below.
+
+      NOT guarded: a URL whose last segment is the document itself
+      (`…/proxy/19278/index.html`), where relative resolution is ALREADY correct
+      and this redirect would make it wrong. Unreachable through knomit, because
+      Go's http.FileServer 301s any path ending in index.html to `./` before a
+      browser ever parses this file. A "last segment contains a dot" heuristic
+      was considered and rejected: it would refuse to fix a legitimate mount at
+      e.g. /apps/knomit.dev, trading an unreachable failure for a plausible one.
     -->
     <script>
       (function () {
         if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
         var p = location.pathname;
         if (!p || p.charAt(p.length - 1) === '/') return;
+        // A pathname may begin with '//' (https://host//knomit gives '//knomit').
+        // location.replace would read that as scheme-relative and navigate to
+        // ANOTHER ORIGIN — an open redirect. Resolving through `new URL(…, href)`
+        // does not help: a leading '//' is an authority to the URL parser even
+        // with a base. Refuse instead; the caller keeps a working page at the
+        // cost of the slash it was missing.
+        if (p.charAt(1) === '/') return;
         location.replace(p + '/' + location.search + location.hash);
       })();
     </script>

--- a/web/index.html
+++ b/web/index.html
@@ -2,14 +2,51 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <!--
+      Trailing-slash guard.
+
+      Everything below resolves relatively (vite `base: './'`), which needs the
+      document to be served at `.../` WITH the slash. At `/proxy/19278` the
+      browser treats `proxy` as the directory and `./assets/x.js` becomes
+      `/proxy/assets/x.js` — blank page. code-server redirects to add the slash,
+      but a hand-rolled proxy (an nginx `location`) need not, so do not depend
+      on it.
+
+      A redirect, not a `<base href>` rewrite. Both recover, because the base a
+      `<base>` sets is what the parser resolves the asset tags against. But the
+      browser's PRELOAD SCANNER runs ahead of the parser and has already fired
+      those requests against the uncorrected base by the time any inline script
+      executes. With `<base>` those speculative fetches belong to the live
+      document, so their failures land in the console: six errors, two of them
+      the alarming "Refused to apply style ... MIME type". A redirect throws the
+      whole document away, so the same wasted fetches are attributed to a page
+      that no longer exists and the console stays clean. Measured, not assumed.
+
+      No redirect loop: the replacement path always ends in `/`, so the second
+      load returns early.
+
+      Both guards below hold the desktop shell harmless, and either alone would
+      do it. tools/desktop/app.go calls window.SetURL("/"), so the pathname ends
+      in `/` on every platform; and on macOS the shell is served over the custom
+      `wails://localhost` scheme, which the protocol check excludes outright
+      rather than reasoning about how a non-special scheme stringifies.
+    -->
+    <script>
+      (function () {
+        if (location.protocol !== 'http:' && location.protocol !== 'https:') return;
+        var p = location.pathname;
+        if (!p || p.charAt(p.length - 1) === '/') return;
+        location.replace(p + '/' + location.search + location.hash);
+      })();
+    </script>
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>knomit</title>
   </head>
   <body>
     <div id="root"></div>
     <!-- Runtime API base; served statically (cloud) or dynamically by Wails (desktop). -->
-    <script src="/config.js"></script>
-    <script type="module" src="/src/main.tsx"></script>
+    <script src="./config.js"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/web/public/config.js
+++ b/web/public/config.js
@@ -1,4 +1,18 @@
-// Runtime API base. Served as a static file in the cloud build (UI and API are
-// same-origin, so the base is empty and API URLs stay relative). The desktop
-// (Wails) build overrides /config.js dynamically with the looknomitck API URL.
-window.__KNOMIT_API_BASE__ = "";
+// Runtime API base. Served as a static file in the cloud build; the desktop
+// (Wails) build never reads this file — configInjectingHandler in
+// tools/desktop/app.go answers /config.js ahead of the static FS with an
+// absolute http://127.0.0.1:<port> base and the __KNOMIT_DESKTOP__ flag.
+//
+// Derived from the document location rather than hardcoded to "", so one bundle
+// serves both a same-origin deployment and one mounted under a path prefix by a
+// prefix-stripping reverse proxy:
+//
+//   served at /                -> ""            -> /api/v1/repos
+//   served at /proxy/19278/    -> "/proxy/19278" -> /proxy/19278/api/v1/repos
+//
+// `new URL('.', ...)` is the directory of the document, so it honours the <base>
+// written by the trailing-slash guard in index.html. The trailing slash is
+// stripped because every caller in web/src/api.ts appends a path that starts
+// with one.
+window.__KNOMIT_API_BASE__ =
+  new URL('.', document.baseURI).pathname.replace(/\/$/, '');

--- a/web/public/config.js
+++ b/web/public/config.js
@@ -10,9 +10,14 @@
 //   served at /                -> ""            -> /api/v1/repos
 //   served at /proxy/19278/    -> "/proxy/19278" -> /proxy/19278/api/v1/repos
 //
-// `new URL('.', ...)` is the directory of the document, so it honours the <base>
-// written by the trailing-slash guard in index.html. The trailing slash is
-// stripped because every caller in web/src/api.ts appends a path that starts
-// with one.
+// `new URL('.', ...)` is the DIRECTORY of the document, which is why index.html
+// carries a guard that redirects a prefixed mount missing its trailing slash:
+// without it this reads /proxy/19278 as the directory /proxy, and every API call
+// goes to /proxy/api/v1/... — a wrong base, not a missing one, so nothing points
+// at the cause. Do not remove that guard on the assumption that something else
+// normalizes the directory; nothing does. (An earlier draft wrote a <base href>
+// instead of redirecting, and this comment used to claim one exists. It does
+// not.) The trailing slash is stripped because every caller in web/src/api.ts
+// appends a path that starts with one.
 window.__KNOMIT_API_BASE__ =
   new URL('.', document.baseURI).pathname.replace(/\/$/, '');

--- a/web/src/pathPrefix.test.ts
+++ b/web/src/pathPrefix.test.ts
@@ -46,6 +46,14 @@ describe('config.js API base', () => {
     ['mounted under a prefix', 'https://box.example/proxy/19278/', '/proxy/19278'],
     ['mounted under a nested prefix', 'https://box.example/a/b/c/', '/a/b/c'],
     ['ignores query and fragment', 'https://knomit.example/proxy/1/?x=1', '/proxy/1'],
+    // NOT a supported state — the degraded value pinned deliberately. Without a
+    // trailing slash the document's DIRECTORY is the parent, so the base comes
+    // out one segment short and every API call goes to /proxy/api/v1/... This is
+    // what index.html's guard exists to prevent, and it is what a fronting proxy
+    // sending `Content-Security-Policy: script-src 'self'` would silently
+    // reinstate by refusing to run that inline guard. Asserted so the failure
+    // mode has a name in the suite rather than being discovered in a browser.
+    ['no trailing slash (guard defeated)', 'https://box.example/proxy/19278', '/proxy'],
   ])('%s: %s -> %o', (_name, baseURI, expected) => {
     expect(deriveApiBase(baseURI)).toBe(expected);
   });
@@ -117,6 +125,19 @@ describe('trailing-slash guard', () => {
     // The replacement path always ends in '/', so this is the second load.
     expect(runGuard({ protocol: 'https:', pathname: '/proxy/19278/' }).replaced).toBeNull();
     expect(runGuard({ protocol: 'https:', pathname: '/' }).replaced).toBeNull();
+  });
+
+  it('refuses a // pathname rather than redirecting off-origin', () => {
+    // https://host//knomit gives pathname '//knomit'. Appending a slash and
+    // handing that to location.replace navigates to https://knomit/ — the target
+    // is scheme-relative, so the host is attacker-chosen. Resolving through
+    // `new URL(target, location.href)` does NOT fix it: a leading '//' is an
+    // authority to the URL parser even with a base.
+    expect(runGuard({ protocol: 'https:', pathname: '//evil.com/x' }).replaced).toBeNull();
+    expect(runGuard({ protocol: 'https:', pathname: '//knomit' }).replaced).toBeNull();
+    // A single leading slash is the normal case and must still be fixed.
+    expect(runGuard({ protocol: 'https:', pathname: '/proxy/19278' }).replaced)
+      .toBe('/proxy/19278/');
   });
 
   it('leaves the desktop shell alone', () => {

--- a/web/src/pathPrefix.test.ts
+++ b/web/src/pathPrefix.test.ts
@@ -1,0 +1,130 @@
+// The three moving parts that let one bundle serve both a same-origin
+// deployment and one mounted under a path prefix by a prefix-stripping reverse
+// proxy (code-server's /proxy/<port>/, an nginx `location`).
+//
+// None of them is reachable from application code: vite.config.ts is build
+// input, public/config.js ships as a static file, and the trailing-slash guard
+// is inline in index.html. So they are pulled in as source text and exercised
+// directly — otherwise the only thing that notices a regression is a blank page
+// in a deployment nobody runs in CI.
+//
+// `?raw` rather than node:fs: tsconfig.app.json deliberately carries only
+// `vite/client` types, and reaching for node:fs here would mean granting node
+// types to all of src/.
+import { describe, expect, it, vi } from 'vitest';
+import indexHtml from '../index.html?raw';
+import configJs from '../public/config.js?raw';
+import viteConfigSrc from '../vite.config.ts?raw';
+
+// --- vite base -------------------------------------------------------------
+
+describe('vite base', () => {
+  it('emits relative asset URLs', () => {
+    // Line comments are stripped first so that the config's own prose about
+    // `base: '/'` cannot satisfy — or defeat — the assertion.
+    const code = viteConfigSrc.split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
+    // Absolute ('/', vite's default) makes the browser resolve /assets/… against
+    // the ORIGIN root, which under a proxy belongs to the proxy, not knomit.
+    expect(code).toMatch(/^\s*base:\s*'\.\/',\s*$/m);
+  });
+});
+
+// --- public/config.js ------------------------------------------------------
+
+// Run the shipped static config.js against a stubbed document, and report the
+// base it sets. Executing the real file (rather than restating its expression)
+// is the point: this fails if the file stops setting the global at all.
+function deriveApiBase(baseURI: string): unknown {
+  const win: Record<string, unknown> = {};
+  new Function('window', 'document', configJs)(win, { baseURI });
+  return win.__KNOMIT_API_BASE__;
+}
+
+describe('config.js API base', () => {
+  it.each([
+    ['same-origin cloud build', 'https://knomit.example/', ''],
+    ['mounted under a prefix', 'https://box.example/proxy/19278/', '/proxy/19278'],
+    ['mounted under a nested prefix', 'https://box.example/a/b/c/', '/a/b/c'],
+    ['ignores query and fragment', 'https://knomit.example/proxy/1/?x=1', '/proxy/1'],
+  ])('%s: %s -> %o', (_name, baseURI, expected) => {
+    expect(deriveApiBase(baseURI)).toBe(expected);
+  });
+
+  it('produces a base that concatenates with an API path', () => {
+    // Every caller in api.ts appends a path that already starts with '/', so a
+    // trailing slash here would produce '//api/v1/...'.
+    expect(deriveApiBase('https://box.example/proxy/19278/') + '/api/v1/repos')
+      .toBe('/proxy/19278/api/v1/repos');
+    expect(deriveApiBase('https://knomit.example/') + '/api/v1/repos')
+      .toBe('/api/v1/repos');
+  });
+});
+
+// --- index.html ------------------------------------------------------------
+
+describe('index.html', () => {
+  it('has no root-absolute asset references', () => {
+    // vite rewrites the tags it injects, but not the hand-written ones. A
+    // reintroduced href="/favicon.svg" resolves against the proxy's root.
+    const absolute = [...indexHtml.matchAll(/(?:src|href)="(\/[^/][^"]*)"/g)].map(m => m[1]);
+    expect(absolute).toEqual([]);
+  });
+
+  it('still references favicon.svg, config.js and the entry, relatively', () => {
+    // Guards the assertion above against passing because the tags were deleted.
+    expect(indexHtml).toContain('href="./favicon.svg"');
+    expect(indexHtml).toContain('src="./config.js"');
+    expect(indexHtml).toContain('src="./src/main.tsx"');
+  });
+});
+
+// --- the trailing-slash guard ---------------------------------------------
+
+// The guard is inline in index.html's <head> — the first <script> with no src.
+function trailingSlashGuard(): string {
+  const m = indexHtml.match(/<script>([\s\S]*?)<\/script>/);
+  if (!m) throw new Error('index.html has no inline guard script');
+  return m[1];
+}
+
+function runGuard(loc: Partial<Location>): { replaced: string | null } {
+  let replaced: string | null = null;
+  const location = {
+    search: '',
+    hash: '',
+    replace: vi.fn((url: string) => { replaced = url; }),
+    ...loc,
+  };
+  new Function('location', trailingSlashGuard())(location);
+  return { replaced };
+}
+
+describe('trailing-slash guard', () => {
+  it('redirects a prefixed mount that is missing its trailing slash', () => {
+    // Without this the browser treats `proxy` as the directory and every
+    // ./assets/… resolves to /proxy/assets/… — 404, blank page.
+    expect(runGuard({ protocol: 'https:', pathname: '/proxy/19278' }).replaced)
+      .toBe('/proxy/19278/');
+  });
+
+  it('carries query and fragment across the redirect', () => {
+    expect(runGuard({
+      protocol: 'https:', pathname: '/proxy/19278', search: '?a=1', hash: '#f',
+    }).replaced).toBe('/proxy/19278/?a=1#f');
+  });
+
+  it('does not redirect when the slash is already there — no loop', () => {
+    // The replacement path always ends in '/', so this is the second load.
+    expect(runGuard({ protocol: 'https:', pathname: '/proxy/19278/' }).replaced).toBeNull();
+    expect(runGuard({ protocol: 'https:', pathname: '/' }).replaced).toBeNull();
+  });
+
+  it('leaves the desktop shell alone', () => {
+    // macOS: the custom wails:// scheme is excluded by protocol. Every platform:
+    // tools/desktop/app.go calls window.SetURL("/"), so the pathname ends in '/'
+    // anyway. Either guard alone is sufficient; both are asserted so that
+    // dropping one is a test failure rather than a silent narrowing.
+    expect(runGuard({ protocol: 'wails:', pathname: '/index.html' }).replaced).toBeNull();
+    expect(runGuard({ protocol: 'http:', pathname: '/' }).replaced).toBeNull();
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -55,6 +55,20 @@ function vendorChunk(id: string): string | undefined {
 
 // https://vite.dev/config/
 export default defineConfig({
+  // Relative asset URLs, so the bundle can be mounted under a path prefix.
+  // A reverse proxy (code-server's /proxy/<port>/, an nginx `location`) strips
+  // the prefix before forwarding, so the server still sees `/`-rooted paths and
+  // needs no prefix awareness — but the HTML it returns did, because vite's
+  // default `base: '/'` writes `/assets/index-<hash>.js` and the browser
+  // resolves that against the ORIGIN root, which belongs to the proxy. Every
+  // asset 404s and the page is blank.
+  //
+  // The usual objection to './' is deep links: a document at /a/b/ resolves
+  // './assets/x.js' against /a/b/, not the mount root. It does not apply here
+  // because the app has NO router — no react-router, no history.pushState — so
+  // the document URL never changes after load and is always the mount root.
+  // Adding a router later means revisiting this.
+  base: './',
   plugins: [react(), keepEmbedSentinel()],
   build: {
     rollupOptions: { output: { manualChunks: vendorChunk } },


### PR DESCRIPTION
Makes `knomit serve`'s UI work when it is reached through a reverse proxy that mounts it under a path prefix, without touching the two existing deployments.

## Why

The dev box runs code-server, which can surface another local app at `https://<host>/proxy/<port>/`. It forwards with the `/proxy/<port>` prefix **stripped** and rewrites nothing in the response body. The HTML arrived fine; every asset reference inside it was an absolute path, so the browser resolved it against the origin root — which belongs to code-server:

| Browser request | Lands on | Result |
|---|---|---|
| `/proxy/19278/` | knomit | 200, index.html |
| `/assets/index-*.js` | **code-server** | 404 |
| `/config.js` | **code-server** | 404 |
| `/favicon.svg` | **code-server** | 404 |

Blank page. Not a bug — absolute asset paths are correct for an app that owns its origin. They just make it un-mountable.

## What changed

- **`web/vite.config.ts`** — `base: './'`. The usual objection (deep links resolving against the wrong directory) doesn't apply: there is no router and no `pushState` anywhere in `web/src`, so the document URL never changes after load.
- **`web/index.html`** — the hand-written paths vite doesn't rewrite: `./favicon.svg`, `./config.js`, and the dev-server entry `./src/main.tsx`. Plus the trailing-slash guard below.
- **`web/public/config.js`** — `__KNOMIT_API_BASE__` derived from `document.baseURI` instead of hardcoded `""`. Desktop is untouched: `configInjectingHandler` answers `/config.js` ahead of the static FS, so this file is never read there.
- **No server-side change.** The proxy strips the prefix before forwarding, so knomit still sees `/`-rooted paths. Confirmed against the real binary, not assumed.

The base stays runtime-derived: one bundle, three deployments.

## The trailing-slash decision — measured, not reasoned

All of the above needs the document served **with** the trailing slash. code-server redirects to add it; a hand-rolled nginx `location` need not, so there's an inline guard rather than a dependency on that.

I implemented both candidates and compared. The browser's **preload scanner** runs ahead of the parser and has already fired the asset requests against the uncorrected base by the time any inline script executes:

| Approach | Console on a no-slash entry |
|---|---|
| `<base href>` rewrite | **6 errors** (3× 404, 2× `Refused to apply style … MIME type`, 1× config.js), then silent recovery |
| `location.replace` | **0 errors**, lands on the canonical URL |

A redirect throws the whole document away, so the same wasted speculative fetches are attributed to a page that no longer exists.

The guard is held off three ways: `http`/`https` only (excluding macOS's `wails://`), a pathname not already ending in `/` (`app.go:194` calls `window.SetURL("/")`, so the desktop shell never qualifies on any platform), and a refusal on a `//` pathname (see the review round below).

## Review round — `/code-review high`, 4 low findings

Two were defects and are fixed in `138aba55`; two were the record being wrong about the code.

- **Open redirect** — a pathname beginning `//` (`https://host//knomit` → `location.pathname === '//knomit'`) made the redirect target scheme-relative. Reproduced: `//evil.com/x` navigated to `https://evil.com/x/`. The guard now refuses. Worth noting for anyone reaching for the obvious repair: resolving through `new URL(target, location.href)` does **not** fix it — a leading `//` is an authority to the URL parser even with a base.
- **Stale comment in `config.js`** claimed `new URL('.', …)` honours a `<base>` written by the guard. There is no `<base>` — an earlier draft wrote one. A maintainer trusting that sentence could delete the redirect believing something else normalizes the directory, and the breakage is silent (base becomes `/proxy`, not `/proxy/19278`).
- **Considered and rejected:** narrowing the guard so it skips a URL whose last segment contains a dot. The concrete case (`…/proxy/19278/index.html`, where relative resolution is already correct) is unreachable — Go's `http.FileServer` 301s any path ending in `index.html` to `./` first — and the heuristic would refuse to fix a legitimate mount at `/apps/knomit.dev`, trading an unreachable failure for a plausible one. Documented in the source instead.
- **CSP** — a fronting proxy adding `script-src 'self'` would silently disable the inline guard, and `config.js` would then derive `/proxy` from `/proxy/19278`. There is no CSP in the codebase today. The degraded value is now pinned in the test table so the failure mode has a name. A server-side variant (`X-Forwarded-Prefix`) would remove the single point of failure, but that's a design change beyond this PR.

### Correction to the first commit message

Its "KNOWN CONSEQUENCE" paragraph is **wrong** and the review caught it. I claimed `newSPAHandler` serves index.html at any path, so `/anything` would blank under a relative base. I reasoned that from the code and never measured it. Probed:

```
/anything    301 -> /           (renders fine — the browser resolves ./ to the root)
/index.html  301 -> /
//evil.com   301 -> /
/anything/   301 -> /anything/  <-- redirects to itself
/a/b/c       301 -> /a/b/
```

So there is no blank-page consequence. The real pathology is `/anything/`, which 301s to itself — `ERR_TOO_MANY_REDIRECTS`. It is **pre-existing and unrelated to this PR** (it depends only on the request path, not on vite's base), noted here so it isn't lost, and deliberately not fixed inside this change.

## Verification

End-to-end against a binary built from this branch, behind a real prefix-stripping proxy:

- **Same-origin** — base `""`, all API calls unprefixed, app renders. Unchanged.
- **Prefixed `/proxy/<port>/`** — base `"/proxy/<port>"`; every asset, font, `config.js`, `favicon.svg`, 6 API endpoints, a POST and an async create-poll all under the prefix, 200, **0 console errors**.
- **Prefixed, no trailing slash** — redirects, loads clean, 0 console errors (re-checked after the guard change).
- Built CSS: no `url(/assets/…)`. `dist/.gitkeep` still restored by `keepEmbedSentinel`.
- `npm run build`, full vitest (**1205 passed**), `tsc -b`, eslint on the new file, `go test ./web/ ./internal/web/`, and `go test -tags desktop ./tools/desktop/` all green.

`web/src/pathPrefix.test.ts` covers all three pieces, which are otherwise unreachable from application code (build input, a static file, inline HTML). Pulled in with `?raw` rather than `node:fs`, since `tsconfig.app.json` deliberately carries only `vite/client` types. Every assertion is sabotage-verified — dropping the base, hardcoding config.js, re-absolutizing favicon or the entry, dropping the protocol check, neutering the guard, and removing the `//` bail each turn the suite red.

## Notes for review

- Two things checked and found **not** to be gaps: HAL `_links` hrefs come back server-absolute and unprefixed, but the UI never dereferences them (`api.ts:1171` only extracts the `after` query param; create-polling rebuilds via `apiUrl(create_id)`). And every request funnels through `apiUrl`/`repoBase`/`branchBase`/`sessionBase`.
- `RepoManager.tsx:1720` **displays** the MCP endpoint as an unprefixed path string. Cosmetic, never fetched; left alone as out of scope.
- SSE wasn't exercised end-to-end (creating a repo by hand needs a full ontology payload). It builds its URL from the same base as the 6 proven calls (`App.tsx:529`), so there's no separate path for the prefix to break — but that's reasoning, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
