### PR TITLE
feat(embeddings): bound inference batches by padded tokens, not doc count

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -70,12 +70,24 @@ func New(ctx context.Context, cfg config.Config, opts Options) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("embedder model config invalid (embeddings.model=%q): %w", cfg.Embeddings.Model, err)
 	}
-	embedder, err := embeddings.NewEmbedder(ctx, model, filepath.Join(cfg.Home, "models"))
+	// 0 is the documented auto sentinel for embeddings.max_batch_tokens, resolved
+	// here rather than in Defaults() because Defaults() runs before the TOML and
+	// env layers and so cannot tell "operator chose this value" from "operator
+	// set nothing" — the same reason remote.known_hosts resolves after the
+	// overlay. Resolution lives at the app layer so a later memory-derived
+	// budget needs no config-package change and no /sys dependency there.
+	maxBatchTokens := cfg.Embeddings.MaxBatchTokens
+	if maxBatchTokens == 0 {
+		maxBatchTokens = embeddings.DefaultMaxBatchTokens
+	}
+	embedder, err := embeddings.NewEmbedder(ctx, model, filepath.Join(cfg.Home, "models"),
+		embeddings.WithMaxBatchTokens(maxBatchTokens))
 	if err != nil {
 		return nil, fmt.Errorf("embedder init failed for model %q (embeddings are required — check ONNX model files / network): %w", model.ID, err)
 	}
 	a.closers = append(a.closers, embedder.Close)
 	log.Info().Str("model", model.ID).Int("dim", model.Dim).
+		Int("max_batch_tokens", maxBatchTokens).
 		Msg("embedder enabled — facts indexed with vectors; semantic search and methodology vector ranking active")
 
 	// LLM adapter.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,6 +80,17 @@ func New(ctx context.Context, cfg config.Config, opts Options) (*App, error) {
 	if maxBatchTokens == 0 {
 		maxBatchTokens = embeddings.DefaultMaxBatchTokens
 	}
+	// Warn rather than reject: both bounds are judgement, not correctness.
+	// The low warning catches a predictable operator error — the constant this
+	// replaced was 32 DOCUMENTS, so someone reading a changelog may well set 32
+	// here and get one max-length document per inference with no other signal.
+	if n := cfg.Embeddings.MaxBatchTokens; n > 0 && n < 2048 {
+		log.Warn().Int("max_batch_tokens", n).
+			Msg("embeddings.max_batch_tokens is below one document's maximum length — the unit is PADDED TOKENS, not documents; every max-length document will run alone")
+	} else if n > 65536 {
+		log.Warn().Int("max_batch_tokens", n).
+			Msg("embeddings.max_batch_tokens is beyond the measured range; per-row overhead is unmodeled above it and peak memory may exceed expectations")
+	}
 	embedder, err := embeddings.NewEmbedder(ctx, model, filepath.Join(cfg.Home, "models"),
 		embeddings.WithMaxBatchTokens(maxBatchTokens))
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,18 @@ type LLMConfig struct {
 // EmbeddingsConfig selects the embedding model (by registry id).
 type EmbeddingsConfig struct {
 	Model string `toml:"model"`
+	// MaxBatchTokens bounds the PADDED token count — rows × the longest row —
+	// fed to one ONNX session.Run. Memory scales with that product, not with
+	// the document count: at a fixed 16384 padded tokens the measured peak is
+	// the same (within 1.3%) whether it is 128×128, 64×256 or 256×64, while a
+	// fixed count of 32 documents ranged from 283 MiB to 9030 MiB on document
+	// length alone. That 9030 MiB run is what OOM-killed the server.
+	//
+	// 0 (the default) means auto: resolved at the app layer, currently to
+	// embeddings.DefaultMaxBatchTokens. A later release derives a smaller value
+	// on memory-constrained hosts and containers without changing this
+	// sentinel, so an explicit 0 keeps meaning "let knomit decide".
+	MaxBatchTokens int `toml:"max_batch_tokens"`
 }
 
 // LogConfig controls logging output. The default is collector-friendly:
@@ -313,6 +325,7 @@ func Load() (Config, error) {
 		envFloatOr("KNOMIT_METHODOLOGY_MIN_SCORE", &cfg.MethodologyMinScore),
 		envFloatOr("KNOMIT_DISCOVERY_CONFIDENCE_THRESHOLD", &cfg.Discovery.ConfidenceThreshold),
 		envIntOr("KNOMIT_DISCOVERY_BLAST_RADIUS_THRESHOLD", &cfg.Discovery.BlastRadiusThreshold),
+		envIntOr("KNOMIT_EMBED_MAX_BATCH_TOKENS", &cfg.Embeddings.MaxBatchTokens),
 		envIntOr("KNOMIT_LOG_MAX_SIZE", &cfg.Log.MaxSizeMB),
 		envIntOr("KNOMIT_LOG_MAX_BACKUPS", &cfg.Log.MaxBackups),
 		envIntOr("KNOMIT_LOG_MAX_AGE", &cfg.Log.MaxAgeDays),
@@ -389,6 +402,14 @@ func (c Config) Validate() error {
 	// meaning — a typo that should fail loudly at boot, like confidence_threshold.
 	if c.Discovery.BlastRadiusThreshold < 0 {
 		return fmt.Errorf("config: discovery.blast_radius_threshold must be >= 0, got %d", c.Discovery.BlastRadiusThreshold)
+	}
+	// embeddings.max_batch_tokens is a padded-token budget, so a negative value
+	// is meaningless and would otherwise reach the packer, which degrades to one
+	// document per inference — a silent ~30x slowdown on re-embed rather than a
+	// visible failure. 0 is VALID and is the documented auto sentinel (the app
+	// layer resolves it), exactly as "" means "normal" for discovery.effort_default.
+	if c.Embeddings.MaxBatchTokens < 0 {
+		return fmt.Errorf("config: embeddings.max_batch_tokens must be >= 0 (0 = auto), got %d", c.Embeddings.MaxBatchTokens)
 	}
 	// log.format selects the sink encoding; an unknown value would silently
 	// fall through to console — fail at boot instead. Empty maps to console.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -428,3 +428,53 @@ func TestReadOnly_EnvOverride(t *testing.T) {
 		t.Fatal("KNOMIT_READ_ONLY=true should set cfg.ReadOnly")
 	}
 }
+
+// TestDefaults_MaxBatchTokensIsAutoSentinel pins the sentinel. It is
+// deliberately ABSENT from Defaults(): Defaults() runs before the TOML and env
+// layers, so a value written there could not be distinguished from an operator
+// who set the same number explicitly. The zero value is what lets the app layer
+// tell "unset" from "chosen", the way remote.known_hosts already does.
+func TestDefaults_MaxBatchTokensIsAutoSentinel(t *testing.T) {
+	if got := Defaults().Embeddings.MaxBatchTokens; got != 0 {
+		t.Errorf("Defaults().Embeddings.MaxBatchTokens = %d, want 0 (the auto sentinel)", got)
+	}
+}
+
+// TestValidate_MaxBatchTokens_AcceptsZero guards the sentinel against a future
+// tightening to "must be > 0", which would reject every config that leaves the
+// knob alone.
+func TestValidate_MaxBatchTokens_AcceptsZero(t *testing.T) {
+	cfg := Defaults()
+	cfg.Embeddings.MaxBatchTokens = 0
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate rejected the auto sentinel: %v", err)
+	}
+}
+
+// TestValidate_MaxBatchTokens_RejectsNegative fails a meaningless budget at
+// boot. A negative value reaching the packer degrades it to one document per
+// inference — a silent ~30x re-embed slowdown rather than a visible error.
+func TestValidate_MaxBatchTokens_RejectsNegative(t *testing.T) {
+	cfg := Defaults()
+	cfg.Embeddings.MaxBatchTokens = -1
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate accepted a negative max_batch_tokens")
+	}
+	if !strings.Contains(err.Error(), "max_batch_tokens") {
+		t.Errorf("error should name the offending key, got: %v", err)
+	}
+}
+
+func TestLoad_MaxBatchTokensEnvOverride(t *testing.T) {
+	t.Setenv("KNOMIT_HOME", t.TempDir()) // empty dir → no TOML, defaults + env only
+	t.Setenv("KNOMIT_EMBED_MAX_BATCH_TOKENS", "8192")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Embeddings.MaxBatchTokens; got != 8192 {
+		t.Errorf("env override MaxBatchTokens: want 8192, got %d", got)
+	}
+}

