### PR TITLE
feat(web): motif search, pivot, and per-repo vocabulary browser APIs

### DIFF
--- a/internal/mcp/explain.go
+++ b/internal/mcp/explain.go
@@ -89,6 +89,13 @@ type explainMotif struct {
 	// DF counts live facts carrying ANY spelling in the cluster, this one
 	// included. 1 means nothing else instantiates it yet.
 	DF int `json:"df"`
+	// ClusterKey is the cluster's STABLE identity — what GET /motifs/{key}
+	// accepts and what state may be keyed on. Canonical flips with usage;
+	// this does not.
+	ClusterKey string `json:"cluster_key,omitempty"`
+	// MemberCount is how many spellings resolve to this cluster (this one
+	// included). 1 means no aliasing — the common case.
+	MemberCount int `json:"member_count,omitempty"`
 	// Siblings are other facts carrying the cluster, most relevant first and
 	// bounded. Empty at df 1.
 	Siblings []string `json:"siblings,omitempty"`
@@ -660,8 +667,10 @@ func explainResume(ctx context.Context, b *repos.Binding, sWrite mcpStore, curso
 
 // explainMotifsShown bounds the sibling list per motif. A PROMPT/RESPONSE-SIZE
 // BUDGET: explain answers about one fact, and an unbounded sibling list on a
-// popular motif would bury it.
-const explainMotifsShown = 5
+// popular motif would bury it. Raised 5→8 with the REST vocabulary surface:
+// member_count tells a reader the list is a preview, and the full cluster is
+// one GET /motifs/{cluster_key} away.
+const explainMotifsShown = 8
 
 // explainMotifs resolves a fact's motifs for the §6 explain surface.
 //
@@ -674,6 +683,10 @@ func explainMotifs(ctx context.Context, rt repos.ReadTarget, s mcpStore, parsed 
 		return nil
 	}
 	branch := rt.Branch
+	// Read ONCE for the whole fact, not per motif: the alias table is the same
+	// table for every entry, and a fact carrying five motifs would otherwise
+	// read it five times.
+	aliasRows, aliasErr := s.motifs.AliasRows(ctx, branch)
 	out := make([]explainMotif, 0, len(parsed.Motifs))
 	for _, m := range parsed.Motifs {
 		entry := explainMotif{Motif: m}
@@ -688,6 +701,21 @@ func explainMotifs(ctx context.Context, rt repos.ReadTarget, s mcpStore, parsed 
 		if err != nil {
 			out = append(out, entry)
 			continue
+		}
+		entry.ClusterKey = key
+		// Member count from the alias table; an unresolved cluster has no
+		// rows and is the singleton it degrades to everywhere else.
+		entry.MemberCount = 1
+		if aliasErr == nil {
+			n := 0
+			for _, row := range aliasRows {
+				if row.ClusterKey == key {
+					n++
+				}
+			}
+			if n > 0 {
+				entry.MemberCount = n
+			}
 		}
 		if def, ok, dErr := s.motifs.Definition(ctx, branch, key); dErr == nil && ok {
 			entry.Definition = def

--- a/internal/mcp/explain_test.go
+++ b/internal/mcp/explain_test.go
@@ -547,3 +547,100 @@ func TestClassifyRefs_EmptySlicesAreNonNil(t *testing.T) {
 	require.Empty(t, cr.Local)
 	require.Empty(t, cr.External)
 }
+
+// expMotif mirrors the explainMotif wire shape. cluster_key and member_count
+// are what let an agent go fact → cluster → REST detail / precise pivot; the
+// pointer on MemberCount distinguishes "key absent" from "present and zero".
+type expMotif struct {
+	Motif       string   `json:"motif"`
+	Canonical   string   `json:"canonical"`
+	Definition  string   `json:"definition"`
+	DF          int      `json:"df"`
+	ClusterKey  string   `json:"cluster_key"`
+	MemberCount *int     `json:"member_count"`
+	Siblings    []string `json:"siblings"`
+}
+
+// writeExplainFactMotifs is writeExplainFact with motifs attached.
+func writeExplainFactMotifs(t *testing.T, ctx context.Context, ri *repos.RepoInstance, path, title string, motifs []string) {
+	t.Helper()
+	f := fact.NewFact(path)
+	f.Title = title
+	f.Body = title + " body text."
+	f.Type = fact.Observation
+	f.Domain = []string{"testing"}
+	f.Confidence = 0.9
+	f.Sources = 1
+	f.Entities = []string{}
+	f.Motifs = motifs
+	content, err := fact.SerializeFact(f)
+	require.NoError(t, err)
+	ri.WithRead(func(svc *store.Service) {
+		_, werr := svc.Facts().WriteFact(ctx, explainTestBranch, path, content, "write "+path, "")
+		require.NoError(t, werr)
+	})
+}
+
+// explainMotifsOf re-reads the raw explain response for the motif block, which
+// the expFact mirror deliberately does not carry.
+func explainMotifsOf(t *testing.T, ctx context.Context, file string) []expMotif {
+	t.Helper()
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{"file": file}
+	result, err := ExplainHandler()(ctx, req)
+	require.NoError(t, err)
+	text := resultText(t, result)
+	require.False(t, result.IsError, "explain error: %s", text)
+
+	var resp struct {
+		Facts []struct {
+			Path   string     `json:"path"`
+			Motifs []expMotif `json:"motifs"`
+		} `json:"facts"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text), &resp), "bad JSON: %s", text)
+	for _, f := range resp.Facts {
+		if f.Path == file {
+			return f.Motifs
+		}
+	}
+	t.Fatalf("explain did not return %s: %s", file, text)
+	return nil
+}
+
+// The explain motif block carries the cluster's STABLE key and how many
+// spellings resolve to it — an agent can then pivot precisely (GET
+// /motifs/{cluster_key}) instead of guessing from the canonical, which flips.
+func TestExplainMotifs_CarryClusterKeyAndMemberCount(t *testing.T) {
+	ri := newLearnTestRepo(t, fact.CodeOntology())
+	ctx := repos.WithRepoInstance(context.Background(), ri)
+
+	writeExplainFactMotifs(t, ctx, ri, "kb/one.md", "Drift one", []string{"config-drift"})
+	writeExplainFactMotifs(t, ctx, ri, "kb/two.md", "Drift two", []string{"config-drifts"})
+	writeExplainFactMotifs(t, ctx, ri, "kb/three.md", "Lonely", []string{"silent-fallback"})
+
+	var wantKey string
+	ri.WithRead(func(svc *store.Service) {
+		require.NoError(t, svc.Motifs().RebuildAliases(ctx, explainTestBranch))
+		k, err := svc.Motifs().ClusterKey(ctx, explainTestBranch, "config-drift")
+		require.NoError(t, err)
+		wantKey = k
+	})
+	require.NotEmpty(t, wantKey)
+
+	motifs := explainMotifsOf(t, ctx, "kb/one.md")
+	require.Len(t, motifs, 1)
+	require.Equal(t, "config-drift", motifs[0].Motif)
+	require.Equal(t, wantKey, motifs[0].ClusterKey,
+		"cluster_key must be the store's stable key, not the spelling or canonical")
+	require.NotNil(t, motifs[0].MemberCount)
+	require.Equal(t, 2, *motifs[0].MemberCount,
+		"both spellings resolve to this cluster")
+
+	// A cluster nothing was aliased into is the singleton it degrades to
+	// everywhere else — 1, never 0 or absent.
+	single := explainMotifsOf(t, ctx, "kb/three.md")
+	require.Len(t, single, 1)
+	require.NotNil(t, single[0].MemberCount)
+	require.Equal(t, 1, *single[0].MemberCount)
+}

--- a/internal/mcp/motif_surfaces_test.go
+++ b/internal/mcp/motif_surfaces_test.go
@@ -104,9 +104,13 @@ func TestMotifMatch_LooseTiersAreNeverReachedByAutomation(t *testing.T) {
 	// which is never the new one. The previous version named eleven files; a
 	// twelfth selecting token-1 would have been invisible to it.
 	//
-	// The three package directories ARE the rule's scope, so the scan reads the
-	// scope rather than a sample of it.
-	dirs := []string{".", "../synthesize", "../store"}
+	// The package directories ARE the rule's scope, so the scan reads the
+	// scope rather than a sample of it. internal/web joined when the REST
+	// surface began forwarding motif filters: a handler that defaulted to a
+	// loose tier, or an error string that merely NAMED one as available, is
+	// exactly what this scan exists to catch — web validation is an allowlist
+	// and must stay silent about the tiers beyond it.
+	dirs := []string{".", "../synthesize", "../store", "../web"}
 	var files []string
 	for _, dir := range dirs {
 		entries, err := os.ReadDir(dir)

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -322,6 +322,9 @@ type MotifIndex interface {
 	// Definition returns a cluster's standing definition, INCLUDING a stale one
 	// — a stale sentence is used as interim rather than gapping the cluster.
 	Definition(ctx context.Context, branch, clusterKey string) (string, bool, error)
+	// Definitions is the bulk Definition + freshness for many clusters at once.
+	// Absent key = no definition. See MotifDefinitionStatus.
+	Definitions(ctx context.Context, branch string, keys []string) (map[string]MotifDefinitionStatus, error)
 	// VocabularyHealth computes the §3.3 metrics over AUTHORED facts only.
 	// Diagnostic; nothing branches on it.
 	VocabularyHealth(ctx context.Context, branch string) (MotifVocabularyHealth, error)

--- a/internal/store/motif_definition.go
+++ b/internal/store/motif_definition.go
@@ -341,3 +341,48 @@ func (mi *motifIndex) MotifCoverage(ctx context.Context, branch string) (with, t
 	}
 	return with, total, nil
 }
+
+// MotifDefinitionStatus is a cluster's standing definition with its freshness.
+// Stale means it was authored against a different membership — served as
+// interim (the Definition designer ruling), but a consumer may say so.
+type MotifDefinitionStatus struct {
+	Definition string
+	Stale      bool
+}
+
+// Definitions is the bulk form of Definition + the staleness comparison, for
+// readers that page over many clusters (the vocabulary browser): one query for
+// the rows, one for the memberships, instead of 2N point reads.
+//
+// A key with no stored definition is ABSENT from the result — "missing" is the
+// absence, not an empty entry, matching Definition's (_, false, nil).
+func (mi *motifIndex) Definitions(ctx context.Context, branch string, keys []string) (map[string]MotifDefinitionStatus, error) {
+	branchID, err := mi.rh.branchID(ctx, branch)
+	if err != nil {
+		return nil, fmt.Errorf("Definitions: %w", err)
+	}
+	stored, err := mi.definitionRows(ctx, branchID)
+	if err != nil {
+		return nil, err
+	}
+	membership, err := mi.clusterMembership(ctx, branchID)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]MotifDefinitionStatus, len(keys))
+	for _, key := range keys {
+		row, ok := stored[key]
+		if !ok {
+			continue
+		}
+		out[key] = MotifDefinitionStatus{
+			Definition: row.definition,
+			// Same comparison ClustersNeedingDefinition applies: authored-over
+			// membership vs current. On an unrebuilt corpus membership[key] is
+			// "" and a stamped definition reads stale, which is honest — the
+			// vocabulary it described is not the one being served.
+			Stale: row.members != membership[key],
+		}
+	}
+	return out, nil
+}

--- a/internal/store/motif_definition_test.go
+++ b/internal/store/motif_definition_test.go
@@ -347,3 +347,46 @@ func TestMotifDefinitions_NoStampReadsCurrentMembership(t *testing.T) {
 				"was written over, so it is current until that membership moves")
 	}
 }
+
+// Definitions is the bulk read the vocabulary browser pages with: one query,
+// keyed on cluster_key, absent = never defined, Stale derived by the same
+// membership comparison ClustersNeedingDefinition uses.
+func TestMotifDefinitions_BulkStatusCurrentStaleMissing(t *testing.T) {
+	svc, branch := motifEnv(t)
+	ctx := context.Background()
+	writeMotifFact(t, svc, branch, "kb/alpha/one.md", []string{"silent-fallback"})
+	writeMotifFact(t, svc, branch, "kb/alpha/two.md", []string{"config-drift"})
+	writeMotifFact(t, svc, branch, "kb/alpha/three.md", []string{"scope-creep"})
+	require.NoError(t, svc.Motifs().RebuildAliases(ctx, branch))
+
+	keyCurrent, err := svc.Motifs().ClusterKey(ctx, branch, "silent-fallback")
+	require.NoError(t, err)
+	keyStale, err := svc.Motifs().ClusterKey(ctx, branch, "config-drift")
+	require.NoError(t, err)
+	keyMissing, err := svc.Motifs().ClusterKey(ctx, branch, "scope-creep")
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Motifs().PutDefinition(ctx, branch, keyCurrent,
+		"A component continues serving after a dependency fails.", DefinitionStamp{}))
+	require.NoError(t, svc.Motifs().PutDefinition(ctx, branch, keyStale,
+		"Configured state diverges from applied state.", DefinitionStamp{}))
+
+	// Membership of keyStale's cluster moves: a new spelling joins mechanically.
+	writeMotifFact(t, svc, branch, "kb/alpha/four.md", []string{"config-drifts"})
+	require.NoError(t, svc.Motifs().RebuildAliases(ctx, branch))
+
+	got, err := svc.Motifs().Definitions(ctx, branch,
+		[]string{keyCurrent, keyStale, keyMissing})
+	require.NoError(t, err)
+
+	require.Equal(t, "A component continues serving after a dependency fails.",
+		got[keyCurrent].Definition)
+	require.False(t, got[keyCurrent].Stale, "membership unchanged → current")
+
+	require.Equal(t, "Configured state diverges from applied state.",
+		got[keyStale].Definition, "stale definitions are served as interim, not dropped")
+	require.True(t, got[keyStale].Stale, "membership moved → stale")
+
+	_, ok := got[keyMissing]
+	require.False(t, ok, "never-defined cluster is ABSENT, not empty")
+}

--- a/internal/web/handlers_facts_collection.go
+++ b/internal/web/handlers_facts_collection.go
@@ -52,6 +52,7 @@ type recentFactItem struct {
 	Type        string      `json:"type,omitempty"`
 	Domain      []string    `json:"domain,omitempty"`
 	Entities    []string    `json:"entities,omitempty"`
+	Motifs      []string    `json:"motifs,omitempty"`
 	CommittedAt int64       `json:"committed_at,omitempty"`
 	Operation   string      `json:"operation,omitempty"`
 	Links       hal.LinkMap `json:"_links"`
@@ -73,6 +74,10 @@ func handleHALFactsCollection(b hal.URLBuilder, provider factsCollectionProvider
 			return
 		}
 		offset, ok := offsetParam(w, r)
+		if !ok {
+			return
+		}
+		motifs, motifMatch, ok := motifParams(w, r)
 		if !ok {
 			return
 		}
@@ -117,6 +122,8 @@ func handleHALFactsCollection(b hal.URLBuilder, provider factsCollectionProvider
 			ExcludeKinds:   splitCSV(qp.Get("exclude_kind")),
 			IncludeOrigins: splitCSV(qp.Get("origin")),
 			EpisodeOps:     splitCSV(qp.Get("ep")),
+			Motifs:         motifs,
+			MotifMatch:     motifMatch,
 		}
 
 		entries, total, err := provider.RecentFacts(r.Context(), ri, branch, opts)
@@ -163,6 +170,7 @@ func handleHALFactsCollection(b hal.URLBuilder, provider factsCollectionProvider
 				Type:        e.Type,
 				Domain:      e.Domain,
 				Entities:    e.Entities,
+				Motifs:      e.Motifs,
 				CommittedAt: e.CommittedAt,
 				Operation:   e.Operation,
 				Links:       hal.LinkMap{"self": {Href: b.Fact(repoName, a, e.Path)}},

--- a/internal/web/handlers_facts_collection_test.go
+++ b/internal/web/handlers_facts_collection_test.go
@@ -439,3 +439,81 @@ func TestHandleHALFactsCollection_StoreError_Returns500(t *testing.T) {
 		t.Errorf("status: %d, want 500", rec.Code)
 	}
 }
+
+// TestHandleHALFactsCollection_MotifFilterReachesSearchOptions locks in that
+// ?motifs= / ?motif_match= on /facts reach SearchOptions.
+func TestHandleHALFactsCollection_MotifFilterReachesSearchOptions(t *testing.T) {
+	provider := &stubFactsCollectionProvider{}
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			factsCollection: provider,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		"/repos/alpha/branches/agent:test/facts?motifs=zero-value-as-valid,silent-fallback&motif_match=stem", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, []string{"zero-value-as-valid", "silent-fallback"}, provider.lastOpts.Motifs)
+	require.Equal(t, store.MotifMatchStem, provider.lastOpts.MotifMatch)
+}
+
+// TestHandleHALFactsCollection_LooseMotifTierRejected: refused at the edge,
+// before any store call (C3/MN6).
+func TestHandleHALFactsCollection_LooseMotifTierRejected(t *testing.T) {
+	provider := &stubFactsCollectionProvider{}
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			factsCollection: provider,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		"/repos/alpha/branches/agent:test/facts?motifs=a-b&motif_match=token-1", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Nil(t, provider.lastOpts.Motifs, "provider must not be called on a rejected tier")
+}
+
+// TestHandleHALFactsCollection_MotifsOnTheWire: rows carry their motifs, and a
+// motif-free row omits the key entirely.
+func TestHandleHALFactsCollection_MotifsOnTheWire(t *testing.T) {
+	provider := &stubFactsCollectionProvider{
+		entries: []store.RecentFactEntry{
+			{Path: "kb/a.md", Title: "Carries a motif", Motifs: []string{"a-b"}},
+			{Path: "kb/b.md", Title: "Carries none"},
+		},
+		total: 2,
+	}
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			factsCollection: provider,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/repos/alpha/branches/agent:test/facts", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var view struct {
+		Embedded struct {
+			Facts []map[string]any `json:"facts"`
+		} `json:"_embedded"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &view))
+	require.Len(t, view.Embedded.Facts, 2)
+	require.Equal(t, []any{"a-b"}, view.Embedded.Facts[0]["motifs"])
+	_, present := view.Embedded.Facts[1]["motifs"]
+	require.False(t, present, "motif-free row must omit the key entirely")
+}

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -77,6 +77,7 @@ type lensFactItem struct {
 	Title       string         `json:"title"`
 	Kind        string         `json:"kind,omitempty"` // omitted when epistemic (the default)
 	Type        string         `json:"type,omitempty"`
+	Motifs      []string       `json:"motifs,omitempty"`
 	CommittedAt int64          `json:"committed_at,omitempty"`
 	Operation   string         `json:"operation,omitempty"`
 	Score       float64        `json:"score"`
@@ -156,6 +157,11 @@ func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
 		// uses. A kb://-qualified path restricts to a single mount (with the
 		// filter made repo-relative); an unqualified path applies per mount,
 		// skipping mounts whose ontology lacks the topic.
+		motifs, motifMatch, ok := motifParams(w, r)
+		if !ok {
+			return
+		}
+
 		targets, err := federate.ReadTargetsFor(b, path)
 		if err != nil {
 			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
@@ -192,8 +198,15 @@ func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
 			ExcludeKinds:   splitCSV(qp.Get("exclude_kind")),
 			IncludeOrigins: splitCSV(qp.Get("origin")),
 			EpisodeOps:     splitCSV(qp.Get("ep")),
-			MinConfidence:  minConfidence,
-			MinSimilarity:  minSimilarity,
+			// Motif terms resolve PER MOUNT against each repo's own alias
+			// vocabulary — there is no cross-mount cluster identity. A mount
+			// that judge-merged two spellings answers for both; one that keeps
+			// them apart answers only for the exact term. Deliberate semantics
+			// (design 2026-08-28), mirrored in openapi.yaml.
+			Motifs:        motifs,
+			MotifMatch:    motifMatch,
+			MinConfidence: minConfidence,
+			MinSimilarity: minSimilarity,
 			// Limit is set per fan-out round below — see `depth`.
 			Offset: 0,
 		}
@@ -323,6 +336,7 @@ func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
 					Title:       e.Title,
 					Kind:        kind,
 					Type:        e.Type,
+					Motifs:      e.Motifs,
 					CommittedAt: e.CommittedAt,
 					Operation:   e.Operation,
 					Score:       e.Score,
@@ -584,6 +598,7 @@ type lensSearchItem struct {
 	Type       string         `json:"type,omitempty"`
 	Domain     []string       `json:"domain,omitempty"`
 	Entities   []string       `json:"entities,omitempty"`
+	Motifs     []string       `json:"motifs,omitempty"`
 	Confidence float64        `json:"confidence,omitempty"`
 	Source     lensFactSource `json:"source"`
 }
@@ -642,6 +657,11 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.Handl
 		// Ontology-aware fan-out target selection — the same seam MCP queryFirstCall
 		// uses. A kb://-qualified path restricts to one mount (filter made
 		// repo-relative); an unqualified path applies per mount.
+		motifs, motifMatch, ok := motifParams(w, r)
+		if !ok {
+			return
+		}
+
 		targets, err := federate.ReadTargetsFor(b, qp.Get("path"))
 		if err != nil {
 			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
@@ -669,9 +689,16 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.Handl
 			ExcludeKinds:   splitCSV(qp.Get("exclude_kind")),
 			IncludeOrigins: splitCSV(qp.Get("origin")),
 			EpisodeOps:     splitCSV(qp.Get("ep")),
-			MinConfidence:  minConfidence,
-			MinSimilarity:  minSimilarity,
-			Limit:          maxLensSearchCandidates,
+			// Motif terms resolve PER MOUNT against each repo's own alias
+			// vocabulary — there is no cross-mount cluster identity. A mount
+			// that judge-merged two spellings answers for both; one that keeps
+			// them apart answers only for the exact term. Deliberate semantics
+			// (design 2026-08-28), mirrored in openapi.yaml.
+			Motifs:        motifs,
+			MotifMatch:    motifMatch,
+			MinConfidence: minConfidence,
+			MinSimilarity: minSimilarity,
+			Limit:         maxLensSearchCandidates,
 		}
 
 		// Fan out to every selected mount at its Binding-resolved branch. Any mount
@@ -724,6 +751,7 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.Handl
 				Type:       res.Type,
 				Domain:     res.Domain,
 				Entities:   res.Entities,
+				Motifs:     res.Motifs,
 				Confidence: res.Confidence,
 				Source: lensFactSource{
 					Repo:   t.RT.RI.Name(),

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -1468,3 +1468,158 @@ func TestLensFanoutDepth_OverflowingOffsetStillClamps(t *testing.T) {
 		})
 	}
 }
+
+// Motif filtering fans out to EVERY mount, carrying the same terms and tier —
+// the per-mount-resolution semantics made testable. Each mount expands the
+// terms against its own alias vocabulary; the handler's job is to make sure
+// every mount is asked the same question.
+func TestLensFacts_MotifFilterReachesEveryMount(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensFactsStub{byRepo: map[string][]store.RecentFactEntry{}}
+	s := &Server{Manager: m, providers: storeProviders{factsCollection: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	if rec := getLensFacts(t, r, "/lenses/eng/facts?motifs=a-b&motif_match=token-2"); rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	for _, repo := range []string{"alpha", "beta"} {
+		opts, ok := stub.lastOpts[repo]
+		if !ok {
+			t.Fatalf("mount %q was never queried", repo)
+		}
+		if got := fmt.Sprint(opts.Motifs); got != "[a-b]" {
+			t.Errorf("%s Motifs: got %v, want [a-b]", repo, opts.Motifs)
+		}
+		if opts.MotifMatch != store.MotifMatchToken2 {
+			t.Errorf("%s MotifMatch: got %q, want token-2", repo, opts.MotifMatch)
+		}
+	}
+}
+
+// The tiers this surface refuses are refused before the fan-out starts — no
+// mount is queried at all (C3/MN6).
+func TestLensFacts_LooseMotifTierRejected(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensFactsStub{byRepo: map[string][]store.RecentFactEntry{}}
+	s := &Server{Manager: m, providers: storeProviders{factsCollection: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts?motifs=a-b&motif_match=token-1")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(stub.lastOpts) != 0 {
+		t.Errorf("mounts were queried despite the rejection: %v", stub.lastOpts)
+	}
+}
+
+// Same two properties on the relevance twin.
+func TestLensSearch_MotifFilterReachesEveryMount(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{}}
+	s := &Server{Manager: m, providers: storeProviders{search: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/search?q=x&motifs=a-b&motif_match=token-2")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	for _, repo := range []string{"alpha", "beta"} {
+		opts, ok := stub.lastOpts[repo]
+		if !ok {
+			t.Fatalf("mount %q was never queried", repo)
+		}
+		if got := fmt.Sprint(opts.Motifs); got != "[a-b]" {
+			t.Errorf("%s Motifs: got %v, want [a-b]", repo, opts.Motifs)
+		}
+		if opts.MotifMatch != store.MotifMatchToken2 {
+			t.Errorf("%s MotifMatch: got %q, want token-2", repo, opts.MotifMatch)
+		}
+	}
+}
+
+func TestLensSearch_LooseMotifTierRejected(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{}}
+	s := &Server{Manager: m, providers: storeProviders{search: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/search?q=x&motifs=a-b&motif_match=token-1")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(stub.lastOpts) != 0 {
+		t.Errorf("mounts were queried despite the rejection: %v", stub.lastOpts)
+	}
+}
+
+// The union rows carry each fact's motifs; a motif-free row omits the key.
+func TestLensFacts_MotifsOnTheWire(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	stub := &lensFactsStub{byRepo: map[string][]store.RecentFactEntry{
+		"alpha": {
+			{Path: "kb/a.md", Title: "Carries a motif", Motifs: []string{"a-b"}, CommittedAt: 2},
+			{Path: "kb/b.md", Title: "Carries none", CommittedAt: 1},
+		},
+	}}
+	s := &Server{Manager: m, providers: storeProviders{factsCollection: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha"}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Facts []map[string]any `json:"facts"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if len(body.Facts) != 2 {
+		t.Fatalf("facts: got %d, want 2; body=%s", len(body.Facts), rec.Body.String())
+	}
+	if got := body.Facts[0]["motifs"]; fmt.Sprint(got) != "[a-b]" {
+		t.Errorf("row 0 motifs: got %v, want [a-b]", got)
+	}
+	if _, present := body.Facts[1]["motifs"]; present {
+		t.Errorf("motif-free row must omit the key entirely; body=%s", rec.Body.String())
+	}
+}
+
+func TestLensSearch_MotifsOnTheWire(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	withMotif := sr("kb/a.md", "Carries a motif", 10)
+	withMotif.Motifs = []string{"a-b"}
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{
+		"alpha": {withMotif, sr("kb/b.md", "Carries none", 5)},
+	}}
+	s := &Server{Manager: m, providers: storeProviders{search: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha"}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/search?q=x")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Results []map[string]any `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if len(body.Results) != 2 {
+		t.Fatalf("results: got %d, want 2; body=%s", len(body.Results), rec.Body.String())
+	}
+	if got := body.Results[0]["motifs"]; fmt.Sprint(got) != "[a-b]" {
+		t.Errorf("row 0 motifs: got %v, want [a-b]", got)
+	}
+	if _, present := body.Results[1]["motifs"]; present {
+		t.Errorf("motif-free row must omit the key entirely; body=%s", rec.Body.String())
+	}
+}

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -1623,3 +1623,168 @@ func TestLensSearch_MotifsOnTheWire(t *testing.T) {
 		t.Errorf("motif-free row must omit the key entirely; body=%s", rec.Body.String())
 	}
 }
+
+// motifResolvingLensStub models PER-MOUNT motif resolution: every mount holds
+// its own corpus AND its own alias table, so one query term legitimately
+// reaches two different answers. This is what the openapi
+// LensMotifMatchTier description promises, and asserting only that both mounts
+// received the same terms cannot tell it apart from write-repo-only resolution.
+type motifResolvingLensStub struct {
+	// facts[repo] is that mount's corpus; each entry carries the exact motif
+	// spelling its author wrote.
+	facts map[string][]store.RecentFactEntry
+	// aliases[repo][term] is the set of spellings that mount resolves term to.
+	// A mount that judge-merged two spellings lists both; a mount that never
+	// did resolves a term to itself, which is the store's own degradation.
+	aliases  map[string]map[string][]string
+	lastOpts map[string]store.SearchOptions
+}
+
+// resolve mirrors the store's exact tier: a query term expands to the
+// spellings THIS mount considers the same mechanism.
+func (s *motifResolvingLensStub) resolve(repo string, terms []string) map[string]bool {
+	out := map[string]bool{}
+	for _, term := range terms {
+		if expanded, ok := s.aliases[repo][term]; ok {
+			for _, sp := range expanded {
+				out[sp] = true
+			}
+			continue
+		}
+		out[term] = true
+	}
+	return out
+}
+
+func (s *motifResolvingLensStub) carriers(repo string, opts store.SearchOptions) []store.RecentFactEntry {
+	if s.lastOpts == nil {
+		s.lastOpts = map[string]store.SearchOptions{}
+	}
+	s.lastOpts[repo] = opts
+	corpus := s.facts[repo]
+	if len(opts.Motifs) == 0 {
+		return corpus
+	}
+	want := s.resolve(repo, opts.Motifs)
+	var out []store.RecentFactEntry
+	for _, e := range corpus {
+		for _, m := range e.Motifs {
+			if want[m] {
+				out = append(out, e)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func (s *motifResolvingLensStub) RecentFacts(
+	_ context.Context,
+	ri *repos.RepoInstance, _ string, opts store.SearchOptions,
+) ([]store.RecentFactEntry, int, error) {
+	e := s.carriers(ri.Name(), opts)
+	return e, len(e), nil
+}
+
+func (s *motifResolvingLensStub) Search(
+	_ context.Context,
+	ri *repos.RepoInstance, _ store.Embedder, _ string, opts store.SearchOptions,
+) ([]store.SearchResult, error) {
+	var out []store.SearchResult
+	for _, e := range s.carriers(ri.Name(), opts) {
+		out = append(out, store.SearchResult{
+			FactWithBody: store.FactWithBody{
+				FactRecord: store.FactRecord{Path: e.Path, Title: e.Title, Type: "observation", Motifs: e.Motifs},
+			},
+			Score: float64(e.CommittedAt),
+		})
+	}
+	return out, nil
+}
+
+// divergentVocabularies builds the asymmetry the semantics turn on: mount alpha
+// judge-merged "config-drift" and "configuration-drifts"; mount beta never did.
+// A query for "config-drift" must therefore pull alpha's aliased fact and NOT
+// beta's identically-spelled one, while still pulling beta's exact carrier —
+// so "beta answered only exactly" is distinguishable from "beta was never
+// asked".
+func divergentVocabularies() *motifResolvingLensStub {
+	return &motifResolvingLensStub{
+		facts: map[string][]store.RecentFactEntry{
+			"alpha": {
+				{Path: "kb/alpha-aliased.md", Title: "Alpha aliased", Motifs: []string{"configuration-drifts"}, CommittedAt: 40},
+			},
+			"beta": {
+				{Path: "kb/beta-exact.md", Title: "Beta exact", Motifs: []string{"config-drift"}, CommittedAt: 30},
+				{Path: "kb/beta-aliased.md", Title: "Beta aliased", Motifs: []string{"configuration-drifts"}, CommittedAt: 20},
+			},
+		},
+		aliases: map[string]map[string][]string{
+			"alpha": {"config-drift": {"config-drift", "configuration-drifts"}},
+			// beta: no alias table at all — every spelling is its own cluster.
+		},
+	}
+}
+
+func TestLensFacts_MotifResolutionIsPerMountNotShared(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := divergentVocabularies()
+	s := &Server{Manager: m, providers: storeProviders{factsCollection: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts?motifs=config-drift")
+	body := decodeLensFacts(t, rec)
+
+	titles := map[string]bool{}
+	for _, f := range body.Facts {
+		titles[f.Title] = true
+	}
+	// alpha merged the spellings, so its aliased fact answers the query.
+	if !titles["Alpha aliased"] {
+		t.Errorf("the merging mount's aliased fact is missing: %v", titles)
+	}
+	// beta did not, so its identically-spelled fact must NOT — this is the
+	// assertion that fails if resolution were shared or write-repo-only.
+	if titles["Beta aliased"] {
+		t.Errorf("the non-merging mount answered for an aliased spelling: %v", titles)
+	}
+	// ...but beta WAS queried and did contribute its exact carrier.
+	if !titles["Beta exact"] {
+		t.Errorf("the non-merging mount contributed nothing at all: %v", titles)
+	}
+}
+
+func TestLensSearch_MotifResolutionIsPerMountNotShared(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := divergentVocabularies()
+	s := &Server{Manager: m, providers: storeProviders{search: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/search?q=x&motifs=config-drift")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Results []struct {
+			Title string `json:"title"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	titles := map[string]bool{}
+	for _, res := range body.Results {
+		titles[res.Title] = true
+	}
+	if !titles["Alpha aliased"] {
+		t.Errorf("the merging mount's aliased fact is missing: %v", titles)
+	}
+	if titles["Beta aliased"] {
+		t.Errorf("the non-merging mount answered for an aliased spelling: %v", titles)
+	}
+	if !titles["Beta exact"] {
+		t.Errorf("the non-merging mount contributed nothing at all: %v", titles)
+	}
+}

--- a/internal/web/handlers_motifs.go
+++ b/internal/web/handlers_motifs.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -297,4 +298,166 @@ func motifClusterMatches(c store.MotifCluster, definition, q string) bool {
 		}
 	}
 	return strings.Contains(strings.ToLower(definition), q)
+}
+
+// Carrier preview bounds for the cluster detail. The preview reuses the exact
+// pivot query (RecentFacts + Motifs filter), so the full list is always one
+// _links.facts away.
+const (
+	motifCarriersDefaultLimit = 20
+	motifCarriersMaxLimit     = 100
+)
+
+// motifCarrierItem is one carrier fact in the detail preview, recency-ordered
+// like the /facts pivot it previews.
+type motifCarrierItem struct {
+	Path        string      `json:"path"`
+	Title       string      `json:"title"`
+	Type        string      `json:"type,omitempty"`
+	CommittedAt int64       `json:"committed_at,omitempty"`
+	Links       hal.LinkMap `json:"_links"`
+}
+
+// motifAliasItem is one member spelling with the audit trail of how it joined
+// the cluster. Method/rationale are absent on an unresolved (singleton)
+// corpus — the spelling is a member because nothing has grouped it yet.
+type motifAliasItem struct {
+	Motif     string `json:"motif"`
+	Method    string `json:"method,omitempty"`
+	Rationale string `json:"rationale,omitempty"`
+}
+
+// motifDetailView is the cluster detail envelope.
+type motifDetailView struct {
+	ClusterKey      string             `json:"cluster_key"`
+	Canonical       string             `json:"canonical"`
+	Members         []string           `json:"members"`
+	DF              int                `json:"df"`
+	Definition      string             `json:"definition,omitempty"`
+	DefinitionState string             `json:"definition_state"`
+	CarrierCount    int                `json:"carrier_count"`
+	Carriers        []motifCarrierItem `json:"carriers"`
+	Aliases         []motifAliasItem   `json:"aliases"`
+	Links           hal.LinkMap        `json:"_links"`
+}
+
+// handleHALMotifCluster serves GET /repos/{repo}/branches/{branch}/motifs/{key}.
+//
+// {key} accepts a cluster_key OR any member spelling; spellings resolve
+// through the store's ClusterKey (which degrades to the mechanical key on an
+// unrebuilt corpus — C2), and the self link always carries the cluster_key
+// (C1). 404 only when the resolved key matches no cluster in the vocabulary.
+func handleHALMotifCluster(b hal.URLBuilder, provider motifsProvider, facts factsCollectionProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		repoName := chi.URLParam(r, "repo")
+		ri := repos.RepoFromContext(r.Context())
+		branch := BranchFromContext(r.Context())
+		a := hal.Anchor{Branch: branch}
+		rawKey := chi.URLParam(r, "key")
+
+		carrierLimit := motifCarriersDefaultLimit
+		if v := r.URL.Query().Get("limit"); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 {
+				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+					"invalid limit value", r.URL.Path)
+				return
+			}
+			carrierLimit = min(n, motifCarriersMaxLimit)
+		}
+
+		clusters, err := provider.Clusters(r.Context(), ri, branch)
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif cluster", branch)
+			return
+		}
+		byKey := make(map[string]store.MotifCluster, len(clusters))
+		for _, c := range clusters {
+			byKey[c.ClusterKey] = c
+		}
+
+		cluster, found := byKey[rawKey]
+		if !found {
+			// Not a cluster key — treat it as a spelling and resolve.
+			key, kerr := provider.ClusterKey(r.Context(), ri, branch, rawKey)
+			if kerr != nil {
+				writeStoreError(w, r, kerr, "Failed to load motif cluster", branch)
+				return
+			}
+			cluster, found = byKey[key]
+		}
+		if !found {
+			hal.WriteProblem(w, http.StatusNotFound, "Unknown motif",
+				`no motif cluster or spelling "`+rawKey+`" in this branch's vocabulary`, r.URL.Path)
+			return
+		}
+
+		defs, err := provider.Definitions(r.Context(), ri, branch, []string{cluster.ClusterKey})
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif cluster", branch)
+			return
+		}
+		st, defined := defs[cluster.ClusterKey]
+
+		// Carriers ARE the pivot: same filter, same recency order, same code
+		// path as /facts?motifs=<members>&motif_match=exact, so the preview
+		// cannot disagree with the full listing it links to. Passing every
+		// member spelling keeps the union correct on an unrebuilt corpus,
+		// where exact-tier resolution knows nothing about siblings (C2).
+		entries, total, err := facts.RecentFacts(r.Context(), ri, branch, store.SearchOptions{
+			Motifs:     cluster.Members,
+			MotifMatch: store.MotifMatchExact,
+			Limit:      carrierLimit,
+		})
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif carriers", branch)
+			return
+		}
+		carriers := make([]motifCarrierItem, 0, len(entries))
+		for _, e := range entries {
+			carriers = append(carriers, motifCarrierItem{
+				Path:        e.Path,
+				Title:       e.Title,
+				Type:        e.Type,
+				CommittedAt: e.CommittedAt,
+				Links:       hal.LinkMap{"self": {Href: b.Fact(repoName, a, e.Path)}},
+			})
+		}
+
+		aliasRows, err := provider.AliasRows(r.Context(), ri, branch)
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif cluster", branch)
+			return
+		}
+		aliases := make([]motifAliasItem, 0, len(cluster.Members))
+		for _, m := range cluster.Members {
+			item := motifAliasItem{Motif: m}
+			if row, ok := aliasRows[m]; ok && row.ClusterKey == cluster.ClusterKey {
+				item.Method = row.Method
+				item.Rationale = row.Rationale
+			}
+			aliases = append(aliases, item)
+		}
+
+		motifsBase := b.Branch(repoName, a) + "/motifs"
+		pivot := url.Values{}
+		pivot.Set("motifs", strings.Join(cluster.Members, ","))
+		pivot.Set("motif_match", string(store.MotifMatchExact))
+
+		hal.WriteHAL(w, http.StatusOK, motifDetailView{
+			ClusterKey:      cluster.ClusterKey,
+			Canonical:       cluster.CanonicalID,
+			Members:         cluster.Members,
+			DF:              cluster.DF,
+			Definition:      st.Definition,
+			DefinitionState: definitionState(st, defined),
+			CarrierCount:    total,
+			Carriers:        carriers,
+			Aliases:         aliases,
+			Links: hal.LinkMap{
+				"self":  {Href: motifsBase + "/" + cluster.ClusterKey},
+				"facts": {Href: b.Branch(repoName, a) + "/facts?" + pivot.Encode()},
+			},
+		})
+	}
 }

