### PR TITLE
fix: stale live head after a long index run, and lens fact sub-resources (#178)

### DIFF
--- a/internal/repos/observer.go
+++ b/internal/repos/observer.go
@@ -2,7 +2,6 @@ package repos
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -14,6 +13,14 @@ import (
 // This was internal/observe, a package with exactly one consumer — this one.
 // The debounce window is a detail of how repos reacts to commits, not a
 // capability any other layer needs, so it lives here unexported.
+//
+// DEFERRAL, NEVER DISCARD. The callback is heavyweight (Acquire →
+// IndexManager().SyncLocked → hub.broadcastStatus), so after a large merge it
+// runs for many seconds. Every state transition therefore happens under mu:
+// `running` used to be an atomic the timer CAS'd, and a failed CAS threw the
+// notification away — `pending` had already been cleared and nothing re-armed,
+// so the heads of commits landing during a long run were lost and every browser
+// tab stayed pinned to a stale commit until it was reloaded (issue #178).
 type commitObserver struct {
 	mu      sync.Mutex
 	delay   time.Duration
@@ -21,7 +28,7 @@ type commitObserver struct {
 	timer   *time.Timer
 	pending string
 	stopped bool
-	running atomic.Bool // true while fn is executing; prevents re-entrant calls
+	running bool // true while fn is executing; prevents re-entrant calls
 }
 
 // newCommitObserver creates an observer that calls fn after delay has elapsed
@@ -42,39 +49,78 @@ func (o *commitObserver) Notify(hash string) {
 	}
 
 	o.pending = hash
+	o.arm()
+}
 
+// arm restarts the debounce timer. The caller holds mu.
+func (o *commitObserver) arm() {
 	if o.timer != nil {
 		o.timer.Stop()
 	}
-	o.timer = time.AfterFunc(o.delay, func() {
-		o.mu.Lock()
-		hash := o.pending
-		o.pending = ""
-		o.mu.Unlock()
+	o.timer = time.AfterFunc(o.delay, o.fire)
+}
 
-		// Skip if a previous invocation is still running.
-		if hash != "" && o.running.CompareAndSwap(false, true) {
-			defer o.running.Store(false)
-			o.fn(hash)
-		}
-	})
+// fire is the debounce timer's callback: it delivers the pending hash, unless
+// a previous run is still in flight.
+//
+// The in-flight case is the one that matters. It leaves `pending` exactly where
+// it is and returns; the run that is still going re-arms the timer when it
+// finishes, so the notification is DEFERRED, not dropped. That is what
+// guarantees the LAST head always reaches the callback.
+func (o *commitObserver) fire() {
+	o.mu.Lock()
+	if o.stopped || o.pending == "" || o.running {
+		o.mu.Unlock()
+		return
+	}
+	hash := o.pending
+	o.pending = ""
+	o.running = true
+	o.mu.Unlock()
+
+	o.fn(hash)
+
+	o.mu.Lock()
+	o.running = false
+	// Anything that arrived while fn ran is still pending — give it a fresh
+	// debounce window rather than losing it.
+	if !o.stopped && o.pending != "" {
+		o.arm()
+	}
+	o.mu.Unlock()
 }
 
 // Stop cancels any pending timer and flushes synchronously if a notification
 // was pending. Safe to call from any goroutine.
+//
+// A flush is skipped when fn is already running: that run owns the callback,
+// and flushing here would break "fn is never called concurrently with itself".
+// The in-flight run's own re-arm is disabled by `stopped`, so its pending head
+// is dropped — at shutdown there is no subscriber left to broadcast to, and the
+// index sync that matters already ran inline in notifyCommit.
 func (o *commitObserver) Stop() {
 	o.mu.Lock()
 	o.stopped = true
 	if o.timer != nil {
 		o.timer.Stop()
+		o.timer = nil
 	}
 	hash := o.pending
 	o.pending = ""
+	flush := hash != "" && !o.running
+	if flush {
+		o.running = true
+	}
 	o.mu.Unlock()
 
-	// Call fn without holding the lock.
-	if hash != "" && o.running.CompareAndSwap(false, true) {
-		defer o.running.Store(false)
-		o.fn(hash)
+	if !flush {
+		return
 	}
+
+	// Call fn without holding the lock.
+	o.fn(hash)
+
+	o.mu.Lock()
+	o.running = false
+	o.mu.Unlock()
 }

--- a/internal/repos/observer_test.go
+++ b/internal/repos/observer_test.go
@@ -55,3 +55,64 @@ func TestObserverStopFlushes(t *testing.T) {
 		t.Fatalf("expected Stop to flush pending, got %v", calls)
 	}
 }
+
+// A notification that lands while the callback is still running must still be
+// delivered. The callback is heavyweight (Acquire → SyncLocked →
+// broadcastStatus), so after a big merge it runs for many seconds; every
+// `learn` commit that lands in that window used to have its head silently
+// dropped, leaving every browser tab pinned to the merge commit until it was
+// reloaded (issue #178).
+func TestObserverDeliversNotificationArrivingDuringCallback(t *testing.T) {
+	var mu sync.Mutex
+	var calls []string
+	blockFirst := true
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	obs := newCommitObserver(20*time.Millisecond, func(hash string) {
+		mu.Lock()
+		calls = append(calls, hash)
+		blocking := blockFirst
+		blockFirst = false
+		mu.Unlock()
+
+		// Only the first run blocks — it is the one the second notification
+		// has to arrive underneath.
+		if blocking {
+			close(started)
+			<-release
+		}
+	})
+	defer obs.Stop()
+
+	obs.Notify("first")
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("callback never ran for the first notification")
+	}
+
+	// Arrives while fn is still running, and the debounce timer fires during
+	// that run — the exact window in which the head used to be discarded.
+	obs.Notify("second")
+	time.Sleep(60 * time.Millisecond)
+	close(release)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(calls)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 2 || calls[0] != "first" || calls[1] != "second" {
+		t.Fatalf("expected the head that arrived mid-run to be delivered, got %v", calls)
+	}
+}

--- a/internal/web/handlers_fact_read.go
+++ b/internal/web/handlers_fact_read.go
@@ -192,12 +192,13 @@ func handleHALFact(b hal.URLBuilder, reader FactReader, subProvider factSubProvi
 		repoName := chi.URLParam(r, "repo")
 		branch := BranchFromContext(r.Context())
 
+		ri := repos.RepoFromContext(r.Context())
+
 		// Dispatch sub-resource requests before any other processing.
-		if dispatchFactSubResource(b, subProvider, repoName, branch, w, r) {
+		if dispatchFactSubResource(b, subProvider, ri, repoName, branch, w, r) {
 			return
 		}
 
-		ri := repos.RepoFromContext(r.Context())
 		path := chi.URLParam(r, "*")
 		if path == "" {
 			hal.WriteProblem(w, http.StatusBadRequest, "Missing fact path",

--- a/internal/web/handlers_fact_sub.go
+++ b/internal/web/handlers_fact_sub.go
@@ -210,9 +210,7 @@ type graphRefEntry struct {
 
 // handleFactCommits serves GET /repos/{repo}/branches/{branch}/facts/*/commits.
 // Dispatched from handleHALFact when the wildcard path ends with "/commits".
-func handleFactCommits(b hal.URLBuilder, provider factSubProvider, repoName, branch, factPath string, w http.ResponseWriter, r *http.Request) {
-	ri := repos.RepoFromContext(r.Context())
-
+func handleFactCommits(b hal.URLBuilder, provider factSubProvider, ri *repos.RepoInstance, repoName, branch, factPath string, w http.ResponseWriter, r *http.Request) {
 	limit, ok := limitParam(w, r)
 	if !ok {
 		return
@@ -270,9 +268,7 @@ func handleFactCommits(b hal.URLBuilder, provider factSubProvider, repoName, bra
 }
 
 // handleFactIncoming serves GET /repos/{repo}/branches/{branch}/facts/*/incoming.
-func handleFactIncoming(b hal.URLBuilder, provider factSubProvider, repoName, branch, factPath string, w http.ResponseWriter, r *http.Request) {
-	ri := repos.RepoFromContext(r.Context())
-
+func handleFactIncoming(b hal.URLBuilder, provider factSubProvider, ri *repos.RepoInstance, repoName, branch, factPath string, w http.ResponseWriter, r *http.Request) {
 	result, err := provider.ExplainFact(r.Context(), ri, branch, factPath)
 	if err != nil {
 		writeStoreError(w, r, err, "Failed to load incoming refs", branch)
@@ -294,9 +290,7 @@ func handleFactIncoming(b hal.URLBuilder, provider factSubProvider, repoName, br
 }
 
 // handleFactOutgoing serves GET /repos/{repo}/branches/{branch}/facts/*/outgoing.
-func handleFactOutgoing(b hal.URLBuilder, provider factSubProvider, repoName, branch, factPath string, w http.ResponseWriter, r *http.Request) {
-	ri := repos.RepoFromContext(r.Context())
-
+func handleFactOutgoing(b hal.URLBuilder, provider factSubProvider, ri *repos.RepoInstance, repoName, branch, factPath string, w http.ResponseWriter, r *http.Request) {
 	result, err := provider.ExplainFact(r.Context(), ri, branch, factPath)
 	if err != nil {
 		writeStoreError(w, r, err, "Failed to load outgoing refs", branch)
@@ -341,31 +335,61 @@ func buildGraphRefItems(b hal.URLBuilder, repoName string, a hal.Anchor, refs []
 	return items
 }
 
+// factSubResources are the suffixes a facts/* wildcard may address instead of
+// the fact itself.
+var factSubResources = [...]string{"commits", "incoming", "outgoing"}
+
+// splitFactSubResource splits a facts/* wildcard path into the fact path and
+// the sub-resource it addresses, or (path, "") when it addresses the fact.
+//
+// Splitting is separated from dispatching because the lens route has to do it
+// FIRST: its path may be kb://<id12>-qualified, and the mount must be resolved
+// from the fact path with the suffix already off. Leaving the two fused is what
+// let "<uuid>.md/incoming" travel into the store as a fact path (issue #178).
+func splitFactSubResource(path string) (factPath, sub string) {
+	for _, s := range factSubResources {
+		if strings.HasSuffix(path, "/"+s) {
+			return strings.TrimSuffix(path, "/"+s), s
+		}
+	}
+	return path, ""
+}
+
 // dispatchFactSubResource checks if a fact wildcard path ends with a known
 // sub-resource suffix and dispatches accordingly. Returns true if dispatched.
 func dispatchFactSubResource(
 	b hal.URLBuilder,
 	subProvider factSubProvider,
+	ri *repos.RepoInstance,
 	repoName, branch string,
 	w http.ResponseWriter,
 	r *http.Request,
 ) bool {
-	path := chi.URLParam(r, "*")
+	factPath, sub := splitFactSubResource(chi.URLParam(r, "*"))
+	return dispatchResolvedFactSubResource(b, subProvider, ri, repoName, branch, factPath, sub, w, r)
+}
 
-	if strings.HasSuffix(path, "/commits") {
-		actualPath := strings.TrimSuffix(path, "/commits")
-		handleFactCommits(b, subProvider, repoName, branch, actualPath, w, r)
-		return true
+// dispatchResolvedFactSubResource dispatches an ALREADY-split sub-resource
+// against an already-resolved mount. The repo route reaches it through
+// dispatchFactSubResource; the lens route calls it directly, after resolving
+// the addressed mount itself.
+func dispatchResolvedFactSubResource(
+	b hal.URLBuilder,
+	subProvider factSubProvider,
+	ri *repos.RepoInstance,
+	repoName, branch, factPath, sub string,
+	w http.ResponseWriter,
+	r *http.Request,
+) bool {
+	switch sub {
+	case "commits":
+		handleFactCommits(b, subProvider, ri, repoName, branch, factPath, w, r)
+	case "incoming":
+		handleFactIncoming(b, subProvider, ri, repoName, branch, factPath, w, r)
+	case "outgoing":
+		handleFactOutgoing(b, subProvider, ri, repoName, branch, factPath, w, r)
+	default:
+		return false
 	}
-	if strings.HasSuffix(path, "/incoming") {
-		actualPath := strings.TrimSuffix(path, "/incoming")
-		handleFactIncoming(b, subProvider, repoName, branch, actualPath, w, r)
-		return true
-	}
-	if strings.HasSuffix(path, "/outgoing") {
-		actualPath := strings.TrimSuffix(path, "/outgoing")
-		handleFactOutgoing(b, subProvider, repoName, branch, actualPath, w, r)
-		return true
-	}
-	return false
+	return true
 }

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -517,8 +517,35 @@ func handleHALLensFact(b hal.URLBuilder, reader FactReader, subProvider factSubP
 		// The mount is resolved, so a sub-resource can be served against it —
 		// with the mount-relative path, which is what the store indexes. The
 		// _links these emit stay repo-scoped, exactly as the fact body's do.
-		if dispatchResolvedFactSubResource(b, subProvider, ri, ri.Name(), branch, rel, sub, w, r) {
-			return
+		//
+		// GATED ON THE FACT BEING READABLE THROUGH THE LENS, and that gate is
+		// what keeps this route from becoming a mount-topology oracle. The
+		// sub-resource handlers report failure through writeStoreError, whose
+		// detail names the branch, and handleFactCommits does not fail at all
+		// for a path with no commits — it answers an empty 200 whose
+		// _links.self carries the mount's repo name and branch. Either one lets
+		// a caller iterate candidate id12s and read "mounted" off the response,
+		// which is exactly what lensFactNotFound exists to prevent. Reading
+		// first collapses "unmounted id", "malformed kb:// path" and "no such
+		// fact" back into one answer for the sub-resources too.
+		//
+		// It also keeps the lens surface internally consistent: a fact you
+		// cannot read through the lens has no sub-resources through it either.
+		// (Residual: an index that lags the git tree could still surface
+		// ErrFactNotLive from a handler, whose detail names the mount branch.
+		// That needs a mounted id to reach at all, so it is not an oracle.)
+		if sub != "" {
+			if _, _, err := reader.Read(r.Context(), ri, hal.Anchor{Branch: branch}, rel, false); err != nil {
+				if errors.Is(err, errFactNotFound) {
+					lensFactNotFound(w, r, requested)
+					return
+				}
+				writeStoreError(w, r, err, "Failed to read fact", branch)
+				return
+			}
+			if dispatchResolvedFactSubResource(b, subProvider, ri, ri.Name(), branch, rel, sub, w, r) {
+				return
+			}
 		}
 
 		a := hal.Anchor{Branch: branch}

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -451,7 +451,14 @@ func (v lensFactView) MarshalJSON() ([]byte, error) {
 // genuinely-missing fact — a caller must not be able to tell an unknown mount
 // from an absent fact (no mount-topology leak). A missing/retracted fact is a
 // 404 in parity with the repo handler; a real backend error surfaces as 500.
-func handleHALLensFact(b hal.URLBuilder, reader FactReader) http.HandlerFunc {
+//
+// It is ALSO the lens twin of handleHALFact's sub-resource dispatch: /commits,
+// /incoming and /outgoing are served here against the mount this handler
+// resolves, because the resolution is the same one and only this handler knows
+// how to do it. Registering the reader alone left those suffixes to fall
+// through into the fact read, where "<uuid>.md/incoming" is just a path that
+// does not exist — a deterministic 500 for every fact (issue #178).
+func handleHALLensFact(b hal.URLBuilder, reader FactReader, subProvider factSubProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		bind := repos.BindingFromContext(r.Context())
 
@@ -461,10 +468,21 @@ func handleHALLensFact(b hal.URLBuilder, reader FactReader) http.HandlerFunc {
 		// back to the raw capture rather than 500 — ParseQualifiedPath will judge
 		// it.
 		raw := chi.URLParam(r, "*")
-		wire := raw
+		requested := raw
 		if dec, derr := url.PathUnescape(raw); derr == nil {
-			wire = dec
+			requested = dec
 		}
+		if requested == "" {
+			hal.WriteProblem(w, http.StatusBadRequest, "Missing fact path",
+				"fact path is required", r.URL.Path)
+			return
+		}
+
+		// Strip the sub-resource suffix BEFORE addressing: the mount is
+		// resolved from the fact path, not from the URL that names one of its
+		// sub-resources. `requested` keeps the full path the client asked for,
+		// so a 404 still echoes what was requested.
+		wire, sub := splitFactSubResource(requested)
 		if wire == "" {
 			hal.WriteProblem(w, http.StatusBadRequest, "Missing fact path",
 				"fact path is required", r.URL.Path)
@@ -481,12 +499,12 @@ func handleHALLensFact(b hal.URLBuilder, reader FactReader) http.HandlerFunc {
 			// A malformed kb:// path or an unmounted id is indistinguishable, on
 			// the wire, from a fact that simply isn't there — same 404.
 			if err != nil {
-				lensFactNotFound(w, r, wire)
+				lensFactNotFound(w, r, requested)
 				return
 			}
 			rt, ok := bind.ByID(id)
 			if !ok {
-				lensFactNotFound(w, r, wire)
+				lensFactNotFound(w, r, requested)
 				return
 			}
 			ri, branch = rt.RI, rt.Branch
@@ -496,11 +514,18 @@ func handleHALLensFact(b hal.URLBuilder, reader FactReader) http.HandlerFunc {
 			ri, branch = bind.Write(), bind.WriteMountBranch()
 		}
 
+		// The mount is resolved, so a sub-resource can be served against it —
+		// with the mount-relative path, which is what the store indexes. The
+		// _links these emit stay repo-scoped, exactly as the fact body's do.
+		if dispatchResolvedFactSubResource(b, subProvider, ri, ri.Name(), branch, rel, sub, w, r) {
+			return
+		}
+
 		a := hal.Anchor{Branch: branch}
 		f, head, err := reader.Read(r.Context(), ri, a, rel, false)
 		if err != nil {
 			if errors.Is(err, errFactNotFound) {
-				lensFactNotFound(w, r, wire)
+				lensFactNotFound(w, r, requested)
 				return
 			}
 			writeStoreError(w, r, err, "Failed to read fact", branch)

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -1788,3 +1788,146 @@ func TestLensSearch_MotifResolutionIsPerMountNotShared(t *testing.T) {
 		t.Errorf("the non-merging mount contributed nothing at all: %v", titles)
 	}
 }
+
+// ── Lens fact sub-resources ──────────────────────────────────────────────────
+//
+// The lens facts route registered only the fact READER, so
+// /lenses/{lens}/facts/{path}/incoming matched the facts/* wildcard as the
+// literal path "…/<uuid>.md/incoming" and fell into the reader, which 500s
+// ("readFileWithHash: entry …: object not found") for EVERY fact. The web UI
+// only escaped it by fetching edges through the source mount's repo-scoped
+// route; any direct API consumer deriving an edge URL from a lens fact URL hit
+// the 500, which reads like corruption but is a missing route (issue #178).
+
+// lensFactSubStub records which mount a sub-resource request resolved to, so a
+// test can assert the dispatch used the addressed mount rather than whatever
+// LensMiddleware happened to leave in the request context (the WRITE repo).
+type lensFactSubStub struct {
+	*stubFactSubProvider
+	gotRepo   string
+	gotBranch string
+	gotPath   string
+}
+
+func (s *lensFactSubStub) ExplainFact(
+	ctx context.Context,
+	ri *repos.RepoInstance, branch, path string,
+) (store.ExplainResult, error) {
+	s.gotRepo, s.gotBranch, s.gotPath = ri.Name(), branch, path
+	return s.stubFactSubProvider.ExplainFact(ctx, ri, branch, path)
+}
+
+type lensRefsBody struct {
+	Count    int         `json:"count"`
+	Links    hal.LinkMap `json:"_links"`
+	Embedded struct {
+		Refs []struct {
+			Path  string `json:"path"`
+			Title string `json:"title"`
+		} `json:"refs"`
+	} `json:"_embedded"`
+}
+
+// A bare kb/… path's /incoming resolves the same way the lens fact READ does:
+// the write repo at its read-mount branch.
+func TestLensFactIncoming_BarePathReadsWriteRepo(t *testing.T) {
+	m, _ := newTestLensManager(t, "zulu", "alpha")
+	sub := &lensFactSubStub{stubFactSubProvider: &stubFactSubProvider{
+		explain: store.ExplainResult{
+			Incoming: []store.RefSummary{
+				{Path: "kb/x/2.md", Title: "Cites it"},
+				{Path: "kb/x/3.md", Title: "Also cites it"},
+			},
+		},
+	}}
+	s := &Server{Manager: m, providers: storeProviders{
+		factReader: &lensFactReaderStub{head: "deadbeef"},
+		factSub:    sub,
+	}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"zulu","reads":[{"repo":"alpha"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts/kb/x/1.md/incoming")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensRefsBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if body.Count != 2 || len(body.Embedded.Refs) != 2 {
+		t.Fatalf("refs: count=%d len=%d, want 2", body.Count, len(body.Embedded.Refs))
+	}
+	zulu := m.Get("zulu")
+	if sub.gotRepo != "zulu" || sub.gotBranch != zulu.AgentBranch() {
+		t.Errorf("resolved to %s@%s, want the write repo zulu@%s", sub.gotRepo, sub.gotBranch, zulu.AgentBranch())
+	}
+	// The sub-resource suffix must be stripped before the path reaches the
+	// store — this is the misparse that produced the 500.
+	if sub.gotPath != "kb/x/1.md" {
+		t.Errorf("path: got %q, want the fact path with /incoming stripped", sub.gotPath)
+	}
+}
+
+// A kb://<id12>/… path's /outgoing resolves to THAT mount at its own branch —
+// not the write repo LensMiddleware leaves in the request context.
+func TestLensFactOutgoing_QualifiedPathHitsMount(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	sub := &lensFactSubStub{stubFactSubProvider: &stubFactSubProvider{
+		explain: store.ExplainResult{
+			Outgoing: []store.RefSummary{{Path: "kb/y/9.md", Title: "Derived from"}},
+		},
+	}}
+	s := &Server{Manager: m, providers: storeProviders{
+		factReader: &lensFactReaderStub{head: "cafe1234"},
+		factSub:    sub,
+	}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	beta := m.Get("beta")
+	id := federate.ID12(beta.ID())
+	rec := getLensFacts(t, r, "/lenses/eng/facts/"+url.PathEscape("kb://"+id+"/kb/y/2.md")+"/outgoing")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body lensRefsBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if body.Count != 1 {
+		t.Fatalf("count: got %d, want 1; body=%s", body.Count, rec.Body.String())
+	}
+	if sub.gotRepo != "beta" || sub.gotBranch != beta.AgentBranch() {
+		t.Errorf("resolved to %s@%s, want the addressed mount beta@%s", sub.gotRepo, sub.gotBranch, beta.AgentBranch())
+	}
+	// The store is queried with the MOUNT-RELATIVE path — the kb://<id12>/
+	// qualifier addresses the mount and must not survive into the lookup.
+	if sub.gotPath != "kb/y/2.md" {
+		t.Errorf("path: got %q, want the mount-relative kb/y/2.md", sub.gotPath)
+	}
+}
+
+// An unmounted id12 must 404 through the sub-resource route too, with the same
+// body as a missing fact — the dispatch may not become a mount-topology oracle.
+func TestLensFactSub_UnknownID404(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		factReader: &lensFactReaderStub{head: "cafe1234"},
+		factSub:    &lensFactSubStub{stubFactSubProvider: &stubFactSubProvider{}},
+	}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts/"+url.PathEscape("kb://0123456789ab/kb/y/2.md")+"/incoming")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	var pb struct {
+		Title string `json:"title"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &pb)
+	if pb.Title != "Fact not found" {
+		t.Errorf("title: got %q, want %q", pb.Title, "Fact not found")
+	}
+}

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	knomitfact "knomit/internal/fact"
@@ -1841,8 +1842,12 @@ func TestLensFactIncoming_BarePathReadsWriteRepo(t *testing.T) {
 		},
 	}}
 	s := &Server{Manager: m, providers: storeProviders{
-		factReader: &lensFactReaderStub{head: "deadbeef"},
-		factSub:    sub,
+		// The fact must exist at the mount: sub-resources are gated on the same
+		// read the fact endpoint performs, so an absent fact 404s here too.
+		factReader: &lensFactReaderStub{head: "deadbeef", byRepo: map[string]map[string]knomitfact.Fact{
+			"zulu": {"kb/x/1.md": mkFact("kb/x/1.md", "Write copy")},
+		}},
+		factSub: sub,
 	}}
 	r := s.NewAPIRouter()
 	createLens(t, m, r, `{"name":"eng","write":"zulu","reads":[{"repo":"alpha"}]}`)
@@ -1879,8 +1884,10 @@ func TestLensFactOutgoing_QualifiedPathHitsMount(t *testing.T) {
 		},
 	}}
 	s := &Server{Manager: m, providers: storeProviders{
-		factReader: &lensFactReaderStub{head: "cafe1234"},
-		factSub:    sub,
+		factReader: &lensFactReaderStub{head: "cafe1234", byRepo: map[string]map[string]knomitfact.Fact{
+			"beta": {"kb/y/2.md": mkFact("kb/y/2.md", "Read only")},
+		}},
+		factSub: sub,
 	}}
 	r := s.NewAPIRouter()
 	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
@@ -1929,5 +1936,53 @@ func TestLensFactSub_UnknownID404(t *testing.T) {
 	_ = json.Unmarshal(rec.Body.Bytes(), &pb)
 	if pb.Title != "Fact not found" {
 		t.Errorf("title: got %q, want %q", pb.Title, "Fact not found")
+	}
+}
+
+// A sub-resource on a MOUNTED id whose fact does not exist must answer exactly
+// like an unmounted id: 404, naming nothing about the mount.
+//
+// Registering the dispatch reopened the topology oracle the read path closes.
+// The sub-resource handlers report failure through writeStoreError, not
+// lensFactNotFound, and handleFactCommits does not fail at all for a path with
+// no commits — it returns an empty 200 whose _links.self carries the mount's
+// real repo name and branch. So a caller could iterate candidate id12s and read
+// "mounted" off a 200 versus a 404, which is precisely what lensFactNotFound's
+// doc and openapi.yaml both promise cannot happen.
+func TestLensFactSub_AbsentFactNeverNamesTheMount(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		factReader: &lensFactReaderStub{head: "cafe1234"}, // no facts anywhere
+		factSub:    &lensFactSubStub{stubFactSubProvider: &stubFactSubProvider{}},
+	}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	beta := m.Get("beta")
+	id := federate.ID12(beta.ID())
+	mounted := url.PathEscape("kb://" + id + "/kb/y/2.md")
+	unmounted := url.PathEscape("kb://0123456789ab/kb/y/2.md")
+
+	for _, sub := range []string{"commits", "incoming", "outgoing"} {
+		recMounted := getLensFacts(t, r, "/lenses/eng/facts/"+mounted+"/"+sub)
+		recUnmounted := getLensFacts(t, r, "/lenses/eng/facts/"+unmounted+"/"+sub)
+
+		if recMounted.Code != http.StatusNotFound {
+			t.Errorf("/%s on a mounted id with no such fact: got %d, want 404; body=%s",
+				sub, recMounted.Code, recMounted.Body.String())
+		}
+		if recUnmounted.Code != recMounted.Code {
+			t.Errorf("/%s: mounted=%d unmounted=%d — the status alone reveals the mount",
+				sub, recMounted.Code, recUnmounted.Code)
+		}
+		// The body may echo the requested path (it differs by id), but it must
+		// never name the mount's repo or its branch.
+		body := recMounted.Body.String()
+		if strings.Contains(body, `"beta"`) || strings.Contains(body, "/repos/beta/") {
+			t.Errorf("/%s response names the mount repo: %s", sub, body)
+		}
+		if strings.Contains(body, beta.AgentBranch()) {
+			t.Errorf("/%s response names the mount branch %q: %s", sub, beta.AgentBranch(), body)
+		}
 	}
 }

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -240,7 +240,7 @@ func (s *Server) NewAPIRouter() chi.Router {
 		r.Group(func(r chi.Router) {
 			r.Use(LensMiddleware(s.Manager))
 			r.Get("/facts", handleHALLensFacts(p.factsCollection))
-			r.Get("/facts/*", handleHALLensFact(b, p.factReader))
+			r.Get("/facts/*", handleHALLensFact(b, p.factReader, p.factSub))
 			r.Get("/search", handleHALLensSearch(p.search, s.Embedder))
 			r.Get("/completions", handleHALLensCompletions(p.completions))
 			r.Get("/stats", handleHALLensStats(p.stats, p.activity))

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -1728,13 +1728,21 @@ paths:
         Every not-found case — unknown mount id, malformed `kb://` path,
         missing or retracted fact — returns a byte-identical 404, so a caller
         cannot probe the lens's mount topology.
+
+        Sub-resources match the repo route: when the path terminates with
+        `/commits`, `/incoming` or `/outgoing`, the suffix is stripped before
+        the mount is addressed and the response is that sub-resource, served
+        from the addressed mount at its resolved branch.
       operationId: getLensFact
       responses:
         "200":
-          description: Fact with its source mount
+          description: Fact with its source mount, or a sub-resource collection
           content:
             application/hal+json:
-              schema: { $ref: "#/components/schemas/LensFact" }
+              schema:
+                oneOf:
+                  - { $ref: "#/components/schemas/LensFact" }
+                  - { $ref: "#/components/schemas/RefsCollection" }
         "400":
           description: Empty fact path
           content:

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -1732,7 +1732,10 @@ paths:
         Sub-resources match the repo route: when the path terminates with
         `/commits`, `/incoming` or `/outgoing`, the suffix is stripped before
         the mount is addressed and the response is that sub-resource, served
-        from the addressed mount at its resolved branch.
+        from the addressed mount at its resolved branch. They are gated on the
+        same read as the fact itself, so a fact you cannot read through the
+        lens 404s identically for its sub-resources — including the empty
+        commit log that would otherwise be a 200 naming the mount.
       operationId: getLensFact
       responses:
         "200":

--- a/web/src/App.sse.test.tsx
+++ b/web/src/App.sse.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
-import App from './App';
+import App, { HEAD_POLL_MS } from './App';
 
 // Characterization tests for the SSE wiring in App (the effect keyed on
 // [state.repo, state.branch]). These pin CURRENT behavior — the diagnostics the
@@ -671,5 +671,33 @@ describe('App SSE — teardown and resubscribe', () => {
     const es = FakeEventSource.instances[0];
     unmount();
     expect(es.closeCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The head has to stay fresh even when the stream does not deliver.
+//
+// Before this, state.headCommit moved only on the page-load bootstrap, an SSE
+// `status` event, and the post-task refresh. A single dropped broadcast — which
+// commitObserver used to do whenever a commit landed while the previous
+// callback was still running — pinned the tab to that commit until the user
+// reloaded, and every fact created afterwards 404'd its edges (issue #178). A
+// dead or lossy stream does the same thing without any server bug at all.
+// ---------------------------------------------------------------------------
+describe('App — head re-poll', () => {
+  beforeEach(() => { vi.useFakeTimers({ shouldAdvanceTime: true }); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('picks up a head whose status broadcast never arrived', async () => {
+    const api = await apiMock();
+    await mountApp();
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('aaaaaaa');
+
+    // A commit lands; its `status` event is never delivered.
+    api.status.mockResolvedValue({ ...STATUS, head: 'bbbbbbb2222' });
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(HEAD_POLL_MS + 100); });
+
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('bbbbbbb');
   });
 });

--- a/web/src/App.sse.test.tsx
+++ b/web/src/App.sse.test.tsx
@@ -693,8 +693,10 @@ describe('App — head re-poll', () => {
     await mountApp();
     expect(screen.getByTestId('footer-commit')).toHaveTextContent('aaaaaaa');
 
-    // A commit lands; its `status` event is never delivered.
-    api.status.mockResolvedValue({ ...STATUS, head: 'bbbbbbb2222' });
+    // A commit lands and IS indexed — head and watermark agree, which is the
+    // state the stream would have broadcast — but its `status` event is never
+    // delivered.
+    api.status.mockResolvedValue({ ...STATUS, head: 'bbbbbbb2222', index_commit: 'bbbbbbb2222' });
 
     await act(async () => { await vi.advanceTimersByTimeAsync(HEAD_POLL_MS + 100); });
 
@@ -729,5 +731,78 @@ describe('App — head re-poll ordering', () => {
     await act(async () => { resolvePoll!({ ...STATUS, head: 'aaaaaaa1111' }); });
 
     expect(screen.getByTestId('footer-commit')).toHaveTextContent('ccccccc');
+  });
+});
+
+// The poll must never advance the head PAST what the index has absorbed.
+//
+// The branch root reports `head` as raw git HEAD, but the SSE `status`
+// broadcast fires only after the commit observer's SyncLocked returns — so the
+// stream's head is always an indexed commit and the poll's is not. During a
+// long post-commit sync the two diverge, and adopting the raw head points every
+// consumer keyed on state.headCommit at a half-built index. The sharp part is
+// that it does not heal: SET_HEAD short-circuits on an unchanged hash, so the
+// post-sync broadcast of that same hash is a no-op and the stale reads stand
+// until something else moves the head.
+describe('App — head re-poll respects the index watermark', () => {
+  beforeEach(() => { vi.useFakeTimers({ shouldAdvanceTime: true }); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('does not adopt a head the index has not reached yet', async () => {
+    const api = await apiMock();
+    await mountApp();
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('aaaaaaa');
+
+    // A commit landed; the observer's sync is still running, so the watermark
+    // still names the previous commit.
+    api.status.mockResolvedValue({ ...STATUS, head: 'bbbbbbb2222', index_commit: 'aaaaaaa1111' });
+    await act(async () => { await vi.advanceTimersByTimeAsync(HEAD_POLL_MS + 100); });
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('aaaaaaa');
+
+    // Sync completes. The next tick picks it up — the poll waits, it does not
+    // give up on the commit.
+    api.status.mockResolvedValue({ ...STATUS, head: 'bbbbbbb2222', index_commit: 'bbbbbbb2222' });
+    await act(async () => { await vi.advanceTimersByTimeAsync(HEAD_POLL_MS + 100); });
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('bbbbbbb');
+  });
+
+  // Deliberate fallback semantics. An unreadable watermark (SyncWatermark
+  // errored, or the branch was never indexed) reports "". This poll IS the
+  // recovery path for a dead stream, so it must keep moving the head rather
+  // than wedge the tab for as long as that condition lasts.
+  it('falls back to the raw head when the watermark is unavailable', async () => {
+    const api = await apiMock();
+    await mountApp();
+
+    api.status.mockResolvedValue({ ...STATUS, head: 'bbbbbbb2222', index_commit: '' });
+    await act(async () => { await vi.advanceTimersByTimeAsync(HEAD_POLL_MS + 100); });
+
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('bbbbbbb');
+  });
+
+  // A store swap makes the branch endpoint answer 200 with head "": the reader
+  // discards WithRead's error, and WithRead skips its closure when Acquire
+  // fails. SET_HEAD has no falsy guard of its own, so an unguarded dispatch
+  // blanks the head — same reason the SSE `status` handler tests `if (s.head)`.
+  it('ignores an empty head', async () => {
+    const api = await apiMock();
+    await mountApp();
+
+    api.status.mockResolvedValue({ ...STATUS, head: '', index_commit: '' });
+    await act(async () => { await vi.advanceTimersByTimeAsync(HEAD_POLL_MS + 100); });
+
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('aaaaaaa');
+  });
+
+  // The same server window reaches the OTHER refresh paths, which apply the
+  // whole payload through SET_STATUS rather than SET_HEAD.
+  it('a post-task status refresh with an empty head keeps the last known head', async () => {
+    const api = await apiMock();
+    const es = await mountApp();
+
+    api.status.mockResolvedValue({ ...STATUS, head: '', index_commit: '' });
+    await act(async () => { es.emit('task', { op: 'sync', status: 'done', message: 'done' }); });
+
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('aaaaaaa');
   });
 });

--- a/web/src/App.sse.test.tsx
+++ b/web/src/App.sse.test.tsx
@@ -701,3 +701,33 @@ describe('App — head re-poll', () => {
     expect(screen.getByTestId('footer-commit')).toHaveTextContent('bbbbbbb');
   });
 });
+
+// The poll must never move the head BACKWARDS. Nothing orders a slow poll
+// response against the SSE stream, so a response captured before a newer
+// `status` event can land after it and re-stale the tab the poll exists to
+// un-stale — for a further 30s, with every consumer keyed on state.headCommit
+// (useFactEdges' own anchor included) refetching at the older commit.
+describe('App — head re-poll ordering', () => {
+  beforeEach(() => { vi.useFakeTimers({ shouldAdvanceTime: true }); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('a slow poll response cannot overwrite a newer head', async () => {
+    const api = await apiMock();
+    const es = await mountApp();
+
+    // Put a poll in flight, holding its response.
+    let resolvePoll: ((v: unknown) => void) | undefined;
+    api.status.mockImplementation(() => new Promise(r => { resolvePoll = r as (v: unknown) => void; }));
+    await act(async () => { await vi.advanceTimersByTimeAsync(HEAD_POLL_MS + 100); });
+    expect(resolvePoll).toBeDefined();
+
+    // A newer head arrives on the stream while that poll is still out.
+    act(() => { es.emit('status', { head: 'ccccccc3333' }); });
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('ccccccc');
+
+    // The poll now answers with what was current when it was issued.
+    await act(async () => { resolvePoll!({ ...STATUS, head: 'aaaaaaa1111' }); });
+
+    expect(screen.getByTestId('footer-commit')).toHaveTextContent('ccccccc');
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -530,7 +530,37 @@ export default function App() {
       api.status(state.repo, state.branch)
         .then(s => {
           if (cancelled || stateRef.current.headCommit !== issuedAt) return;
-          dispatch({ type: 'SET_HEAD', head: s.head });
+          // Advance to the INDEXED head, not raw git HEAD. The two differ, and
+          // only during the window this poll is most likely to fire in. The
+          // branch root reports `head` straight off Branches().HeadCommit,
+          // while the SSE `status` broadcast is emitted only AFTER the commit
+          // observer's IndexManager().SyncLocked returns — so every head the
+          // stream delivers is one the index has already absorbed, and this
+          // one is not. Writing an un-indexed head back mid-sync points every
+          // consumer keyed on state.headCommit (Library's search/chrono
+          // effects, useFactEdges, RightPanel) at a half-built index; worse,
+          // SET_HEAD short-circuits on an unchanged hash, so the post-sync
+          // broadcast of that SAME hash is a no-op and the stale results stand
+          // indefinitely rather than for the length of the sync. index_commit
+          // is the sync watermark — the newest commit the index has absorbed —
+          // which is exactly what the stream broadcasts.
+          //
+          // Fallback when the watermark is unavailable (SyncWatermark errored,
+          // or the branch has never been indexed) is the raw head: it reports
+          // "" then, and this poll is the recovery path for a dead or lossy
+          // stream, so refusing to move the head would wedge the tab for as
+          // long as that condition lasts — the failure this effect exists to
+          // prevent. Preferring the watermark is a correctness win when it is
+          // there; its absence must not cost us the recovery.
+          //
+          // An empty head is not an answer either way. defaultBranchRootReader
+          // discards WithRead's error, and WithRead returns the Acquire error
+          // without running the closure, so during a store swap or open the
+          // branch endpoint answers 200 with head "". Same guard the SSE
+          // `status` handler applies.
+          const head = s.index_commit || s.head;
+          if (!head) return;
+          dispatch({ type: 'SET_HEAD', head });
         })
         .catch(() => {
           // Best-effort. A failed poll tells us nothing new about the head, and

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,8 +56,13 @@ const REMOTE_RECHECK_MS = 60_000;
 // server used to DROP a head broadcast whenever the commit landed while the
 // previous notification's callback was still running (issue #178). This poll is
 // the belt-and-braces half of that fix, and it covers the lossy-stream case the
-// server fix cannot: it is cheap, and only a changed head re-renders anything
-// (SET_HEAD returns the same state for an unchanged one).
+// server fix cannot.
+//
+// It dispatches SET_HEAD, not SET_STATUS, and the distinction is the whole
+// reason it is cheap: SET_HEAD returns the SAME state object for an unchanged
+// head, so a quiet repo re-renders nothing, while SET_STATUS rebuilds state
+// unconditionally and would re-render every open tab every 30s forever. The
+// stream already carries full status; this only needs to carry the head.
 export const HEAD_POLL_MS = 30_000;
 
 function loadLeftPanelWidth(): number {
@@ -515,8 +520,18 @@ export default function App() {
     if (!state.repo || !state.branch) return;
     let cancelled = false;
     const id = setInterval(() => {
+      // What the head was when this request went out. Nothing orders a poll
+      // response against the SSE stream, so a response captured before a newer
+      // `status` event can land after it — and writing it back would re-stale
+      // the tab for another full interval, which is the opposite of this
+      // effect's purpose. If anything moved the head while we were in flight,
+      // that source is fresher than this answer by construction; drop it.
+      const issuedAt = stateRef.current.headCommit;
       api.status(state.repo, state.branch)
-        .then(s => { if (!cancelled) dispatch(statusAction(s)); })
+        .then(s => {
+          if (cancelled || stateRef.current.headCommit !== issuedAt) return;
+          dispatch({ type: 'SET_HEAD', head: s.head });
+        })
         .catch(() => {
           // Best-effort. A failed poll tells us nothing new about the head, and
           // the stream (or the next tick) is still the primary path — logging

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,6 +46,20 @@ const TASK_LINGER_MS = 8_000;
 // screen. Nothing polls while the remote is healthy — see the recheck effect.
 const REMOTE_RECHECK_MS = 60_000;
 
+// How often the branch head is re-read as a fallback for the SSE `status`
+// stream. Exported for the test that pins the behavior.
+//
+// The head is otherwise only ever moved by three one-shot events — the
+// page-load bootstrap, a `status` event, and the post-task refresh — so a
+// stream that goes quiet leaves the tab pinned to whatever it last heard, with
+// no signal and no recovery short of a reload. That is not hypothetical: the
+// server used to DROP a head broadcast whenever the commit landed while the
+// previous notification's callback was still running (issue #178). This poll is
+// the belt-and-braces half of that fix, and it covers the lossy-stream case the
+// server fix cannot: it is cheap, and only a changed head re-renders anything
+// (SET_HEAD returns the same state for an unchanged one).
+export const HEAD_POLL_MS = 30_000;
+
 function loadLeftPanelWidth(): number {
   const fallback = Math.max(LEFT_PANEL_MIN, Math.round(window.innerWidth * LEFT_PANEL_DEFAULT_FRACTION));
   try {
@@ -292,7 +306,11 @@ export default function App() {
   // same api.explain call independently, for the same fact at the same anchor.
   // The anchor rules — which mount, which commit, when to fall back — moved
   // into the hook with the fetch; see useFactEdges.
-  const edges = useFactEdges(state);
+  // A live edges 404 means this tab's cached head is stale; the hook re-reads
+  // the head to recover and hands it back here so the whole app stops being
+  // stale, not just the fetch that noticed.
+  const applyDiscoveredHead = useCallback((head: string) => dispatch({ type: 'SET_HEAD', head }), []);
+  const edges = useFactEdges(state, applyDiscoveredHead);
 
 
   // 12-hex KB-store id → repo name, for the References labels in FactBody. The
@@ -489,6 +507,25 @@ export default function App() {
     }, 2000);
     return () => { cancelled = true; clearInterval(id); };
   }, [state.indexState, state.repo, state.branch]);
+
+  // Re-read the branch head on a slow cycle. See HEAD_POLL_MS: this is the
+  // fallback for a `status` event that never arrives, whether because the
+  // server dropped it or because the stream is dead.
+  useEffect(() => {
+    if (!state.repo || !state.branch) return;
+    let cancelled = false;
+    const id = setInterval(() => {
+      api.status(state.repo, state.branch)
+        .then(s => { if (!cancelled) dispatch(statusAction(s)); })
+        .catch(() => {
+          // Best-effort. A failed poll tells us nothing new about the head, and
+          // the stream (or the next tick) is still the primary path — logging
+          // it would put a line in the console every 30s for an outage the SSE
+          // handler already reports.
+        });
+    }, HEAD_POLL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [state.repo, state.branch]);
 
   // Reconcile the remote-error banner with the PERSISTED remote status.
   //

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1477,11 +1477,17 @@ export const api = {
     incoming: RefGroup[];
     outgoing: RefGroup[];
   }> => {
-    // When commit is set, use the commit-anchored sub-resource endpoints so
-    // refs reflect the state of the source/target at that commit (the
-    // commit-anchored handler dispatches /incoming and /outgoing to the
-    // *AtCommit store primitives). Without this, navigating to a specific
-    // version of a fact in the Explain view would show no refs.
+    // When commit is set, use the commit-anchored sub-resource endpoints so the
+    // refs are THIS version's.
+    //
+    // Both routes end in the same version-aware primitives — the HEAD route's
+    // ExplainFact resolves the path's HEAD-active commit out of branch_facts
+    // and then calls IncomingAtCommit/OutgoingAtCommit itself — so the anchor
+    // does not decide whether edges carry a target_commit. What it decides is
+    // WHICH VERSION OF THIS FACT the edges belong to: HEAD-active, or the one
+    // live at the pinned commit. Reading an older version through the HEAD
+    // route would therefore show the HEAD version's refs, and a fact retracted
+    // at HEAD would show none at all (ErrFactNotLive → 404).
     const factURL = commit
       ? `${branchBase(repo, branch)}/commits/${commit}/facts/${path}`
       : `${branchBase(repo, branch)}/facts/${path}`;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -547,6 +547,25 @@ function parseSSELines(text: string): SSEEvent[] {
 // `title` is the class; `error` remains as a fallback for any body that
 // predates the problem+json unification. Callers pass a statusText fallback
 // for non-JSON bodies.
+/**
+ * An Error carrying the HTTP status that produced it, so a caller can tell a
+ * 404 ("no such thing there") from a transport failure or a 500. The status is
+ * ADDED to an ordinary Error rather than carried by a subclass so `String(err)`
+ * stays byte-identical for every existing consumer that renders it.
+ */
+export interface HttpError extends Error { status?: number }
+
+function httpError(status: number, message: string): HttpError {
+  const e = new Error(message) as HttpError;
+  e.status = status;
+  return e;
+}
+
+/** True when err is an HTTP 404 — a missing resource, not a failed request. */
+export function isNotFound(err: unknown): boolean {
+  return (err as HttpError | null)?.status === 404;
+}
+
 function errorText(body: unknown, fallback: string): string {
   const b = body as { detail?: string; title?: string; error?: string } | null;
   return b?.detail || b?.title || b?.error || fallback;
@@ -1556,8 +1575,8 @@ export const api = {
       });
     };
     return Promise.all([
-      fetch(`${factURL}/incoming${edgeQuery}`).then(r => r.ok ? r.json() : r.json().then((e: unknown) => { throw new Error(errorText(e, r.statusText)); })),
-      fetch(`${factURL}/outgoing${edgeQuery}`).then(r => r.ok ? r.json() : r.json().then((e: unknown) => { throw new Error(errorText(e, r.statusText)); })),
+      fetch(`${factURL}/incoming${edgeQuery}`).then(r => r.ok ? r.json() : r.json().then((e: unknown) => { throw httpError(r.status, errorText(e, r.statusText)); })),
+      fetch(`${factURL}/outgoing${edgeQuery}`).then(r => r.ok ? r.json() : r.json().then((e: unknown) => { throw httpError(r.status, errorText(e, r.statusText)); })),
     ]).then(([inc, out]) => ({
       incoming: groupRefs(parseRefs(inc), 'incoming'),
       outgoing: groupRefs(parseRefs(out), 'outgoing'),

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -350,7 +350,17 @@ function applyAction(s: AppState, a: Action): AppState {
     case 'SET_STATUS':
       return {
         ...s,
-        headCommit: a.head,
+        // A blank head is the server declining to answer, not a repo with no
+        // commits: the branch root discards WithRead's error, and WithRead
+        // skips the closure when Acquire fails, so a store swap or open makes
+        // it answer 200 with head "". Both refresh call sites (the 2s indexing
+        // poll and the post-task refresh) run in exactly that window. Blanking
+        // headCommit there drops the head pill, sends edge reads to the
+        // un-anchored route and churns every refetch keyed on it. Keeping the
+        // last known head cannot smuggle a stale one across a repo switch:
+        // SET_CONTEXT and SET_LENS both clear headCommit before the status
+        // bootstrap re-runs, so `s.headCommit` is already "" by then.
+        headCommit: a.head || s.headCommit,
         branch: a.branch,
         embeddingsEnabled: a.embeddingsEnabled,
         ontologyRoot: a.ontologyRoot || s.ontologyRoot,

--- a/web/src/useFactEdges.stalehead.test.tsx
+++ b/web/src/useFactEdges.stalehead.test.tsx
@@ -10,6 +10,7 @@
 // answer: re-read the head and retry. A history/diff anchor is the opposite —
 // the commit is the user's pin, and dropping it would violate
 // kb/invariants/ui/navigation/every-hop-is-path-plus-commit.
+import { useState } from 'react';
 import { it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { useFactEdges } from './useFactEdges';
@@ -114,4 +115,31 @@ it('a live 404 that survives a fresh head is reported, not retried forever', asy
 
   const edgeCalls = urls.filter(u => u.includes('/facts/kb/x/1.md/'));
   expect(edgeCalls.length).toBe(2); // one incoming + one outgoing, no retry storm
+});
+
+// The tests above hold `state` fixed, so the effect never re-runs and the
+// hook's own retry is what settles. App is not shaped like that: reporting the
+// head re-anchors the state, which changes the `anchor` dep, which re-runs the
+// effect — so the retry's own fetches are dropped by their `stale()` guard and
+// a fresh run is what renders. Pin the caller shape App actually has, so this
+// file stops asserting a path the product does not take.
+it('recovers in a caller that re-anchors on the reported head', async () => {
+  function AppShaped() {
+    const [headCommit, setHead] = useState('staleHEAD');
+    const edges = useFactEdges({ ...liveStale, headCommit }, setHead);
+    if (edges.loading) return <div data-testid="out">loading</div>;
+    return <div data-testid="out">{edges.error ?? `ok:${edges.incoming.length}`}</div>;
+  }
+
+  render(<AppShaped />);
+  await waitFor(() => expect(screen.getByTestId('out').textContent).toBe('ok:1'));
+
+  // Bounded, whichever run settles it: the head is re-read exactly once. A
+  // second 404 would find the head unmoved and fail out rather than loop.
+  const statusCalls = urls.filter(u => u.endsWith('/repos/alpha/branches/agent:main'));
+  expect(statusCalls.length).toBe(1);
+
+  // Recovery is at the fresh head, and the stale one is never revisited.
+  expect(urls.some(u => u.includes('/commits/freshHEAD/facts/kb/x/1.md/incoming'))).toBe(true);
+  expect(urls.filter(u => u.includes('/commits/staleHEAD/')).length).toBe(2); // the original pair only
 });

--- a/web/src/useFactEdges.stalehead.test.tsx
+++ b/web/src/useFactEdges.stalehead.test.tsx
@@ -1,0 +1,117 @@
+// A LIVE view must not treat its cached head as authoritative.
+//
+// In a repo context the edges request is anchored at state.headCommit, which is
+// refreshed only by the page-load bootstrap, SSE `status` events, and the
+// post-task status refresh. A dropped `status` broadcast (issue #178) pins the
+// tab to an old commit, and every fact created after it 404s its edges — raw,
+// on a fact whose body loads fine at HEAD, reading like data corruption.
+//
+// Live means "the current head", so a 404 there is a stale cache, not an
+// answer: re-read the head and retry. A history/diff anchor is the opposite —
+// the commit is the user's pin, and dropping it would violate
+// kb/invariants/ui/navigation/every-hop-is-path-plus-commit.
+import { it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useFactEdges } from './useFactEdges';
+import { init } from './state';
+import type { AppState } from './state';
+
+const urls: string[] = [];
+
+function Probe({ state, onHead }: { state: AppState; onHead?: (head: string) => void }) {
+  const edges = useFactEdges(state, onHead);
+  if (edges.loading) return <div data-testid="out">loading</div>;
+  return <div data-testid="out">{edges.error ?? `ok:${edges.incoming.length}`}</div>;
+}
+
+const refsBody = { _embedded: { refs: [{ path: 'kb/x/2.md', title: 'Cites it', commit: 'c1' }] } };
+
+function reply(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 404 ? 'Not Found' : 'OK',
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+// The store answers correctly for whatever anchor it is given; the wrong ANCHOR
+// is the problem. So: 404 at the stale head, 200 at the fresh one.
+beforeEach(() => {
+  urls.length = 0;
+  vi.stubGlobal('fetch', vi.fn((url: unknown) => {
+    const u = String(url);
+    urls.push(u);
+    if (u.includes('/commits/staleHEAD/') || u.includes('/commits/pinnedSHA/')) {
+      return Promise.resolve(reply({
+        title: 'Fact not found',
+        detail: 'no fact at path "kb/x/1.md" on branch "agent/main" at commit "staleHEAD"',
+      }, 404));
+    }
+    if (u.endsWith('/repos/alpha/branches/agent:main')) {
+      return Promise.resolve(reply({ head: 'freshHEAD', embeddings_enabled: false, index_state: 'ready' }));
+    }
+    return Promise.resolve(reply(refsBody));
+  }));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const liveStale: AppState = {
+  ...init,
+  context: { kind: 'repo', repo: 'alpha' },
+  repo: 'alpha',
+  branch: 'agent/main',
+  headCommit: 'staleHEAD',
+  factPath: 'kb/x/1.md',
+  asOf: { mode: 'live' },
+};
+
+it('live 404 at the cached head re-reads the head and retries there', async () => {
+  const heads: string[] = [];
+  render(<Probe state={liveStale} onHead={h => heads.push(h)} />);
+
+  await waitFor(() => expect(screen.getByTestId('out').textContent).toBe('ok:1'));
+
+  // It asked the server what the head actually is...
+  expect(urls.some(u => u.endsWith('/repos/alpha/branches/agent:main'))).toBe(true);
+  // ...retried there...
+  expect(urls.some(u => u.includes('/commits/freshHEAD/facts/kb/x/1.md/incoming'))).toBe(true);
+  // ...and reported the fresh head so the rest of the app stops being stale too.
+  expect(heads).toContain('freshHEAD');
+});
+
+it('a history pin that 404s is an answer, not a stale cache: no head refresh', async () => {
+  const heads: string[] = [];
+  render(
+    <Probe
+      state={{ ...liveStale, headCommit: 'freshHEAD', asOf: { mode: 'history', commit: 'pinnedSHA' } }}
+      onHead={h => heads.push(h)}
+    />,
+  );
+
+  await waitFor(() => expect(screen.getByTestId('out').textContent).toContain('no fact at path'));
+
+  // The pin is the user's intent. Never re-anchor it, and never silently show
+  // a different version's edges.
+  expect(heads).toEqual([]);
+  expect(urls.some(u => u.endsWith('/repos/alpha/branches/agent:main'))).toBe(false);
+  expect(urls.every(u => !u.includes('/commits/freshHEAD/'))).toBe(true);
+});
+
+it('a live 404 that survives a fresh head is reported, not retried forever', async () => {
+  vi.stubGlobal('fetch', vi.fn((url: unknown) => {
+    const u = String(url);
+    urls.push(u);
+    if (u.endsWith('/repos/alpha/branches/agent:main')) {
+      // The head has not moved — the 404 is the real answer.
+      return Promise.resolve(reply({ head: 'staleHEAD', embeddings_enabled: false, index_state: 'ready' }));
+    }
+    return Promise.resolve(reply({ title: 'Fact not found', detail: 'gone' }, 404));
+  }));
+
+  render(<Probe state={liveStale} />);
+  await waitFor(() => expect(screen.getByTestId('out').textContent).toContain('gone'));
+
+  const edgeCalls = urls.filter(u => u.includes('/facts/kb/x/1.md/'));
+  expect(edgeCalls.length).toBe(2); // one incoming + one outgoing, no retry storm
+});

--- a/web/src/useFactEdges.ts
+++ b/web/src/useFactEdges.ts
@@ -68,6 +68,16 @@ const EMPTY: FactEdges = {
  * `onHead` is read through a ref rather than taken as a dependency: it exists to
  * report a discovery, and letting a caller's callback identity re-trigger the
  * fetch would make an unmemoized prop a refetch loop.
+ *
+ * WHICH RUN ACTUALLY RENDERS depends on the caller, and both are correct. In a
+ * caller that re-anchors on the reported head (App does: SET_HEAD → headCommit →
+ * `anchor`), reporting changes a dep, the effect re-runs, and the retry's own
+ * fetches are discarded by their `stale()` guard — the fresh run is what
+ * renders, at the cost of one redundant pair. Keeping the local retry anyway is
+ * what makes the hook correct on its own: a caller that passes no `onHead`, or
+ * ignores it, still recovers instead of sitting on the error. Either way the
+ * head is re-read at most once per failure — a second 404 finds the head
+ * unmoved and reports it, so there is no loop.
  */
 export function useFactEdges(state: AppState, onHead?: (head: string) => void): FactEdges {
   const [edges, setEdges] = useState<{ incoming: RefGroup[]; outgoing: RefGroup[] }>({ incoming: [], outgoing: [] });
@@ -115,9 +125,16 @@ export function useFactEdges(state: AppState, onHead?: (head: string) => void): 
         .catch(err => {
           if (stale()) return;
           // Only a live view anchored on a cached head can be wrong about WHERE
-          // it is looking. Anything else — a lens context (no commit in the
-          // URL), a user's history pin, a non-404 — is reported as-is.
-          if (!mayRefreshHead || !live || at === '' || !isNotFound(err)) {
+          // it is looking. Anything else — a lens context, a user's history
+          // pin, a non-404 — is reported as-is.
+          //
+          // `!lensCtx` is redundant TODAY (edgeAnchorCommit returns '' for a
+          // lens, so `at === ''` already excludes it) and is stated anyway,
+          // because the thing it guards is not local: state.headCommit is the
+          // WRITE repo's head, so if lens live edges ever became anchored on
+          // the mount head, this would write a READ MOUNT's head into it. The
+          // assumption is cheaper to pin here than to rediscover there.
+          if (!mayRefreshHead || !live || lensCtx || at === '' || !isNotFound(err)) {
             fail(err);
             return;
           }

--- a/web/src/useFactEdges.ts
+++ b/web/src/useFactEdges.ts
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react';
-import { api } from './api';
+import { useState, useMemo, useRef, useEffect } from 'react';
+import { api, isNotFound } from './api';
 import type { RefGroup } from './api';
 import type { AppState } from './state';
 import { factHistoryAnchor, edgeAnchorCommit, isLive, isLensContext } from './state';
@@ -49,11 +49,34 @@ const EMPTY: FactEdges = {
  * getLensFact). Fetching before then reads the wrong mount and yields an empty
  * edge set — so this waits, and re-runs when factSource lands. RightPanel had
  * this guard; EdgesRail did not, which is one way the two calls could differ.
+ *
+ * A LIVE 404 IS A STALE CACHE, NOT AN ANSWER. Live edge fetches are anchored at
+ * state.headCommit, which only the page-load bootstrap, SSE `status` events and
+ * the post-task refresh ever move. One dropped broadcast pinned tabs to an old
+ * commit indefinitely, and every fact created after it 404'd its edges — raw,
+ * on a fact whose body loads fine at HEAD, reading like data corruption
+ * (issue #178). So a live 404 re-reads the head and retries there ONCE, and
+ * reports the head it learned through `onHead` so the rest of the app stops
+ * being stale too. It gives up if the head has not actually moved: that 404 is
+ * the real answer, and retrying it would be a request loop.
+ *
+ * This is confined to LIVE views on purpose. In history or diff mode the commit
+ * is the user's pin — re-anchoring it would answer a question they did not ask,
+ * which is what kb/invariants/ui/navigation/every-hop-is-path-plus-commit
+ * forbids ("the target still exists" is never a reason to drop the pin).
+ *
+ * `onHead` is read through a ref rather than taken as a dependency: it exists to
+ * report a discovery, and letting a caller's callback identity re-trigger the
+ * fetch would make an unmemoized prop a refetch loop.
  */
-export function useFactEdges(state: AppState): FactEdges {
+export function useFactEdges(state: AppState, onHead?: (head: string) => void): FactEdges {
   const [edges, setEdges] = useState<{ incoming: RefGroup[]; outgoing: RefGroup[] }>({ incoming: [], outgoing: [] });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Synced in an effect, not during render: a ref write during render is both a
+  // lint error and a real hazard under concurrent rendering.
+  const onHeadRef = useRef(onHead);
+  useEffect(() => { onHeadRef.current = onHead; });
 
   const factPath = state.factPath;
   const lensCtx = isLensContext(state);
@@ -69,17 +92,49 @@ export function useFactEdges(state: AppState): FactEdges {
 
     setLoading(true);
     setError(null);
-    api.explain(a.repo, a.branch, a.path, anchor, live ? undefined : { fallback: 'before' })
-      .then(e => {
-        if (stale()) return;
-        setEdges({ incoming: e.incoming, outgoing: e.outgoing });
-      })
-      .catch(err => {
-        if (stale()) return;
-        setEdges({ incoming: [], outgoing: [] });
-        setError(String(err));
-      })
-      .finally(() => { if (!stale()) setLoading(false); });
+
+    const settle = (e: { incoming: RefGroup[]; outgoing: RefGroup[] }) => {
+      setEdges(e);
+      setLoading(false);
+    };
+    // A FAILED FETCH IS NOT A ZERO, but the arrays are still cleared: the error
+    // is what consumers render, and stale edges under a new fact would be worse
+    // than none. See ConnectionsMenu.
+    const fail = (err: unknown) => {
+      setEdges({ incoming: [], outgoing: [] });
+      setError(String(err));
+      setLoading(false);
+    };
+
+    const run = (at: string, mayRefreshHead: boolean) => {
+      api.explain(a.repo, a.branch, a.path, at, live ? undefined : { fallback: 'before' })
+        .then(e => {
+          if (stale()) return;
+          settle({ incoming: e.incoming, outgoing: e.outgoing });
+        })
+        .catch(err => {
+          if (stale()) return;
+          // Only a live view anchored on a cached head can be wrong about WHERE
+          // it is looking. Anything else — a lens context (no commit in the
+          // URL), a user's history pin, a non-404 — is reported as-is.
+          if (!mayRefreshHead || !live || at === '' || !isNotFound(err)) {
+            fail(err);
+            return;
+          }
+          api.status(a.repo, a.branch)
+            .then(s => {
+              if (stale()) return;
+              if (!s.head || s.head === at) {
+                fail(err); // the head has not moved; the 404 is the answer
+                return;
+              }
+              onHeadRef.current?.(s.head);
+              run(s.head, false);
+            })
+            .catch(() => { if (!stale()) fail(err); });
+        });
+    };
+    run(anchor, true);
     // Deps are the resolved anchor values, not `state`: every field that can
     // change WHICH edges these are appears here, and nothing else re-fetches.
   }, [factPath, a.repo, a.branch, a.path, anchor, live, lensCtx, state.factSource?.repo, state.factSource?.branch]);


### PR DESCRIPTION
Closes #178 — three separable defects from one investigation, one commit each.

## 1 — `commitObserver` dropped head notifications (root cause)

`internal/repos/observer.go` cleared `pending` and then CAS'd on an atomic
`running` flag. A failed CAS — the previous callback still in flight — threw the
notification away: nothing re-armed, nothing re-notified. The doc comment
promised deferral; the code implemented a drop.

The callback is heavyweight (`Acquire → IndexManager().SyncLocked →
hub.broadcastStatus`), so after a `local_wins` merge it runs for many seconds
while the merged facts index and embed. Every `learn` commit landing in that
window lost its SSE `status` broadcast, and tabs held a stale `state.headCommit`
indefinitely. The store index stayed correct — the inline `im.Sync` in
`notifyCommit` is unaffected — which is why the server looked healthy while the
UI erred.

`running` now lives under the mutex with everything else, and a timer firing
mid-run leaves `pending` in place and returns; the in-flight run re-arms the
debounce timer when it finishes. The last head is always delivered. `Stop()`
keeps its semantics — flush unless `fn` is already running, so `fn` is still
never concurrent with itself.

## 2 — a LIVE view treated its cached head as authoritative

`useFactEdges` now reads a 404 in a **live** view as evidence about the anchor
rather than an answer: re-read the head, and if it actually moved, retry there
once and report the head upward so the rest of the app un-stales too. If the
head has not moved, the 404 is the real answer and is rendered — no retry loop.

Confined to live views on purpose: in history or diff mode the commit is the
user's pin, and re-anchoring it would break
`kb/invariants/ui/navigation/every-hop-is-path-plus-commit`.

`App` also re-polls the head every 30s. That is the belt-and-braces half — it
covers a stream that is merely lossy or dead, which no server fix reaches, and
it would have masked defect 1 entirely. `SET_HEAD` returns the same state for an
unchanged head, so a quiet repo re-renders nothing.

`api.explain`'s rejections now carry the HTTP status (added to a plain `Error`,
so `String(err)` is unchanged for every consumer that renders it) — without it a
404 is indistinguishable from a transport failure, and retrying the latter would
be wrong.

## 3 — lens routes had no fact sub-resources

`/lenses/{lens}/facts/{path}/incoming` matched the `facts/*` wildcard as the
literal path `…/<uuid>.md/incoming` and fell into the fact reader, which cannot
walk into a blob: HTTP 500 for every fact, deterministically. The web UI escaped
it only because `useFactEdges` fetches edges through the source mount's
repo-scoped route.

Only the lens fact handler knows how to resolve a `kb://<id12>/…` address, so
that is where the dispatch belongs. `splitFactSubResource` separates splitting
from dispatching because the lens route must strip the suffix **before**
addressing. The three sub-resource handlers now take the resolved
`*repos.RepoInstance` instead of `repos.RepoFromContext` — under `LensMiddleware`
that context value is the lens's *write* repo, the wrong mount for a qualified
path. 404s still echo the full requested path and stay byte-identical across
unknown mount / malformed `kb://` / missing fact, so the dispatch does not become
a mount-topology oracle.

## Deliberately out of scope

A fact path with some *other* trailing segment still 500s from the go-git tree
walk. That is a pre-existing wart on the repo route too, and mapping go-git's
"object not found" to a 404 would also mask genuine object-store corruption — it
needs its own decision, not a silent widening here.

## Verification

Each fix started from a test watched failing for the right reason.

- `go test ./internal/repos/` — ok (380.8s)
- `go test ./internal/web/` — ok (343.0s)
- `npx vitest run` — 1325/1326
- `go build ./...`, `go vet`, `tsc -b`, `eslint` on changed files — clean

One pre-existing failure, unrelated and unchanged by this branch:
`App.sse.test.tsx > after a resubscribe the new stream drives the app and the
old one is dead` fails identically on the unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4Fr2As3v1UZT1CiF7SE2J