--- a/internal/embeddings/batching.go
+++ b/internal/embeddings/batching.go
@@ -25,17 +25,22 @@ import (
 const DefaultMaxBatchTokens = 16384
 
 // minRowCharge is the floor each row is charged when packing, whatever its real
-// token length. It caps a batch at DefaultMaxBatchTokens/minRowCharge = 256
-// rows, which the token budget alone would not: at 2048 rows of 8 tokens the
-// measured delta is 1683 MiB against ~1150 MiB for the same token count in
-// fewer, longer rows — a per-row cost of ~0.26 MiB that the token model does
-// not capture.
+// token length. It caps a batch at budget/minRowCharge rows — 256 at the
+// default budget, scaling with whatever the operator configures — which the
+// token budget alone would not: at 2048 rows of 8 tokens the measured delta is
+// 1683 MiB against ~1150 MiB for the same token count in fewer, longer rows, a
+// per-row cost of ~0.26 MiB the token model does not capture.
 //
-// It also preserves the cancellation contract documented on store.Embedder
-// ("cancelling bounds latency to one batch"). Two callers are bounded by no
-// constant at all — learn.go embeds an entire incoming write request, and
-// motif_alias.go embeds a whole motif vocabulary in one call — so without this
-// floor either could become a single uninterruptible session.Run.
+// It also bounds cancellation latency, which store.Embedder documents as "one
+// batch". Be honest about the direction: two callers are bounded by no constant
+// at all (learn.go embeds an entire incoming write request, motif_alias.go a
+// whole motif vocabulary), so without this floor either could become one
+// unbounded uninterruptible session.Run. But against the OLD fixed 32-document
+// chunk, short-string cancellation latency GROWS — up to 256 rows per run at
+// the default rather than 32. The new contract is uniform rather than strictly
+// better: cancelling costs at most one budget's worth of inference on every
+// path, which for short strings is more than before and for long documents far
+// less.
 const minRowCharge = 64
 
 // encodedRow is one tokenized text: input ids and attention mask, already
@@ -102,14 +107,24 @@ func packByTokenBudget(lens []int, budget int) [][]int {
 		// narrow ones up to its width — and padding is real ONNX compute, not
 		// just memory. Compare doubled rather than halved to avoid the rounding
 		// that integer division would introduce at small widths.
-		for j := i + 1; j < end; j++ {
+		//
+		// Never cut to a singleton (hence j > i+1): a batch of one wastes no
+		// padding by definition, so cutting there buys nothing and costs a run.
+		// Without this guard a smoothly decaying corpus — every neighbour more
+		// than 2x smaller, e.g. 2048/1000/490/240/118 — degenerates into one
+		// run per document, which is the pathology this packer exists to avoid.
+		for j := i + 2; j < end; j++ {
 			if charge(lens[idx[j]])*2 < width {
 				end = j
 				break
 			}
 		}
 
-		batches = append(batches, idx[i:end])
+		// Three-index slice: batches must not share spare capacity with idx, or
+		// a later append to one would overwrite the next batch's first index —
+		// silently, and as exactly the neighbour's-vector corruption the
+		// scatter-back comment below warns about.
+		batches = append(batches, idx[i:end:end])
 		i = end
 	}
 	return batches

--- a/internal/embeddings/batching.go
+++ b/internal/embeddings/batching.go
@@ -1,0 +1,168 @@
+package embeddings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// DefaultMaxBatchTokens is the padded-token budget for one ONNX session.Run
+// when the operator has configured none.
+//
+// Memory scales with the PADDED token count — rows × the longest row in the
+// batch, since embedBatch pads every row to the longest — not with the document
+// count. Measured on embeddinggemma (see
+// .claude/plans/2026-08-29-embed-memory-results.txt), holding batch × seq at
+// this value: 128×128 = 1154 MiB, 64×256 = 1159 MiB, 256×64 = 1144 MiB. Within
+// 1.3% of each other, which is why the budget bounds the product rather than
+// either factor.
+//
+// The worst shape this budget permits is 8 rows × 2048 tokens (MaxTokens),
+// measured at 1820 MiB above the ~675 MiB resident model. The fixed count it
+// replaces — 32 documents — reached 9030 MiB on the same corpus, which is what
+// OOM-killed the server: search_index.go's rebuild chunk was also 32, so the
+// two constants being equal made every long chunk exactly one maximal run.
+const DefaultMaxBatchTokens = 16384
+
+// minRowCharge is the floor each row is charged when packing, whatever its real
+// token length. It caps a batch at DefaultMaxBatchTokens/minRowCharge = 256
+// rows, which the token budget alone would not: at 2048 rows of 8 tokens the
+// measured delta is 1683 MiB against ~1150 MiB for the same token count in
+// fewer, longer rows — a per-row cost of ~0.26 MiB that the token model does
+// not capture.
+//
+// It also preserves the cancellation contract documented on store.Embedder
+// ("cancelling bounds latency to one batch"). Two callers are bounded by no
+// constant at all — learn.go embeds an entire incoming write request, and
+// motif_alias.go embeds a whole motif vocabulary in one call — so without this
+// floor either could become a single uninterruptible session.Run.
+const minRowCharge = 64
+
+// encodedRow is one tokenized text: input ids and attention mask, already
+// truncated to the model's MaxTokens. Rows are carried rather than strings so
+// packing can see token lengths without tokenizing twice.
+type encodedRow struct {
+	ids  []int64
+	mask []int64
+}
+
+// charge is the width a row is billed at when packing. Never below
+// minRowCharge, and never below 1 — packByTokenBudget divides by it, and a
+// zero-token encoding is a real input (embedBatch guards maxLen == 0 for the
+// same reason), so a zero charge would panic on an empty document.
+func charge(tokenLen int) int {
+	if tokenLen < minRowCharge {
+		return minRowCharge
+	}
+	return tokenLen
+}
+
+// packByTokenBudget groups row indices into batches whose padded cost — rows ×
+// the widest row — stays within budget. Returns indices into lens, so callers
+// must scatter results back to those positions.
+//
+// Rows are ordered by charged width, descending. That does two jobs: it makes
+// the first row's width the batch maximum, so k×L ≤ budget holds by
+// construction, and it groups similar lengths together so padding waste stays
+// low.
+//
+// Two rows are not negotiable. A row wider than the whole budget still runs, as
+// a batch of one — a document cannot be split, so the budget is a target with
+// exactly one documented exception. And a non-positive budget degrades to one
+// row per batch rather than looping forever; that is unreachable through config
+// (app resolves 0 to the default, Validate rejects negatives) and guards
+// programmer error only.
+func packByTokenBudget(lens []int, budget int) [][]int {
+	if len(lens) == 0 {
+		return nil
+	}
+
+	idx := make([]int, len(lens))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool {
+		return charge(lens[idx[a]]) > charge(lens[idx[b]])
+	})
+
+	var batches [][]int
+	for i := 0; i < len(idx); {
+		width := charge(lens[idx[i]])
+		k := budget / width
+		if k < 1 {
+			k = 1
+		}
+		end := i + k
+		if end > len(idx) {
+			end = len(idx)
+		}
+
+		// Stop at a length cliff. Descending order keeps neighbours similar, but
+		// where the corpus steps down sharply a wide row would otherwise drag
+		// narrow ones up to its width — and padding is real ONNX compute, not
+		// just memory. Compare doubled rather than halved to avoid the rounding
+		// that integer division would introduce at small widths.
+		for j := i + 1; j < end; j++ {
+			if charge(lens[idx[j]])*2 < width {
+				end = j
+				break
+			}
+		}
+
+		batches = append(batches, idx[i:end])
+		i = end
+	}
+	return batches
+}
+
+// embedInBatches packs rows into budget-bounded batches, runs each, and
+// restores every result to its INPUT position. The reordering is why that last
+// step matters: callers correlate the returned slice positionally with the
+// titles/bodies they passed (search_index.go's rebuild, learn.go's dedup,
+// every EmbedShortStrings consumer), so scattering wrongly would give each
+// fact its neighbour's vector — a corruption no length check would catch.
+//
+// ctx is checked at entry and before each batch. It is a checkpoint, not an
+// abort: sess.Run cannot be interrupted, so cancelling bounds latency to one
+// batch, exactly as store.Embedder documents.
+func embedInBatches(ctx context.Context, rows []encodedRow, budget int, run func([]encodedRow) ([][]float32, error)) ([][]float32, error) {
+	// Checked at entry as well as per batch: with no rows the loop body never
+	// runs, and returning (empty, nil) on a cancelled context would break the
+	// "observed at entry to each call" promise the Embedder interface makes.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	lens := make([]int, len(rows))
+	for i, r := range rows {
+		lens[i] = len(r.ids)
+	}
+
+	out := make([][]float32, len(rows))
+	for _, batch := range packByTokenBudget(lens, budget) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		sub := make([]encodedRow, len(batch))
+		for j, at := range batch {
+			sub[j] = rows[at]
+		}
+
+		vecs, err := run(sub)
+		if err != nil {
+			// Return nothing rather than the partially scattered slice: it would
+			// be the right length with nil holes, which a caller checking only
+			// len() would read as success.
+			return nil, err
+		}
+		if len(vecs) != len(batch) {
+			return nil, fmt.Errorf("embedInBatches: run returned %d vectors for %d rows", len(vecs), len(batch))
+		}
+
+		for j, at := range batch {
+			out[at] = vecs[j]
+		}
+	}
+	return out, nil
+}