--- a/internal/web/handlers_motifs.go
+++ b/internal/web/handlers_motifs.go
@@ -1,0 +1,300 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"knomit/internal/repos"
+	"knomit/internal/store"
+	"knomit/internal/web/hal"
+)
+
+// motifsProvider is the narrow interface the motif vocabulary handlers depend
+// on. Every method is a straight pass-through to store.MotifIndex — the seam
+// exists for test injection, mirroring domainsProvider.
+type motifsProvider interface {
+	Clusters(ctx context.Context, ri *repos.RepoInstance, branch string) ([]store.MotifCluster, error)
+	Definitions(ctx context.Context, ri *repos.RepoInstance, branch string, keys []string) (map[string]store.MotifDefinitionStatus, error)
+	VocabularyHealth(ctx context.Context, ri *repos.RepoInstance, branch string) (store.MotifVocabularyHealth, error)
+	AliasRows(ctx context.Context, ri *repos.RepoInstance, branch string) (map[string]store.AliasRow, error)
+	ClusterKey(ctx context.Context, ri *repos.RepoInstance, branch, motif string) (string, error)
+}
+
+type defaultMotifsProvider struct{}
+
+func (defaultMotifsProvider) Clusters(ctx context.Context, ri *repos.RepoInstance, branch string) ([]store.MotifCluster, error) {
+	var (
+		out []store.MotifCluster
+		err error
+	)
+	ri.WithRead(func(svc *store.Service) {
+		if svc == nil {
+			return
+		}
+		out, err = svc.Motifs().Clusters(ctx, branch)
+	})
+	return out, err
+}
+
+func (defaultMotifsProvider) Definitions(ctx context.Context, ri *repos.RepoInstance, branch string, keys []string) (map[string]store.MotifDefinitionStatus, error) {
+	var (
+		out map[string]store.MotifDefinitionStatus
+		err error
+	)
+	ri.WithRead(func(svc *store.Service) {
+		if svc == nil {
+			return
+		}
+		out, err = svc.Motifs().Definitions(ctx, branch, keys)
+	})
+	return out, err
+}
+
+func (defaultMotifsProvider) VocabularyHealth(ctx context.Context, ri *repos.RepoInstance, branch string) (store.MotifVocabularyHealth, error) {
+	var (
+		out store.MotifVocabularyHealth
+		err error
+	)
+	ri.WithRead(func(svc *store.Service) {
+		if svc == nil {
+			return
+		}
+		out, err = svc.Motifs().VocabularyHealth(ctx, branch)
+	})
+	return out, err
+}
+
+func (defaultMotifsProvider) AliasRows(ctx context.Context, ri *repos.RepoInstance, branch string) (map[string]store.AliasRow, error) {
+	var (
+		out map[string]store.AliasRow
+		err error
+	)
+	ri.WithRead(func(svc *store.Service) {
+		if svc == nil {
+			return
+		}
+		out, err = svc.Motifs().AliasRows(ctx, branch)
+	})
+	return out, err
+}
+
+func (defaultMotifsProvider) ClusterKey(ctx context.Context, ri *repos.RepoInstance, branch, motif string) (string, error) {
+	var (
+		out string
+		err error
+	)
+	ri.WithRead(func(svc *store.Service) {
+		if svc == nil {
+			return
+		}
+		out, err = svc.Motifs().ClusterKey(ctx, branch, motif)
+	})
+	return out, err
+}
+
+// Paging bounds for the motifs collection. Its own knobs rather than
+// limitParam's: a vocabulary page is one row per CLUSTER with members and a
+// definition attached, a different weight class from fact rows.
+const (
+	motifsDefaultLimit = 50
+	motifsMaxLimit     = 200
+)
+
+// motifEntry is one cluster in the vocabulary collection.
+//
+// cluster_key is the STABLE identity and what self links carry; canonical is
+// the df-elected representative and merely what humans read (design C1).
+type motifEntry struct {
+	ClusterKey      string      `json:"cluster_key"`
+	Canonical       string      `json:"canonical"`
+	Members         []string    `json:"members"`
+	DF              int         `json:"df"`
+	Definition      string      `json:"definition,omitempty"`
+	DefinitionState string      `json:"definition_state"`
+	Links           hal.LinkMap `json:"_links"`
+}
+
+// motifHealthView is MotifVocabularyHealth on the wire, plus the two derived
+// ratios so a browser header needs no arithmetic.
+type motifHealthView struct {
+	Clusters           int     `json:"clusters"`
+	Recurring          int     `json:"recurring"`
+	Mints              int     `json:"mints"`
+	Links              int     `json:"links"`
+	EpistemicRecurring int     `json:"epistemic_recurring"`
+	RecurrenceRate     float64 `json:"recurrence_rate"`
+	MintToLinkRatio    float64 `json:"mint_to_link_ratio"`
+}
+
+// motifsView is the collection envelope. Not hal.CollectionView because the
+// vocabulary carries a health summary beside the page.
+type motifsView struct {
+	Count    int                     `json:"count"`
+	Health   motifHealthView         `json:"health"`
+	Links    hal.LinkMap             `json:"_links"`
+	Embedded map[string][]motifEntry `json:"_embedded"`
+}
+
+// definitionState renders a cluster's Definitions lookup as the wire enum.
+func definitionState(st store.MotifDefinitionStatus, ok bool) string {
+	switch {
+	case !ok:
+		return "missing"
+	case st.Stale:
+		return "stale"
+	default:
+		return "current"
+	}
+}
+
+// handleHALMotifs serves GET /repos/{repo}/branches/{branch}/motifs — the
+// per-repo motif vocabulary, one entry per cluster, df-desc by default.
+func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		repoName := chi.URLParam(r, "repo")
+		ri := repos.RepoFromContext(r.Context())
+		branch := BranchFromContext(r.Context())
+		a := hal.Anchor{Branch: branch}
+		qp := r.URL.Query()
+
+		sortBy := qp.Get("sort")
+		if sortBy == "" {
+			sortBy = "df"
+		}
+		if sortBy != "df" && sortBy != "name" {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+				`invalid sort value (accepted: "df", "name")`, r.URL.Path)
+			return
+		}
+		limit := motifsDefaultLimit
+		if v := qp.Get("limit"); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 {
+				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+					"invalid limit value", r.URL.Path)
+				return
+			}
+			limit = min(n, motifsMaxLimit)
+		}
+		offset := 0
+		if v := qp.Get("offset"); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 0 {
+				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+					"invalid offset value", r.URL.Path)
+				return
+			}
+			offset = n
+		}
+
+		clusters, err := provider.Clusters(r.Context(), ri, branch)
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif vocabulary", branch)
+			return
+		}
+		health, err := provider.VocabularyHealth(r.Context(), ri, branch)
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif vocabulary", branch)
+			return
+		}
+
+		// Definitions for every cluster in one bulk read. Fetched before
+		// narrowing because ?q= matches definition text too.
+		keys := make([]string, len(clusters))
+		for i, c := range clusters {
+			keys[i] = c.ClusterKey
+		}
+		defs, err := provider.Definitions(r.Context(), ri, branch, keys)
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif vocabulary", branch)
+			return
+		}
+
+		if q := strings.ToLower(strings.TrimSpace(qp.Get("q"))); q != "" {
+			// A NEW slice, never clusters[:0]: filtering in place rewrites the
+			// backing array the provider handed over, so a provider that
+			// returns a cached or shared slice would be silently corrupted by
+			// a read request.
+			kept := make([]store.MotifCluster, 0, len(clusters))
+			for _, c := range clusters {
+				if motifClusterMatches(c, defs[c.ClusterKey].Definition, q) {
+					kept = append(kept, c)
+				}
+			}
+			clusters = kept
+		}
+
+		// Clusters arrives df-desc / canonical-asc from the store; only the
+		// name sort re-orders.
+		if sortBy == "name" {
+			// Same reasoning as the narrowing above: sort a copy, never the
+			// provider's own slice.
+			sorted := make([]store.MotifCluster, len(clusters))
+			copy(sorted, clusters)
+			clusters = sorted
+			sort.Slice(clusters, func(i, j int) bool {
+				return clusters[i].CanonicalID < clusters[j].CanonicalID
+			})
+		}
+
+		total := len(clusters)
+		motifsBase := b.Branch(repoName, a) + "/motifs"
+		links := hal.LinkMap{"self": {Href: selfWithQuery(motifsBase, r)}}
+		if offset+limit < total {
+			nextQ := r.URL.Query()
+			nextQ.Set("offset", strconv.Itoa(offset+limit))
+			links["next"] = hal.Link{Href: motifsBase + "?" + nextQ.Encode()}
+		}
+		if offset > 0 {
+			prevQ := r.URL.Query()
+			prevQ.Set("offset", strconv.Itoa(max(offset-limit, 0)))
+			links["prev"] = hal.Link{Href: motifsBase + "?" + prevQ.Encode()}
+		}
+
+		page := clusters[min(offset, total):min(offset+limit, total)]
+		items := make([]motifEntry, 0, len(page))
+		for _, c := range page {
+			st, ok := defs[c.ClusterKey]
+			items = append(items, motifEntry{
+				ClusterKey:      c.ClusterKey,
+				Canonical:       c.CanonicalID,
+				Members:         c.Members,
+				DF:              c.DF,
+				Definition:      st.Definition,
+				DefinitionState: definitionState(st, ok),
+				Links:           hal.LinkMap{"self": {Href: motifsBase + "/" + c.ClusterKey}},
+			})
+		}
+
+		hal.WriteHAL(w, http.StatusOK, motifsView{
+			Count: total,
+			Health: motifHealthView{
+				Clusters:           health.Clusters,
+				Recurring:          health.Recurring,
+				Mints:              health.Mints,
+				Links:              health.Links,
+				EpistemicRecurring: health.EpistemicRecurring,
+				RecurrenceRate:     health.RecurrenceRate(),
+				MintToLinkRatio:    health.MintToLinkRatio(),
+			},
+			Links:    links,
+			Embedded: map[string][]motifEntry{"motifs": items},
+		})
+	}
+}
+
+// motifClusterMatches reports whether q (already lowercased) occurs in any
+// member spelling or in the cluster's definition.
+func motifClusterMatches(c store.MotifCluster, definition, q string) bool {
+	for _, m := range c.Members {
+		if strings.Contains(strings.ToLower(m), q) {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(definition), q)
+}

--- a/internal/web/handlers_motifs.go
+++ b/internal/web/handlers_motifs.go
@@ -124,11 +124,21 @@ type motifEntry struct {
 
 // motifHealthView is MotifVocabularyHealth on the wire, plus the two derived
 // ratios so a browser header needs no arithmetic.
+//
+// Every count is PREFIXED with the population it measures, because this block
+// sits beside `count` in the same envelope and the two are not the same
+// number. VocabularyHealth is computed over AUTHORED facts only, while `count`
+// comes from the vocabulary query and includes every origin; and `count` is
+// narrowed by ?q= while these are not — health describes the corpus, not the
+// page. Bare `clusters` next to `count` reads as a contradiction; the prefix
+// is what makes the disagreement legible instead of a bug report.
 type motifHealthView struct {
-	Clusters           int     `json:"clusters"`
-	Recurring          int     `json:"recurring"`
-	Mints              int     `json:"mints"`
-	Links              int     `json:"links"`
+	AuthoredClusters  int `json:"authored_clusters"`
+	AuthoredRecurring int `json:"authored_recurring"`
+	AuthoredMints     int `json:"authored_mints"`
+	AuthoredLinks     int `json:"authored_links"`
+	// EpistemicRecurring keeps its own name: it already names its population,
+	// and it is a NARROWER one than the authored_* counts (kind, not origin).
 	EpistemicRecurring int     `json:"epistemic_recurring"`
 	RecurrenceRate     float64 `json:"recurrence_rate"`
 	MintToLinkRatio    float64 `json:"mint_to_link_ratio"`
@@ -290,12 +300,15 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 		}
 
 		hal.WriteHAL(w, http.StatusOK, motifsView{
+			// Count is the post-narrowing total over EVERY origin; the health
+			// block beside it is authored-only and unnarrowed. See
+			// motifHealthView for why its fields carry the population prefix.
 			Count: total,
 			Health: motifHealthView{
-				Clusters:           health.Clusters,
-				Recurring:          health.Recurring,
-				Mints:              health.Mints,
-				Links:              health.Links,
+				AuthoredClusters:   health.Clusters,
+				AuthoredRecurring:  health.Recurring,
+				AuthoredMints:      health.Mints,
+				AuthoredLinks:      health.Links,
 				EpistemicRecurring: health.EpistemicRecurring,
 				RecurrenceRate:     health.RecurrenceRate(),
 				MintToLinkRatio:    health.MintToLinkRatio(),

--- a/internal/web/handlers_motifs.go
+++ b/internal/web/handlers_motifs.go
@@ -137,11 +137,18 @@ type motifHealthView struct {
 	AuthoredRecurring int `json:"authored_recurring"`
 	AuthoredMints     int `json:"authored_mints"`
 	AuthoredLinks     int `json:"authored_links"`
-	// EpistemicRecurring keeps its own name: it already names its population,
-	// and it is a NARROWER one than the authored_* counts (kind, not origin).
-	EpistemicRecurring int     `json:"epistemic_recurring"`
-	RecurrenceRate     float64 `json:"recurrence_rate"`
-	MintToLinkRatio    float64 `json:"mint_to_link_ratio"`
+	// AuthoredEpistemicRecurring narrows the authored population AGAIN, by
+	// kind: VocabularyHealth counts it with a `kind = 'epistemic'` CASE
+	// evaluated INSIDE the same `origin = 'authored'` filter as every other
+	// count here, so its population is authored AND epistemic — not epistemic
+	// instead of authored. It is the number the activation floor reads, and it
+	// diverges from AuthoredRecurring badly enough (measured up to 5x) that
+	// the qualifier has to be on the wire.
+	AuthoredEpistemicRecurring int `json:"authored_epistemic_recurring"`
+	// The two ratios are derived from the authored counts above, so they carry
+	// the same population as everything else in this block.
+	RecurrenceRate  float64 `json:"recurrence_rate"`
+	MintToLinkRatio float64 `json:"mint_to_link_ratio"`
 }
 
 // motifsView is the collection envelope. Not hal.CollectionView because the
@@ -189,10 +196,18 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 			n, err := strconv.Atoi(v)
 			// A HARD CEILING, not a clamp, matching limitParam: a client that
 			// asked for 500 and silently received 200 rows has no way to tell
-			// that from "there were only 200".
-			if err != nil || n < 1 || n > motifsMaxLimit {
-				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
-					"invalid limit value", r.URL.Path)
+			// that from "there were only 200". Split into limitParam's three
+			// messages so the refusal says WHICH bound was missed and what it
+			// is, rather than making the caller guess.
+			switch {
+			case err != nil:
+				badParam(w, r, "invalid limit value")
+				return
+			case n < 1:
+				badParam(w, r, "limit must be at least 1")
+				return
+			case n > motifsMaxLimit:
+				badParam(w, r, "limit must not exceed "+strconv.Itoa(motifsMaxLimit))
 				return
 			}
 			limit = n
@@ -200,9 +215,12 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 		offset := 0
 		if v := qp.Get("offset"); v != "" {
 			n, err := strconv.Atoi(v)
-			if err != nil || n < 0 {
-				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
-					"invalid offset value", r.URL.Path)
+			switch {
+			case err != nil:
+				badParam(w, r, "invalid offset value")
+				return
+			case n < 0:
+				badParam(w, r, "offset must not be negative")
 				return
 			}
 			offset = n
@@ -305,13 +323,13 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 			// motifHealthView for why its fields carry the population prefix.
 			Count: total,
 			Health: motifHealthView{
-				AuthoredClusters:   health.Clusters,
-				AuthoredRecurring:  health.Recurring,
-				AuthoredMints:      health.Mints,
-				AuthoredLinks:      health.Links,
-				EpistemicRecurring: health.EpistemicRecurring,
-				RecurrenceRate:     health.RecurrenceRate(),
-				MintToLinkRatio:    health.MintToLinkRatio(),
+				AuthoredClusters:           health.Clusters,
+				AuthoredRecurring:          health.Recurring,
+				AuthoredMints:              health.Mints,
+				AuthoredLinks:              health.Links,
+				AuthoredEpistemicRecurring: health.EpistemicRecurring,
+				RecurrenceRate:             health.RecurrenceRate(),
+				MintToLinkRatio:            health.MintToLinkRatio(),
 			},
 			Links:    links,
 			Embedded: map[string][]motifEntry{"motifs": items},
@@ -388,10 +406,17 @@ func handleHALMotifCluster(b hal.URLBuilder, provider motifsProvider, facts fact
 		carrierLimit := motifCarriersDefaultLimit
 		if v := r.URL.Query().Get("limit"); v != "" {
 			n, err := strconv.Atoi(v)
-			// Hard ceiling, same reasoning as the collection's limit.
-			if err != nil || n < 1 || n > motifCarriersMaxLimit {
-				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
-					"invalid limit value", r.URL.Path)
+			// Hard ceiling, same reasoning and same messages as the
+			// collection's limit.
+			switch {
+			case err != nil:
+				badParam(w, r, "invalid limit value")
+				return
+			case n < 1:
+				badParam(w, r, "limit must be at least 1")
+				return
+			case n > motifCarriersMaxLimit:
+				badParam(w, r, "limit must not exceed "+strconv.Itoa(motifCarriersMaxLimit))
 				return
 			}
 			carrierLimit = n

--- a/internal/web/handlers_motifs.go
+++ b/internal/web/handlers_motifs.go
@@ -100,7 +100,9 @@ func (defaultMotifsProvider) ClusterKey(ctx context.Context, ri *repos.RepoInsta
 
 // Paging bounds for the motifs collection. Its own knobs rather than
 // limitParam's: a vocabulary page is one row per CLUSTER with members and a
-// definition attached, a different weight class from fact rows.
+// definition attached, a different weight class from fact rows. The MAXIMUM is
+// a hard ceiling exactly as limitParam's is — over it is a 400, never a quiet
+// smaller page.
 const (
 	motifsDefaultLimit = 50
 	motifsMaxLimit     = 200
@@ -175,12 +177,15 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 		limit := motifsDefaultLimit
 		if v := qp.Get("limit"); v != "" {
 			n, err := strconv.Atoi(v)
-			if err != nil || n < 1 {
+			// A HARD CEILING, not a clamp, matching limitParam: a client that
+			// asked for 500 and silently received 200 rows has no way to tell
+			// that from "there were only 200".
+			if err != nil || n < 1 || n > motifsMaxLimit {
 				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
 					"invalid limit value", r.URL.Path)
 				return
 			}
-			limit = min(n, motifsMaxLimit)
+			limit = n
 		}
 		offset := 0
 		if v := qp.Get("offset"); v != "" {
@@ -244,11 +249,23 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 		}
 
 		total := len(clusters)
+		// Page bounds by REMAINDER, never by the sum offset+limit. An offset
+		// near MaxInt clears the `n < 0` parse guard above and then wraps the
+		// sum NEGATIVE, which passes every `< total` test written as a sum and
+		// reaches the slice expression as a negative bound — a bounds panic on
+		// an unauthenticated GET. `limit < total-offset` asks the same question
+		// with operands that cannot overflow (offset is capped at total first).
+		start := min(offset, total)
+		end := total
+		if limit < total-start {
+			end = start + limit
+		}
+
 		motifsBase := b.Branch(repoName, a) + "/motifs"
 		links := hal.LinkMap{"self": {Href: selfWithQuery(motifsBase, r)}}
-		if offset+limit < total {
+		if end < total {
 			nextQ := r.URL.Query()
-			nextQ.Set("offset", strconv.Itoa(offset+limit))
+			nextQ.Set("offset", strconv.Itoa(end))
 			links["next"] = hal.Link{Href: motifsBase + "?" + nextQ.Encode()}
 		}
 		if offset > 0 {
@@ -257,7 +274,7 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 			links["prev"] = hal.Link{Href: motifsBase + "?" + prevQ.Encode()}
 		}
 
-		page := clusters[min(offset, total):min(offset+limit, total)]
+		page := clusters[start:end]
 		items := make([]motifEntry, 0, len(page))
 		for _, c := range page {
 			st, ok := defs[c.ClusterKey]
@@ -302,7 +319,7 @@ func motifClusterMatches(c store.MotifCluster, definition, q string) bool {
 
 // Carrier preview bounds for the cluster detail. The preview reuses the exact
 // pivot query (RecentFacts + Motifs filter), so the full list is always one
-// _links.facts away.
+// _links.facts away. The maximum is a hard ceiling (400 above it), not a clamp.
 const (
 	motifCarriersDefaultLimit = 20
 	motifCarriersMaxLimit     = 100
@@ -358,12 +375,13 @@ func handleHALMotifCluster(b hal.URLBuilder, provider motifsProvider, facts fact
 		carrierLimit := motifCarriersDefaultLimit
 		if v := r.URL.Query().Get("limit"); v != "" {
 			n, err := strconv.Atoi(v)
-			if err != nil || n < 1 {
+			// Hard ceiling, same reasoning as the collection's limit.
+			if err != nil || n < 1 || n > motifCarriersMaxLimit {
 				hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
 					"invalid limit value", r.URL.Path)
 				return
 			}
-			carrierLimit = min(n, motifCarriersMaxLimit)
+			carrierLimit = n
 		}
 
 		clusters, err := provider.Clusters(r.Context(), ri, branch)

--- a/internal/web/handlers_motifs_test.go
+++ b/internal/web/handlers_motifs_test.go
@@ -575,9 +575,22 @@ func TestHandleHALMotifs_OverflowingOffsetIsAnEmptyPage(t *testing.T) {
 func TestHandleHALMotifs_HealthNamesItsPopulationAndIgnoresQ(t *testing.T) {
 	stub := &stubMotifsProvider{
 		clusters: threeClusters(),
-		// Fewer than len(clusters): the authored-only population is smaller,
-		// exactly as a corpus with distilled facts reports.
-		health: store.MotifVocabularyHealth{Clusters: 2, Recurring: 1, Mints: 2, Links: 3, EpistemicRecurring: 1},
+		// FIVE DISTINCT VALUES, none of them 3 (the cluster count) or 1 (the
+		// ?q=-narrowed count), so every field's assertion below can only pass
+		// if that field is wired to its own source. The previous fixture had
+		// Recurring == EpistemicRecurring == 1 and Clusters == Mints == 2, and
+		// a swap within either pair stayed green — the divergence between
+		// authored_recurring and authored_epistemic_recurring is the whole
+		// reason the qualifier exists, so a fixture that hides it undercuts
+		// the test it belongs to.
+		//
+		// Mints deliberately differs from Clusters here, which the real store
+		// never produces (it mints exactly once per cluster). That is the
+		// point: this fixture pins WIRING, not corpus arithmetic. Do not
+		// "correct" it back into agreement — doing so disarms the assertion.
+		// The genuine invariants are kept, since they are free:
+		// EpistemicRecurring <= Recurring <= Clusters.
+		health: store.MotifVocabularyHealth{Clusters: 9, Recurring: 4, Mints: 8, Links: 7, EpistemicRecurring: 2},
 	}
 	r := motifsServer(t, stub)
 
@@ -585,11 +598,27 @@ func TestHandleHALMotifs_HealthNamesItsPopulationAndIgnoresQ(t *testing.T) {
 	if body.Count != 3 {
 		t.Errorf("count: got %d, want 3 (every cluster)", body.Count)
 	}
-	if body.Health.AuthoredClusters != 2 {
-		t.Errorf("authored_clusters: got %d, want 2 (the authored-only population)", body.Health.AuthoredClusters)
-	}
-	if body.Health.AuthoredRecurring != 1 || body.Health.AuthoredMints != 2 || body.Health.AuthoredLinks != 3 {
-		t.Errorf("health: got %+v", body.Health)
+	// One assertion per field, each naming its own expected value: a single
+	// combined check reports "health: got {...}" and leaves the reader to work
+	// out which field moved.
+	for _, f := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"authored_clusters", body.Health.AuthoredClusters, 9},
+		{"authored_recurring", body.Health.AuthoredRecurring, 4},
+		{"authored_mints", body.Health.AuthoredMints, 8},
+		{"authored_links", body.Health.AuthoredLinks, 7},
+		// authored AND epistemic — VocabularyHealth computes it with a kind
+		// CASE inside the same origin='authored' filter, so it narrows by kind
+		// as well as origin. Distinct from authored_recurring above precisely
+		// so that wiring this to Recurring fails.
+		{"authored_epistemic_recurring", body.Health.AuthoredEpistemicRecurring, 2},
+	} {
+		if f.got != f.want {
+			t.Errorf("%s: got %d, want %d", f.name, f.got, f.want)
+		}
 	}
 
 	// ?q= narrows count. It does NOT narrow health — the health block is a
@@ -598,15 +627,12 @@ func TestHandleHALMotifs_HealthNamesItsPopulationAndIgnoresQ(t *testing.T) {
 	if narrowed.Count != 1 {
 		t.Errorf("narrowed count: got %d, want 1", narrowed.Count)
 	}
-	if narrowed.Health.AuthoredClusters != 2 {
-		t.Errorf("authored_clusters under ?q=: got %d, want the unnarrowed 2", narrowed.Health.AuthoredClusters)
+	if narrowed.Health.AuthoredClusters != 9 {
+		t.Errorf("authored_clusters under ?q=: got %d, want the unnarrowed 9", narrowed.Health.AuthoredClusters)
 	}
-
-	// The epistemic count is authored AND epistemic — VocabularyHealth
-	// computes it with a kind CASE inside the same origin='authored' filter —
-	// so it carries the prefix too.
-	if body.Health.AuthoredEpistemicRecurring != 1 {
-		t.Errorf("authored_epistemic_recurring: got %d, want 1", body.Health.AuthoredEpistemicRecurring)
+	if narrowed.Health.AuthoredEpistemicRecurring != 2 {
+		t.Errorf("authored_epistemic_recurring under ?q=: got %d, want the unnarrowed 2",
+			narrowed.Health.AuthoredEpistemicRecurring)
 	}
 
 	// The unqualified names must be gone from the wire: a reader who sees

--- a/internal/web/handlers_motifs_test.go
+++ b/internal/web/handlers_motifs_test.go
@@ -51,9 +51,11 @@ func (s *stubMotifsProvider) ClusterKey(_ context.Context, _ *repos.RepoInstance
 type motifsCollectionBody struct {
 	Count  int `json:"count"`
 	Health struct {
-		Clusters       int     `json:"clusters"`
-		Recurring      int     `json:"recurring"`
-		RecurrenceRate float64 `json:"recurrence_rate"`
+		AuthoredClusters  int     `json:"authored_clusters"`
+		AuthoredRecurring int     `json:"authored_recurring"`
+		AuthoredMints     int     `json:"authored_mints"`
+		AuthoredLinks     int     `json:"authored_links"`
+		RecurrenceRate    float64 `json:"recurrence_rate"`
 	} `json:"health"`
 	Links struct {
 		Self struct {
@@ -137,7 +139,7 @@ func TestHandleHALMotifs_ReturnsRankedCollection(t *testing.T) {
 	if body.Count != 3 {
 		t.Errorf("count: got %d, want 3", body.Count)
 	}
-	if body.Health.Clusters != 3 || body.Health.Recurring != 3 {
+	if body.Health.AuthoredClusters != 3 || body.Health.AuthoredRecurring != 3 {
 		t.Errorf("health: got %+v", body.Health)
 	}
 	if body.Health.RecurrenceRate != 1 {
@@ -529,5 +531,50 @@ func TestHandleHALMotifs_OverflowingOffsetIsAnEmptyPage(t *testing.T) {
 				t.Errorf("next must be absent past the end: %q", body.Links.Next.Href)
 			}
 		})
+	}
+}
+
+// `count` and the health block count DIFFERENT POPULATIONS, and the wire names
+// have to say so. count is every cluster from the vocabulary query and is
+// narrowed by ?q=; health is computed over AUTHORED facts only and is NOT
+// narrowed. Two numbers that disagree for two good reasons are a bug report
+// waiting to happen unless the names carry the qualifier.
+func TestHandleHALMotifs_HealthNamesItsPopulationAndIgnoresQ(t *testing.T) {
+	stub := &stubMotifsProvider{
+		clusters: threeClusters(),
+		// Fewer than len(clusters): the authored-only population is smaller,
+		// exactly as a corpus with distilled facts reports.
+		health: store.MotifVocabularyHealth{Clusters: 2, Recurring: 1, Mints: 2, Links: 3, EpistemicRecurring: 1},
+	}
+	r := motifsServer(t, stub)
+
+	body := decodeMotifs(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs"))
+	if body.Count != 3 {
+		t.Errorf("count: got %d, want 3 (every cluster)", body.Count)
+	}
+	if body.Health.AuthoredClusters != 2 {
+		t.Errorf("authored_clusters: got %d, want 2 (the authored-only population)", body.Health.AuthoredClusters)
+	}
+	if body.Health.AuthoredRecurring != 1 || body.Health.AuthoredMints != 2 || body.Health.AuthoredLinks != 3 {
+		t.Errorf("health: got %+v", body.Health)
+	}
+
+	// ?q= narrows count. It does NOT narrow health — the health block is a
+	// corpus-level diagnostic, not a description of the page.
+	narrowed := decodeMotifs(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?q=fallback"))
+	if narrowed.Count != 1 {
+		t.Errorf("narrowed count: got %d, want 1", narrowed.Count)
+	}
+	if narrowed.Health.AuthoredClusters != 2 {
+		t.Errorf("authored_clusters under ?q=: got %d, want the unnarrowed 2", narrowed.Health.AuthoredClusters)
+	}
+
+	// The unqualified names must be gone from the wire: a reader who sees
+	// "clusters" beside "count" reads them as the same population.
+	raw := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs").Body.String()
+	for _, gone := range []string{`"clusters"`, `"recurring"`, `"mints"`, `"links"`} {
+		if containsSub(raw, gone) {
+			t.Errorf("unqualified health field %s is still on the wire: %s", gone, raw)
+		}
 	}
 }

--- a/internal/web/handlers_motifs_test.go
+++ b/internal/web/handlers_motifs_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"knomit/internal/repos"
@@ -277,4 +278,227 @@ func containsSub(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// ── cluster detail ────────────────────────────────────────────────────────────
+
+// motifDetailBody mirrors the cluster detail wire shape.
+type motifDetailBody struct {
+	ClusterKey      string   `json:"cluster_key"`
+	Canonical       string   `json:"canonical"`
+	Members         []string `json:"members"`
+	DF              int      `json:"df"`
+	Definition      string   `json:"definition"`
+	DefinitionState string   `json:"definition_state"`
+	CarrierCount    int      `json:"carrier_count"`
+	Carriers        []struct {
+		Path        string `json:"path"`
+		Title       string `json:"title"`
+		Type        string `json:"type"`
+		CommittedAt int64  `json:"committed_at"`
+	} `json:"carriers"`
+	Aliases []struct {
+		Motif     string `json:"motif"`
+		Method    string `json:"method"`
+		Rationale string `json:"rationale"`
+	} `json:"aliases"`
+	Links struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		Facts struct {
+			Href string `json:"href"`
+		} `json:"facts"`
+	} `json:"_links"`
+}
+
+func motifDetailServer(t *testing.T, stub *stubMotifsProvider, facts *stubFactsCollectionProvider) http.Handler {
+	t.Helper()
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			motifs:          stub,
+			factsCollection: facts,
+		},
+	}
+	return s.NewAPIRouter()
+}
+
+func decodeMotifDetail(t *testing.T, rec *httptest.ResponseRecorder) motifDetailBody {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body motifDetailBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	return body
+}
+
+func driftClusterStub() *stubMotifsProvider {
+	return &stubMotifsProvider{
+		clusters: []store.MotifCluster{{
+			ClusterKey:  "drift-config",
+			CanonicalID: "config-drift",
+			Members:     []string{"config-drift", "configuration-drifts"},
+			DF:          4,
+		}},
+		defs: map[string]store.MotifDefinitionStatus{
+			"drift-config": {Definition: "Configured state diverges from applied state."},
+		},
+		aliases: map[string]store.AliasRow{
+			"config-drift": {
+				CanonicalID: "config-drift", ClusterKey: "drift-config",
+				Method: "mechanical",
+			},
+			"configuration-drifts": {
+				CanonicalID: "config-drift", ClusterKey: "drift-config",
+				Method: "judge", Rationale: "same mechanism",
+			},
+		},
+	}
+}
+
+func driftCarriers() *stubFactsCollectionProvider {
+	return &stubFactsCollectionProvider{
+		entries: []store.RecentFactEntry{
+			{Path: "kb/a.md", Title: "Newest carrier", Type: "observation", CommittedAt: 200},
+			{Path: "kb/b.md", Title: "Older carrier", Type: "policy", CommittedAt: 100},
+		},
+		// The corpus holds more carriers than this preview page shows.
+		total: 4,
+	}
+}
+
+func TestHandleHALMotifCluster_ByClusterKey(t *testing.T) {
+	stub, facts := driftClusterStub(), driftCarriers()
+	r := motifDetailServer(t, stub, facts)
+	body := decodeMotifDetail(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/drift-config"))
+
+	if body.ClusterKey != "drift-config" || body.Canonical != "config-drift" {
+		t.Errorf("identity: got %q/%q", body.ClusterKey, body.Canonical)
+	}
+	if len(body.Members) != 2 || body.DF != 4 {
+		t.Errorf("members/df: got %v / %d", body.Members, body.DF)
+	}
+	if body.DefinitionState != "current" {
+		t.Errorf("definition_state: got %q, want current", body.DefinitionState)
+	}
+	if len(body.Carriers) != 2 {
+		t.Fatalf("carriers: got %d, want 2", len(body.Carriers))
+	}
+	if body.Carriers[0].Path != "kb/a.md" || body.Carriers[0].Title != "Newest carrier" {
+		t.Errorf("carrier 0: got %+v", body.Carriers[0])
+	}
+	// carrier_count is the CORPUS total, not the page length — a preview that
+	// reported its own length would claim the cluster has two carriers.
+	if body.CarrierCount != 4 {
+		t.Errorf("carrier_count: got %d, want 4 (the store's total)", body.CarrierCount)
+	}
+	if len(body.Aliases) != 2 {
+		t.Fatalf("aliases: got %d, want 2", len(body.Aliases))
+	}
+	byMotif := map[string]string{}
+	for _, a := range body.Aliases {
+		byMotif[a.Motif] = a.Method + "/" + a.Rationale
+	}
+	if byMotif["config-drift"] != "mechanical/" {
+		t.Errorf("mechanical row: got %q", byMotif["config-drift"])
+	}
+	if byMotif["configuration-drifts"] != "judge/same mechanism" {
+		t.Errorf("judge row: got %q", byMotif["configuration-drifts"])
+	}
+	if !containsSub(body.Links.Self.Href, "/motifs/drift-config") {
+		t.Errorf("self: got %q", body.Links.Self.Href)
+	}
+	wantFacts := "/facts?motif_match=exact&motifs=config-drift%2Cconfiguration-drifts"
+	if !containsSub(body.Links.Facts.Href, wantFacts) {
+		t.Errorf("facts link: got %q, want suffix %q", body.Links.Facts.Href, wantFacts)
+	}
+
+	// The carriers preview IS the pivot query: same filter, same tier, so the
+	// preview can never disagree with the listing it links to.
+	if got := strings.Join(facts.lastOpts.Motifs, ","); got != "config-drift,configuration-drifts" {
+		t.Errorf("carriers query Motifs: got %v, want every member spelling", facts.lastOpts.Motifs)
+	}
+	if facts.lastOpts.MotifMatch != store.MotifMatchExact {
+		t.Errorf("carriers query MotifMatch: got %q, want exact", facts.lastOpts.MotifMatch)
+	}
+	if facts.lastOpts.Limit != 20 {
+		t.Errorf("carriers query Limit: got %d, want the default 20", facts.lastOpts.Limit)
+	}
+}
+
+func TestHandleHALMotifCluster_BySpelling(t *testing.T) {
+	stub := driftClusterStub()
+	stub.clusterKeys = map[string]string{"configuration-drifts": "drift-config"}
+	r := motifDetailServer(t, stub, driftCarriers())
+	body := decodeMotifDetail(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/configuration-drifts"))
+
+	if body.ClusterKey != "drift-config" {
+		t.Errorf("cluster_key: got %q, want drift-config", body.ClusterKey)
+	}
+	// The self link canonicalizes to the cluster key regardless of how the
+	// reader arrived (C1).
+	if !containsSub(body.Links.Self.Href, "/motifs/drift-config") {
+		t.Errorf("self: got %q, want the cluster key", body.Links.Self.Href)
+	}
+}
+
+func TestHandleHALMotifCluster_UnknownIs404(t *testing.T) {
+	r := motifDetailServer(t, driftClusterStub(), driftCarriers())
+	rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/never-heard-of-it")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// An unrebuilt corpus has an empty alias table: every spelling is its own
+// singleton cluster. That degradation is a 200 with one member and no audit
+// rows — never a 404 (C2).
+func TestHandleHALMotifCluster_SingletonOnUnrebuiltCorpus(t *testing.T) {
+	stub := &stubMotifsProvider{
+		clusters: []store.MotifCluster{{
+			ClusterKey: "silent-fallback", CanonicalID: "silent-fallback",
+			Members: []string{"silent-fallback"}, DF: 1,
+		}},
+		aliases: map[string]store.AliasRow{},
+	}
+	rec := getMotifs(t, motifDetailServer(t, stub, driftCarriers()),
+		"/repos/alpha/branches/agent:test/motifs/silent-fallback")
+	body := decodeMotifDetail(t, rec)
+
+	if len(body.Members) != 1 || body.Members[0] != "silent-fallback" {
+		t.Errorf("members: got %v", body.Members)
+	}
+	if body.DefinitionState != "missing" {
+		t.Errorf("definition_state: got %q, want missing", body.DefinitionState)
+	}
+	if len(body.Aliases) != 1 || body.Aliases[0].Method != "" {
+		t.Errorf("aliases: got %+v, want one member with no audit row", body.Aliases)
+	}
+	if !containsSub(rec.Body.String(), `"aliases":[`) {
+		t.Errorf("aliases must serialize as an array, not null: %s", rec.Body.String())
+	}
+}
+
+func TestHandleHALMotifCluster_CarriersLimitParam(t *testing.T) {
+	stub := driftClusterStub()
+	facts := driftCarriers()
+	r := motifDetailServer(t, stub, facts)
+
+	decodeMotifDetail(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/drift-config?limit=5"))
+	if facts.lastOpts.Limit != 5 {
+		t.Errorf("limit=5: got %d", facts.lastOpts.Limit)
+	}
+
+	decodeMotifDetail(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/drift-config?limit=500"))
+	if facts.lastOpts.Limit != 100 {
+		t.Errorf("limit=500: got %d, want the 100 ceiling", facts.lastOpts.Limit)
+	}
+
+	if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/drift-config?limit=0"); rec.Code != http.StatusBadRequest {
+		t.Errorf("limit=0: got %d, want 400", rec.Code)
+	}
 }

--- a/internal/web/handlers_motifs_test.go
+++ b/internal/web/handlers_motifs_test.go
@@ -56,6 +56,8 @@ type motifsCollectionBody struct {
 		AuthoredMints     int     `json:"authored_mints"`
 		AuthoredLinks     int     `json:"authored_links"`
 		RecurrenceRate    float64 `json:"recurrence_rate"`
+
+		AuthoredEpistemicRecurring int `json:"authored_epistemic_recurring"`
 	} `json:"health"`
 	Links struct {
 		Self struct {
@@ -275,6 +277,12 @@ func TestHandleHALMotifs_Paging(t *testing.T) {
 		if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?"+bad); rec.Code != http.StatusBadRequest {
 			t.Errorf("%s: got %d, want 400", bad, rec.Code)
 		}
+	}
+	// A refusal that says only "invalid" makes the caller guess the bound; the
+	// ceiling refusal names the number, as limitParam's does.
+	rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?limit=201")
+	if !containsSub(rec.Body.String(), "limit must not exceed 200") {
+		t.Errorf("over-ceiling detail must name the ceiling: %s", rec.Body.String())
 	}
 }
 
@@ -519,6 +527,10 @@ func TestHandleHALMotifCluster_CarriersLimitParam(t *testing.T) {
 			t.Errorf("%s: got %d, want 400", bad, rec.Code)
 		}
 	}
+	rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/drift-config?limit=101")
+	if !containsSub(rec.Body.String(), "limit must not exceed 100") {
+		t.Errorf("over-ceiling detail must name the ceiling: %s", rec.Body.String())
+	}
 }
 
 // An offset near MaxInt passes the `n < 0` parse guard, and then offset+limit
@@ -530,13 +542,17 @@ func TestHandleHALMotifs_OverflowingOffsetIsAnEmptyPage(t *testing.T) {
 	stub := &stubMotifsProvider{clusters: threeClusters()}
 	r := motifsServer(t, stub)
 
-	for _, offset := range []string{
-		strconv.Itoa(math.MaxInt),
-		strconv.Itoa(math.MaxInt - 10),
-		"9223372036854775807",
+	// Three DISTINCT points, each genuinely inside the overflow window FOR ITS
+	// OWN LIMIT — the window is offset > MaxInt-limit, so it moves with the
+	// limit and a case must carry the limit that puts it inside. The third
+	// lands the old sum exactly on MaxInt+1, the shallowest overflow there is.
+	for _, tc := range []struct{ name, query string }{
+		{"MaxInt at the default limit", "offset=" + strconv.Itoa(math.MaxInt)},
+		{"MaxInt-10 at the default limit", "offset=" + strconv.Itoa(math.MaxInt-10)},
+		{"overflows exactly at MaxInt+1", "offset=" + strconv.Itoa(math.MaxInt-199) + "&limit=200"},
 	} {
-		t.Run(offset, func(t *testing.T) {
-			rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?offset="+offset)
+		t.Run(tc.name, func(t *testing.T) {
+			rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?"+tc.query)
 			body := decodeMotifs(t, rec)
 			if len(body.Embedded.Motifs) != 0 {
 				t.Errorf("page: got %d entries, want none past the end", len(body.Embedded.Motifs))
@@ -586,10 +602,17 @@ func TestHandleHALMotifs_HealthNamesItsPopulationAndIgnoresQ(t *testing.T) {
 		t.Errorf("authored_clusters under ?q=: got %d, want the unnarrowed 2", narrowed.Health.AuthoredClusters)
 	}
 
+	// The epistemic count is authored AND epistemic — VocabularyHealth
+	// computes it with a kind CASE inside the same origin='authored' filter —
+	// so it carries the prefix too.
+	if body.Health.AuthoredEpistemicRecurring != 1 {
+		t.Errorf("authored_epistemic_recurring: got %d, want 1", body.Health.AuthoredEpistemicRecurring)
+	}
+
 	// The unqualified names must be gone from the wire: a reader who sees
 	// "clusters" beside "count" reads them as the same population.
 	raw := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs").Body.String()
-	for _, gone := range []string{`"clusters"`, `"recurring"`, `"mints"`, `"links"`} {
+	for _, gone := range []string{`"clusters"`, `"recurring"`, `"mints"`, `"links"`, `"epistemic_recurring"`} {
 		if containsSub(raw, gone) {
 			t.Errorf("unqualified health field %s is still on the wire: %s", gone, raw)
 		}

--- a/internal/web/handlers_motifs_test.go
+++ b/internal/web/handlers_motifs_test.go
@@ -3,8 +3,10 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -247,11 +249,10 @@ func TestHandleHALMotifs_Paging(t *testing.T) {
 		t.Error("prev link missing on the second page")
 	}
 
-	// Over the ceiling clamps rather than erroring.
-	if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?limit=500"); rec.Code != http.StatusOK {
-		t.Errorf("limit=500: got %d, want 200 (clamped, not refused), body=%s", rec.Code, rec.Body.String())
-	}
-	for _, bad := range []string{"limit=0", "limit=x", "offset=-1", "offset=x"} {
+	// The ceiling is HARD, not a clamp (the params.go house rule): a client
+	// that asked for 500 and silently got 200 rows cannot tell that from "there
+	// were only 200".
+	for _, bad := range []string{"limit=201", "limit=500", "limit=0", "limit=x", "offset=-1", "offset=x"} {
 		if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?"+bad); rec.Code != http.StatusBadRequest {
 			t.Errorf("%s: got %d, want 400", bad, rec.Code)
 		}
@@ -493,12 +494,40 @@ func TestHandleHALMotifCluster_CarriersLimitParam(t *testing.T) {
 		t.Errorf("limit=5: got %d", facts.lastOpts.Limit)
 	}
 
-	decodeMotifDetail(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/drift-config?limit=500"))
-	if facts.lastOpts.Limit != 100 {
-		t.Errorf("limit=500: got %d, want the 100 ceiling", facts.lastOpts.Limit)
+	// The carrier ceiling is hard too: over it is a 400, never a quiet 100.
+	for _, bad := range []string{"limit=101", "limit=500", "limit=0", "limit=x"} {
+		if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/drift-config?"+bad); rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: got %d, want 400", bad, rec.Code)
+		}
 	}
+}
 
-	if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs/drift-config?limit=0"); rec.Code != http.StatusBadRequest {
-		t.Errorf("limit=0: got %d, want 400", rec.Code)
+// An offset near MaxInt passes the `n < 0` parse guard, and then offset+limit
+// WRAPS NEGATIVE — clearing every `< total` comparison written as a sum and
+// reaching the slice expression as a negative bound. The result is a bounds
+// panic on an unauthenticated GET, so the arithmetic must never form the sum.
+// Mirrors TestLensFanoutDepth_OverflowingOffsetStillClamps.
+func TestHandleHALMotifs_OverflowingOffsetIsAnEmptyPage(t *testing.T) {
+	stub := &stubMotifsProvider{clusters: threeClusters()}
+	r := motifsServer(t, stub)
+
+	for _, offset := range []string{
+		strconv.Itoa(math.MaxInt),
+		strconv.Itoa(math.MaxInt - 10),
+		"9223372036854775807",
+	} {
+		t.Run(offset, func(t *testing.T) {
+			rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?offset="+offset)
+			body := decodeMotifs(t, rec)
+			if len(body.Embedded.Motifs) != 0 {
+				t.Errorf("page: got %d entries, want none past the end", len(body.Embedded.Motifs))
+			}
+			if body.Count != 3 {
+				t.Errorf("count: got %d, want the unnarrowed total 3", body.Count)
+			}
+			if body.Links.Next != nil {
+				t.Errorf("next must be absent past the end: %q", body.Links.Next.Href)
+			}
+		})
 	}
 }

--- a/internal/web/handlers_motifs_test.go
+++ b/internal/web/handlers_motifs_test.go
@@ -1,0 +1,280 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// stubMotifsProvider implements motifsProvider for tests.
+type stubMotifsProvider struct {
+	clusters    []store.MotifCluster
+	clustersErr error
+	defs        map[string]store.MotifDefinitionStatus
+	health      store.MotifVocabularyHealth
+	aliases     map[string]store.AliasRow
+	clusterKeys map[string]string // spelling → cluster key for ClusterKey()
+}
+
+func (s *stubMotifsProvider) Clusters(_ context.Context, _ *repos.RepoInstance, _ string) ([]store.MotifCluster, error) {
+	return s.clusters, s.clustersErr
+}
+
+func (s *stubMotifsProvider) Definitions(_ context.Context, _ *repos.RepoInstance, _ string, _ []string) (map[string]store.MotifDefinitionStatus, error) {
+	return s.defs, nil
+}
+
+func (s *stubMotifsProvider) VocabularyHealth(_ context.Context, _ *repos.RepoInstance, _ string) (store.MotifVocabularyHealth, error) {
+	return s.health, nil
+}
+
+func (s *stubMotifsProvider) AliasRows(_ context.Context, _ *repos.RepoInstance, _ string) (map[string]store.AliasRow, error) {
+	return s.aliases, nil
+}
+
+func (s *stubMotifsProvider) ClusterKey(_ context.Context, _ *repos.RepoInstance, _, motif string) (string, error) {
+	if k, ok := s.clusterKeys[motif]; ok {
+		return k, nil
+	}
+	return motif, nil // mirror the store: unresolved spelling degrades to itself
+}
+
+// motifsCollectionBody mirrors the vocabulary collection wire shape.
+type motifsCollectionBody struct {
+	Count  int `json:"count"`
+	Health struct {
+		Clusters       int     `json:"clusters"`
+		Recurring      int     `json:"recurring"`
+		RecurrenceRate float64 `json:"recurrence_rate"`
+	} `json:"health"`
+	Links struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		Next *struct {
+			Href string `json:"href"`
+		} `json:"next"`
+		Prev *struct {
+			Href string `json:"href"`
+		} `json:"prev"`
+	} `json:"_links"`
+	Embedded struct {
+		Motifs []struct {
+			ClusterKey      string   `json:"cluster_key"`
+			Canonical       string   `json:"canonical"`
+			Members         []string `json:"members"`
+			DF              int      `json:"df"`
+			Definition      string   `json:"definition"`
+			DefinitionState string   `json:"definition_state"`
+			Links           struct {
+				Self struct {
+					Href string `json:"href"`
+				} `json:"self"`
+			} `json:"_links"`
+		} `json:"motifs"`
+	} `json:"_embedded"`
+}
+
+func motifsServer(t *testing.T, stub *stubMotifsProvider) http.Handler {
+	t.Helper()
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			motifs: stub,
+		},
+	}
+	return s.NewAPIRouter()
+}
+
+func getMotifs(t *testing.T, r http.Handler, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, url, nil))
+	return rec
+}
+
+func decodeMotifs(t *testing.T, rec *httptest.ResponseRecorder) motifsCollectionBody {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body motifsCollectionBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	return body
+}
+
+// threeClusters is the df-desc order Clusters already returns.
+func threeClusters() []store.MotifCluster {
+	return []store.MotifCluster{
+		{ClusterKey: "drift-config", CanonicalID: "config-drift", Members: []string{"config-drift", "configuration-drifts"}, DF: 5},
+		{ClusterKey: "fallback-silent", CanonicalID: "silent-fallback", Members: []string{"silent-fallback"}, DF: 2},
+		{ClusterKey: "creep-scope", CanonicalID: "scope-creep", Members: []string{"scope-creep"}, DF: 2},
+	}
+}
+
+func TestHandleHALMotifs_ReturnsRankedCollection(t *testing.T) {
+	stub := &stubMotifsProvider{
+		clusters: threeClusters(),
+		defs: map[string]store.MotifDefinitionStatus{
+			"drift-config":    {Definition: "Configured state diverges from applied state."},
+			"fallback-silent": {Definition: "A component keeps serving after a dependency fails.", Stale: true},
+			// creep-scope is deliberately absent: never defined.
+		},
+		health: store.MotifVocabularyHealth{Clusters: 3, Recurring: 3, Mints: 3, Links: 6, EpistemicRecurring: 2},
+	}
+	body := decodeMotifs(t, getMotifs(t, motifsServer(t, stub), "/repos/alpha/branches/agent:test/motifs"))
+
+	if body.Count != 3 {
+		t.Errorf("count: got %d, want 3", body.Count)
+	}
+	if body.Health.Clusters != 3 || body.Health.Recurring != 3 {
+		t.Errorf("health: got %+v", body.Health)
+	}
+	if body.Health.RecurrenceRate != 1 {
+		t.Errorf("recurrence_rate: got %v, want 1", body.Health.RecurrenceRate)
+	}
+	entries := body.Embedded.Motifs
+	if len(entries) != 3 {
+		t.Fatalf("entries: got %d, want 3", len(entries))
+	}
+	wantKeys := []string{"drift-config", "fallback-silent", "creep-scope"}
+	wantStates := []string{"current", "stale", "missing"}
+	for i, e := range entries {
+		if e.ClusterKey != wantKeys[i] {
+			t.Errorf("entry %d cluster_key: got %q, want %q", i, e.ClusterKey, wantKeys[i])
+		}
+		if e.DefinitionState != wantStates[i] {
+			t.Errorf("entry %d definition_state: got %q, want %q", i, e.DefinitionState, wantStates[i])
+		}
+		want := "/repos/alpha/branches/agent:test/motifs/" + wantKeys[i]
+		if got := e.Links.Self.Href; len(got) < len(want) || got[len(got)-len(want):] != want {
+			t.Errorf("entry %d self: got %q, want suffix %q", i, got, want)
+		}
+	}
+	// Humans read the canonical; the URL keys on the cluster key (C1).
+	if entries[0].Canonical != "config-drift" {
+		t.Errorf("canonical: got %q, want config-drift", entries[0].Canonical)
+	}
+	if entries[0].DF != 5 {
+		t.Errorf("df: got %d, want 5", entries[0].DF)
+	}
+	if len(entries[0].Members) != 2 {
+		t.Errorf("members: got %v, want both spellings", entries[0].Members)
+	}
+	if entries[2].Definition != "" {
+		t.Errorf("missing definition must be empty, got %q", entries[2].Definition)
+	}
+}
+
+func TestHandleHALMotifs_SortName(t *testing.T) {
+	stub := &stubMotifsProvider{clusters: threeClusters()}
+	r := motifsServer(t, stub)
+
+	body := decodeMotifs(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?sort=name"))
+	want := []string{"config-drift", "scope-creep", "silent-fallback"}
+	for i, e := range body.Embedded.Motifs {
+		if e.Canonical != want[i] {
+			t.Errorf("entry %d canonical: got %q, want %q", i, e.Canonical, want[i])
+		}
+	}
+
+	if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?sort=bogus"); rec.Code != http.StatusBadRequest {
+		t.Errorf("sort=bogus: got %d, want 400, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleHALMotifs_NarrowByQ(t *testing.T) {
+	stub := &stubMotifsProvider{
+		clusters: threeClusters(),
+		defs: map[string]store.MotifDefinitionStatus{
+			// The definition, not any member spelling, is what "diverges" hits.
+			"drift-config": {Definition: "Configured state diverges from applied state."},
+		},
+	}
+	r := motifsServer(t, stub)
+
+	body := decodeMotifs(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?q=FALLBACK"))
+	if body.Count != 1 {
+		t.Fatalf("count: got %d, want 1 (count reflects the narrowed total)", body.Count)
+	}
+	if body.Embedded.Motifs[0].ClusterKey != "fallback-silent" {
+		t.Errorf("kept the wrong cluster: %q", body.Embedded.Motifs[0].ClusterKey)
+	}
+
+	body = decodeMotifs(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?q=diverges"))
+	if body.Count != 1 || body.Embedded.Motifs[0].ClusterKey != "drift-config" {
+		t.Errorf("definition text must be searchable: count=%d entries=%+v", body.Count, body.Embedded.Motifs)
+	}
+}
+
+func TestHandleHALMotifs_Paging(t *testing.T) {
+	stub := &stubMotifsProvider{clusters: threeClusters()}
+	r := motifsServer(t, stub)
+
+	body := decodeMotifs(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?limit=2"))
+	if len(body.Embedded.Motifs) != 2 {
+		t.Errorf("page: got %d entries, want 2", len(body.Embedded.Motifs))
+	}
+	if body.Count != 3 {
+		t.Errorf("count: got %d, want 3 (the total, not the page)", body.Count)
+	}
+	if body.Links.Next == nil {
+		t.Fatal("next link missing while a third cluster remains")
+	}
+	if !containsSub(body.Links.Next.Href, "offset=2") {
+		t.Errorf("next href: got %q, want offset=2", body.Links.Next.Href)
+	}
+	if body.Links.Prev != nil {
+		t.Errorf("prev must be absent on the first page: %q", body.Links.Prev.Href)
+	}
+
+	body = decodeMotifs(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?limit=2&offset=2"))
+	if len(body.Embedded.Motifs) != 1 {
+		t.Errorf("last page: got %d entries, want 1", len(body.Embedded.Motifs))
+	}
+	if body.Links.Next != nil {
+		t.Errorf("next must be absent on the last page: %q", body.Links.Next.Href)
+	}
+	if body.Links.Prev == nil {
+		t.Error("prev link missing on the second page")
+	}
+
+	// Over the ceiling clamps rather than erroring.
+	if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?limit=500"); rec.Code != http.StatusOK {
+		t.Errorf("limit=500: got %d, want 200 (clamped, not refused), body=%s", rec.Code, rec.Body.String())
+	}
+	for _, bad := range []string{"limit=0", "limit=x", "offset=-1", "offset=x"} {
+		if rec := getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs?"+bad); rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: got %d, want 400", bad, rec.Code)
+		}
+	}
+}
+
+func TestHandleHALMotifs_EmptyVocabulary(t *testing.T) {
+	rec := getMotifs(t, motifsServer(t, &stubMotifsProvider{}), "/repos/alpha/branches/agent:test/motifs")
+	body := decodeMotifs(t, rec)
+	if body.Count != 0 {
+		t.Errorf("count: got %d, want 0", body.Count)
+	}
+	if !containsSub(rec.Body.String(), `"motifs":[]`) {
+		t.Errorf("empty vocabulary must serialize an empty array, not null: %s", rec.Body.String())
+	}
+}
+
+// containsSub is strings.Contains, kept local so the test file's intent reads
+// without an import alias collision.
+func containsSub(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/handlers_motifs_test.go
+++ b/internal/web/handlers_motifs_test.go
@@ -178,6 +178,12 @@ func TestHandleHALMotifs_ReturnsRankedCollection(t *testing.T) {
 	}
 }
 
+// TWO requests against ONE stub, deliberately: the name sort must order a COPY,
+// never the slice the provider handed over. Sorting in place would leave the
+// stub's own cluster list permanently reordered, so the df-desc request that
+// follows would answer in name order — which is exactly what a reader of a
+// caching provider would hit in production. Deleting the copy in
+// handlers_motifs.go fails the second half of this test.
 func TestHandleHALMotifs_SortName(t *testing.T) {
 	stub := &stubMotifsProvider{clusters: threeClusters()}
 	r := motifsServer(t, stub)
@@ -187,6 +193,17 @@ func TestHandleHALMotifs_SortName(t *testing.T) {
 	for i, e := range body.Embedded.Motifs {
 		if e.Canonical != want[i] {
 			t.Errorf("entry %d canonical: got %q, want %q", i, e.Canonical, want[i])
+		}
+	}
+
+	// The default (df-desc) order must survive the name-sorted request above.
+	body = decodeMotifs(t, getMotifs(t, r, "/repos/alpha/branches/agent:test/motifs"))
+	wantKeys := []string{"drift-config", "fallback-silent", "creep-scope"}
+	for i, e := range body.Embedded.Motifs {
+		if e.ClusterKey != wantKeys[i] {
+			t.Fatalf("entry %d after a ?sort=name request: got %q, want %q — "+
+				"the name sort reordered the provider's own slice",
+				i, e.ClusterKey, wantKeys[i])
 		}
 	}
 

--- a/internal/web/handlers_search_hal.go
+++ b/internal/web/handlers_search_hal.go
@@ -59,6 +59,7 @@ type searchResultItem struct {
 	Type       string      `json:"type,omitempty"`
 	Domain     []string    `json:"domain,omitempty"`
 	Entities   []string    `json:"entities,omitempty"`
+	Motifs     []string    `json:"motifs,omitempty"`
 	Confidence float64     `json:"confidence,omitempty"`
 	Links      hal.LinkMap `json:"_links"`
 }
@@ -113,6 +114,10 @@ func handleSearch(b hal.URLBuilder, provider searchProvider, emb store.Embedder)
 		if !ok {
 			return
 		}
+		motifs, motifMatch, ok := motifParams(w, r)
+		if !ok {
+			return
+		}
 
 		q := store.SearchOptions{
 			Text:           text,
@@ -126,6 +131,8 @@ func handleSearch(b hal.URLBuilder, provider searchProvider, emb store.Embedder)
 			ExcludeKinds:   splitCSV(excludeKindStr),
 			IncludeOrigins: splitCSV(originStr),
 			EpisodeOps:     splitCSV(epStr),
+			Motifs:         motifs,
+			MotifMatch:     motifMatch,
 			MinConfidence:  minConfidence,
 			MinSimilarity:  minSimilarity,
 			Limit:          limit,
@@ -158,6 +165,7 @@ func handleSearch(b hal.URLBuilder, provider searchProvider, emb store.Embedder)
 				Type:       res.Type,
 				Domain:     res.Domain,
 				Entities:   res.Entities,
+				Motifs:     res.Motifs,
 				Confidence: res.Confidence,
 				Links:      hal.LinkMap{"self": {Href: b.Fact(repoName, a, res.Path)}},
 			}

--- a/internal/web/handlers_search_test.go
+++ b/internal/web/handlers_search_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"knomit/internal/repos"
@@ -260,5 +261,124 @@ func TestHandleSearch_MinSimilarityAndDomainExactReachProvider(t *testing.T) {
 	}
 	if !provider.lastQuery.DomainExact {
 		t.Errorf("DomainExact: got false, want true")
+	}
+}
+
+// TestHandleSearch_MotifFilterReachesSearchOptions locks in that ?motifs= /
+// ?motif_match= on /search reach SearchOptions.Motifs / MotifMatch — the motif
+// axis is only queryable if the params survive the handler.
+func TestHandleSearch_MotifFilterReachesSearchOptions(t *testing.T) {
+	provider := &stubSearchProvider{}
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			search: provider,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		"/repos/alpha/branches/agent:test/search?q=x&motifs=zero-value-as-valid,silent-fallback&motif_match=stem", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d, body=%s", rec.Code, rec.Body.String())
+	}
+	want := []string{"zero-value-as-valid", "silent-fallback"}
+	if !reflect.DeepEqual(provider.lastQuery.Motifs, want) {
+		t.Errorf("Motifs: got %v want %v", provider.lastQuery.Motifs, want)
+	}
+	if provider.lastQuery.MotifMatch != store.MotifMatchStem {
+		t.Errorf("MotifMatch: got %q want stem", provider.lastQuery.MotifMatch)
+	}
+}
+
+// TestHandleSearch_LooseMotifTierRejected: the tiers this surface refuses are
+// refused at the edge, before any store call (C3/MN6).
+func TestHandleSearch_LooseMotifTierRejected(t *testing.T) {
+	provider := &stubSearchProvider{}
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			search: provider,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		"/repos/alpha/branches/agent:test/search?motifs=a-b&motif_match=token-1", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400, body=%s", rec.Code, rec.Body.String())
+	}
+	if provider.lastQuery.Motifs != nil {
+		t.Errorf("provider was called despite the rejection: %v", provider.lastQuery)
+	}
+}
+
+// TestHandleSearch_MotifsOnTheWire: rows carry their motifs, and a motif-free
+// row serializes with no motifs key at all (byte-compat for corpora that never
+// ran a motif pass).
+func TestHandleSearch_MotifsOnTheWire(t *testing.T) {
+	provider := &stubSearchProvider{
+		results: []store.SearchResult{
+			{
+				FactWithBody: store.FactWithBody{
+					FactRecord: store.FactRecord{
+						Path:   "kb/a.md",
+						Title:  "Carries a motif",
+						Motifs: []string{"a-b"},
+					},
+				},
+			},
+			{
+				FactWithBody: store.FactWithBody{
+					FactRecord: store.FactRecord{
+						Path:  "kb/b.md",
+						Title: "Carries none",
+					},
+				},
+			},
+		},
+	}
+	s := &Server{
+		Manager: newTestManagerWithRepos(t, "alpha"),
+		providers: storeProviders{
+			search: provider,
+		},
+	}
+	r := s.NewAPIRouter()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		"/repos/alpha/branches/agent:test/search?q=x", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var view struct {
+		Embedded struct {
+			Results []map[string]any `json:"results"`
+		} `json:"_embedded"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &view); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(view.Embedded.Results) != 2 {
+		t.Fatalf("results: got %d want 2", len(view.Embedded.Results))
+	}
+	got, ok := view.Embedded.Results[0]["motifs"]
+	if !ok {
+		t.Fatalf("row 0: motifs key absent, body=%s", rec.Body.String())
+	}
+	if !reflect.DeepEqual(got, []any{"a-b"}) {
+		t.Errorf("row 0 motifs: got %v want [a-b]", got)
+	}
+	if _, present := view.Embedded.Results[1]["motifs"]; present {
+		t.Errorf("row 1: motif-free row must omit the key entirely, body=%s", rec.Body.String())
 	}
 }

--- a/internal/web/params.go
+++ b/internal/web/params.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"knomit/internal/store"
 	"knomit/internal/web/hal"
 )
 
@@ -100,4 +101,32 @@ func selfWithQuery(base string, r *http.Request) string {
 		return base + "?" + r.URL.RawQuery
 	}
 	return base
+}
+
+// motifParams parses the motifs / motif_match query parameters shared by the
+// repo and lens search + facts collections.
+//
+// The REST surface accepts only the tiers safe outside a deliberate reader
+// session: exact (default), stem, token-2. The looser tiers are deliberately
+// not named anywhere in this package — the validation is an ALLOWLIST, and the
+// MN6 AST guard (internal/mcp/motif_surfaces_test.go) scans internal/web to
+// keep it that way. The error message therefore lists what IS accepted and
+// stays silent about what exists beyond it.
+//
+// motif_match without motifs parses fine and stays inert, matching the MCP
+// tool and the store (SearchOptions.MotifMatch does nothing without Motifs).
+func motifParams(w http.ResponseWriter, r *http.Request) (motifs []string, tier store.MotifMatchTier, ok bool) {
+	qp := r.URL.Query()
+	motifs = splitCSV(qp.Get("motifs"))
+	switch v := qp.Get("motif_match"); v {
+	case "":
+		tier = store.MotifMatchExact
+	case string(store.MotifMatchExact), string(store.MotifMatchStem), string(store.MotifMatchToken2):
+		tier = store.MotifMatchTier(v)
+	default:
+		hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+			`invalid motif_match value (accepted: "exact", "stem", "token-2")`, r.URL.Path)
+		return nil, "", false
+	}
+	return motifs, tier, true
 }

--- a/internal/web/params_test.go
+++ b/internal/web/params_test.go
@@ -3,7 +3,10 @@ package web
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
+
+	"knomit/internal/store"
 )
 
 func TestLimitParam(t *testing.T) {
@@ -128,5 +131,45 @@ func TestSelfWithQuery(t *testing.T) {
 	bare := httptest.NewRequest(http.MethodGet, "/x", nil)
 	if got := selfWithQuery("/base", bare); got != "/base" {
 		t.Errorf("got %q", got)
+	}
+}
+
+func TestMotifParams(t *testing.T) {
+	cases := []struct {
+		name       string
+		query      string
+		wantMotifs []string
+		wantTier   store.MotifMatchTier
+		wantOK     bool
+	}{
+		{"absent is inert exact", "", nil, store.MotifMatchExact, true},
+		{"csv motifs default exact", "motifs=a-b,c-d", []string{"a-b", "c-d"}, store.MotifMatchExact, true},
+		{"stem accepted", "motifs=a-b&motif_match=stem", []string{"a-b"}, store.MotifMatchStem, true},
+		{"token-2 accepted", "motifs=a-b&motif_match=token-2", []string{"a-b"}, store.MotifMatchToken2, true},
+		{"loose tier rejected", "motifs=a-b&motif_match=token-1", nil, "", false},
+		{"soft rejected", "motifs=a-b&motif_match=soft", nil, "", false},
+		{"garbage rejected", "motifs=a-b&motif_match=fuzzy", nil, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/x?"+tc.query, nil)
+			rec := httptest.NewRecorder()
+			motifs, tier, ok := motifParams(rec, req)
+			if ok != tc.wantOK {
+				t.Fatalf("ok: got %v want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				if rec.Code != http.StatusBadRequest {
+					t.Fatalf("status: got %d want 400", rec.Code)
+				}
+				return
+			}
+			if !reflect.DeepEqual(motifs, tc.wantMotifs) {
+				t.Errorf("motifs: got %v want %v", motifs, tc.wantMotifs)
+			}
+			if tier != tc.wantTier {
+				t.Errorf("tier: got %q want %q", tier, tc.wantTier)
+			}
+		})
 	}
 }

--- a/internal/web/providers.go
+++ b/internal/web/providers.go
@@ -42,6 +42,7 @@ type storeProviders struct {
 	factSub          factSubProvider
 	stats            statsProvider
 	domains          domainsProvider
+	motifs           motifsProvider
 	completions      completionsProvider
 	factsCollection  factsCollectionProvider
 	activity         activityProvider
@@ -72,6 +73,9 @@ func (p storeProviders) withDefaults() storeProviders {
 	}
 	if p.search == nil {
 		p.search = defaultSearchProvider{}
+	}
+	if p.motifs == nil {
+		p.motifs = defaultMotifsProvider{}
 	}
 	if p.commits == nil {
 		p.commits = defaultCommitsProvider{}

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -202,6 +202,7 @@ func (s *Server) NewAPIRouter() chi.Router {
 				r.Get("/domains", handleHALDomains(b, p.domains))
 				r.Get("/domains/{name}", handleHALDomainFacts(b, p.domains))
 				r.Get("/motifs", handleHALMotifs(b, p.motifs))
+				r.Get("/motifs/{key}", handleHALMotifCluster(b, p.motifs, p.factsCollection))
 				r.Get("/stats", handleHALStats(b, p.stats))
 				r.Get("/events", handleHALEvents())
 

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -201,6 +201,7 @@ func (s *Server) NewAPIRouter() chi.Router {
 				r.Get("/completions", handleHALCompletions(b, p.completions))
 				r.Get("/domains", handleHALDomains(b, p.domains))
 				r.Get("/domains/{name}", handleHALDomainFacts(b, p.domains))
+				r.Get("/motifs", handleHALMotifs(b, p.motifs))
 				r.Get("/stats", handleHALStats(b, p.stats))
 				r.Get("/events", handleHALEvents())
 

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -562,6 +562,8 @@ paths:
         - { name: exclude_kind,   in: query, description: CSV, schema: { type: string } }
         - { name: origin,         in: query, description: CSV, schema: { type: string } }
         - { name: ep,             in: query, description: CSV (episode operations), schema: { type: string } }
+        - $ref: "#/components/parameters/MotifFilter"
+        - $ref: "#/components/parameters/MotifMatchTier"
         - { name: min_confidence, in: query, description: "Non-numeric is 400.", schema: { type: number, format: double } }
       responses:
         "200":
@@ -811,6 +813,8 @@ paths:
         - { name: exclude_kind,   in: query, description: CSV, schema: { type: string } }
         - { name: origin,         in: query, description: CSV, schema: { type: string } }
         - { name: ep,             in: query, description: CSV (episode operations), schema: { type: string } }
+        - $ref: "#/components/parameters/MotifFilter"
+        - $ref: "#/components/parameters/MotifMatchTier"
       responses:
         "200":
           description: Collection of search results
@@ -892,6 +896,76 @@ paths:
           content:
             application/hal+json:
               schema: { $ref: "#/components/schemas/FactsCollection" }
+        "400": { $ref: "#/components/responses/Problem" }
+        "404": { $ref: "#/components/responses/Problem" }
+        "500": { $ref: "#/components/responses/Problem" }
+
+  /repos/{repo}/branches/{branch}/motifs:
+    parameters:
+      - $ref: "#/components/parameters/Repo"
+      - $ref: "#/components/parameters/Branch"
+    get:
+      tags: [stats, search]
+      summary: Motif vocabulary (one entry per cluster)
+      description: |
+        The branch's resolved motif vocabulary: one entry per CLUSTER, not per
+        spelling, most frequent first. Two spellings of one mechanism are one
+        entry, with `members` listing both.
+
+        On a corpus whose alias rebuild never ran, every spelling is its own
+        singleton cluster — an empty alias table degrades to singletons here,
+        it does not produce an empty vocabulary.
+
+        Motif clusters do not appear in `/stats`; this endpoint is the
+        vocabulary surface.
+      operationId: listMotifs
+      parameters:
+        - { name: q,      in: query, description: "Case-insensitive substring narrow over member spellings AND definition text. `count` reflects the narrowed total.", schema: { type: string } }
+        - { name: sort,   in: query, description: "`df` (document frequency desc, ties by canonical asc) or `name` (canonical asc). Any other value is a 400.", schema: { type: string, enum: [df, name], default: df } }
+        - { name: limit,  in: query, description: "Page size. Values above the maximum are clamped; zero, negative, or non-integer is a 400.", schema: { type: integer, default: 50, minimum: 1, maximum: 200 } }
+        - { name: offset, in: query, description: "Non-negative; negative or non-integer is 400.", schema: { type: integer, default: 0, minimum: 0 } }
+      responses:
+        "200":
+          description: Motif vocabulary page with a health summary
+          content:
+            application/hal+json:
+              schema: { $ref: "#/components/schemas/MotifsCollection" }
+        "400": { $ref: "#/components/responses/Problem" }
+        "404": { $ref: "#/components/responses/Problem" }
+        "500": { $ref: "#/components/responses/Problem" }
+
+  /repos/{repo}/branches/{branch}/motifs/{key}:
+    parameters:
+      - $ref: "#/components/parameters/Repo"
+      - $ref: "#/components/parameters/Branch"
+      - name: key
+        in: path
+        required: true
+        description: |
+          A `cluster_key` or any member spelling; the response and its `self`
+          link always carry the `cluster_key`. A spelling in no cluster is a
+          404.
+        schema: { type: string }
+    get:
+      tags: [stats, search]
+      summary: Motif cluster detail (carriers, aliases, pivot)
+      description: |
+        The collection entry plus a recency-ordered preview of the facts
+        carrying the cluster and the audit trail of how each member spelling
+        joined it.
+
+        `carriers` is a PREVIEW of the same query `_links.facts` performs, so
+        the two can never disagree; `carrier_count` is the corpus total, not
+        the preview length.
+      operationId: getMotifCluster
+      parameters:
+        - { name: limit, in: query, description: "Carrier preview size. Values above the maximum are clamped; zero, negative, or non-integer is a 400.", schema: { type: integer, default: 20, minimum: 1, maximum: 100 } }
+      responses:
+        "200":
+          description: Motif cluster
+          content:
+            application/hal+json:
+              schema: { $ref: "#/components/schemas/MotifClusterDetail" }
         "400": { $ref: "#/components/responses/Problem" }
         "404": { $ref: "#/components/responses/Problem" }
         "500": { $ref: "#/components/responses/Problem" }
@@ -1617,6 +1691,8 @@ paths:
         - { name: ep,             in: query, description: CSV (episode operations), schema: { type: string } }
         - { name: min_confidence, in: query, description: "Non-numeric is 400.", schema: { type: number, format: double } }
         - { name: min_similarity, in: query, description: "Non-numeric is 400.", schema: { type: number, format: double } }
+        - $ref: "#/components/parameters/MotifFilter"
+        - $ref: "#/components/parameters/LensMotifMatchTier"
       responses:
         "200":
           description: Deduped union of facts
@@ -1697,6 +1773,8 @@ paths:
         - { name: ep,             in: query, description: CSV (episode operations), schema: { type: string } }
         - { name: min_confidence, in: query, description: "Non-numeric is 400.", schema: { type: number, format: double } }
         - { name: min_similarity, in: query, description: "Non-numeric is 400.", schema: { type: number, format: double } }
+        - $ref: "#/components/parameters/MotifFilter"
+        - $ref: "#/components/parameters/LensMotifMatchTier"
       responses:
         "200":
           description: Fused union of search results
@@ -1906,6 +1984,48 @@ components:
         mount-qualified `kb://<id12>/kb/…` path. Qualified paths must be
         percent-encoded by the client.
       schema: { type: string }
+    MotifFilter:
+      name: motifs
+      in: query
+      description: |
+        CSV of motif spellings. Filters to facts carrying a matching motif —
+        the aspect axis: the general regularity a fact instantiates, independent
+        of its subject.
+
+        Matching is CLUSTER-level by default: a spelling resolves through the
+        repo's alias vocabulary, so a corpus that spells one mechanism two ways
+        answers for both. On a corpus whose alias rebuild never ran, every
+        spelling is its own singleton cluster and the filter is exact.
+
+        A motif filter that resolves to nothing matches nothing — it never
+        silently widens to the unfiltered set.
+      schema: { type: string }
+    MotifMatchTier:
+      name: motif_match
+      in: query
+      description: |
+        Strictness of `motifs` matching. This surface accepts `exact` (the
+        default), `stem`, and `token-2`; any other value is a 400, never a
+        silent downgrade. Looser tiers exist for a reader who types them in a
+        deliberate session and are not reachable from the web API.
+
+        Inert without `motifs`.
+      schema: { type: string, enum: [exact, stem, "token-2"], default: exact }
+    LensMotifMatchTier:
+      name: motif_match
+      in: query
+      description: |
+        Strictness of `motifs` matching. This surface accepts `exact` (the
+        default), `stem`, and `token-2`; any other value is a 400, never a
+        silent downgrade.
+
+        Motif terms resolve per mount against each repo's own alias vocabulary;
+        there is no cross-mount cluster identity. A mount that merged two
+        spellings answers for both; one that keeps them apart answers only for
+        the exact term.
+
+        Inert without `motifs`.
+      schema: { type: string, enum: [exact, stem, "token-2"], default: exact }
     LensRepoNarrow:
       name: repo
       in: query
@@ -2156,6 +2276,7 @@ components:
         confidence:   { type: number, format: double }
         committed_at: { type: string, format: date-time }
         operation:    { type: string }
+        motifs:       { type: array, items: { type: string }, description: "The fact's motifs. Absent entirely on a fact carrying none." }
         _links:       { $ref: "#/components/schemas/LinkMap" }
 
     RefView:
@@ -2336,6 +2457,103 @@ components:
                 domains:
                   type: array
                   items: { $ref: "#/components/schemas/DomainEntry" }
+
+    MotifVocabularyHealth:
+      type: object
+      description: Diagnostic summary of the branch's motif vocabulary. Nothing branches on it.
+      required: [clusters, recurring, mints, links, epistemic_recurring, recurrence_rate, mint_to_link_ratio]
+      properties:
+        clusters:            { type: integer, description: Size of the resolved vocabulary. }
+        recurring:           { type: integer, description: "Clusters with df >= 2 — the ones that actually connect two facts." }
+        mints:               { type: integer, description: "One per cluster: every cluster was minted exactly once." }
+        links:               { type: integer, description: "Every SUBSEQUENT use — total motif instances minus the mints." }
+        epistemic_recurring: { type: integer, description: "Clusters with df >= 2 counting EPISTEMIC carriers only. Diverges from `recurring`, sometimes by a lot." }
+        recurrence_rate:     { type: number, format: double, description: Fraction of clusters carried by more than one fact. }
+        mint_to_link_ratio:  { type: number, format: double, description: "Mints per link. Above 1 means the vocabulary is growing faster than it is reused." }
+
+    MotifClusterEntry:
+      type: object
+      description: |
+        One motif cluster. `cluster_key` is the STABLE identity and what URLs
+        and persisted state key on; `canonical` is the df-elected
+        representative spelling and flips as usage shifts — display it, never
+        key on it.
+      required: [cluster_key, canonical, members, df, definition_state, _links]
+      properties:
+        cluster_key: { type: string, description: Stable cluster identity. }
+        canonical:   { type: string, description: Representative spelling, for display only. }
+        members:     { type: array, items: { type: string }, description: Every spelling resolving to this cluster, sorted. }
+        df:          { type: integer, description: Live facts carrying any member, counted once each. }
+        definition:  { type: string, description: "The cluster's glossary sentence. Absent when none was ever authored; PRESENT when stale (a stale sentence is served as interim rather than gapping the cluster)." }
+        definition_state:
+          type: string
+          enum: [current, stale, missing]
+          description: |
+            Freshness of `definition`, derived by comparing the membership it
+            was authored against with the current membership — not a flag
+            anything has to remember to set. `stale` means the sentence
+            describes a different membership and is served as interim.
+        _links: { $ref: "#/components/schemas/LinkMap" }
+
+    MotifCarrier:
+      type: object
+      required: [path, title, _links]
+      properties:
+        path:         { type: string }
+        title:        { type: string }
+        type:         { type: string }
+        committed_at: { type: integer, format: int64, description: Unix seconds. }
+        _links:       { $ref: "#/components/schemas/LinkMap" }
+
+    MotifAlias:
+      type: object
+      description: |
+        One member spelling with the audit trail of how it joined the cluster.
+        `method` and `rationale` are absent on an unresolved (singleton)
+        corpus — the spelling is a member because nothing has grouped it yet.
+      required: [motif]
+      properties:
+        motif:     { type: string }
+        method:    { type: string, enum: [mechanical, judge], description: How the spelling joined the cluster. }
+        rationale: { type: string, description: "The written rationale, present on judge merges." }
+
+    MotifClusterDetail:
+      allOf:
+        - $ref: "#/components/schemas/MotifClusterEntry"
+        - type: object
+          required: [carrier_count, carriers, aliases]
+          properties:
+            carrier_count:
+              type: integer
+              description: "Total live facts carrying the cluster — the CORPUS count, not the length of `carriers`."
+            carriers:
+              type: array
+              description: |
+                Recency-ordered preview of the carrying facts, bounded by
+                `limit`. This is the same query `_links.facts` performs, so the
+                preview cannot disagree with the full listing.
+              items: { $ref: "#/components/schemas/MotifCarrier" }
+            aliases:
+              type: array
+              items: { $ref: "#/components/schemas/MotifAlias" }
+            _links:
+              allOf:
+                - $ref: "#/components/schemas/LinkMap"
+                - description: "Carries `self` (always the cluster_key) and `facts` (the full pivot: `/facts?motifs=<members>&motif_match=exact`)."
+
+    MotifsCollection:
+      allOf:
+        - $ref: "#/components/schemas/CollectionBase"
+        - type: object
+          required: [health]
+          properties:
+            health: { $ref: "#/components/schemas/MotifVocabularyHealth" }
+            _embedded:
+              type: object
+              properties:
+                motifs:
+                  type: array
+                  items: { $ref: "#/components/schemas/MotifClusterEntry" }
 
     Highlight:
       type: object
@@ -2959,6 +3177,7 @@ components:
         type:         { type: string }
         committed_at: { type: integer, format: int64 }
         operation:    { type: string }
+        motifs:       { type: array, items: { type: string }, description: "The fact's motifs. Absent entirely on a fact carrying none." }
         score:        { type: number, format: double }
         source:       { $ref: "#/components/schemas/LensSource" }
 
@@ -2996,6 +3215,7 @@ components:
         type:       { type: string }
         domain:     { type: array, items: { type: string } }
         entities:   { type: array, items: { type: string } }
+        motifs:     { type: array, items: { type: string }, description: "The fact's motifs. Absent entirely on a fact carrying none." }
         confidence: { type: number, format: double }
         source:     { $ref: "#/components/schemas/LensSource" }
 

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -2470,15 +2470,24 @@ components:
         vocabulary listing over every origin. The two therefore disagree
         routinely and for two independent reasons, which is why the field names
         carry their population.
-      required: [authored_clusters, authored_recurring, authored_mints, authored_links, epistemic_recurring, recurrence_rate, mint_to_link_ratio]
+      required: [authored_clusters, authored_recurring, authored_mints, authored_links, authored_epistemic_recurring, recurrence_rate, mint_to_link_ratio]
       properties:
         authored_clusters:   { type: integer, description: "Size of the resolved vocabulary over authored facts. NOT the envelope's `count`, which spans every origin and is narrowed by `q`." }
         authored_recurring:  { type: integer, description: "Authored clusters with df >= 2 — the ones that actually connect two facts." }
         authored_mints:      { type: integer, description: "One per authored cluster: every cluster was minted exactly once." }
         authored_links:      { type: integer, description: "Every SUBSEQUENT use — total motif instances minus the mints." }
-        epistemic_recurring: { type: integer, description: "Clusters with df >= 2 counting EPISTEMIC carriers only — a narrower population again (kind, not origin). Diverges from `authored_recurring`, sometimes by a lot." }
-        recurrence_rate:     { type: number, format: double, description: Fraction of clusters carried by more than one fact. }
-        mint_to_link_ratio:  { type: number, format: double, description: "Mints per link. Above 1 means the vocabulary is growing faster than it is reused." }
+        authored_epistemic_recurring:
+          type: integer
+          description: |
+            Clusters with df >= 2 counting AUTHORED AND EPISTEMIC carriers —
+            the epistemic test is applied within the same authored-only
+            population as every other count here, narrowing it by kind as WELL
+            as origin, not instead of it. This is the number the motif
+            activation floor reads, and it diverges from `authored_recurring`
+            sometimes by several times over, so the two are reported side by
+            side deliberately.
+        recurrence_rate:     { type: number, format: double, description: "Fraction of clusters carried by more than one fact. Derived from the authored counts above, so it describes the same authored-only population." }
+        mint_to_link_ratio:  { type: number, format: double, description: "Mints per link. Above 1 means the vocabulary is growing faster than it is reused. Derived from the authored counts above, so it describes the same authored-only population." }
 
     MotifClusterEntry:
       type: object

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -2492,7 +2492,15 @@ components:
         cluster_key: { type: string, description: Stable cluster identity. }
         canonical:   { type: string, description: Representative spelling, for display only. }
         members:     { type: array, items: { type: string }, description: Every spelling resolving to this cluster, sorted. }
-        df:          { type: integer, description: Live facts carrying any member, counted once each. }
+        df:
+          type: integer
+          description: |
+            Live facts carrying any member, counted once each, computed by the
+            VOCABULARY query. Read it as the cluster's frequency and its rank
+            among its siblings — the pivot's own total is `carrier_count`, which
+            comes from the pivot query itself and is the authority on how many
+            facts `_links.facts` returns. The two are the same quantity asked of
+            two independent queries and can differ in flight.
         definition:  { type: string, description: "The cluster's glossary sentence. Absent when none was ever authored; PRESENT when stale (a stale sentence is served as interim rather than gapping the cluster)." }
         definition_state:
           type: string
@@ -2534,7 +2542,14 @@ components:
           properties:
             carrier_count:
               type: integer
-              description: "Total live facts carrying the cluster — the CORPUS count, not the length of `carriers`."
+              description: |
+                Total live facts carrying the cluster — the CORPUS count, not
+                the length of `carriers`.
+
+                AUTHORITATIVE for "how many facts does `_links.facts` return":
+                it is produced by that very query. `df` answers the same
+                question from the vocabulary query instead, so prefer this one
+                whenever the number is about the pivot.
             carriers:
               type: array
               description: |

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -922,7 +922,7 @@ paths:
       parameters:
         - { name: q,      in: query, description: "Case-insensitive substring narrow over member spellings AND definition text. `count` reflects the narrowed total.", schema: { type: string } }
         - { name: sort,   in: query, description: "`df` (document frequency desc, ties by canonical asc) or `name` (canonical asc). Any other value is a 400.", schema: { type: string, enum: [df, name], default: df } }
-        - { name: limit,  in: query, description: "Page size. Values above the maximum are clamped; zero, negative, or non-integer is a 400.", schema: { type: integer, default: 50, minimum: 1, maximum: 200 } }
+        - { name: limit,  in: query, description: "1–200; out-of-range or non-integer is 400. The maximum is a hard ceiling, not a clamp.", schema: { type: integer, default: 50, minimum: 1, maximum: 200 } }
         - { name: offset, in: query, description: "Non-negative; negative or non-integer is 400.", schema: { type: integer, default: 0, minimum: 0 } }
       responses:
         "200":
@@ -959,7 +959,7 @@ paths:
         the preview length.
       operationId: getMotifCluster
       parameters:
-        - { name: limit, in: query, description: "Carrier preview size. Values above the maximum are clamped; zero, negative, or non-integer is a 400.", schema: { type: integer, default: 20, minimum: 1, maximum: 100 } }
+        - { name: limit, in: query, description: "Carrier preview size. 1–100; out-of-range or non-integer is 400. The maximum is a hard ceiling, not a clamp.", schema: { type: integer, default: 20, minimum: 1, maximum: 100 } }
       responses:
         "200":
           description: Motif cluster

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -2460,14 +2460,23 @@ components:
 
     MotifVocabularyHealth:
       type: object
-      description: Diagnostic summary of the branch's motif vocabulary. Nothing branches on it.
-      required: [clusters, recurring, mints, links, epistemic_recurring, recurrence_rate, mint_to_link_ratio]
+      description: |
+        Diagnostic summary of the branch's motif vocabulary. Nothing branches
+        on it.
+
+        Every count here is computed over AUTHORED facts only, and none of them
+        is narrowed by the collection's `q` parameter — this block describes the
+        CORPUS, while the envelope's `count` describes the (possibly narrowed)
+        vocabulary listing over every origin. The two therefore disagree
+        routinely and for two independent reasons, which is why the field names
+        carry their population.
+      required: [authored_clusters, authored_recurring, authored_mints, authored_links, epistemic_recurring, recurrence_rate, mint_to_link_ratio]
       properties:
-        clusters:            { type: integer, description: Size of the resolved vocabulary. }
-        recurring:           { type: integer, description: "Clusters with df >= 2 — the ones that actually connect two facts." }
-        mints:               { type: integer, description: "One per cluster: every cluster was minted exactly once." }
-        links:               { type: integer, description: "Every SUBSEQUENT use — total motif instances minus the mints." }
-        epistemic_recurring: { type: integer, description: "Clusters with df >= 2 counting EPISTEMIC carriers only. Diverges from `recurring`, sometimes by a lot." }
+        authored_clusters:   { type: integer, description: "Size of the resolved vocabulary over authored facts. NOT the envelope's `count`, which spans every origin and is narrowed by `q`." }
+        authored_recurring:  { type: integer, description: "Authored clusters with df >= 2 — the ones that actually connect two facts." }
+        authored_mints:      { type: integer, description: "One per authored cluster: every cluster was minted exactly once." }
+        authored_links:      { type: integer, description: "Every SUBSEQUENT use — total motif instances minus the mints." }
+        epistemic_recurring: { type: integer, description: "Clusters with df >= 2 counting EPISTEMIC carriers only — a narrower population again (kind, not origin). Diverges from `authored_recurring`, sometimes by a lot." }
         recurrence_rate:     { type: number, format: double, description: Fraction of clusters carried by more than one fact. }
         mint_to_link_ratio:  { type: number, format: double, description: "Mints per link. Above 1 means the vocabulary is growing faster than it is reused." }
 
@@ -2547,7 +2556,10 @@ components:
         - type: object
           required: [health]
           properties:
-            health: { $ref: "#/components/schemas/MotifVocabularyHealth" }
+            health:
+              allOf:
+                - $ref: "#/components/schemas/MotifVocabularyHealth"
+                - description: "Corpus-level and authored-only; unlike `count`, it is NOT narrowed by `q`."
             _embedded:
               type: object
               properties:


### PR DESCRIPTION
Motifs become a first-class query axis on the REST surface, plus a per-repo vocabulary browser API.

## What

**Filtering / pivot** — `motifs` (CSV) + `motif_match` params on all four fact-listing endpoints: repo `/search` and `/facts`, lens `/search` and `/facts`. The default `exact` tier resolves through the alias table, so pivoting on a spelling is cluster-level out of the box. Accepted tiers: `exact`, `stem`, `token-2` — anything looser is a 400 (MN6: loose tiers are for a caller who types them; the AST guard now scans `internal/web` to keep it that way). Lens resolution is per-mount against each repo's own vocabulary, stated in the spec and pinned by a divergent-vocabulary test.

**Vocabulary browser (per-repo)** —
- `GET .../motifs`: paged cluster list (`q` narrowing over members + definitions, `sort=df|name`, overflow-safe paging, hard limit ceiling), each entry `cluster_key` / `canonical` / `members` / `df` / `definition` + `definition_state` (current|stale|missing), plus an `authored_*` vocabulary-health block.
- `GET .../motifs/{key}`: accepts a `cluster_key` or any member spelling (self link always canonicalizes to the key), returns carriers (the preview issues the same `RecentFacts` pivot query its `_links.facts` advertises, so the two cannot diverge), `carrier_count`, and alias rows with judge method + rationale.

**Store** — one new method: bulk `MotifIndex.Definitions` with membership-derived staleness.

**MCP** — `knomit_explain`'s motif block gains `cluster_key` + `member_count`; sibling cap 5 → 8.

**OpenAPI** — params, two new paths, schemas; shared components per the file's idiom.

## Key invariants held

- URLs/state key on `cluster_key`; `canonical` is display-only (it flips as df shifts).
- All reads go through `store.MotifIndex` / `motifClusterKeyExpr` — an unrebuilt corpus degrades to singleton clusters everywhere, never an empty vocabulary.
- Motifs stay inert unless asked for; `/stats` untouched.

## Review trail

Two-session review: an initial pass found 6 issues (1 HIGH: integer-overflow panic in paging; silent limit clamps vs the package's 400 rule; health block counting a different population than the list; plus doc/test-strength items) — all fixed and re-verified, including sabotage checks on the MN6 guard, the sort-copy guard, the per-mount lens resolution, and every health-field wiring assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
