### PR TITLE
fix(web): a pivot keeps the fact you are reading

### DIFF
--- a/web/src/state.motif.test.ts
+++ b/web/src/state.motif.test.ts
@@ -15,7 +15,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { reducer, init } from './state';
-import type { AppState } from './state';
+import type { AppState, FilterChip } from './state';
 
 const at = (over: Partial<AppState> = {}): AppState => ({
   ...init, repo: 'knomit-kb', branch: 'agent/test',
@@ -76,6 +76,21 @@ describe('PIVOT_MOTIF', () => {
       filters: [{ category: 'motif', value: MOTIF, returnPath: 'kb/gotchas' }],
     });
     expect(reducer(pinned, { type: 'PIVOT_MOTIF', motif: MOTIF })).toBe(pinned);
+  });
+
+  it('collapses a typed union even when the pivot names its first chip', () => {
+    // Motif chips accumulate when TYPED into the FilterBar (ADD_FILTER appends
+    // them), and two of them are a union — the one thing this arm exists to
+    // undo. Reading "is this already pinned?" off the first matching chip
+    // no-opped that collapse, and only when the reader had typed the pivoted
+    // shape FIRST: same gesture, opposite outcome, decided by typing order.
+    const union: FilterChip[] = [{ category: 'motif', value: 'a' }, { category: 'motif', value: 'b' }];
+    for (const filters of [union, [...union].reverse()]) {
+      const s = at({ filters });
+      const after = reducer(s, { type: 'PIVOT_MOTIF', motif: 'a' });
+      expect(after.filters).toEqual([{ category: 'motif', value: 'a' }]);
+      expect(after.navStack.length - s.navStack.length).toBe(1);
+    }
   });
 
   it('still pivots when the same motif is pinned but a path chip is there to drop', () => {

--- a/web/src/state.motif.test.ts
+++ b/web/src/state.motif.test.ts
@@ -25,7 +25,7 @@ const at = (over: Partial<AppState> = {}): AppState => ({
 const MOTIF = 'failure-presents-as-success';
 
 describe('PIVOT_MOTIF', () => {
-  it('sets the chip, drops path and the open fact in ONE arm, with exactly one push', () => {
+  it('sets the chip and drops path in ONE arm, with exactly one push', () => {
     const before = at({
       librarySort: 'path',
       factPath: 'kb/gotchas/store/testing/searchoptions-zero-limit/71123f5f.md',
@@ -38,10 +38,59 @@ describe('PIVOT_MOTIF', () => {
     // never saw, and the ≈ segment promises "go back": the chip that IS the
     // pivot carries where it came from, so leaving can honour the promise.
     expect(after.filters).toEqual([{ category: 'motif', value: MOTIF, returnPath: 'kb/gotchas' }]);
-    expect(after.factPath).toBeNull();
     // Exactly one — a delta, not "non-empty". Two dispatches for one intent is
     // the smell the invariant names; so is a move that pushes twice.
     expect(after.navStack.length - before.navStack.length).toBe(1);
+  });
+
+  it('leaves the open fact ALONE — the list that arrives decides whether it survives', () => {
+    // This arm used to clear factPath, on the grounds that the refetched list
+    // would select its own first row. Every list branch already does that, and
+    // only when the open fact did NOT survive the refetch (api.recent,
+    // api.search and the lens rows each hold the same guard), so the clear
+    // bought nothing and cost two bugs:
+    //
+    //   • Between the dispatch and the response the right panel had no fact
+    //     to draw, so the ontology dashboard FLASHED up in the middle of a
+    //     move that never meant to leave the fact.
+    //   • When the pivot changed no query at all — the same motif pinned
+    //     again from a carrier's own header — nothing refetched, so nothing
+    //     re-selected, and the dashboard stayed: a dead end reached by a
+    //     button that promised a list.
+    //
+    // Keeping it is also the better answer on the common path: you pivot on a
+    // motif OF the fact you are reading, so that fact is a carrier, is in the
+    // list, and reading it should not be interrupted to show you row 0.
+    const open = 'kb/gotchas/store/testing/searchoptions-zero-limit/71123f5f.md';
+    const after = reducer(at({ factPath: open }), { type: 'PIVOT_MOTIF', motif: MOTIF });
+    expect(after.factPath).toBe(open);
+  });
+
+  it('is a no-op when the motif asked for is the one already pinned', () => {
+    // Reached from a carrier's own header: the chip, the list and the fact are
+    // already what the button offers, so there is nothing to do and nothing to
+    // remember — pushing here would spend a Back press on a view that never
+    // changed. Same defence as EXIT_MOTIF's stray-dispatch arm below.
+    const pinned = at({
+      factPath: 'kb/gotchas/store/testing/searchoptions-zero-limit/71123f5f.md',
+      filters: [{ category: 'motif', value: MOTIF, returnPath: 'kb/gotchas' }],
+    });
+    expect(reducer(pinned, { type: 'PIVOT_MOTIF', motif: MOTIF })).toBe(pinned);
+  });
+
+  it('still pivots when the same motif is pinned but a path chip is there to drop', () => {
+    // Not a no-op: the chip set is the same shape, but the path narrows the
+    // list, so dropping it is a real change to what the reader is looking at
+    // — and the displaced folder has to be stashed for the exit.
+    const s = at({
+      filters: [
+        { category: 'motif', value: MOTIF },
+        { category: 'path', value: 'kb/gotchas' },
+      ],
+    });
+    const after = reducer(s, { type: 'PIVOT_MOTIF', motif: MOTIF });
+    expect(after.filters).toEqual([{ category: 'motif', value: MOTIF, returnPath: 'kb/gotchas' }]);
+    expect(after.navStack.length - s.navStack.length).toBe(1);
   });
 
   it('does NOT write librarySort — the mode the reader came from is the record', () => {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -474,8 +474,7 @@ function applyAction(s: AppState, a: Action): AppState {
       };
     case 'PIVOT_MOTIF': {
       // Everything the pivot changes, set in one arm: the chip that IS the
-      // query, the sort it must arrive in, and the open fact cleared so the
-      // refetched list selects its own first row. The
+      // query, and the path it displaces. The
       // motif chip REPLACES any previous one rather than accumulating — a
       // pivot is "show me this shape", and two motif chips widen, so keeping
       // the old one would silently return a union nobody asked for.
@@ -500,14 +499,32 @@ function applyAction(s: AppState, a: Action): AppState {
       // erasing the only record of where the reader came from. That is the
       // exact bug EXIT_SEARCH's comment describes, and it is why leaving a
       // pivot can now put an ontology browser back in the ontology.
+      //
+      // factPath is NOT cleared, and that is the whole of the fix for two
+      // faults that shared one cause. Clearing it here was justified by "the
+      // refetched list selects its own first row" — but every list branch
+      // already does that, and each does it only when the open fact did NOT
+      // survive the refetch (api.recent, api.search and the lens rows hold the
+      // same guard). So the clear decided nothing the fetch would not decide
+      // better, while owning the gap between the two: with no fact to draw,
+      // the right panel fell back to the ontology dashboard, which FLASHED up
+      // mid-pivot and then STAYED whenever the pivot changed no query — the
+      // same motif pinned again from a carrier's own header refetches nothing,
+      // so nothing ever re-selected. Leaving the fact alone is also the better
+      // answer on the common path: the motif was read off the open fact, so
+      // that fact is a carrier and the reader keeps their place.
       const pathChip = s.filters.find(f => f.category === 'path');
       const prevMotif = s.filters.find(f => f.category === 'motif');
+      // Nothing to do: this shape is already the query and there is no path to
+      // displace, so the only thing a rebuild would add is a Back press that
+      // returns to the identical view. EXIT_MOTIF guards its stray dispatch
+      // the same way.
+      if (prevMotif?.value === a.motif && !pathChip) return s;
       const filters = s.filters.filter(f => f.category !== 'motif' && f.category !== 'path');
       const returnPath = pathChip?.value ?? prevMotif?.returnPath;
       return {
         ...s,
         filters: [...filters, { category: 'motif' as const, value: a.motif, ...(returnPath ? { returnPath } : {}) }],
-        factPath: null,
         navStack: pushNav(s),
       };
     }

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -514,12 +514,20 @@ function applyAction(s: AppState, a: Action): AppState {
       // answer on the common path: the motif was read off the open fact, so
       // that fact is a carrier and the reader keeps their place.
       const pathChip = s.filters.find(f => f.category === 'path');
-      const prevMotif = s.filters.find(f => f.category === 'motif');
+      const motifChips = s.filters.filter(f => f.category === 'motif');
+      const prevMotif = motifChips[0];
       // Nothing to do: this shape is already the query and there is no path to
       // displace, so the only thing a rebuild would add is a Back press that
       // returns to the identical view. EXIT_MOTIF guards its stray dispatch
       // the same way.
-      if (prevMotif?.value === a.motif && !pathChip) return s;
+      //
+      // ONE motif chip, counted — not "the first motif chip happens to match".
+      // Chips typed into the FilterBar accumulate, so `motif:a` + `motif:b` is
+      // a reachable union, and a `.find()` here would read the union's FIRST
+      // member and no-op a pivot whose whole job is to collapse it: the reader
+      // asks for one shape, keeps two, and the answer depends on which order
+      // they typed them in. Collapsing is exactly what the arm below does.
+      if (motifChips.length === 1 && prevMotif.value === a.motif && !pathChip) return s;
       const filters = s.filters.filter(f => f.category !== 'motif' && f.category !== 'path');
       const returnPath = pathChip?.value ?? prevMotif?.returnPath;
       return {


### PR DESCRIPTION
Two faults reported against the motif pivot, one cause.

## The cause

`PIVOT_MOTIF` cleared `factPath`, justified by *"the refetched list selects its own first row"*. Every list branch already does that — `api.recent` (`Library.tsx:423`), `api.search` (`:468`) and the lens rows (`:556`) each hold the same guard, and each fires **only when the open fact did not survive the refetch**. So the clear decided nothing the fetch would not decide better, while owning the gap between the two: with no fact to draw, `RightPanel` falls back to the ontology dashboard.

- **Pivoting to a different motif** left that gap open for the length of the fetch — the dashboard flashed up mid-move.
- **Pivoting to the motif already pinned** (the `Open all N carriers` button in a carrier's own header) changes no query, so `filtersKey` / `path` / `effectiveSort` are unchanged, nothing refetched, nothing re-selected — and the dashboard *stayed*. A button promising a list landed the reader on the root summary.

## The change

`web/src/state.ts` — stop clearing `factPath`, and make the re-pivot a no-op outright (same motif, no path chip to displace: the chip, the list and the fact are already what the button offers, so a rebuild would only spend a Back press on an identical view — `EXIT_MOTIF` guards its stray dispatch the same way).

Side effect worth having: pivoting on a motif *of the fact you are reading* now keeps that fact open, since it is a carrier and is in the list that arrives.

## Evidence

Same instrumented click (MutationObserver + rAF sampling over 2s) against the running dev UI, before and after:

| | dashboard mounted | frames with no fact |
|---|---|---|
| before | yes | 4 |
| after | no | 0 |

The originally reported sequence — motif from the Shapes block → first carrier opens → motif in the fact chrome → `Open all 6 carriers` — now keeps the fact open, list intact, panel closed, no dashboard.

## Tests

`web/src/state.motif.test.ts`: three new cases (the fact survives a pivot; a same-motif re-pivot is a no-op; the same motif *with* a path chip still pivots and stashes the displaced folder). The old case's `expect(after.factPath).toBeNull()` is gone — it encoded the behaviour that caused both faults.

Suite: 1349 passed, 1 failed — `Library.keyboard.test.tsx > drives selection/navigation when live`, which fails identically on a clean tree in a full run and passes in isolation (known flake). `tsc --noEmit` clean; no new lint findings in either file.

Web-only — the pivot's REST answers were correct throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)