--- a/internal/embeddings/batching_test.go
+++ b/internal/embeddings/batching_test.go
@@ -1,0 +1,341 @@
+package embeddings
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// cost is the memory-relevant size of a batch: every row is padded to the
+// longest row in it, so the tensor fed to ONNX is rows × longest. Peak RSS
+// measured on embeddinggemma tracks this product (~71 KiB/token-row at
+// seq=128 rising to ~141 KiB at seq=2048), which is why the budget bounds it
+// rather than bounding the document count.
+func cost(lens []int, batch []int) int {
+	maxLen := 0
+	for _, i := range batch {
+		if lens[i] > maxLen {
+			maxLen = lens[i]
+		}
+	}
+	return len(batch) * maxLen
+}
+
+// TestPackByTokenBudget_NeverExceedsBudget is the invariant the whole change
+// exists to establish: no single session.Run may be handed more padded tokens
+// than the budget. A batch of one is the sole exception — a document cannot be
+// split, so an oversized document still runs alone.
+func TestPackByTokenBudget_NeverExceedsBudget(t *testing.T) {
+	cases := []struct {
+		name   string
+		lens   []int
+		budget int
+	}{
+		{"uniform long docs", repeatLen(2048, 32), 16384},
+		{"uniform short facts", repeatLen(128, 100), 16384},
+		{"one long doc among short ones", append([]int{2048}, repeatLen(128, 99)...), 16384},
+		{"descending ladder", []int{2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1}, 4096},
+		{"ascending ladder", []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048}, 4096},
+		{"single doc", []int{2048}, 16384},
+		{"tiny budget forces singletons", repeatLen(2048, 4), 512},
+		{"zero-length rows", []int{0, 0, 5}, 4096},
+		{"zero-length rows, zero budget", []int{0, 0, 5}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			batches := packByTokenBudget(tc.lens, tc.budget)
+			for bi, b := range batches {
+				if len(b) == 0 {
+					t.Fatalf("batch %d is empty", bi)
+				}
+				if c := cost(tc.lens, b); c > tc.budget && len(b) > 1 {
+					t.Errorf("batch %d: cost %d exceeds budget %d with %d rows; only a singleton may overflow",
+						bi, c, tc.budget, len(b))
+				}
+			}
+		})
+	}
+}
+
+// TestPackByTokenBudget_CoversEveryRowExactlyOnce guards the scatter/gather:
+// a dropped index silently loses a fact's embedding, a duplicated one silently
+// overwrites a neighbour's.
+func TestPackByTokenBudget_CoversEveryRowExactlyOnce(t *testing.T) {
+	lens := []int{2048, 7, 512, 512, 1, 1024, 300, 300, 300, 2048}
+	got := []int{}
+	for _, b := range packByTokenBudget(lens, 4096) {
+		got = append(got, b...)
+	}
+	sort.Ints(got)
+	if len(got) != len(lens) {
+		t.Fatalf("packed %d rows, want %d", len(got), len(lens))
+	}
+	for i := range got {
+		if got[i] != i {
+			t.Fatalf("packed indices = %v, want each of 0..%d exactly once", got, len(lens)-1)
+		}
+	}
+}
+
+// TestPackByTokenBudget_OversizedRowRunsAlone pins the no-infinite-loop edge:
+// a row longer than the entire budget must still be emitted, as a batch of one.
+func TestPackByTokenBudget_OversizedRowRunsAlone(t *testing.T) {
+	batches := packByTokenBudget([]int{5000, 10}, 1024)
+	for _, b := range batches {
+		if len(b) == 1 && b[0] == 0 {
+			return
+		}
+	}
+	t.Fatalf("oversized row was not emitted as its own batch: %v", batches)
+}
+
+// TestPackByTokenBudget_EmptyInput keeps the empty case from producing a
+// phantom batch that would hand ONNX a zero-row tensor.
+func TestPackByTokenBudget_EmptyInput(t *testing.T) {
+	if b := packByTokenBudget(nil, 16384); len(b) != 0 {
+		t.Fatalf("packByTokenBudget(nil) = %v, want no batches", b)
+	}
+}
+
+// TestPackByTokenBudget_ChargesShortRowsAtTheMinimum pins the rail. Rows are
+// charged max(len, minRowCharge), which caps a batch at budget/minRowCharge
+// rows however short the rows are. That cap does two jobs: it bounds the
+// per-row overhead measured at batch=2048/seq=8 (1683 MiB delta vs ~1150 for
+// the same token count in fewer rows), and it preserves the cancellation
+// contract in store/interfaces.go — without it, learn.go (which embeds an
+// entire incoming write request, uncapped) and motif_alias.go (a whole motif
+// vocabulary in one call) would each become one uninterruptible session.Run.
+func TestPackByTokenBudget_ChargesShortRowsAtTheMinimum(t *testing.T) {
+	const budget = 16384
+	batches := packByTokenBudget(repeatLen(8, 300), budget)
+	if len(batches) == 0 {
+		t.Fatal("no batches")
+	}
+	want := budget / minRowCharge
+	if len(batches[0]) != want {
+		t.Errorf("first batch has %d rows, want exactly %d (budget/minRowCharge); "+
+			"short rows must be charged at the minimum, not their raw length",
+			len(batches[0]), want)
+	}
+}
+
+// TestPackByTokenBudget_CliffCutoff pins the padding-waste guard. Descending
+// order keeps neighbours similar, but at a length cliff a long row would
+// otherwise drag short rows up to its width — real ONNX compute, not just
+// memory. One 2048-token doc among 128-token facts must run alone rather than
+// padding seven neighbours to 2048.
+func TestPackByTokenBudget_CliffCutoff(t *testing.T) {
+	lens := append([]int{2048}, repeatLen(128, 99)...)
+	batches := packByTokenBudget(lens, 16384)
+	if len(batches[0]) != 1 {
+		t.Errorf("first batch has %d rows, want 1 — the long doc should not drag "+
+			"128-token rows up to width 2048", len(batches[0]))
+	}
+}
+
+// TestEmbedInBatches_PreservesInputOrder is the correctness cost of packing:
+// batching by length reorders rows, so results must be scattered back to their
+// input positions. Getting this wrong assigns every fact its neighbour's
+// vector — a corruption no length assertion would catch.
+func TestEmbedInBatches_PreservesInputOrder(t *testing.T) {
+	// Lengths chosen so the packer definitely reorders: interleaved long/short.
+	rows := make([]encodedRow, 12)
+	want := make([][]float32, len(rows))
+	for i := range rows {
+		n := 8
+		if i%2 == 0 {
+			n = 2000
+		}
+		rows[i] = encodedRow{ids: make([]int64, n), mask: make([]int64, n)}
+		// Tag each row with its input index so we can assert identity.
+		rows[i].ids[0] = int64(i)
+		want[i] = []float32{float32(i)}
+	}
+
+	run := func(batch []encodedRow) ([][]float32, error) {
+		out := make([][]float32, len(batch))
+		for i, r := range batch {
+			out[i] = []float32{float32(r.ids[0])}
+		}
+		return out, nil
+	}
+
+	got, err := embedInBatches(context.Background(), rows, 4096, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d vectors, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i][0] != want[i][0] {
+			t.Errorf("row %d: got vector tagged %v, want %v — results were not restored to input order",
+				i, got[i][0], want[i][0])
+		}
+	}
+}
+
+// TestEmbedInBatches_BoundsEveryRunByBudget asserts the invariant end-to-end
+// through the loop rather than in the packer alone.
+func TestEmbedInBatches_BoundsEveryRunByBudget(t *testing.T) {
+	const budget = 4096
+	rows := make([]encodedRow, 40)
+	for i := range rows {
+		n := 1024
+		if i%3 == 0 {
+			n = 2048
+		}
+		rows[i] = encodedRow{ids: make([]int64, n), mask: make([]int64, n)}
+	}
+
+	run := func(batch []encodedRow) ([][]float32, error) {
+		maxLen := 0
+		for _, r := range batch {
+			if len(r.ids) > maxLen {
+				maxLen = len(r.ids)
+			}
+		}
+		if c := len(batch) * maxLen; c > budget && len(batch) > 1 {
+			return nil, fmt.Errorf("run got %d padded tokens (%d rows × %d), over budget %d",
+				c, len(batch), maxLen, budget)
+		}
+		return make([][]float32, len(batch)), nil
+	}
+
+	if _, err := embedInBatches(context.Background(), rows, budget, run); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestEmbedInBatches_NonPositiveBudgetFallsBackToOneRunPerRow keeps a
+// misconfigured budget from wedging the packer or silently restoring the
+// unbounded behavior this change removes.
+func TestEmbedInBatches_NonPositiveBudgetFallsBackToOneRunPerRow(t *testing.T) {
+	rows := []encodedRow{
+		{ids: make([]int64, 10), mask: make([]int64, 10)},
+		{ids: make([]int64, 20), mask: make([]int64, 20)},
+	}
+	runs := 0
+	run := func(batch []encodedRow) ([][]float32, error) {
+		runs++
+		if len(batch) != 1 {
+			t.Errorf("batch of %d rows on a non-positive budget, want singletons", len(batch))
+		}
+		return make([][]float32, len(batch)), nil
+	}
+	if _, err := embedInBatches(context.Background(), rows, 0, run); err != nil {
+		t.Fatal(err)
+	}
+	if runs != 2 {
+		t.Errorf("ran %d times, want one per row", runs)
+	}
+}
+
+// TestEmbedInBatches_CancelledBetweenBatches carries forward the per-batch
+// cancellation checkpoint across the move from fixed chunks to packed batches.
+func TestEmbedInBatches_CancelledBetweenBatches(t *testing.T) {
+	rows := make([]encodedRow, 64)
+	for i := range rows {
+		rows[i] = encodedRow{ids: make([]int64, 2048), mask: make([]int64, 2048)}
+	}
+
+	t.Run("cancelled after the first batch", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		batches := 0
+		run := func(batch []encodedRow) ([][]float32, error) {
+			batches++
+			cancel()
+			return make([][]float32, len(batch)), nil
+		}
+		if _, err := embedInBatches(ctx, rows, 4096, run); !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+		if batches != 1 {
+			t.Errorf("ran %d batches after cancellation, want 1 (the in-flight one)", batches)
+		}
+	})
+
+	t.Run("pre-cancelled runs no inference at all", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		run := func(batch []encodedRow) ([][]float32, error) {
+			t.Fatal("run must not be called on a pre-cancelled context")
+			return nil, nil
+		}
+		if _, err := embedInBatches(ctx, rows, 4096, run); !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("empty input still observes cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		run := func(batch []encodedRow) ([][]float32, error) {
+			t.Fatal("run must not be called for empty input")
+			return nil, nil
+		}
+		if _, err := embedInBatches(ctx, nil, 4096, run); !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	})
+}
+
+func repeatLen(n, count int) []int {
+	out := make([]int, count)
+	for i := range out {
+		out[i] = n
+	}
+	return out
+}
+
+// TestEmbedInBatches_ErrorReturnsNoPartialResults pins the error path. Results
+// are scattered into a preallocated slice, so a mid-corpus failure would
+// otherwise return a slice that is the right length but silently full of nil
+// holes — which a caller checking only len() would accept as success.
+func TestEmbedInBatches_ErrorReturnsNoPartialResults(t *testing.T) {
+	rows := make([]encodedRow, 40)
+	for i := range rows {
+		rows[i] = encodedRow{ids: make([]int64, 2048), mask: make([]int64, 2048)}
+	}
+
+	calls := 0
+	boom := errors.New("inference exploded")
+	run := func(batch []encodedRow) ([][]float32, error) {
+		calls++
+		if calls == 2 {
+			return nil, boom
+		}
+		out := make([][]float32, len(batch))
+		for i := range out {
+			out[i] = []float32{1}
+		}
+		return out, nil
+	}
+
+	got, err := embedInBatches(context.Background(), rows, 4096, run)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want %v", err, boom)
+	}
+	if got != nil {
+		t.Errorf("got %d results alongside the error, want nil — a partially "+
+			"scattered slice would read as success to a len()-checking caller", len(got))
+	}
+}
+
+// TestEmbedInBatches_ShortReturnFromRunIsRejected guards the scatter against an
+// embedder that breaks the 1:1 contract: writing fewer vectors than rows would
+// leave nil holes that callers index positionally (search_index.go, learn.go).
+func TestEmbedInBatches_ShortReturnFromRunIsRejected(t *testing.T) {
+	rows := make([]encodedRow, 4)
+	for i := range rows {
+		rows[i] = encodedRow{ids: make([]int64, 100), mask: make([]int64, 100)}
+	}
+	run := func(batch []encodedRow) ([][]float32, error) {
+		return make([][]float32, len(batch)-1), nil // one short
+	}
+	if _, err := embedInBatches(context.Background(), rows, 16384, run); err == nil {
+		t.Fatal("short return from run was accepted, want an error")
+	}
+}

--- a/internal/embeddings/batching_test.go
+++ b/internal/embeddings/batching_test.go
@@ -124,15 +124,38 @@ func TestPackByTokenBudget_ChargesShortRowsAtTheMinimum(t *testing.T) {
 // TestPackByTokenBudget_CliffCutoff pins the padding-waste guard. Descending
 // order keeps neighbours similar, but at a length cliff a long row would
 // otherwise drag short rows up to its width — real ONNX compute, not just
-// memory. One 2048-token doc among 128-token facts must run alone rather than
-// padding seven neighbours to 2048.
+// memory. Budget 16384 would otherwise put the 2048-token doc with seven
+// 128-token facts, all padded to 2048; the cutoff stops it at one neighbour.
 func TestPackByTokenBudget_CliffCutoff(t *testing.T) {
 	lens := append([]int{2048}, repeatLen(128, 99)...)
 	batches := packByTokenBudget(lens, 16384)
-	if len(batches[0]) != 1 {
-		t.Errorf("first batch has %d rows, want 1 — the long doc should not drag "+
-			"128-token rows up to width 2048", len(batches[0]))
+	if len(batches[0]) > 2 {
+		t.Errorf("first batch has %d rows, want at most 2 — the long doc should not "+
+			"drag a run of 128-token rows up to width 2048", len(batches[0]))
 	}
+}
+
+// TestPackByTokenBudget_CliffNeverCutsToSingleton guards the cutoff against
+// eating the packer it protects. A batch of one wastes no padding by
+// definition, so cutting there buys nothing and costs a run. Without the guard
+// a smoothly decaying corpus — every neighbour more than 2x smaller — becomes
+// one run per document, the exact pathology this packer exists to avoid.
+func TestPackByTokenBudget_CliffNeverCutsToSingleton(t *testing.T) {
+	t.Run("adjacent pair stays paired", func(t *testing.T) {
+		batches := packByTokenBudget([]int{2048, 1000}, 16384)
+		if len(batches) != 1 || len(batches[0]) != 2 {
+			t.Errorf("got %v, want a single batch of 2 — a cut here saves no padding", batches)
+		}
+	})
+
+	t.Run("decaying corpus does not become all singletons", func(t *testing.T) {
+		lens := []int{2048, 1000, 490, 240, 118}
+		batches := packByTokenBudget(lens, 16384)
+		if len(batches) >= len(lens) {
+			t.Errorf("got %d batches for %d rows (%v) — a smoothly decaying corpus "+
+				"degenerated to one run per document", len(batches), len(lens), batches)
+		}
+	})
 }
 
 // TestEmbedInBatches_PreservesInputOrder is the correctness cost of packing:

--- a/internal/embeddings/embedder.go
+++ b/internal/embeddings/embedder.go
@@ -124,6 +124,15 @@ func NewEmbedder(ctx context.Context, m Model, cacheDir string, opts ...Option) 
 	for _, opt := range opts {
 		opt(e)
 	}
+	// Hold the "always positive" field invariant by construction rather than by
+	// convention at the call site. A non-positive budget reaching the packer
+	// degrades to one row per inference for the process lifetime — a silent
+	// ~30x slowdown, not a failure — and the ways to get one are all plausible:
+	// a tool flag, or a future memory resolver returning 0 on an unreadable
+	// /sys. Clamp here so no caller has to remember.
+	if e.maxBatchTokens <= 0 {
+		e.maxBatchTokens = DefaultMaxBatchTokens
+	}
 	return e, nil
 }
 
@@ -170,6 +179,13 @@ func (e *Embedder) EmbedDocuments(ctx context.Context, titles, bodies []string) 
 	if len(titles) != len(bodies) {
 		return nil, fmt.Errorf("EmbedDocuments: %d titles vs %d bodies", len(titles), len(bodies))
 	}
+	// Checked before tokenizing, not just inside embedInBatches: encodeAll is
+	// evaluated as an argument expression, so without this a cancelled caller
+	// would pay a full tokenization pass (and any truncation warnings) before
+	// the error came back.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	texts := make([]string, len(bodies))
 	for i := range bodies {
 		texts[i] = e.docText(titles[i], bodies[i])
@@ -184,6 +200,10 @@ func (e *Embedder) EmbedDocuments(ctx context.Context, titles, bodies []string) 
 //
 // ctx is checked before each batch, exactly as in EmbedDocuments.
 func (e *Embedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]float32, error) {
+	// Checked before tokenizing, for the reason given in EmbedDocuments.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	rendered := make([]string, len(texts))
 	for i, t := range texts {
 		rendered[i] = e.shortStringText(t)
@@ -243,6 +263,11 @@ func (e *Embedder) embedBatch(texts []string) ([][]float32, error) {
 
 // encodeAll tokenizes every text into a row of ids and mask, each truncated to
 // the model's MaxTokens.
+//
+// This holds the whole input tokenized at once, which is inherent to
+// length-aware packing: the packer cannot group by width without knowing every
+// width first. The cost is bounded by the caller's request size, and the ids
+// are the model input anyway — the alternative is tokenizing twice.
 func (e *Embedder) encodeAll(texts []string) []encodedRow {
 	rows := make([]encodedRow, len(texts))
 	for i, text := range texts {

--- a/internal/embeddings/embedder.go
+++ b/internal/embeddings/embedder.go
@@ -17,11 +17,6 @@ import (
 	"knomit/internal/embeddings/params"
 )
 
-// docBatchSize is how many documents share one ONNX session.Run in
-// EmbedDocuments. Each run pads its texts to the longest in the chunk, so a
-// modest batch keeps padding waste low while amortizing per-call overhead.
-const docBatchSize = 32
-
 // ortOnce ensures InitializeEnvironment is called only once per process.
 var ortOnce sync.Once
 var ortInitErr error
@@ -85,13 +80,30 @@ type Embedder struct {
 	model Model
 	sess  *ort.DynamicAdvancedSession
 	tk    *tok.Tokenizer
+	// maxBatchTokens is the padded-token budget for one session.Run. Always
+	// positive for an Embedder built by NewEmbedder; see DefaultMaxBatchTokens.
+	maxBatchTokens int
+}
+
+// Option customizes an Embedder at construction.
+type Option func(*Embedder)
+
+// WithMaxBatchTokens sets the padded-token budget for one session.Run.
+//
+// The caller is responsible for passing a positive value: the app layer
+// resolves an unset config (0, the documented auto sentinel) to
+// DefaultMaxBatchTokens before calling. Absent this option the default applies,
+// which is what keeps tools/calibrate and tools/motifannex deterministic across
+// machines rather than inheriting a host-derived budget.
+func WithMaxBatchTokens(n int) Option {
+	return func(e *Embedder) { e.maxBatchTokens = n }
 }
 
 // NewEmbedder loads the model+tokenizer for descriptor m from <cacheDir>/<id>/,
 // downloading them first if missing. ctx bounds those downloads — cancelling it
 // aborts a fetch in progress, which is what keeps a dead mirror from hanging
 // server boot (embeddings are mandatory, so this runs before the server listens).
-func NewEmbedder(ctx context.Context, m Model, cacheDir string) (*Embedder, error) {
+func NewEmbedder(ctx context.Context, m Model, cacheDir string, opts ...Option) (*Embedder, error) {
 	if err := initORT(); err != nil {
 		return nil, fmt.Errorf("onnxruntime init: %w", err)
 	}
@@ -108,7 +120,11 @@ func NewEmbedder(ctx context.Context, m Model, cacheDir string) (*Embedder, erro
 		_ = tk.Close()
 		return nil, fmt.Errorf("create onnx session: %w", err)
 	}
-	return &Embedder{model: m, sess: sess, tk: tk}, nil
+	e := &Embedder{model: m, sess: sess, tk: tk, maxBatchTokens: DefaultMaxBatchTokens}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e, nil
 }
 
 func (e *Embedder) Dim() int   { return e.model.Dim }
@@ -146,9 +162,10 @@ func (e *Embedder) EmbedDocument(ctx context.Context, title, body string) ([]flo
 }
 
 // EmbedDocuments embeds (title, body) pairs, batching the ONNX inference so a
-// full-corpus re-embed issues one session.Run per docBatchSize docs rather than
-// one per doc. ctx is checked before each batch, so cancelling a re-embed costs
-// at most one in-flight batch rather than the remainder of the corpus.
+// full-corpus re-embed issues one session.Run per maxBatchTokens of padded
+// input rather than one per doc. ctx is checked before each batch, so
+// cancelling a re-embed costs at most one in-flight batch rather than the
+// remainder of the corpus.
 func (e *Embedder) EmbedDocuments(ctx context.Context, titles, bodies []string) ([][]float32, error) {
 	if len(titles) != len(bodies) {
 		return nil, fmt.Errorf("EmbedDocuments: %d titles vs %d bodies", len(titles), len(bodies))
@@ -157,7 +174,7 @@ func (e *Embedder) EmbedDocuments(ctx context.Context, titles, bodies []string) 
 	for i := range bodies {
 		texts[i] = e.docText(titles[i], bodies[i])
 	}
-	return embedInBatches(ctx, texts, e.embedBatch)
+	return embedInBatches(ctx, e.encodeAll(texts), e.maxBatchTokens, e.runRows)
 }
 
 // EmbedShortStrings embeds bare short strings — fact titles, and from Phase 2
@@ -171,7 +188,7 @@ func (e *Embedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]f
 	for i, t := range texts {
 		rendered[i] = e.shortStringText(t)
 	}
-	return embedInBatches(ctx, rendered, e.embedBatch)
+	return embedInBatches(ctx, e.encodeAll(rendered), e.maxBatchTokens, e.runRows)
 }
 
 // shortStringText renders one short string through the model's descriptor. The
@@ -179,34 +196,6 @@ func (e *Embedder) EmbedShortStrings(ctx context.Context, texts []string) ([][]f
 // template is not reached at all.
 func (e *Embedder) shortStringText(s string) string {
 	return fillTemplate(e.model.ShortStringTemplate, "", s)
-}
-
-// embedInBatches splits texts into docBatchSize chunks and feeds each to run,
-// abandoning the remainder as soon as ctx is done. Split out from
-// EmbedDocuments (rather than inlined) so the cancellation checkpoint — the
-// only cancellation this layer can actually offer — is exercisable without a
-// loaded ONNX session.
-func embedInBatches(ctx context.Context, texts []string, run func([]string) ([][]float32, error)) ([][]float32, error) {
-	// Checked at entry as well as per batch: with no texts the loop body never
-	// runs, and returning (empty, nil) on a cancelled context would break the
-	// "observed at entry to each call" promise the Embedder interface makes —
-	// and that EmbedQuery / EmbedDocument already keep.
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	out := make([][]float32, 0, len(texts))
-	for i := 0; i < len(texts); i += docBatchSize {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		end := min(i+docBatchSize, len(texts))
-		vecs, err := run(texts[i:end])
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, vecs...)
-	}
-	return out, nil
 }
 
 // docText renders a document for embedding. When the model's DocTemplate has a
@@ -244,20 +233,36 @@ func (e *Embedder) encode(text string) (ids, mask []int64) {
 	return ids, mask
 }
 
-// embedBatch tokenizes texts, pads them to the longest in the batch, runs one
-// ONNX inference, pools per the descriptor, and L2-normalizes each row.
+// embedBatch tokenizes texts and runs them as a single batch. The single-shot
+// paths (EmbedQuery, EmbedDocument) use it directly; the batched paths encode
+// once through encodeAll instead, so packing can read token lengths without
+// tokenizing twice.
 func (e *Embedder) embedBatch(texts []string) ([][]float32, error) {
-	n := len(texts)
+	return e.runRows(e.encodeAll(texts))
+}
+
+// encodeAll tokenizes every text into a row of ids and mask, each truncated to
+// the model's MaxTokens.
+func (e *Embedder) encodeAll(texts []string) []encodedRow {
+	rows := make([]encodedRow, len(texts))
+	for i, text := range texts {
+		ids, mask := e.encode(text)
+		rows[i] = encodedRow{ids: ids, mask: mask}
+	}
+	return rows
+}
+
+// runRows pads rows to the longest in the batch, runs one ONNX inference, pools
+// per the descriptor, and L2-normalizes each row.
+func (e *Embedder) runRows(rows []encodedRow) ([][]float32, error) {
+	n := len(rows)
 	if n == 0 {
 		return nil, nil
 	}
-	rowIDs := make([][]int64, n)
-	rowMask := make([][]int64, n)
 	maxLen := 0
-	for i, text := range texts {
-		rowIDs[i], rowMask[i] = e.encode(text)
-		if len(rowIDs[i]) > maxLen {
-			maxLen = len(rowIDs[i])
+	for _, r := range rows {
+		if len(r.ids) > maxLen {
+			maxLen = len(r.ids)
 		}
 	}
 	if maxLen == 0 {
@@ -268,9 +273,9 @@ func (e *Embedder) embedBatch(texts []string) ([][]float32, error) {
 	// (pad token id 0 + attention_mask 0, so padding is ignored downstream).
 	flatIDs := make([]int64, n*maxLen)
 	flatMask := make([]int64, n*maxLen)
-	for i := range n {
-		copy(flatIDs[i*maxLen:], rowIDs[i])
-		copy(flatMask[i*maxLen:], rowMask[i])
+	for i, r := range rows {
+		copy(flatIDs[i*maxLen:], r.ids)
+		copy(flatMask[i*maxLen:], r.mask)
 	}
 
 	inputs, err := e.buildInputs(flatIDs, flatMask, int64(n), int64(maxLen))

--- a/internal/embeddings/embedder_ctx_test.go
+++ b/internal/embeddings/embedder_ctx_test.go
@@ -6,54 +6,11 @@ import (
 	"testing"
 )
 
-// TestEmbedDocuments_CancelledBetweenBatches pins the per-batch cancellation
-// checkpoint in the EmbedDocuments loop. Cancelling a full-corpus re-embed must
-// abandon the remaining batches rather than grinding through the whole corpus;
-// the checkpoint is what bounds cancellation latency to one batch.
-//
-// Driven through embedInBatches with a counting run func so the assertion is
-// about the loop, not about ONNX — the real sess.Run is uninterruptible and
-// needs a cached model, neither of which this invariant depends on.
-func TestEmbedDocuments_CancelledBetweenBatches(t *testing.T) {
-	texts := make([]string, docBatchSize*3) // three batches' worth
-	for i := range texts {
-		texts[i] = "doc"
-	}
-
-	t.Run("cancelled after the first batch", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		batches := 0
-		run := func(chunk []string) ([][]float32, error) {
-			batches++
-			cancel() // caller gives up while this batch is in flight
-			return make([][]float32, len(chunk)), nil
-		}
-		_, err := embedInBatches(ctx, texts, run)
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("err = %v, want context.Canceled", err)
-		}
-		if batches != 1 {
-			t.Errorf("ran %d batches after cancellation, want 1 (the in-flight one)", batches)
-		}
-	})
-
-	t.Run("pre-cancelled runs no inference at all", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		batches := 0
-		run := func(chunk []string) ([][]float32, error) {
-			batches++
-			return make([][]float32, len(chunk)), nil
-		}
-		_, err := embedInBatches(ctx, texts, run)
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("err = %v, want context.Canceled", err)
-		}
-		if batches != 0 {
-			t.Errorf("ran %d batches on a pre-cancelled ctx, want 0", batches)
-		}
-	})
-}
+// The batching-loop cancellation tests that used to live here moved to
+// batching_test.go when embedInBatches changed from fixed docBatchSize chunks
+// to token-budget packing: TestEmbedInBatches_CancelledBetweenBatches carries
+// all three of their cases forward. What remains is the single-shot companion,
+// which does not go through the batching loop at all.
 
 // TestEmbedQuery_CancelledContext is the single-shot companion: a pre-cancelled
 // context must short-circuit before inference. The embedder here is a zero
@@ -72,24 +29,5 @@ func TestEmbedQuery_CancelledContext(t *testing.T) {
 	e = &Embedder{model: Model{DocTemplate: "search_document: {content}"}}
 	if _, err := e.EmbedDocument(ctx, "t", "b"); !errors.Is(err, context.Canceled) {
 		t.Fatalf("EmbedDocument err = %v, want context.Canceled", err)
-	}
-}
-
-// TestEmbedInBatches_EmptyInput_StillObservesCancellation closes the one gap in
-// the "ctx is observed at entry to each call" contract the Embedder interface
-// documents: with no texts the loop body never runs, so a fully cancelled
-// context used to yield (empty, nil) — a success. EmbedQuery and EmbedDocument
-// both check at entry, and callers that branch on the error rather than the
-// (empty) result would silently treat a cancelled re-embed as a completed one.
-func TestEmbedInBatches_EmptyInput_StillObservesCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	run := func(chunk []string) ([][]float32, error) {
-		t.Fatal("run must not be called for empty input")
-		return nil, nil
-	}
-	if _, err := embedInBatches(ctx, nil, run); !errors.Is(err, context.Canceled) {
-		t.Fatalf("err = %v, want context.Canceled", err)
 	}
 }

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -516,6 +516,11 @@ type LiveFactTitle struct {
 // checkpoint and so a future remote embedder (which genuinely could abort a
 // request) needs no signature change — not because this implementation can
 // interrupt itself.
+//
+// Note "one batch" is not a fixed quantity: the in-process implementation packs
+// batches to a padded-token budget (embeddings.max_batch_tokens), so this
+// latency bound scales with that setting and with the length of the documents
+// in flight.
 type Embedder interface {
 	EmbedQuery(ctx context.Context, text string) ([]float32, error)
 	EmbedDocument(ctx context.Context, title, body string) ([]float32, error)

--- a/internal/store/search_index.go
+++ b/internal/store/search_index.go
@@ -944,6 +944,13 @@ func (si *searchIndex) rebuildFacts(ctx context.Context, branch, head string, pr
 // rebuildEmbeddings computes embeddings for all facts missing from facts_vec.
 // Bodies are fetched one chunk at a time so memory usage is bounded by batchSize,
 // not by the total number of facts.
+//
+// batchSize bounds raw body BYTES only. It is no longer the inference safety
+// rail: the embedder now splits whatever it is handed into batches bounded by a
+// padded-token budget, so a chunk of long facts becomes several session.Runs
+// rather than one oversized one. Raising batchSize is therefore safe for
+// inference memory — but it has not been measured for throughput, so it stays
+// at 32 until it has.
 func (si *searchIndex) rebuildEmbeddings(ctx context.Context, progress RebuildProgress) (int, error) {
 	emb := si.rh.getEmbedder()
 	if emb == nil {

--- a/internal/store/search_index.go
+++ b/internal/store/search_index.go
@@ -945,12 +945,15 @@ func (si *searchIndex) rebuildFacts(ctx context.Context, branch, head string, pr
 // Bodies are fetched one chunk at a time so memory usage is bounded by batchSize,
 // not by the total number of facts.
 //
-// batchSize bounds raw body BYTES only. It is no longer the inference safety
-// rail: the embedder now splits whatever it is handed into batches bounded by a
-// padded-token budget, so a chunk of long facts becomes several session.Runs
-// rather than one oversized one. Raising batchSize is therefore safe for
-// inference memory — but it has not been measured for throughput, so it stays
-// at 32 until it has.
+// batchSize bounds a DOCUMENT COUNT — the number of rowids in one IN clause and
+// so the number of bodies held at once — not any byte total. It is no longer
+// the inference safety rail: the embedder now splits whatever it is handed into
+// batches bounded by a padded-token budget, so a chunk of long facts becomes
+// several session.Runs rather than one oversized one.
+//
+// Raising it is therefore safe for INFERENCE memory specifically. It is not
+// free: raw bodies, the tokenized rows encodeAll retains, and the result slice
+// all scale linearly with it. It stays at 32 until a raise is measured.
 func (si *searchIndex) rebuildEmbeddings(ctx context.Context, progress RebuildProgress) (int, error) {
 	emb := si.rh.getEmbedder()
 	if emb == nil {


### PR DESCRIPTION
## What and why

ONNX inference memory scales with **rows × padded sequence length** — `embedBatch`
pads every row in a batch to the longest row in it. The old `docBatchSize = 32`
bounded the *document count* instead, so the identical config spanned 283 MiB to
9030 MiB purely on how long the documents happened to be.

**That is what OOM-killed the server on 2026-08-29.** `rebuildEmbeddings` has its
own chunk size (`search_index.go`, sized for raw body *bytes*) and it was **also
32** — so rebuild always handed the embedder exactly one maximal `session.Run`.
The two constants being equal made the worst case structural: it was the rebuild
path's steady state whenever a chunk held long facts, not a rare pile-up.

Confirmed from the cgroup at the time: `memory.events` showed `oom 0, oom_kill 1`
with `memory.max` unset (a global OOM, not a cgroup-limit one) and `memory.peak`
of 14.58 GiB against 15.56 GiB of RAM, no swap.

This replaces the fixed count with a budget on padded tokens per `session.Run`.

## Measured

Peak RSS, one process per config (the ONNX Runtime arena retains its high-water
mark for the process lifetime, so a single process only reports a monotonic
maximum). Baseline resident model ~675 MiB; `delta` is above that.

| batch | seq | peak | delta |
|---|---|---|---|
| 8 | 2048 | 2490 MiB | 1820 MiB | ← worst case at the new default
| 16 | 2048 | 4909 MiB | 4228 MiB |
| **32** | **2048** | **9702 MiB** | **9030 MiB** | ← the old fixed default
| 32 | 512 | 1921 MiB | 1247 MiB |
| 32 | 128 | 959 MiB | 283 MiB |

**Worst case drops 9030 MiB → 1820 MiB.**

At a constant `batch × seq = 16384` the shape barely matters, which is why the
budget bounds the product rather than either factor:

| batch × seq | delta |
|---|---|
| 128 × 128 | 1154 MiB |
| 64 × 256 | 1161 MiB |
| 256 × 64 | 1143 MiB |
| 2048 × 8 | 1683 MiB |

That last row is the per-row overhead (~0.26 MiB/row) the token model does not
capture, and is the measured basis for `minRowCharge = 64`.

## Design notes

- Rows are sorted by charged width **descending**, so the first row's width is the
  batch maximum and `rows × width ≤ budget` holds by construction.
- Rows are charged `max(len, 64)`, capping a batch at 256 rows. This bounds the
  per-row overhead above, and preserves the cancellation bound `store.Embedder`
  documents ("cancelling bounds latency to one batch") for callers bounded by no
  constant at all — `learn.go` embeds an entire incoming write request,
  `motif_alias.go` a whole motif vocabulary.
- A batch stops early at a length cliff, so one long document does not pad its
  neighbours to full width. Padding is real ONNX compute, not just memory.
- Packing reorders rows, so results are **scattered back to input positions**.
  Every caller correlates the returned slice positionally; getting this wrong
  would give each fact its neighbour's vector. A mid-corpus failure returns `nil`
  rather than a right-length slice full of holes.
- `embeddings.max_batch_tokens` / `KNOMIT_EMBED_MAX_BATCH_TOKENS` is absent from
  `Defaults()` so `0` can mean "unset" — `Defaults()` runs before the TOML and env
  layers and could not otherwise tell an explicit 16384 from silence, the same
  reason `remote.known_hosts` resolves after the overlay. The app layer resolves
  `0`; a later release derives a smaller value on constrained hosts and in
  containers without changing the sentinel.
- `NewEmbedder` takes a variadic option, so `tools/calibrate` and
  `tools/motifannex` compile untouched and stay on the fixed default —
  deterministic across machines, which for the calibration tool is the point.
- `search_index.go`'s `batchSize = 32` is **unchanged**; only its stale comment is
  updated to record that it bounds body bytes and is no longer the inference rail.

## Testing

- `gofmt`, `go build ./...`, `go vet ./...` all clean.
- `internal/embeddings` and `internal/config` green. New tests cover the budget
  bound, index coverage, the singleton exception, zero-length rows (a division-by-
  zero the first draft had), the cliff cutoff, the row-charge rail, input-order
  preservation, the error path, short returns, and all three cancellation cases.
- **Real-ONNX tests run explicitly against a cached model** — they `SKIP` under a
  plain `go test ./...` because they need `KNOMIT_EMBED_TEST_CACHE`. Notably
  `TestEmbedDocumentsBatchMatchesSingle` (batched vs single, cosine ≥ 0.9999)
  passes: that is the guard against a scatter-back regression, and it is the
  riskiest property of this change.

### Pre-existing failures (not from this PR)

`go test ./...` times out four packages at the 600s default: `internal/repos`,
`internal/store`, `internal/synthesize`, `internal/web`. These are **not**
assertion failures and **not** caused by this change — verified by running the
same four packages in a clean worktree at base `594c3e6b` (identical result) and
at pre-motif-merge `02eaf159` (also identical). The hang is
`store.(*Service).Close` → `database/sql` teardown at `service.go:420`, reached
via `repos.Manager.initLocal`; no embedder is in that path. Note `make test` sets
no `-timeout`, so it hits the same wall.

Refinement from a later run: `internal/store` **passes in 300s** when fewer
packages run in parallel, so this is contention-driven flakiness under the full
parallel `./...` invocation rather than a deterministic hang. Out of scope here;
deserves its own investigation.

## Review outcomes

Two independent high-effort reviews. **No correctness findings** — the budget
invariant, termination, and scatter-back were each independently verified sound.
The converged fixes are applied in the second commit:

- **The cliff cutoff could eat the packer it protects.** On a smoothly decaying
  corpus — every neighbour more than 2× smaller, e.g. `2048/1000/490/240/118` —
  every batch cut to a singleton, degenerating into one inference per document.
  That is the exact pathology this packer exists to avoid, and a decaying length
  distribution is what a real corpus looks like. Now a cut only happens once a
  batch holds two rows.
- `ctx` is checked **before** tokenizing; `encodeAll` was an argument expression,
  so a cancelled caller paid a full tokenization pass before erroring.
- Batches use a three-index slice, so they cannot share spare capacity with the
  index array — a future `append` would otherwise silently overwrite the next
  batch's first index.
- `NewEmbedder` clamps a non-positive budget, so the "always positive" invariant
  holds by construction rather than by convention at one call site.
- Sanity **warnings** (not rejections) when an explicit budget is below one
  document's maximum length or beyond the measured range. The constant this
  replaced was 32 *documents*, so setting `32` here is a predictable operator
  error that would otherwise degrade silently to one document per inference.
- Comment corrections, including two overclaims of mine: `search_index.go`'s
  `batchSize` bounds a *document count*, not body bytes; and the row-charge rail
  is **not** strictly better than the old chunk (see below).

### One honest regression

Short-text workloads now peak near the same ceiling as long ones — roughly
1.1 GiB at the default budget, against the old ~283 MiB for a 32-document run of
short facts. Cancellation latency for short strings likewise grows (up to 256
rows per run rather than 32). This is the intended *uniform ceiling*: cancelling
costs at most one budget's worth of inference on every path, which for short
strings is more than before and for long documents far less. Since the ONNX
arena retains its high-water mark, a short-text-only server will hold more
steady-state RSS than it did. The follow-up PR's clamp-down is what covers small
hosts.

## Post-merge actions

The knomit server is deliberately **down** until this deploys — its boot-time
indexing backlog re-triggers the maximal rebuild runs, so it would go straight
back down. Nothing below could be recorded via `/knomit-remember` at authoring
time, so it rides here instead. **Once the server is back, record each:**

1. *(invariant)* Embedding inference memory scales with `rows × padded_seq`, not
   document count — `embedBatch` pads every row to the batch's longest, so a fixed
   doc count spanned 283 MiB to 9030 MiB on length alone.
2. *(invariant)* The ONNX Runtime arena retains its high-water RSS for the process
   lifetime — the worst single batch sets steady-state memory, not a transient.
   This is also why the measurement harness runs one process per config.
3. *(discovery — the 2026-08-29 OOM root cause)* `rebuildEmbeddings`' chunk size
   (`search_index.go`, sized for body bytes) equalled the old `docBatchSize = 32`,
   so rebuild always fed the embedder exactly one maximal `session.Run`. The OOM
   was rebuild's steady state on long facts, not a rare pile-up. **General lesson:
   a caller-side constant silently carried the entire inference-memory safety
   story.**
4. *(invariant)* `store.Embedder`'s ctx is a cancellation *checkpoint* only —
   `sess.Run` is uninterruptible; latency is bounded by one batch. The
   `minRowCharge = 64` rail keeps that documented bound meaningful for short-row
   corpora (`learn.go` and `motif_alias.go` embed unbounded row counts).
5. *(decision)* `embeddings.max_batch_tokens`: budget on padded tokens per run,
   default 16384 (worst case measured 1820 MiB delta); `0` = auto sentinel
   reserved for the follow-up clamp-down resolver; never auto-size **up**.
6. *(invariant, until the follow-up PR's semaphore)* `lockBranch` is per-branch and
   the `Embedder` is a single shared instance, so concurrent rebuild/learn on
   different branches run `sess.Run` concurrently and their peaks **add**. The
   per-run budget is not a per-process bound until batch inference is serialized.
7. *(reference)* The memory measurement harness and raw results live in
   `.claude/plans/2026-08-29-embed-memory-*` — one process per config, env-driven
   `KNOMIT_MEASURE_BATCH`/`SEQ`. Note `.claude/plans` is gitignored, so these are
   local-only and not in this repo.

8. *(deployed and confirmed 2026-08-29)* This shipped and ran the real
   workload. The server reindexed all three repos and **survived**, on a corpus
   containing facts long enough to trip the 2048-token truncation — so the
   maximal-batch path was genuinely exercised, not skirted.

   | | old code | this PR |
   |---|---|---|
   | peak RSS | 9702 MiB *(one batch)* | **4219 MiB** *(entire run)* |
   | swap used | — | 0 B |
   | cgroup `oom_kill` | 1 | still 1 — no new kill |

   That counter is the cleanest proof available: `memory.events` `oom_kill` is
   cumulative for the cgroup's lifetime and code-server has not restarted, so it
   still reads this morning's original kill. A second kill would read `2`.

   **Two corrections to what this checklist originally predicted:**

   - The expected ceiling of ~1.8 GiB above the ~675 MiB resident model assumed a
     *single* rebuild. It **scales with concurrent branch activity**: `lockBranch`
     is per-branch and the `Embedder` is one shared instance, so overlapping runs
     add. Measured at 3 repos: 4.0 GiB mid-run. Expect that until the follow-up
     PR's semaphore lands.
   - **RSS does not come back down.** Post-index RSS (4203 MiB) equals peak
     (4219 MiB), because the ONNX arena retains its high-water mark for the
     process lifetime. knomit now rests at ~4.2 GiB *indefinitely*, not just while
     indexing. This also means **`S` cannot be measured from an idle server** —
     idle RSS *is* peak RSS. The only valid window is after boot and before the
     first embedding batch, which is why the follow-up PR makes it self-measuring
     rather than a remembered manual step.

Then: restart the server (its indexing backlog is safe under the budget), measure
non-embedding RSS for the follow-up PR's sizing formula, and run `/knomit-review`
after the burst of remembering above.

## Follow-ups (not in this PR)

- Auto-size the budget **down** from cgroup/host memory limits, plus a capacity-1
  semaphore around batch inference to make the per-run bound a per-process one.
- Raise `search_index.go`'s `batchSize` from 32 — safe for inference memory now,
  but gated on wall-clock measurements that do not exist yet.
- **Promote the measurement harness into the repo.** It currently lives only under
  the gitignored `.claude/plans`, so it is local to one machine. The follow-up PR
  needs it again anyway — to measure non-embedding RSS and to verify that
  concurrent `session.Run`s buy no throughput — so landing it then as a proper
  checked-in tool preserves it without overriding the repo's `.claude` policy.
