### PR TITLE
A lens has one motif vocabulary

### DIFF
--- a/internal/federate/motifs.go
+++ b/internal/federate/motifs.go
@@ -1,0 +1,354 @@
+package federate
+
+import (
+	"context"
+	"sort"
+
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// The lens-wide motif vocabulary: every mount's clusters merged into one.
+//
+// A motif cluster_key is a MECHANICAL function of a spelling (store's
+// groupingKey: canonicalize → tokenize → sort → join), so the same key names
+// the same shape in every repo and merging by key is sound. It is not
+// SUFFICIENT, though: a judge merge is per-branch, so one mount can have pulled
+// `quiet-degradation` under the key `fallback-silent` while another still keys
+// it `degradation-quiet`. Merging by key alone would then emit that one
+// spelling in two rows of one vocabulary, and the two rows would answer
+// different queries from names the reader cannot tell apart.
+//
+// So per-mount clusters are unioned TRANSITIVELY: two clusters are the same
+// cluster when they share a cluster_key OR share any member spelling (within a
+// mount a spelling belongs to exactly one cluster, so a shared spelling is
+// evidence the two are one shape).
+//
+// THIS LIVES IN federate, not in a consumer, because two surfaces answer motif
+// queries against a lens — the REST /lenses/{lens}/{facts,search,motifs} and
+// the MCP knomit_query fan-out — and a second implementation kept in step is
+// exactly the failure the union exists to prevent. The web surface shipped the
+// widening first and MCP did not, which left the most-used motif path (recall)
+// still dropping mounts; one definition here is what makes that impossible to
+// repeat.
+
+// MotifGroup is one merged cluster: what every mount contributed about one
+// shape, resolved into a single row.
+type MotifGroup struct {
+	// keys is every constituent cluster key, from every mount. The merged
+	// cluster is addressed by the smallest of them (see Key).
+	keys    map[string]bool
+	members map[string]bool
+	// DF / DFTotal are per-mount SUMS. Mounts are distinct repos, but distinct
+	// is not disjoint: a re-rooted fork mounted beside its upstream shares
+	// server-generated fact UUIDs, so one fact can be counted twice. That is
+	// the same accepted over-count the lens /stats histograms make, for the
+	// same reason — an aggregate carries no per-fact paths to dedupe on.
+	DF      int
+	DFTotal int
+	// Canonical is ELECTED, mirroring store.electCanonical at the granularity
+	// a merged view has: the representative of the highest-df constituent,
+	// ties broken lexicographically. Deterministic, and independent of the
+	// order mounts were added in.
+	Canonical string
+	bestDF    int
+	// mountKeys[ri] is the set of keys THAT MOUNT contributed, which is not
+	// the same set as keys and must not be confused with it. keys is the union
+	// across mounts, so it holds keys this mount never used — and a key another
+	// mount coined can perfectly well name an UNRELATED cluster here, since a
+	// cluster key is a mechanical function of a spelling and two corpora can
+	// both hold that spelling in different company. Anything asking "did THIS
+	// mount file this row under THIS cluster" has to read the per-mount set.
+	mountKeys map[*repos.RepoInstance]map[string]bool
+}
+
+// Key is the merged cluster's identity: the lexicographically smallest
+// constituent key.
+//
+// Smallest rather than, say, the highest-df mount's, because a cluster key is
+// what definitions and URLs hang off and the store's own rule is that it must
+// be STABLE UNDER DF CHANGE. min() is that, is deterministic, does not depend
+// on mount order, and for a lens over one repo is that repo's own key — so a
+// lens of one reports the vocabulary of the repo it wraps, unchanged.
+func (g *MotifGroup) Key() string {
+	key := ""
+	for k := range g.keys {
+		if key == "" || k < key {
+			key = k
+		}
+	}
+	return key
+}
+
+// Members is every spelling in the merged cluster, sorted.
+func (g *MotifGroup) Members() []string {
+	out := make([]string, 0, len(g.members))
+	for m := range g.members {
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ContributedKey reports whether ri filed this merged cluster under key. Use it
+// — never the union's key set — when attributing per-mount state (an alias
+// row's audit trail, say) to a merged row.
+func (g *MotifGroup) ContributedKey(ri *repos.RepoInstance, key string) bool {
+	return g.mountKeys[ri][key]
+}
+
+// MotifUnion merges per-mount vocabularies into one lens-wide vocabulary.
+//
+// Union-find over group indices: byKey and byMember can point at an absorbed
+// group, and find() walks to the survivor. Absorption always goes into the
+// LOWER index, so the result does not depend on which order two groups happened
+// to meet.
+type MotifUnion struct {
+	groups   []*MotifGroup
+	parent   []int
+	byKey    map[string]int
+	byMember map[string]int
+}
+
+// NewMotifUnion returns an empty union.
+func NewMotifUnion() *MotifUnion {
+	return &MotifUnion{byKey: map[string]int{}, byMember: map[string]int{}}
+}
+
+func (u *MotifUnion) find(i int) int {
+	for u.parent[i] != i {
+		u.parent[i] = u.parent[u.parent[i]]
+		i = u.parent[i]
+	}
+	return i
+}
+
+// absorb folds group b into group a (a < b), applying every election rule.
+func (u *MotifUnion) absorb(a, b int) {
+	ga, gb := u.groups[a], u.groups[b]
+	for k := range gb.keys {
+		ga.keys[k] = true
+	}
+	for m := range gb.members {
+		ga.members[m] = true
+	}
+	for ri, keys := range gb.mountKeys {
+		if ga.mountKeys[ri] == nil {
+			ga.mountKeys[ri] = map[string]bool{}
+		}
+		for k := range keys {
+			ga.mountKeys[ri][k] = true
+		}
+	}
+	ga.DF += gb.DF
+	ga.DFTotal += gb.DFTotal
+	if gb.bestDF > ga.bestDF || (gb.bestDF == ga.bestDF && gb.Canonical < ga.Canonical) {
+		ga.Canonical, ga.bestDF = gb.Canonical, gb.bestDF
+	}
+	u.parent[b] = a
+	u.groups[b] = nil
+}
+
+// Add folds one mount's cluster into the union.
+func (u *MotifUnion) Add(ri *repos.RepoInstance, c store.MotifCluster) {
+	g := &MotifGroup{
+		keys:      map[string]bool{c.ClusterKey: true},
+		members:   map[string]bool{},
+		DF:        c.DF,
+		DFTotal:   c.DFTotal,
+		Canonical: c.CanonicalID,
+		bestDF:    c.DF,
+		mountKeys: map[*repos.RepoInstance]map[string]bool{ri: {c.ClusterKey: true}},
+	}
+	for _, m := range c.Members {
+		g.members[m] = true
+	}
+	idx := len(u.groups)
+	u.groups = append(u.groups, g)
+	u.parent = append(u.parent, idx)
+
+	// Every existing group this cluster touches, by key or by any spelling.
+	touched := map[int]bool{}
+	if i, ok := u.byKey[c.ClusterKey]; ok {
+		touched[u.find(i)] = true
+	}
+	for _, m := range c.Members {
+		if i, ok := u.byMember[m]; ok {
+			touched[u.find(i)] = true
+		}
+	}
+	root := idx
+	for other := range touched {
+		a, b := min(root, other), max(root, other)
+		if a == b {
+			continue
+		}
+		u.absorb(a, b)
+		root = a
+	}
+	// Re-point every index this group owns at the survivor. Cheap, and it
+	// keeps find() shallow.
+	g = u.groups[root]
+	for k := range g.keys {
+		u.byKey[k] = root
+	}
+	for m := range g.members {
+		u.byMember[m] = root
+	}
+}
+
+// Groups returns the merged vocabulary in the store's own order (df-desc,
+// canonical-asc), so a merged list is ordered exactly as a per-repo one is.
+func (u *MotifUnion) Groups() []*MotifGroup {
+	out := make([]*MotifGroup, 0, len(u.groups))
+	for i, g := range u.groups {
+		if g == nil || u.find(i) != i {
+			continue
+		}
+		out = append(out, g)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].DF != out[j].DF {
+			return out[i].DF > out[j].DF
+		}
+		return out[i].Canonical < out[j].Canonical
+	})
+	return out
+}
+
+// Lookup resolves a raw term to a merged group. It accepts the merged cluster
+// key, ANY mount's constituent key, and any member spelling — all three name
+// the same cluster, and a reader arriving from a repo-scoped link holds the
+// second kind.
+func (u *MotifUnion) Lookup(raw string) (*MotifGroup, bool) {
+	if i, ok := u.byKey[raw]; ok {
+		return u.groups[u.find(i)], true
+	}
+	if i, ok := u.byMember[raw]; ok {
+		return u.groups[u.find(i)], true
+	}
+	return nil, false
+}
+
+// ExpandTerms widens caller-supplied motif terms to the whole merged cluster
+// each one names.
+//
+// A term in no cluster is left alone — its own singleton, which is what the
+// store does with it too. Order-preserving and duplicate-free: two terms in one
+// cluster (two chips a reader widened with) must not send the same spelling
+// twice.
+func (u *MotifUnion) ExpandTerms(terms []string) []string {
+	seen := make(map[string]bool, len(terms))
+	out := make([]string, 0, len(terms))
+	add := func(s string) {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	for _, term := range terms {
+		g, found := u.Lookup(term)
+		if !found {
+			add(term)
+			continue
+		}
+		for _, m := range g.Members() {
+			add(m)
+		}
+	}
+	return out
+}
+
+// MotifClusterReader reads one mount's resolved motif vocabulary. Both
+// consumers already have a seam for this — the web handlers' motifsProvider and
+// MCP's ri.WithRead — so the union takes the read as a function rather than
+// growing an interface each caller would have to satisfy twice.
+type MotifClusterReader func(ctx context.Context, rt repos.ReadTarget) ([]store.MotifCluster, error)
+
+// BuildMotifUnion reads every target's vocabulary and merges it.
+//
+// Any mount error fails the WHOLE call (RFC §9.1 — a lens never silently
+// shrinks its read set): a union missing a mount is a smaller vocabulary
+// presented as the whole one, which no field in any response is allowed to
+// disclose.
+func BuildMotifUnion(ctx context.Context, targets []Target, read MotifClusterReader) (*MotifUnion, error) {
+	u := NewMotifUnion()
+	for _, t := range targets {
+		clusters, err := read(ctx, t.RT)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range clusters {
+			u.Add(t.RT.RI, c)
+		}
+	}
+	return u, nil
+}
+
+// ExpandMotifTerms widens a caller's motif terms to the binding's MERGED
+// clusters, so every mount is asked about the whole shape rather than about one
+// mount's name for it.
+//
+// THIS IS THE CORRECTNESS SEAM FOR EVERY MOTIF-FILTERED LENS READ, and without
+// it a lens query silently drops mounts its own vocabulary counted. The store's
+// exact tier is per-branch canonical equality (store.expandMotifQuery): a term
+// resolves through THAT branch's alias table, and a mount that carries the
+// cluster under a different spelling — because the canonical is ELECTED per
+// branch, and a judge merge is per-branch — resolves the term to itself, finds
+// no member with that canonical, and contributes ZERO facts. A row reading
+// "df 7" then answers with 5.
+//
+// SEMANTICS THIS ESTABLISHES, stated because it is a real behaviour change and
+// compresses into a falsehood if left implicit: a judge merge on ANY mount
+// changes what a motif term returns for the WHOLE lens. Read through a lens,
+// the mounts share one vocabulary, exactly as one repo's folders share one —
+// which is what "a lens answers like a single repo" means when the question is
+// about motifs. It is READ-ONLY: no mount's alias table, canonical election or
+// verdict history is touched, and the same repo read directly still answers
+// with its own vocabulary alone.
+//
+// Expansion runs over the FULL read set, branch-wide, and callers must not pass
+// a path- or repo-narrowed target list. Cluster identity is a property of the
+// LENS, and a term minted from the whole vocabulary has to keep meaning the
+// same shape when the list under it is narrowed — resolving through a narrowed
+// union re-runs the exact bug this fixes, since the excluded mount may be the
+// one spelling it differently.
+//
+// FAILURE COUPLING, new with this and worth knowing: because the read set is
+// always the full one, a mount the caller EXCLUDED with repo= can still fail
+// the request. That follows from the term being lens-wide (§9.1 says a lens
+// never answers from a shrunken read set), but it is a coupling that did not
+// exist before — a narrowed query used not to touch the mounts it narrowed
+// away.
+//
+// ONE MOUNT IS SKIPPED, and that is a semantic choice, not an optimisation.
+// Widening there would NOT be a no-op: a single branch's ClustersUnder already
+// groups mechanically-equal spellings into one cluster (`config-drift` and
+// `drift-config` sort to the same key), while the store's exact tier resolves a
+// bare term through per-spelling canonicals — so on an unrebuilt corpus a
+// widened term would reach cluster siblings that the same repo, read directly,
+// does not. A lens over one repo must answer EXACTLY like that repo, so the
+// widening starts at two mounts, where the union is the only thing that can say
+// which spellings are one shape.
+//
+// Which does mean a lens over two mounts is looser at the exact tier than one
+// repo is, on a corpus whose aliases have never been rebuilt. That is the same
+// semantics stated above, seen from the other side: the union is the lens's
+// vocabulary, and it says those spellings are one shape.
+func ExpandMotifTerms(ctx context.Context, b *repos.Binding, read MotifClusterReader, terms []string) ([]string, error) {
+	if len(terms) == 0 || read == nil {
+		return terms, nil
+	}
+	targets, err := ReadTargetsFor(b, "")
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) <= 1 {
+		return terms, nil
+	}
+	u, err := BuildMotifUnion(ctx, targets, read)
+	if err != nil {
+		return nil, err
+	}
+	return u.ExpandTerms(terms), nil
+}

--- a/internal/federate/motifs.go
+++ b/internal/federate/motifs.go
@@ -265,18 +265,39 @@ func (u *MotifUnion) ExpandTerms(terms []string) []string {
 // growing an interface each caller would have to satisfy twice.
 type MotifClusterReader func(ctx context.Context, rt repos.ReadTarget) ([]store.MotifCluster, error)
 
+// MotifReadError names the mount whose vocabulary read failed.
+//
+// The mount has to travel with the error because the consumers' error responses
+// are ABOUT the mount: the web layer turns store.ErrBranchNotFound into a 404
+// reading `no branch named "<branch>"`, and a fan-out that dropped the branch
+// would render that message as `no branch named ""` in exactly the case it
+// exists for — a mount pinned to a deleted branch. Unwrap keeps errors.Is
+// working through it, so the sentinel checks downstream are unaffected.
+type MotifReadError struct {
+	Repo   string
+	Branch string
+	Err    error
+}
+
+func (e *MotifReadError) Error() string {
+	return "motif vocabulary read failed on mount " + e.Repo + "@" + e.Branch + ": " + e.Err.Error()
+}
+
+func (e *MotifReadError) Unwrap() error { return e.Err }
+
 // BuildMotifUnion reads every target's vocabulary and merges it.
 //
 // Any mount error fails the WHOLE call (RFC §9.1 — a lens never silently
 // shrinks its read set): a union missing a mount is a smaller vocabulary
 // presented as the whole one, which no field in any response is allowed to
-// disclose.
+// disclose. The failure is returned as *MotifReadError so the caller can name
+// the mount it came from.
 func BuildMotifUnion(ctx context.Context, targets []Target, read MotifClusterReader) (*MotifUnion, error) {
 	u := NewMotifUnion()
 	for _, t := range targets {
 		clusters, err := read(ctx, t.RT)
 		if err != nil {
-			return nil, err
+			return nil, &MotifReadError{Repo: t.RT.RI.Name(), Branch: t.RT.Branch, Err: err}
 		}
 		for _, c := range clusters {
 			u.Add(t.RT.RI, c)

--- a/internal/mcp/query.go
+++ b/internal/mcp/query.go
@@ -113,7 +113,7 @@ func queryTool() mcpgo.Tool {
 			mcpgo.WithStringItems(),
 		),
 		mcpgo.WithArray("motifs",
-			mcpgo.Description("Filter by motif — the general regularity a fact instantiates (mechanism, failure shape, pattern), independent of its subject. Use to find facts about DIFFERENT subjects that exemplify the same thing."),
+			mcpgo.Description("Filter by motif — the general regularity a fact instantiates (mechanism, failure shape, pattern), independent of its subject. Use to find facts about DIFFERENT subjects that exemplify the same thing. Through a lens the mounts share ONE motif vocabulary, so a term reaches every spelling any mount groups with it, on every mount."),
 			mcpgo.WithStringItems(),
 		),
 		mcpgo.WithString("motif_match",

--- a/internal/mcp/query.go
+++ b/internal/mcp/query.go
@@ -251,6 +251,10 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 	if msg := motifMatchUnavailable(q); msg != "" {
 		return mcpgo.NewToolResultError(msg), nil
 	}
+	// Widen motif terms to the lens's merged clusters BEFORE the fan-out.
+	if err := widenMotifsForLens(ctx, b, &q); err != nil {
+		return mcpgo.NewToolResultError(err.Error()), nil
+	}
 	targets, err := federate.ReadTargetsFor(b, q.Path)
 	if err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
@@ -362,6 +366,41 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 	return queryResume(ctx, b, sWrite, sess.ID, pageSize, includeBody)
 }
 
+// mcpMotifClusters reads one mount's resolved motif vocabulary — the union's
+// per-mount read, in MCP's own store-acquisition idiom.
+//
+// Branch-wide (no path scope): cluster identity is a property of the lens, not
+// of the path filter the caller happened to send.
+func mcpMotifClusters(ctx context.Context, rt repos.ReadTarget) ([]store.MotifCluster, error) {
+	s, release, err := storeIndices(rt.RI)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return s.motifs.ClustersUnder(ctx, rt.Branch, "")
+}
+
+// widenMotifsForLens replaces each caller-supplied motif term with every
+// spelling in its MERGED cluster, so a lens-bound query asks every mount about
+// the whole shape rather than about one mount's name for it.
+//
+// The SAME seam the REST lens reads go through (federate.ExpandMotifTerms), and
+// deliberately not a second implementation: without it a motif-filtered
+// knomit_query against a lens silently drops every mount that spells the shape
+// differently — the store's exact tier is per-branch canonical equality, and a
+// judge merge is per-branch. That makes recall, the most-used motif path,
+// answer from a smaller read set than the lens has, which is precisely what
+// RFC §9.1 forbids. A single-mount binding is skipped: with nothing to merge
+// the expansion is provably an identity.
+func widenMotifsForLens(ctx context.Context, b *repos.Binding, q *store.SearchOptions) error {
+	widened, err := federate.ExpandMotifTerms(ctx, b, mcpMotifClusters, q.Motifs)
+	if err != nil {
+		return err
+	}
+	q.Motifs = widened
+	return nil
+}
+
 // parseQueryFilters reads the shared filter arguments into SearchOptions.
 // Limit is set by the caller per mode.
 func parseQueryFilters(req mcpgo.CallToolRequest) (store.SearchOptions, error) {
@@ -421,6 +460,12 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 	}
 	if !hasAnyFilter(q) {
 		return mcpgo.NewToolResultError("at least one of text, entities, domain, applies_to, path, type, origin, motifs, or min_confidence is required"), nil
+	}
+	// Widen motif terms to the lens's merged clusters BEFORE the fan-out. After
+	// hasAnyFilter, so the "no filter supplied" message stays about what the
+	// caller actually sent.
+	if err := widenMotifsForLens(ctx, b, &q); err != nil {
+		return mcpgo.NewToolResultError(err.Error()), nil
 	}
 	targets, err := federate.ReadTargetsFor(b, q.Path)
 	if err != nil {

--- a/internal/mcp/query_motif_federation_test.go
+++ b/internal/mcp/query_motif_federation_test.go
@@ -169,3 +169,50 @@ func TestQueryFederation_TwoMountsResolveThroughTheUnionsVocabulary(t *testing.T
 	titles := queryTitles(t, text)
 	require.Len(t, titles, 2, "both spellings are one shape once a union exists: %s", text)
 }
+
+// §9.1 ON THE WIDENING PATH: a mount that cannot be read while a motif term is
+// being resolved fails the WHOLE query.
+//
+// This is the rule everywhere else in the fan-out, but the widening is where it
+// bites hardest and where it was going unpinned: a lens must never answer a
+// motif query from a smaller read set than it has, and an unreadable mount is
+// precisely a mount whose contribution is unknown. Answering anyway would hand
+// back a plausible, smaller result with nothing on it to say so — the failure
+// mode the whole no-federation-metadata decision is built around.
+//
+// The mount is broken by pinning it to a branch that does not exist, which is
+// the realistic version of this (a lens outliving a deleted branch), and the
+// message has to NAME it — that is what federate.MotifReadError carries.
+//
+// WHICH ASSERTION IS LOAD-BEARING: the message one. A broken mount is read
+// twice on this path — once to resolve the term, once by the fan-out — so
+// IsError stays true even if the widening never touched it, and on its own that
+// check cannot tell the two apart. Naming the mount is what distinguishes them:
+// the widening's failure is a federate.MotifReadError carrying repo@branch,
+// while the fan-out's is a bare "RecentFacts: branch ... not found". Verified
+// against the write-mount-only mutant, which leaves IsError true and fails on
+// exactly these two lines.
+func TestQueryFederation_MotifWideningFailureFailsTheWholeQuery(t *testing.T) {
+	repoA, ctxA := fedRepo(t)
+	repoB, _ := fedRepo(t)
+	seedMotifFact(t, ctxA, "seed-a", "AlphaCarrier", []any{"config-drift"})
+
+	b := repos.NewBindingForTest(repoA,
+		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
+		repos.ReadTarget{RI: repoB, Branch: "no/such/branch"},
+	)
+
+	for _, sort := range []string{"recent", "relevance"} {
+		t.Run(sort, func(t *testing.T) {
+			result, text := queryVia(t, b, map[string]any{
+				"motifs": []any{"config-drift"}, "motif_match": "exact", "sort": sort,
+			})
+			require.Truef(t, result.IsError,
+				"an unreadable mount must fail the query, not shrink the read set silently: %s", text)
+			// Naming the mount is the difference between a diagnosable failure
+			// and "something went wrong somewhere in your lens".
+			require.Contains(t, text, repoB.Name(), "the failure must name the mount: %s", text)
+			require.Contains(t, text, "no/such/branch", "the failure must name the branch: %s", text)
+		})
+	}
+}

--- a/internal/mcp/query_motif_federation_test.go
+++ b/internal/mcp/query_motif_federation_test.go
@@ -184,14 +184,19 @@ func TestQueryFederation_TwoMountsResolveThroughTheUnionsVocabulary(t *testing.T
 // the realistic version of this (a lens outliving a deleted branch), and the
 // message has to NAME it — that is what federate.MotifReadError carries.
 //
-// WHICH ASSERTION IS LOAD-BEARING: the message one. A broken mount is read
-// twice on this path — once to resolve the term, once by the fan-out — so
-// IsError stays true even if the widening never touched it, and on its own that
-// check cannot tell the two apart. Naming the mount is what distinguishes them:
-// the widening's failure is a federate.MotifReadError carrying repo@branch,
-// while the fan-out's is a bare "RecentFacts: branch ... not found". Verified
-// against the write-mount-only mutant, which leaves IsError true and fails on
-// exactly these two lines.
+// WHICH ASSERTION IS LOAD-BEARING, because it is none of the obvious ones. A
+// broken mount is read TWICE on this path — once to resolve the term, once by
+// the fan-out — so under a mutant where the widening never touches it the query
+// still errors, from RecentFacts, and IsError stays true. Nor does asserting
+// the branch discriminate: the fan-out's own message is
+// `RecentFacts: branch "no/such/branch": branch not found`, which carries it
+// verbatim. And the repo NAME is worthless here — these fixtures name every
+// repo "test", four characters that also sit inside the healthy mount's
+// agent/test.
+//
+// Only federate.MotifReadError's own prefix can distinguish them, because only
+// the widening produces it. That is what is asserted, and the write-mount-only
+// mutant dies on exactly that line.
 func TestQueryFederation_MotifWideningFailureFailsTheWholeQuery(t *testing.T) {
 	repoA, ctxA := fedRepo(t)
 	repoB, _ := fedRepo(t)
@@ -209,10 +214,14 @@ func TestQueryFederation_MotifWideningFailureFailsTheWholeQuery(t *testing.T) {
 			})
 			require.Truef(t, result.IsError,
 				"an unreadable mount must fail the query, not shrink the read set silently: %s", text)
-			// Naming the mount is the difference between a diagnosable failure
-			// and "something went wrong somewhere in your lens".
-			require.Contains(t, text, repoB.Name(), "the failure must name the mount: %s", text)
-			require.Contains(t, text, "no/such/branch", "the failure must name the branch: %s", text)
+			// The widening's own error, which nothing else on this path can
+			// produce — this is the line that says the term was resolved
+			// against the whole read set rather than part of it.
+			require.Containsf(t, text, "motif vocabulary read failed on mount",
+				"the failure must come from the widening, not merely from the later fan-out: %s", text)
+			// ...and it must be diagnosable: which mount, at which branch.
+			require.Containsf(t, text, repoB.Name()+"@no/such/branch",
+				"the failure must name the mount and its branch: %s", text)
 		})
 	}
 }

--- a/internal/mcp/query_motif_federation_test.go
+++ b/internal/mcp/query_motif_federation_test.go
@@ -1,0 +1,171 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/repos"
+)
+
+// The MCP twin of the REST lens-motif regression. knomit_query is the
+// most-used motif path there is — recall runs through it — and it fans out over
+// the same mounts the REST reads do, so it needs the same widening or a
+// lens-bound motif filter answers from a smaller read set than the lens has.
+//
+// The divergence here needs no judge merge, which is what makes it a fair test
+// of the ordinary case rather than of an exotic one. A cluster key is the
+// SORTED stemmed tokens of a spelling, so `config-drift` and `drift-config` are
+// mechanically ONE cluster in every repo — but the representative spelling is
+// ELECTED per branch from what that branch carries. Mount A carries only
+// `config-drift` and elects it; mount B carries only `drift-config` and elects
+// that. The store's exact tier is per-branch canonical equality, so a query for
+// `config-drift` resolves on B to itself, matches no spelling whose canonical
+// equals it, and B contributes nothing at all.
+
+// seedMotifFact writes one fact carrying exactly the given motifs into the repo
+// bound to ctx, and returns nothing — these tests assert on titles.
+func seedMotifFact(t *testing.T, ctx context.Context, moment, title string, motifs []any) {
+	t.Helper()
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{
+		"moment_name": moment,
+		"facts": []any{
+			map[string]any{
+				"topic":      "principles",
+				"category":   "mission/store",
+				"title":      title,
+				"body":       "designer authored " + title + " with a motif.",
+				"kind":       "pragmatic",
+				"type":       "policy",
+				"domain":     []any{"store"},
+				"confidence": 0.8,
+				"sources":    1,
+				"entities":   []any{"designer"},
+				"motifs":     motifs,
+				"refs":       []any{},
+			},
+		},
+	}
+	result, err := LearnHandler()(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Falsef(t, result.IsError, "seed failed: %s", resultText(t, result))
+}
+
+// divergentMotifLens builds the two mounts described above and returns a lens
+// binding over both (write = A).
+func divergentMotifLens(t *testing.T) *repos.Binding {
+	t.Helper()
+	repoA, ctxA := fedRepo(t)
+	repoB, ctxB := fedRepo(t)
+	seedMotifFact(t, ctxA, "seed-a", "AlphaCarrier", []any{"config-drift"})
+	seedMotifFact(t, ctxB, "seed-b", "BravoCarrier", []any{"drift-config"})
+	return repos.NewBindingForTest(repoA,
+		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
+		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
+	)
+}
+
+func queryTitles(t *testing.T, text string) map[string]bool {
+	t.Helper()
+	var resp queryResponse
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+	titles := map[string]bool{}
+	for _, f := range resp.Facts {
+		titles[f.Title] = true
+	}
+	return titles
+}
+
+// THE REGRESSION, recency path. Both mounts carry the shape; both must answer.
+func TestQueryFederation_MotifTermReachesEveryMount_Recent(t *testing.T) {
+	b := divergentMotifLens(t)
+	result, text := queryVia(t, b, map[string]any{
+		"motifs": []any{"config-drift"}, "motif_match": "exact", "sort": "recent",
+	})
+	require.Falsef(t, result.IsError, "query failed: %s", text)
+
+	titles := queryTitles(t, text)
+	require.True(t, titles["AlphaCarrier"], "the electing mount's carrier is missing: %s", text)
+	require.True(t, titles["BravoCarrier"],
+		"the mount that spells the shape differently contributed nothing — the lens answered from a smaller read set than it has: %s", text)
+}
+
+// The relevance path fans out separately (queryFirstCall, RRF-fused), so it
+// needs its own assertion — the same defect with a different envelope.
+func TestQueryFederation_MotifTermReachesEveryMount_Relevance(t *testing.T) {
+	b := divergentMotifLens(t)
+	result, text := queryVia(t, b, map[string]any{
+		"motifs": []any{"config-drift"}, "motif_match": "exact",
+	})
+	require.Falsef(t, result.IsError, "query failed: %s", text)
+
+	titles := queryTitles(t, text)
+	require.True(t, titles["AlphaCarrier"], "the electing mount's carrier is missing: %s", text)
+	require.True(t, titles["BravoCarrier"],
+		"the mount that spells the shape differently contributed nothing: %s", text)
+}
+
+// Naming the OTHER mount's spelling is the same query — the term names a shape,
+// and which spelling the caller happened to hold does not change which facts
+// carry it.
+func TestQueryFederation_EitherSpellingNamesTheSameShape(t *testing.T) {
+	b := divergentMotifLens(t)
+	_, text := queryVia(t, b, map[string]any{
+		"motifs": []any{"drift-config"}, "motif_match": "exact", "sort": "recent",
+	})
+	titles := queryTitles(t, text)
+	require.True(t, titles["AlphaCarrier"], "asking by the read mount's spelling lost the write mount: %s", text)
+	require.True(t, titles["BravoCarrier"], "asking by its own spelling lost the read mount: %s", text)
+}
+
+// A term in no cluster is passed through unchanged — its own singleton, which
+// is what the store does with it too. It must not become an empty filter that
+// quietly matches everything.
+func TestQueryFederation_UnknownMotifTermMatchesNothing(t *testing.T) {
+	b := divergentMotifLens(t)
+	_, text := queryVia(t, b, map[string]any{
+		"motifs": []any{"nothing-like-this"}, "motif_match": "exact", "sort": "recent",
+	})
+	titles := queryTitles(t, text)
+	require.Empty(t, titles, "an unknown motif must select nothing, not everything: %s", text)
+}
+
+// A binding over ONE mount is skipped by the widening, and the answer is the
+// repo's own. This is NOT a free assertion: widening a single mount would not
+// be a no-op — ClustersUnder groups `config-drift` and `drift-config` into one
+// cluster (same sorted tokens) while the store's exact tier resolves a bare
+// term through per-spelling canonicals, so a widened term would reach a sibling
+// the repo read directly does not. A lens over one repo must answer exactly
+// like that repo, which is what this pins.
+func TestQueryFederation_MotifWideningIsSkippedForOneMount(t *testing.T) {
+	repoA, ctxA := fedRepo(t)
+	seedMotifFact(t, ctxA, "seed-a", "AlphaCarrier", []any{"config-drift"})
+	seedMotifFact(t, ctxA, "seed-a2", "AlphaOther", []any{"drift-config"})
+	b := repos.NewBindingForTest(repoA, repos.ReadTarget{RI: repoA, Branch: "agent/test"})
+
+	_, text := queryVia(t, b, map[string]any{
+		"motifs": []any{"config-drift"}, "motif_match": "exact", "sort": "recent",
+	})
+	titles := queryTitles(t, text)
+	require.True(t, titles["AlphaCarrier"], "the repo's own resolution was disturbed: %s", text)
+	require.False(t, titles["AlphaOther"],
+		"a single mount answered for a cluster sibling — the widening ran where a lens must answer exactly like the repo it wraps: %s", text)
+}
+
+// And the other side of that boundary, stated so it cannot be read as an
+// accident: over TWO mounts the union IS the vocabulary, so a term reaches
+// every spelling the union calls one shape — looser, at the exact tier, than a
+// single unrebuilt repo would be. That is the federation semantics, not a leak.
+func TestQueryFederation_TwoMountsResolveThroughTheUnionsVocabulary(t *testing.T) {
+	b := divergentMotifLens(t)
+	_, text := queryVia(t, b, map[string]any{
+		"motifs": []any{"config-drift"}, "motif_match": "exact", "sort": "recent",
+	})
+	titles := queryTitles(t, text)
+	require.Len(t, titles, 2, "both spellings are one shape once a union exists: %s", text)
+}

--- a/internal/web/handlers_lenses_motifs.go
+++ b/internal/web/handlers_lenses_motifs.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -155,7 +156,17 @@ func expandLensMotifs(
 	}
 	out, err := federate.ExpandMotifTerms(r.Context(), bind, read, terms)
 	if err != nil {
-		writeStoreError(w, r, err, "Failed to resolve motif filter", "")
+		// The failing mount's branch, not "": writeStoreError renders
+		// store.ErrBranchNotFound as `no branch named "<branch>"`, and this is
+		// the fan-out where a mount pinned to a deleted branch actually shows
+		// up. An empty branch there would print the message with the one word
+		// it exists to carry missing.
+		var readErr *federate.MotifReadError
+		branch := ""
+		if errors.As(err, &readErr) {
+			branch = readErr.Branch
+		}
+		writeStoreError(w, r, err, "Failed to resolve motif filter", branch)
 		return nil, false
 	}
 	return out, true

--- a/internal/web/handlers_lenses_motifs.go
+++ b/internal/web/handlers_lenses_motifs.go
@@ -1,9 +1,9 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"net/url"
-	"sort"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -14,61 +14,40 @@ import (
 	"knomit/internal/web/hal"
 )
 
-// ─── the union ───────────────────────────────────────────────────────────────
-//
-// A motif cluster_key is a MECHANICAL function of a spelling (store's
-// groupingKey: canonicalize → tokenize → sort → join), so the same key names
-// the same shape in every repo and merging by key is sound. It is not
-// SUFFICIENT, though: a judge merge is per-branch, so one mount can have pulled
-// `quiet-degradation` under the key `fallback-silent` while another still keys
-// it `degradation-quiet`. Merging by key alone would then emit that one
-// spelling in two rows of one vocabulary, and the two rows would pivot to
-// different lists from names the reader cannot tell apart.
-//
-// So per-mount clusters are unioned TRANSITIVELY: two clusters are the same
-// cluster when they share a cluster_key OR share any member spelling (within a
-// mount a spelling belongs to exactly one cluster, so a shared spelling is
-// evidence the two are one shape). That rule is also what makes the pivot
-// correct by construction — the merged member list IS the `motifs=` CSV the
-// detail's _links.facts sends, and every mount expands that union against its
-// own alias table, which is exactly what the lens search/facts fan-out already
-// does with a caller-supplied motif filter.
+// The lens-wide motif vocabulary lives in internal/federate (MotifUnion), not
+// here, because TWO surfaces answer motif queries against a lens: this REST
+// group and the MCP knomit_query fan-out. This file holds only what is a
+// rendering concern — the definition election and the pooled health block —
+// and reaches for federate for everything that decides which spellings are one
+// shape.
 
-// motifGroup is one merged cluster under construction.
-type motifGroup struct {
-	// keys is every constituent cluster key, from every mount. The merged
-	// cluster is addressed by the smallest of them (see clusterKey).
-	keys    map[string]bool
-	members map[string]bool
-	// df / dfTotal are per-mount SUMS. Mounts are distinct repos, but distinct
-	// is not disjoint: a re-rooted fork mounted beside its upstream shares
-	// server-generated fact UUIDs, so one fact can be counted twice. That is
-	// the same accepted over-count the /lenses/{lens}/stats histograms make,
-	// for the same reason — an aggregate carries no per-fact paths to dedupe
-	// on (kb/gotchas/lens/browsing-ui-accepted-gaps). The carrier list on the
-	// detail DOES carry paths, and dedupes exactly.
-	df      int
-	dfTotal int
-	// canonical is ELECTED, mirroring store.electCanonical at the granularity
-	// the wire gives us: the representative of the highest-df constituent,
-	// ties broken lexicographically. Deterministic, and independent of mount
-	// order.
-	canonical string
-	bestDF    int
-	// The definition shown is the FRESHEST across mounts: current beats stale
-	// beats missing, ties broken write-mount-first then binding order.
-	def      store.MotifDefinitionStatus
-	defRank  int // 0 none, 1 stale, 2 current
-	defWrite bool
-	// mountKeys[ri] is the set of keys THAT MOUNT contributed, which is not
-	// the same set as `keys` and must not be confused with it. `keys` is the
-	// union across mounts, so it holds keys this mount never used — and a key
-	// another mount coined can perfectly well name an UNRELATED cluster here,
-	// since a cluster key is a mechanical function of a spelling and two
-	// corpora can both have that spelling in different company. Anything
-	// asking "did THIS mount file this row under THIS cluster" has to read
-	// the per-mount set; the alias attribution below is that question.
-	mountKeys map[*repos.RepoInstance]map[string]bool
+// motifDefinitionOf elects the definition shown for a MERGED cluster: the
+// freshest across mounts (current beats stale beats missing), ties broken
+// write-mount-first then binding order.
+//
+// Kept here rather than in the union because a definition is a thing the web
+// surface DISPLAYS; the union's job is which spellings are one shape. It reads
+// each mount's own constituent key via ContributedKey, never the union's key
+// set — a key another mount coined can name an unrelated cluster on this one.
+func motifDefinitionOf(
+	g *federate.MotifGroup, targets []federate.Target, write *repos.RepoInstance,
+	defsByMount []map[string]store.MotifDefinitionStatus,
+) (store.MotifDefinitionStatus, bool) {
+	var best store.MotifDefinitionStatus
+	bestRank, bestWrite := 0, false
+	for i, t := range targets {
+		isWrite := t.RT.RI == write
+		for key, st := range defsByMount[i] {
+			if !g.ContributedKey(t.RT.RI, key) {
+				continue
+			}
+			rank := definitionRank(st, true)
+			if rank > bestRank || (rank == bestRank && isWrite && !bestWrite) {
+				best, bestRank, bestWrite = st, rank, isWrite
+			}
+		}
+	}
+	return best, bestRank > 0
 }
 
 // definitionRank scores a mount's definition for the election above.
@@ -83,233 +62,57 @@ func definitionRank(st store.MotifDefinitionStatus, ok bool) int {
 	}
 }
 
-// motifUnion merges per-mount vocabularies into one lens-wide vocabulary.
+// gatherLensMotifs reads every target's vocabulary into one merged union, and
+// (optionally) each mount's definitions and pooled health beside it.
 //
-// Union-find over group indices: byKey and byMember can point at an absorbed
-// group, and find() walks to the survivor. Absorption always goes into the
-// LOWER index, so the result does not depend on which order two groups happened
-// to meet.
-type motifUnion struct {
-	groups   []*motifGroup
-	parent   []int
-	byKey    map[string]int
-	byMember map[string]int
-}
-
-func newMotifUnion() *motifUnion {
-	return &motifUnion{byKey: map[string]int{}, byMember: map[string]int{}}
-}
-
-func (u *motifUnion) find(i int) int {
-	for u.parent[i] != i {
-		u.parent[i] = u.parent[u.parent[i]]
-		i = u.parent[i]
-	}
-	return i
-}
-
-// absorb folds group b into group a (a < b), applying every election rule.
-func (u *motifUnion) absorb(a, b int) {
-	ga, gb := u.groups[a], u.groups[b]
-	for k := range gb.keys {
-		ga.keys[k] = true
-	}
-	for ri, keys := range gb.mountKeys {
-		if ga.mountKeys[ri] == nil {
-			ga.mountKeys[ri] = map[string]bool{}
-		}
-		for k := range keys {
-			ga.mountKeys[ri][k] = true
-		}
-	}
-	for m := range gb.members {
-		ga.members[m] = true
-	}
-	ga.df += gb.df
-	ga.dfTotal += gb.dfTotal
-	if gb.bestDF > ga.bestDF || (gb.bestDF == ga.bestDF && gb.canonical < ga.canonical) {
-		ga.canonical, ga.bestDF = gb.canonical, gb.bestDF
-	}
-	if gb.defRank > ga.defRank || (gb.defRank == ga.defRank && gb.defWrite && !ga.defWrite) {
-		ga.def, ga.defRank, ga.defWrite = gb.def, gb.defRank, gb.defWrite
-	}
-	u.parent[b] = a
-	u.groups[b] = nil
-}
-
-// add folds one mount's cluster into the union.
-func (u *motifUnion) add(ri *repos.RepoInstance, c store.MotifCluster, def store.MotifDefinitionStatus, defined, isWrite bool) {
-	g := &motifGroup{
-		keys:      map[string]bool{c.ClusterKey: true},
-		members:   map[string]bool{},
-		df:        c.DF,
-		dfTotal:   c.DFTotal,
-		canonical: c.CanonicalID,
-		bestDF:    c.DF,
-		def:       def,
-		defRank:   definitionRank(def, defined),
-		defWrite:  isWrite,
-		mountKeys: map[*repos.RepoInstance]map[string]bool{ri: {c.ClusterKey: true}},
-	}
-	for _, m := range c.Members {
-		g.members[m] = true
-	}
-	idx := len(u.groups)
-	u.groups = append(u.groups, g)
-	u.parent = append(u.parent, idx)
-
-	// Every existing group this cluster touches, by key or by any spelling.
-	touched := map[int]bool{}
-	if i, ok := u.byKey[c.ClusterKey]; ok {
-		touched[u.find(i)] = true
-	}
-	for _, m := range c.Members {
-		if i, ok := u.byMember[m]; ok {
-			touched[u.find(i)] = true
-		}
-	}
-	root := idx
-	for other := range touched {
-		a, b := min(root, other), max(root, other)
-		if a == b {
-			continue
-		}
-		u.absorb(a, b)
-		root = a
-	}
-	// Re-point every index this group owns at the survivor. Cheap, and it
-	// keeps find() shallow.
-	g = u.groups[root]
-	for k := range g.keys {
-		u.byKey[k] = root
-	}
-	for m := range g.members {
-		u.byMember[m] = root
-	}
-}
-
-// clusterKey is a merged cluster's identity: the lexicographically smallest
-// constituent key.
-//
-// Smallest rather than, say, the highest-df mount's, because a cluster key is
-// what definitions and URLs hang off and the store's own rule is that it must
-// be STABLE UNDER DF CHANGE. min() is that, is deterministic, does not depend
-// on mount order, and for a lens over one repo is the repo's own key — so a
-// lens of one answers with the vocabulary of the repo it wraps, unchanged.
-func (g *motifGroup) clusterKey() string {
-	key := ""
-	for k := range g.keys {
-		if key == "" || k < key {
-			key = k
-		}
-	}
-	return key
-}
-
-func (g *motifGroup) sortedMembers() []string {
-	out := make([]string, 0, len(g.members))
-	for m := range g.members {
-		out = append(out, m)
-	}
-	sort.Strings(out)
-	return out
-}
-
-// resolve renders the merged vocabulary in the store's own order (df-desc,
-// canonical-asc), plus the definition map keyed by merged cluster key —
-// presence meaning "some mount had one", exactly as the per-repo Definitions
-// bulk read means it.
-func (u *motifUnion) resolve() ([]store.MotifCluster, map[string]store.MotifDefinitionStatus) {
-	clusters := make([]store.MotifCluster, 0, len(u.groups))
-	defs := make(map[string]store.MotifDefinitionStatus, len(u.groups))
-	for i, g := range u.groups {
-		if g == nil || u.find(i) != i {
-			continue
-		}
-		key := g.clusterKey()
-		clusters = append(clusters, store.MotifCluster{
-			ClusterKey:  key,
-			CanonicalID: g.canonical,
-			Members:     g.sortedMembers(),
-			DF:          g.df,
-			DFTotal:     g.dfTotal,
-		})
-		if g.defRank > 0 {
-			defs[key] = g.def
-		}
-	}
-	sort.Slice(clusters, func(i, j int) bool {
-		if clusters[i].DF != clusters[j].DF {
-			return clusters[i].DF > clusters[j].DF
-		}
-		return clusters[i].CanonicalID < clusters[j].CanonicalID
-	})
-	return clusters, defs
-}
-
-// lookup resolves a raw {key} path segment to a merged group. It accepts the
-// merged cluster key, ANY mount's constituent key, and any member spelling —
-// all three name the same cluster, and a reader arriving from a repo-scoped
-// link holds the second kind.
-//
-// No fallback to the store's per-branch ClusterKey resolution, unlike the repo
-// detail: Clusters returns members straight from fact_motifs, so every spelling
-// carried by a live fact is already a member here, and a spelling carried by no
-// live fact resolves to a key with no cluster — a 404 either way.
-func (u *motifUnion) lookup(raw string) (*motifGroup, bool) {
-	if i, ok := u.byKey[raw]; ok {
-		return u.groups[u.find(i)], true
-	}
-	if i, ok := u.byMember[raw]; ok {
-		return u.groups[u.find(i)], true
-	}
-	return nil, false
-}
-
-// gatherLensMotifs fans the vocabulary read out over targets and folds every
-// mount's clusters into one union, pooling the health counts as it goes.
+// COST, and a FAILURE COUPLING. This is a per-mount Clusters read on every
+// call, and there is no cache behind it. Affordable on the vocabulary block and the picker, which fire once
+// per panel; worth knowing about on the cluster detail, which runs once PER
+// MOTIF on an opened fact — a 3-motif fact in a 5-mount lens is 15 Clusters
+// reads. Anything more would be a cache, and a cache would need an invalidation
+// story per mount per branch. (The motif-filter expansion path shares the same
+// union machinery but goes through federate.ExpandMotifTerms, which reads
+// clusters only and skips a single-mount binding entirely.)
 //
 // Any mount error fails the WHOLE request (RFC §9.1 — a lens never silently
 // shrinks its read set): returning the surviving mounts' vocabulary would
 // present a smaller union as if it were the whole one, which no field in the
-// response is allowed to disclose (kb/decisions/lens/no-federation-metadata-in-responses).
-// On that path it writes the problem response and returns ok=false.
-// COST. This is a per-mount Clusters read (plus Definitions, plus
-// VocabularyHealth) on every call, and there is no cache behind it. That is
-// affordable on the vocabulary block and the picker, which fire once per
-// panel; it is worth knowing about on the two callers that fire repeatedly:
-// expandLensMotifs runs on every motif-filtered list request, and the cluster
-// detail runs once PER MOTIF on an opened fact — so a 3-motif fact in a
-// 5-mount lens is 15 Clusters reads. `withDefs` and `withHealth` exist to keep
-// each caller from paying for reads it does not use (the expansion path needs
-// neither), which is the whole optimisation here. Anything more would be a
-// cache, and a cache would need an invalidation story per mount per branch.
+// response is allowed to disclose. On that path it writes the problem response
+// and returns ok=false.
+//
+// On the FILTER path (federate.ExpandMotifTerms) that rule reaches further than
+// it used to, and it is worth saying plainly: because a term's meaning is
+// lens-wide, the expansion reads EVERY mount even for a `repo=`-narrowed
+// request, so a mount the caller excluded can fail their query. That follows
+// from §9.1 — the term is resolved against the lens, and a lens does not answer
+// from a shrunken read set — but it is a coupling a narrowed query did not have
+// before this shipped.
 func gatherLensMotifs(
 	w http.ResponseWriter, r *http.Request, bind *repos.Binding,
 	provider motifsProvider, targets []federate.Target, withDefs, withHealth bool,
-) (*motifUnion, store.MotifVocabularyHealth, bool) {
-	u := newMotifUnion()
+) (*federate.MotifUnion, []map[string]store.MotifDefinitionStatus, store.MotifVocabularyHealth, bool) {
 	var pooled store.MotifVocabularyHealth
-	for _, t := range targets {
-		isWrite := t.RT.RI == bind.Write()
+	defsByMount := make([]map[string]store.MotifDefinitionStatus, len(targets))
+	u := federate.NewMotifUnion()
+	for i, t := range targets {
 		clusters, err := provider.Clusters(r.Context(), t.RT.RI, t.RT.Branch, t.Path)
 		if err != nil {
 			writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
-			return nil, pooled, false
+			return nil, nil, pooled, false
 		}
-		var defs map[string]store.MotifDefinitionStatus
 		if withDefs {
-			defs, err = provider.Definitions(r.Context(), t.RT.RI, t.RT.Branch, motifClusterKeys(clusters))
+			defs, err := provider.Definitions(r.Context(), t.RT.RI, t.RT.Branch, motifClusterKeys(clusters))
 			if err != nil {
 				writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
-				return nil, pooled, false
+				return nil, nil, pooled, false
 			}
+			defsByMount[i] = defs
 		}
 		if withHealth {
 			h, err := provider.VocabularyHealth(r.Context(), t.RT.RI, t.RT.Branch, t.Path)
 			if err != nil {
 				writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
-				return nil, pooled, false
+				return nil, nil, pooled, false
 			}
 			// POOLED counts. The two ratios are derived from the pooled totals
 			// exactly ONCE, below — never averaged across mounts. Averaging
@@ -325,45 +128,20 @@ func gatherLensMotifs(
 			pooled.EpistemicRecurring += h.EpistemicRecurring
 		}
 		for _, c := range clusters {
-			st, defined := defs[c.ClusterKey]
-			u.add(t.RT.RI, c, st, defined, isWrite)
+			u.Add(t.RT.RI, c)
 		}
 	}
-	return u, pooled, true
+	return u, defsByMount, pooled, true
 }
 
-// expandLensMotifs widens a caller's motif terms to the lens's MERGED clusters,
-// so every mount is asked about the whole shape rather than about one mount's
-// name for it.
+// expandLensMotifs widens a caller's motif terms through the lens's merged
+// vocabulary before a filtered read fans out. A thin adapter over
+// federate.ExpandMotifTerms — the ONE definition the MCP fan-out shares, so a
+// chip minted anywhere is correct because the seam resolves it, not because
+// the caller remembered to send members. See that function for the semantics
+// this establishes and the failure coupling it accepts.
 //
-// This is the correctness seam for every motif-filtered lens read, and without
-// it a lens pivot silently drops mounts its own count included. The store's
-// exact tier is per-branch canonical equality (store.expandMotifQuery): a term
-// resolves through THAT branch's alias table, and a mount that carries the
-// cluster under a different spelling — because the canonical is ELECTED per
-// branch, and a judge merge is per-branch — resolves the term to itself, finds
-// no member with that canonical, and contributes ZERO facts. So a row reading
-// "df 7" pivots to a list of 5, on a surface whose entire promise is that the
-// count and the list are the same query.
-//
-// The detail's carrier preview never had the bug because it sends the merged
-// member list. Fixing it HERE rather than teaching each client to send members
-// is the point: a chip minted anywhere — the vocabulary block, the filter
-// picker's completions, a hand-typed motif:, a script — is now correct because
-// the ENDPOINT resolves it, not because the caller remembered to.
-//
-// Expansion runs over the FULL read set, branch-wide, and deliberately ignores
-// the calling query's own ?path= and ?repo= narrowing. Cluster identity is a
-// property of the LENS (the same reason the cluster detail refuses ?repo=), and
-// a term minted from the whole vocabulary must keep meaning the same shape when
-// the list under it is narrowed. Resolving through a narrowed union would
-// re-run the exact bug this fixes: narrow to the one mount that spells it
-// differently, and the term resolves to nothing.
-//
-// A term in no cluster is left alone — its own singleton, which is what the
-// store does with it too. On a lens of one the expansion is an identity: every
-// member of a cluster resolves to that cluster's canonical anyway, so the
-// widened set selects exactly the rows the bare term did.
+// On error it writes the problem response and returns ok=false.
 func expandLensMotifs(
 	w http.ResponseWriter, r *http.Request, bind *repos.Binding,
 	provider motifsProvider, terms []string,
@@ -371,36 +149,14 @@ func expandLensMotifs(
 	if len(terms) == 0 || provider == nil {
 		return terms, true
 	}
-	targets, err := federate.ReadTargetsFor(bind, "")
+	read := func(ctx context.Context, rt repos.ReadTarget) ([]store.MotifCluster, error) {
+		// Branch-wide: identity is not scoped by where the reader stands.
+		return provider.Clusters(ctx, rt.RI, rt.Branch, "")
+	}
+	out, err := federate.ExpandMotifTerms(r.Context(), bind, read, terms)
 	if err != nil {
-		hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter", err.Error(), r.URL.Path)
+		writeStoreError(w, r, err, "Failed to resolve motif filter", "")
 		return nil, false
-	}
-	// Neither definitions nor health: this path only needs which spellings
-	// belong together, and it runs on every motif-filtered list request.
-	u, _, ok := gatherLensMotifs(w, r, bind, provider, targets, false, false)
-	if !ok {
-		return nil, false
-	}
-	// Order-preserving and duplicate-free: two terms in one cluster (two chips
-	// the reader widened with) must not send the same spelling twice.
-	seen := make(map[string]bool, len(terms))
-	out := make([]string, 0, len(terms))
-	add := func(s string) {
-		if !seen[s] {
-			seen[s] = true
-			out = append(out, s)
-		}
-	}
-	for _, term := range terms {
-		g, found := u.lookup(term)
-		if !found {
-			add(term)
-			continue
-		}
-		for _, m := range g.sortedMembers() {
-			add(m)
-		}
 	}
 	return out, true
 }
@@ -445,11 +201,31 @@ func handleHALLensMotifs(b hal.URLBuilder, provider motifsProvider) http.Handler
 			return
 		}
 
-		u, health, ok := gatherLensMotifs(w, r, bind, provider, targets, true, true)
+		u, defsByMount, health, ok := gatherLensMotifs(w, r, bind, provider, targets, true, true)
 		if !ok {
 			return
 		}
-		clusters, defs := u.resolve()
+
+		// Render the merged vocabulary through the SAME renderer the per-repo
+		// endpoint uses. `defs` carries presence as meaning, exactly as the
+		// per-mount bulk read does: a key absent from it has no definition on
+		// any mount.
+		groups := u.Groups()
+		clusters := make([]store.MotifCluster, 0, len(groups))
+		defs := make(map[string]store.MotifDefinitionStatus, len(groups))
+		for _, g := range groups {
+			key := g.Key()
+			clusters = append(clusters, store.MotifCluster{
+				ClusterKey:  key,
+				CanonicalID: g.Canonical,
+				Members:     g.Members(),
+				DF:          g.DF,
+				DFTotal:     g.DFTotal,
+			})
+			if st, defined := motifDefinitionOf(g, targets, bind.Write(), defsByMount); defined {
+				defs[key] = st
+			}
+		}
 
 		renderMotifCollection(w, r, b.Lens(lensName)+"/motifs", clusters, defs, health, p)
 	}
@@ -486,17 +262,18 @@ func handleHALLensMotifCluster(b hal.URLBuilder, provider motifsProvider, facts 
 			return
 		}
 
-		u, _, ok := gatherLensMotifs(w, r, bind, provider, targets, true, false)
+		u, defsByMount, _, ok := gatherLensMotifs(w, r, bind, provider, targets, true, false)
 		if !ok {
 			return
 		}
-		group, found := u.lookup(rawKey)
+		group, found := u.Lookup(rawKey)
 		if !found {
 			hal.WriteProblem(w, http.StatusNotFound, "Unknown motif",
 				`no motif cluster or spelling "`+rawKey+`" in this lens's vocabulary`, r.URL.Path)
 			return
 		}
-		key, members := group.clusterKey(), group.sortedMembers()
+		key, members := group.Key(), group.Members()
+		def, defined := motifDefinitionOf(group, targets, bind.Write(), defsByMount)
 
 		// Carriers ARE the pivot: the same filter, the same tier, the same code
 		// path as /lenses/{lens}/facts?motifs=<members>&motif_match=exact, so
@@ -609,7 +386,7 @@ func handleHALLensMotifCluster(b hal.URLBuilder, provider motifsProvider, facts 
 					// corpora can reach the same key with different membership.
 					// Checking the union set would attribute another mount's
 					// audit trail to a spelling this one files somewhere else.
-					if row, ok := rows[m]; ok && group.mountKeys[t.RT.RI][row.ClusterKey] {
+					if row, ok := rows[m]; ok && group.ContributedKey(t.RT.RI, row.ClusterKey) {
 						rowFor[m] = row
 					}
 				}
@@ -631,12 +408,12 @@ func handleHALLensMotifCluster(b hal.URLBuilder, provider motifsProvider, facts 
 
 		hal.WriteHAL(w, http.StatusOK, motifDetailView{
 			ClusterKey:      key,
-			Canonical:       group.canonical,
+			Canonical:       group.Canonical,
 			Members:         members,
-			DF:              group.df,
-			DFTotal:         group.dfTotal,
-			Definition:      group.def.Definition,
-			DefinitionState: definitionState(group.def, group.defRank > 0),
+			DF:              group.DF,
+			DFTotal:         group.DFTotal,
+			Definition:      def.Definition,
+			DefinitionState: definitionState(def, defined),
 			CarrierCount:    carrierCount,
 			Carriers:        carriers,
 			Aliases:         aliases,

--- a/internal/web/handlers_lenses_motifs.go
+++ b/internal/web/handlers_lenses_motifs.go
@@ -1,0 +1,540 @@
+package web
+
+import (
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+	"knomit/internal/web/hal"
+)
+
+// ─── the union ───────────────────────────────────────────────────────────────
+//
+// A motif cluster_key is a MECHANICAL function of a spelling (store's
+// groupingKey: canonicalize → tokenize → sort → join), so the same key names
+// the same shape in every repo and merging by key is sound. It is not
+// SUFFICIENT, though: a judge merge is per-branch, so one mount can have pulled
+// `quiet-degradation` under the key `fallback-silent` while another still keys
+// it `degradation-quiet`. Merging by key alone would then emit that one
+// spelling in two rows of one vocabulary, and the two rows would pivot to
+// different lists from names the reader cannot tell apart.
+//
+// So per-mount clusters are unioned TRANSITIVELY: two clusters are the same
+// cluster when they share a cluster_key OR share any member spelling (within a
+// mount a spelling belongs to exactly one cluster, so a shared spelling is
+// evidence the two are one shape). That rule is also what makes the pivot
+// correct by construction — the merged member list IS the `motifs=` CSV the
+// detail's _links.facts sends, and every mount expands that union against its
+// own alias table, which is exactly what the lens search/facts fan-out already
+// does with a caller-supplied motif filter.
+
+// motifGroup is one merged cluster under construction.
+type motifGroup struct {
+	// keys is every constituent cluster key, from every mount. The merged
+	// cluster is addressed by the smallest of them (see clusterKey).
+	keys    map[string]bool
+	members map[string]bool
+	// df / dfTotal are per-mount SUMS. Mounts are distinct repos, but distinct
+	// is not disjoint: a re-rooted fork mounted beside its upstream shares
+	// server-generated fact UUIDs, so one fact can be counted twice. That is
+	// the same accepted over-count the /lenses/{lens}/stats histograms make,
+	// for the same reason — an aggregate carries no per-fact paths to dedupe
+	// on (kb/gotchas/lens/browsing-ui-accepted-gaps). The carrier list on the
+	// detail DOES carry paths, and dedupes exactly.
+	df      int
+	dfTotal int
+	// canonical is ELECTED, mirroring store.electCanonical at the granularity
+	// the wire gives us: the representative of the highest-df constituent,
+	// ties broken lexicographically. Deterministic, and independent of mount
+	// order.
+	canonical string
+	bestDF    int
+	// The definition shown is the FRESHEST across mounts: current beats stale
+	// beats missing, ties broken write-mount-first then binding order.
+	def      store.MotifDefinitionStatus
+	defRank  int // 0 none, 1 stale, 2 current
+	defWrite bool
+}
+
+// definitionRank scores a mount's definition for the election above.
+func definitionRank(st store.MotifDefinitionStatus, ok bool) int {
+	switch {
+	case !ok:
+		return 0
+	case st.Stale:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// motifUnion merges per-mount vocabularies into one lens-wide vocabulary.
+//
+// Union-find over group indices: byKey and byMember can point at an absorbed
+// group, and find() walks to the survivor. Absorption always goes into the
+// LOWER index, so the result does not depend on which order two groups happened
+// to meet.
+type motifUnion struct {
+	groups   []*motifGroup
+	parent   []int
+	byKey    map[string]int
+	byMember map[string]int
+}
+
+func newMotifUnion() *motifUnion {
+	return &motifUnion{byKey: map[string]int{}, byMember: map[string]int{}}
+}
+
+func (u *motifUnion) find(i int) int {
+	for u.parent[i] != i {
+		u.parent[i] = u.parent[u.parent[i]]
+		i = u.parent[i]
+	}
+	return i
+}
+
+// absorb folds group b into group a (a < b), applying every election rule.
+func (u *motifUnion) absorb(a, b int) {
+	ga, gb := u.groups[a], u.groups[b]
+	for k := range gb.keys {
+		ga.keys[k] = true
+	}
+	for m := range gb.members {
+		ga.members[m] = true
+	}
+	ga.df += gb.df
+	ga.dfTotal += gb.dfTotal
+	if gb.bestDF > ga.bestDF || (gb.bestDF == ga.bestDF && gb.canonical < ga.canonical) {
+		ga.canonical, ga.bestDF = gb.canonical, gb.bestDF
+	}
+	if gb.defRank > ga.defRank || (gb.defRank == ga.defRank && gb.defWrite && !ga.defWrite) {
+		ga.def, ga.defRank, ga.defWrite = gb.def, gb.defRank, gb.defWrite
+	}
+	u.parent[b] = a
+	u.groups[b] = nil
+}
+
+// add folds one mount's cluster into the union.
+func (u *motifUnion) add(c store.MotifCluster, def store.MotifDefinitionStatus, defined, isWrite bool) {
+	g := &motifGroup{
+		keys:      map[string]bool{c.ClusterKey: true},
+		members:   map[string]bool{},
+		df:        c.DF,
+		dfTotal:   c.DFTotal,
+		canonical: c.CanonicalID,
+		bestDF:    c.DF,
+		def:       def,
+		defRank:   definitionRank(def, defined),
+		defWrite:  isWrite,
+	}
+	for _, m := range c.Members {
+		g.members[m] = true
+	}
+	idx := len(u.groups)
+	u.groups = append(u.groups, g)
+	u.parent = append(u.parent, idx)
+
+	// Every existing group this cluster touches, by key or by any spelling.
+	touched := map[int]bool{}
+	if i, ok := u.byKey[c.ClusterKey]; ok {
+		touched[u.find(i)] = true
+	}
+	for _, m := range c.Members {
+		if i, ok := u.byMember[m]; ok {
+			touched[u.find(i)] = true
+		}
+	}
+	root := idx
+	for other := range touched {
+		a, b := min(root, other), max(root, other)
+		if a == b {
+			continue
+		}
+		u.absorb(a, b)
+		root = a
+	}
+	// Re-point every index this group owns at the survivor. Cheap, and it
+	// keeps find() shallow.
+	g = u.groups[root]
+	for k := range g.keys {
+		u.byKey[k] = root
+	}
+	for m := range g.members {
+		u.byMember[m] = root
+	}
+}
+
+// clusterKey is a merged cluster's identity: the lexicographically smallest
+// constituent key.
+//
+// Smallest rather than, say, the highest-df mount's, because a cluster key is
+// what definitions and URLs hang off and the store's own rule is that it must
+// be STABLE UNDER DF CHANGE. min() is that, is deterministic, does not depend
+// on mount order, and for a lens over one repo is the repo's own key — so a
+// lens of one answers with the vocabulary of the repo it wraps, unchanged.
+func (g *motifGroup) clusterKey() string {
+	key := ""
+	for k := range g.keys {
+		if key == "" || k < key {
+			key = k
+		}
+	}
+	return key
+}
+
+func (g *motifGroup) sortedMembers() []string {
+	out := make([]string, 0, len(g.members))
+	for m := range g.members {
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// resolve renders the merged vocabulary in the store's own order (df-desc,
+// canonical-asc), plus the definition map keyed by merged cluster key —
+// presence meaning "some mount had one", exactly as the per-repo Definitions
+// bulk read means it.
+func (u *motifUnion) resolve() ([]store.MotifCluster, map[string]store.MotifDefinitionStatus) {
+	clusters := make([]store.MotifCluster, 0, len(u.groups))
+	defs := make(map[string]store.MotifDefinitionStatus, len(u.groups))
+	for i, g := range u.groups {
+		if g == nil || u.find(i) != i {
+			continue
+		}
+		key := g.clusterKey()
+		clusters = append(clusters, store.MotifCluster{
+			ClusterKey:  key,
+			CanonicalID: g.canonical,
+			Members:     g.sortedMembers(),
+			DF:          g.df,
+			DFTotal:     g.dfTotal,
+		})
+		if g.defRank > 0 {
+			defs[key] = g.def
+		}
+	}
+	sort.Slice(clusters, func(i, j int) bool {
+		if clusters[i].DF != clusters[j].DF {
+			return clusters[i].DF > clusters[j].DF
+		}
+		return clusters[i].CanonicalID < clusters[j].CanonicalID
+	})
+	return clusters, defs
+}
+
+// lookup resolves a raw {key} path segment to a merged group. It accepts the
+// merged cluster key, ANY mount's constituent key, and any member spelling —
+// all three name the same cluster, and a reader arriving from a repo-scoped
+// link holds the second kind.
+//
+// No fallback to the store's per-branch ClusterKey resolution, unlike the repo
+// detail: Clusters returns members straight from fact_motifs, so every spelling
+// carried by a live fact is already a member here, and a spelling carried by no
+// live fact resolves to a key with no cluster — a 404 either way.
+func (u *motifUnion) lookup(raw string) (*motifGroup, bool) {
+	if i, ok := u.byKey[raw]; ok {
+		return u.groups[u.find(i)], true
+	}
+	if i, ok := u.byMember[raw]; ok {
+		return u.groups[u.find(i)], true
+	}
+	return nil, false
+}
+
+// gatherLensMotifs fans the vocabulary read out over targets and folds every
+// mount's clusters into one union, pooling the health counts as it goes.
+//
+// Any mount error fails the WHOLE request (RFC §9.1 — a lens never silently
+// shrinks its read set): returning the surviving mounts' vocabulary would
+// present a smaller union as if it were the whole one, which no field in the
+// response is allowed to disclose (kb/decisions/lens/no-federation-metadata-in-responses).
+// On that path it writes the problem response and returns ok=false.
+func gatherLensMotifs(
+	w http.ResponseWriter, r *http.Request, bind *repos.Binding,
+	provider motifsProvider, targets []federate.Target, withHealth bool,
+) (*motifUnion, store.MotifVocabularyHealth, bool) {
+	u := newMotifUnion()
+	var pooled store.MotifVocabularyHealth
+	for _, t := range targets {
+		isWrite := t.RT.RI == bind.Write()
+		clusters, err := provider.Clusters(r.Context(), t.RT.RI, t.RT.Branch, t.Path)
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
+			return nil, pooled, false
+		}
+		defs, err := provider.Definitions(r.Context(), t.RT.RI, t.RT.Branch, motifClusterKeys(clusters))
+		if err != nil {
+			writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
+			return nil, pooled, false
+		}
+		if withHealth {
+			h, err := provider.VocabularyHealth(r.Context(), t.RT.RI, t.RT.Branch, t.Path)
+			if err != nil {
+				writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
+				return nil, pooled, false
+			}
+			// POOLED counts. The two ratios are derived from the pooled totals
+			// exactly ONCE, below — never averaged across mounts. Averaging
+			// ratios answers a different question and gets a different number:
+			// two mounts at 8/4 and 2/16 average to 1.0625 while the vocabulary
+			// they jointly describe is at 10/20 = 0.5. This is the same move
+			// handleHALLensStats makes for AxisFromSeparation: sum the raw
+			// counters, apply the rule once.
+			pooled.Clusters += h.Clusters
+			pooled.Recurring += h.Recurring
+			pooled.Mints += h.Mints
+			pooled.Links += h.Links
+			pooled.EpistemicRecurring += h.EpistemicRecurring
+		}
+		for _, c := range clusters {
+			st, defined := defs[c.ClusterKey]
+			u.add(c, st, defined, isWrite)
+		}
+	}
+	return u, pooled, true
+}
+
+// ─── collection ──────────────────────────────────────────────────────────────
+
+// handleHALLensMotifs serves GET /lenses/{lens}/motifs — the motif vocabulary
+// of a lens's write repo + N read mounts, merged into one list.
+//
+// It is the lens twin of handleHALMotifs and shares its query parsing, its
+// narrowing/ordering/paging and its envelope (motifCollectionQuery +
+// renderMotifCollection), so the two surfaces answer with the same shape by
+// construction rather than by being edited in step. The lens-only parts are the
+// fan-out, the cluster union, and the pooled health block.
+//
+// This is the surface the v1 motif work deliberately left out — MotifsBlock's
+// header said "there is no single vocabulary across a lens". There is one now,
+// and this is its definition.
+func handleHALLensMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bind := repos.BindingFromContext(r.Context())
+		lensName := chi.URLParam(r, "lens")
+
+		p, ok := motifCollectionQuery(w, r)
+		if !ok {
+			return
+		}
+
+		// Ontology-aware fan-out target selection — the same seam every other
+		// lens read uses. ?path= is SCOPE here exactly as it is on the repo
+		// endpoint, so it reaches each mount's Clusters AND VocabularyHealth.
+		targets, err := federate.ReadTargetsFor(bind, p.path)
+		if err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+				err.Error(), r.URL.Path)
+			return
+		}
+		// Optional repeatable `repo=<mount name>` narrows the fan-out (422 on
+		// an unknown mount name) — the shared lens union-read filter.
+		targets, ok = narrowByRepo(w, r, bind, targets, r.URL.Query()["repo"])
+		if !ok {
+			return
+		}
+
+		u, health, ok := gatherLensMotifs(w, r, bind, provider, targets, true)
+		if !ok {
+			return
+		}
+		clusters, defs := u.resolve()
+
+		renderMotifCollection(w, r, b.Lens(lensName)+"/motifs", clusters, defs, health, p)
+	}
+}
+
+// ─── cluster detail ──────────────────────────────────────────────────────────
+
+// handleHALLensMotifCluster serves GET /lenses/{lens}/motifs/{key} — one
+// merged cluster, with a carrier preview drawn from every mount.
+//
+// {key} accepts the merged cluster_key, any mount's own cluster_key, or any
+// member spelling; the self link always carries the merged key (C1). 404 only
+// when nothing in the union answers to it.
+//
+// Branch-wide on every mount, and no ?repo= narrowing: a cluster is addressed
+// by IDENTITY here, and its identity is a property of the lens, not of where
+// the reader was standing or which mounts they had selected. The repo detail
+// passes "" for the same reason.
+func handleHALLensMotifCluster(b hal.URLBuilder, provider motifsProvider, facts factsCollectionProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		bind := repos.BindingFromContext(r.Context())
+		lensName := chi.URLParam(r, "lens")
+		rawKey := chi.URLParam(r, "key")
+
+		carrierLimit, ok := motifCarrierLimit(w, r)
+		if !ok {
+			return
+		}
+
+		targets, err := federate.ReadTargetsFor(bind, "")
+		if err != nil {
+			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+				err.Error(), r.URL.Path)
+			return
+		}
+
+		u, _, ok := gatherLensMotifs(w, r, bind, provider, targets, false)
+		if !ok {
+			return
+		}
+		group, found := u.lookup(rawKey)
+		if !found {
+			hal.WriteProblem(w, http.StatusNotFound, "Unknown motif",
+				`no motif cluster or spelling "`+rawKey+`" in this lens's vocabulary`, r.URL.Path)
+			return
+		}
+		key, members := group.clusterKey(), group.sortedMembers()
+
+		// Carriers ARE the pivot: the same filter, the same tier, the same code
+		// path as /lenses/{lens}/facts?motifs=<members>&motif_match=exact, so
+		// the preview cannot disagree with the listing it links to. Passing
+		// every MERGED spelling is what makes the union correct per mount: each
+		// mount expands only what its own alias table knows, and the union of
+		// spellings is what covers the shapes it has not merged yet.
+		lists := make([][]store.RecentFactEntry, len(targets))
+		stamps := make([][]int64, len(targets))
+		total, fetched := 0, 0
+		truncated := false
+		for i, t := range targets {
+			entries, n, err := facts.RecentFacts(r.Context(), t.RT.RI, t.RT.Branch, store.SearchOptions{
+				Motifs:     members,
+				MotifMatch: store.MotifMatchExact,
+				Limit:      carrierLimit,
+			})
+			if err != nil {
+				writeStoreError(w, r, err, "Failed to load motif carriers", t.RT.Branch)
+				return
+			}
+			lists[i] = entries
+			total += n
+			fetched += len(entries)
+			if len(entries) < n {
+				truncated = true
+			}
+			stamps[i] = make([]int64, len(entries))
+			for j, e := range entries {
+				stamps[i][j] = e.CommittedAt
+			}
+		}
+
+		// Dedupe by repo-relative path through the ONE definition every lens
+		// union surface shares (write mount wins, then binding order), then
+		// merge by committed_at — comparable across mounts, unlike a relevance
+		// rank, and this preview has no text query.
+		winner := federate.WriteFirstWinners(targets, bind.Write(), lists,
+			func(e store.RecentFactEntry) string { return e.Path })
+		carriers := make([]motifCarrierItem, 0, min(fetched, carrierLimit))
+		deduped := 0
+		for _, ref := range federate.MergeRecent(stamps, fetched) {
+			e := lists[ref.Mount][ref.Rank]
+			if winner[e.Path] != ref.Mount {
+				continue
+			}
+			deduped++
+			if len(carriers) >= carrierLimit {
+				continue
+			}
+			// Qualified HERE, after the dedupe and never before: dedupe exists
+			// because one path can live on two mounts (a re-rooted fork shares
+			// fact UUIDs), and keying on qualified paths would give the copies
+			// different keys, so both would survive and the write mount would
+			// stop winning. A bare read-mount path on the wire resolves against
+			// the WRITE repo and 404s when opened — the /stats highlights
+			// incident, which this row shape would otherwise repeat.
+			wire := lensWirePath(bind, targets[ref.Mount].RT, e.Path)
+			carriers = append(carriers, motifCarrierItem{
+				Path:        wire,
+				Title:       e.Title,
+				Type:        e.Type,
+				CommittedAt: e.CommittedAt,
+				// PathEscape, unlike the repo builder's raw append: a qualified
+				// path is kb://<id12>/… and its "//" would otherwise be a path
+				// segment boundary. This is the escaping the web client already
+				// uses on /lenses/{lens}/facts/{path}.
+				Links: hal.LinkMap{"self": {Href: b.Lens(lensName) + "/facts/" + url.PathEscape(wire)}},
+			})
+		}
+
+		// carrier_count counts MATCHES, never rows transferred
+		// (kb/invariants/web/collections/count-vs-transfer). When no mount
+		// truncated we hold every match, so the deduped union length IS the
+		// cardinality — forks and all. When one did, the overlap is unknowable
+		// without fetching the rest, and the summed per-mount count is the best
+		// available answer: an upper bound, off by exactly the number of
+		// cross-mount path collisions. Same trade, same reasoning, as the lens
+		// facts collection's total.
+		carrierCount := deduped
+		if truncated {
+			carrierCount = total
+		}
+
+		// Alias rows: one per merged member, taking the audit trail from the
+		// mount that actually recorded a decision about that spelling — write
+		// mount first, then binding order, mirroring WriteFirstWinners' rule
+		// (Reads() is name-sorted, so the write mount is not positionally
+		// first and has to be prioritised explicitly).
+		rowFor := map[string]store.AliasRow{}
+		for _, pass := range []bool{true, false} {
+			for _, t := range targets {
+				if (t.RT.RI == bind.Write()) != pass {
+					continue
+				}
+				rows, err := provider.AliasRows(r.Context(), t.RT.RI, t.RT.Branch)
+				if err != nil {
+					writeStoreError(w, r, err, "Failed to load motif cluster", t.RT.Branch)
+					return
+				}
+				for _, m := range members {
+					if _, taken := rowFor[m]; taken {
+						continue
+					}
+					// Only a row whose own cluster key is one this merged
+					// cluster is made of: a spelling that a mount files under
+					// some other cluster is not evidence about this one.
+					if row, ok := rows[m]; ok && group.keys[row.ClusterKey] {
+						rowFor[m] = row
+					}
+				}
+			}
+		}
+		aliases := make([]motifAliasItem, 0, len(members))
+		for _, m := range members {
+			item := motifAliasItem{Motif: m}
+			if row, ok := rowFor[m]; ok {
+				item.Method = row.Method
+				item.Rationale = row.Rationale
+			}
+			aliases = append(aliases, item)
+		}
+
+		pivot := url.Values{}
+		pivot.Set("motifs", strings.Join(members, ","))
+		pivot.Set("motif_match", string(store.MotifMatchExact))
+
+		hal.WriteHAL(w, http.StatusOK, motifDetailView{
+			ClusterKey:      key,
+			Canonical:       group.canonical,
+			Members:         members,
+			DF:              group.df,
+			DFTotal:         group.dfTotal,
+			Definition:      group.def.Definition,
+			DefinitionState: definitionState(group.def, group.defRank > 0),
+			CarrierCount:    carrierCount,
+			Carriers:        carriers,
+			Aliases:         aliases,
+			Links: hal.LinkMap{
+				"self":  {Href: b.Lens(lensName) + "/motifs/" + key},
+				"facts": {Href: b.Lens(lensName) + "/facts?" + pivot.Encode()},
+			},
+		})
+	}
+}

--- a/internal/web/handlers_lenses_motifs.go
+++ b/internal/web/handlers_lenses_motifs.go
@@ -60,6 +60,15 @@ type motifGroup struct {
 	def      store.MotifDefinitionStatus
 	defRank  int // 0 none, 1 stale, 2 current
 	defWrite bool
+	// mountKeys[ri] is the set of keys THAT MOUNT contributed, which is not
+	// the same set as `keys` and must not be confused with it. `keys` is the
+	// union across mounts, so it holds keys this mount never used — and a key
+	// another mount coined can perfectly well name an UNRELATED cluster here,
+	// since a cluster key is a mechanical function of a spelling and two
+	// corpora can both have that spelling in different company. Anything
+	// asking "did THIS mount file this row under THIS cluster" has to read
+	// the per-mount set; the alias attribution below is that question.
+	mountKeys map[*repos.RepoInstance]map[string]bool
 }
 
 // definitionRank scores a mount's definition for the election above.
@@ -105,6 +114,14 @@ func (u *motifUnion) absorb(a, b int) {
 	for k := range gb.keys {
 		ga.keys[k] = true
 	}
+	for ri, keys := range gb.mountKeys {
+		if ga.mountKeys[ri] == nil {
+			ga.mountKeys[ri] = map[string]bool{}
+		}
+		for k := range keys {
+			ga.mountKeys[ri][k] = true
+		}
+	}
 	for m := range gb.members {
 		ga.members[m] = true
 	}
@@ -121,7 +138,7 @@ func (u *motifUnion) absorb(a, b int) {
 }
 
 // add folds one mount's cluster into the union.
-func (u *motifUnion) add(c store.MotifCluster, def store.MotifDefinitionStatus, defined, isWrite bool) {
+func (u *motifUnion) add(ri *repos.RepoInstance, c store.MotifCluster, def store.MotifDefinitionStatus, defined, isWrite bool) {
 	g := &motifGroup{
 		keys:      map[string]bool{c.ClusterKey: true},
 		members:   map[string]bool{},
@@ -132,6 +149,7 @@ func (u *motifUnion) add(c store.MotifCluster, def store.MotifDefinitionStatus, 
 		def:       def,
 		defRank:   definitionRank(def, defined),
 		defWrite:  isWrite,
+		mountKeys: map[*repos.RepoInstance]map[string]bool{ri: {c.ClusterKey: true}},
 	}
 	for _, m := range c.Members {
 		g.members[m] = true
@@ -256,9 +274,19 @@ func (u *motifUnion) lookup(raw string) (*motifGroup, bool) {
 // present a smaller union as if it were the whole one, which no field in the
 // response is allowed to disclose (kb/decisions/lens/no-federation-metadata-in-responses).
 // On that path it writes the problem response and returns ok=false.
+// COST. This is a per-mount Clusters read (plus Definitions, plus
+// VocabularyHealth) on every call, and there is no cache behind it. That is
+// affordable on the vocabulary block and the picker, which fire once per
+// panel; it is worth knowing about on the two callers that fire repeatedly:
+// expandLensMotifs runs on every motif-filtered list request, and the cluster
+// detail runs once PER MOTIF on an opened fact — so a 3-motif fact in a
+// 5-mount lens is 15 Clusters reads. `withDefs` and `withHealth` exist to keep
+// each caller from paying for reads it does not use (the expansion path needs
+// neither), which is the whole optimisation here. Anything more would be a
+// cache, and a cache would need an invalidation story per mount per branch.
 func gatherLensMotifs(
 	w http.ResponseWriter, r *http.Request, bind *repos.Binding,
-	provider motifsProvider, targets []federate.Target, withHealth bool,
+	provider motifsProvider, targets []federate.Target, withDefs, withHealth bool,
 ) (*motifUnion, store.MotifVocabularyHealth, bool) {
 	u := newMotifUnion()
 	var pooled store.MotifVocabularyHealth
@@ -269,10 +297,13 @@ func gatherLensMotifs(
 			writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
 			return nil, pooled, false
 		}
-		defs, err := provider.Definitions(r.Context(), t.RT.RI, t.RT.Branch, motifClusterKeys(clusters))
-		if err != nil {
-			writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
-			return nil, pooled, false
+		var defs map[string]store.MotifDefinitionStatus
+		if withDefs {
+			defs, err = provider.Definitions(r.Context(), t.RT.RI, t.RT.Branch, motifClusterKeys(clusters))
+			if err != nil {
+				writeStoreError(w, r, err, "Failed to load motif vocabulary", t.RT.Branch)
+				return nil, pooled, false
+			}
 		}
 		if withHealth {
 			h, err := provider.VocabularyHealth(r.Context(), t.RT.RI, t.RT.Branch, t.Path)
@@ -295,10 +326,83 @@ func gatherLensMotifs(
 		}
 		for _, c := range clusters {
 			st, defined := defs[c.ClusterKey]
-			u.add(c, st, defined, isWrite)
+			u.add(t.RT.RI, c, st, defined, isWrite)
 		}
 	}
 	return u, pooled, true
+}
+
+// expandLensMotifs widens a caller's motif terms to the lens's MERGED clusters,
+// so every mount is asked about the whole shape rather than about one mount's
+// name for it.
+//
+// This is the correctness seam for every motif-filtered lens read, and without
+// it a lens pivot silently drops mounts its own count included. The store's
+// exact tier is per-branch canonical equality (store.expandMotifQuery): a term
+// resolves through THAT branch's alias table, and a mount that carries the
+// cluster under a different spelling — because the canonical is ELECTED per
+// branch, and a judge merge is per-branch — resolves the term to itself, finds
+// no member with that canonical, and contributes ZERO facts. So a row reading
+// "df 7" pivots to a list of 5, on a surface whose entire promise is that the
+// count and the list are the same query.
+//
+// The detail's carrier preview never had the bug because it sends the merged
+// member list. Fixing it HERE rather than teaching each client to send members
+// is the point: a chip minted anywhere — the vocabulary block, the filter
+// picker's completions, a hand-typed motif:, a script — is now correct because
+// the ENDPOINT resolves it, not because the caller remembered to.
+//
+// Expansion runs over the FULL read set, branch-wide, and deliberately ignores
+// the calling query's own ?path= and ?repo= narrowing. Cluster identity is a
+// property of the LENS (the same reason the cluster detail refuses ?repo=), and
+// a term minted from the whole vocabulary must keep meaning the same shape when
+// the list under it is narrowed. Resolving through a narrowed union would
+// re-run the exact bug this fixes: narrow to the one mount that spells it
+// differently, and the term resolves to nothing.
+//
+// A term in no cluster is left alone — its own singleton, which is what the
+// store does with it too. On a lens of one the expansion is an identity: every
+// member of a cluster resolves to that cluster's canonical anyway, so the
+// widened set selects exactly the rows the bare term did.
+func expandLensMotifs(
+	w http.ResponseWriter, r *http.Request, bind *repos.Binding,
+	provider motifsProvider, terms []string,
+) ([]string, bool) {
+	if len(terms) == 0 || provider == nil {
+		return terms, true
+	}
+	targets, err := federate.ReadTargetsFor(bind, "")
+	if err != nil {
+		hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter", err.Error(), r.URL.Path)
+		return nil, false
+	}
+	// Neither definitions nor health: this path only needs which spellings
+	// belong together, and it runs on every motif-filtered list request.
+	u, _, ok := gatherLensMotifs(w, r, bind, provider, targets, false, false)
+	if !ok {
+		return nil, false
+	}
+	// Order-preserving and duplicate-free: two terms in one cluster (two chips
+	// the reader widened with) must not send the same spelling twice.
+	seen := make(map[string]bool, len(terms))
+	out := make([]string, 0, len(terms))
+	add := func(s string) {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	for _, term := range terms {
+		g, found := u.lookup(term)
+		if !found {
+			add(term)
+			continue
+		}
+		for _, m := range g.sortedMembers() {
+			add(m)
+		}
+	}
+	return out, true
 }
 
 // ─── collection ──────────────────────────────────────────────────────────────
@@ -341,7 +445,7 @@ func handleHALLensMotifs(b hal.URLBuilder, provider motifsProvider) http.Handler
 			return
 		}
 
-		u, health, ok := gatherLensMotifs(w, r, bind, provider, targets, true)
+		u, health, ok := gatherLensMotifs(w, r, bind, provider, targets, true, true)
 		if !ok {
 			return
 		}
@@ -382,7 +486,7 @@ func handleHALLensMotifCluster(b hal.URLBuilder, provider motifsProvider, facts 
 			return
 		}
 
-		u, _, ok := gatherLensMotifs(w, r, bind, provider, targets, false)
+		u, _, ok := gatherLensMotifs(w, r, bind, provider, targets, true, false)
 		if !ok {
 			return
 		}
@@ -497,10 +601,15 @@ func handleHALLensMotifCluster(b hal.URLBuilder, provider motifsProvider, facts 
 					if _, taken := rowFor[m]; taken {
 						continue
 					}
-					// Only a row whose own cluster key is one this merged
-					// cluster is made of: a spelling that a mount files under
-					// some other cluster is not evidence about this one.
-					if row, ok := rows[m]; ok && group.keys[row.ClusterKey] {
+					// Only a row whose own cluster key is one THIS MOUNT
+					// contributed to the merge. The union's `keys` would be the
+					// wrong set: it holds keys other mounts coined, and a key
+					// coined elsewhere can name an unrelated cluster here — a
+					// cluster key is a mechanical function of a spelling, so two
+					// corpora can reach the same key with different membership.
+					// Checking the union set would attribute another mount's
+					// audit trail to a spelling this one files somewhere else.
+					if row, ok := rows[m]; ok && group.mountKeys[t.RT.RI][row.ClusterKey] {
 						rowFor[m] = row
 					}
 				}

--- a/internal/web/handlers_lenses_motifs_test.go
+++ b/internal/web/handlers_lenses_motifs_test.go
@@ -942,7 +942,12 @@ func TestLensFacts_MotifWideningFailsTheWholeRequest(t *testing.T) {
 	// is deliberate and documented; this pins that it is real rather than
 	// accidental, so a later change cannot quietly drop it as a bug.
 	rec := getLensFacts(t, r, "/lenses/eng/facts?motifs=config-drift&repo=alpha")
-	if rec.Code == http.StatusOK {
-		t.Fatalf("a mount excluded by repo= still resolves the term, so its failure must not produce 200; body=%s", rec.Body.String())
+	// The exact status, not merely "not 200": the stub fails with a plain
+	// error, so 500 is the one right answer here. A future change that broke
+	// repo= narrowing into a 4xx would still be "not 200" and would leave this
+	// green while the coupling it pins had silently changed.
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d, want 500 — a mount excluded by repo= still resolves the term, so its failure fails the request; body=%s",
+			rec.Code, rec.Body.String())
 	}
 }

--- a/internal/web/handlers_lenses_motifs_test.go
+++ b/internal/web/handlers_lenses_motifs_test.go
@@ -1,0 +1,608 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+	"knomit/internal/web/hal"
+)
+
+// lensMotifsStub is a per-repo motifsProvider: each mount's call is answered
+// from a map keyed by the repo's name, so a single stub drives the whole
+// fan-out. It records the path prefix each mount was asked for, so a test can
+// assert the scope reached every mount rather than only that the page rendered.
+type lensMotifsStub struct {
+	clusters map[string][]store.MotifCluster
+	defs     map[string]map[string]store.MotifDefinitionStatus
+	health   map[string]store.MotifVocabularyHealth
+	aliases  map[string]map[string]store.AliasRow
+	errRepo  string
+
+	lastPath       map[string]string
+	lastHealthPath map[string]string
+	lastKeys       map[string][]string
+}
+
+func (s *lensMotifsStub) Clusters(_ context.Context, ri *repos.RepoInstance, _, pathPrefix string) ([]store.MotifCluster, error) {
+	if s.lastPath == nil {
+		s.lastPath = map[string]string{}
+	}
+	s.lastPath[ri.Name()] = pathPrefix
+	if s.errRepo != "" && ri.Name() == s.errRepo {
+		return nil, errors.New("db on fire")
+	}
+	return s.clusters[ri.Name()], nil
+}
+
+func (s *lensMotifsStub) Definitions(_ context.Context, ri *repos.RepoInstance, _ string, keys []string) (map[string]store.MotifDefinitionStatus, error) {
+	if s.lastKeys == nil {
+		s.lastKeys = map[string][]string{}
+	}
+	s.lastKeys[ri.Name()] = keys
+	if s.errRepo != "" && ri.Name() == s.errRepo {
+		return nil, errors.New("db on fire")
+	}
+	return s.defs[ri.Name()], nil
+}
+
+func (s *lensMotifsStub) VocabularyHealth(_ context.Context, ri *repos.RepoInstance, _, pathPrefix string) (store.MotifVocabularyHealth, error) {
+	if s.lastHealthPath == nil {
+		s.lastHealthPath = map[string]string{}
+	}
+	s.lastHealthPath[ri.Name()] = pathPrefix
+	if s.errRepo != "" && ri.Name() == s.errRepo {
+		return store.MotifVocabularyHealth{}, errors.New("db on fire")
+	}
+	return s.health[ri.Name()], nil
+}
+
+func (s *lensMotifsStub) AliasRows(_ context.Context, ri *repos.RepoInstance, _ string) (map[string]store.AliasRow, error) {
+	if s.errRepo != "" && ri.Name() == s.errRepo {
+		return nil, errors.New("db on fire")
+	}
+	return s.aliases[ri.Name()], nil
+}
+
+func (s *lensMotifsStub) ClusterKey(_ context.Context, _ *repos.RepoInstance, _, motif string) (string, error) {
+	return motif, nil
+}
+
+// lensMotifsServer wires a two-mount lens (write=alpha, read=beta) over the
+// given stubs and returns the router plus the manager (for id12 lookups).
+func lensMotifsServer(t *testing.T, motifs *lensMotifsStub, facts factsCollectionProvider) (http.Handler, *repos.Manager) {
+	t.Helper()
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{motifs: motifs, factsCollection: facts}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+	return r, m
+}
+
+// ─── collection ──────────────────────────────────────────────────────────────
+
+// Two mounts, three kinds of overlap in one fixture:
+//   - `drift-config` carries the SAME cluster key on both mounts → one row.
+//   - beta's `degradation-quiet` shares no key with alpha's `fallback-silent`
+//     but DOES share the spelling `quiet-degradation` (alpha's judge merged it
+//     in) → still one row, because a spelling belongs to exactly one cluster.
+//   - `creep-scope` exists on alpha only → passes through untouched.
+func splitVocabularyStub() *lensMotifsStub {
+	return &lensMotifsStub{
+		clusters: map[string][]store.MotifCluster{
+			"alpha": {
+				{ClusterKey: "drift-config", CanonicalID: "config-drift", Members: []string{"config-drift"}, DF: 5, DFTotal: 9},
+				{ClusterKey: "fallback-silent", CanonicalID: "silent-fallback", Members: []string{"quiet-degradation", "silent-fallback"}, DF: 4, DFTotal: 4},
+				{ClusterKey: "creep-scope", CanonicalID: "scope-creep", Members: []string{"scope-creep"}, DF: 1, DFTotal: 1},
+			},
+			"beta": {
+				{ClusterKey: "degradation-quiet", CanonicalID: "quiet-degradation", Members: []string{"quiet-degradation"}, DF: 3, DFTotal: 3},
+				{ClusterKey: "drift-config", CanonicalID: "configuration-drifts", Members: []string{"configuration-drifts"}, DF: 2, DFTotal: 6},
+			},
+		},
+	}
+}
+
+func TestLensMotifs_UnionMergesClustersAcrossMounts(t *testing.T) {
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), nil)
+	body := decodeMotifs(t, getLensFacts(t, r, "/lenses/eng/motifs"))
+
+	if body.Count != 3 {
+		t.Fatalf("count: got %d, want 3 merged clusters; body=%+v", body.Count, body.Embedded.Motifs)
+	}
+	byKey := map[string]int{}
+	for i, e := range body.Embedded.Motifs {
+		byKey[e.ClusterKey] = i
+	}
+
+	// Same key on both mounts: members union, df and df_total sum.
+	i, ok := byKey["drift-config"]
+	if !ok {
+		t.Fatalf("no drift-config row; got %+v", body.Embedded.Motifs)
+	}
+	drift := body.Embedded.Motifs[i]
+	if got := strings.Join(drift.Members, ","); got != "config-drift,configuration-drifts" {
+		t.Errorf("drift members: got %q, want the sorted union", got)
+	}
+	if drift.DF != 7 || drift.DFTotal != 15 {
+		t.Errorf("drift counts: got df=%d df_total=%d, want 7/15 (per-mount sums)", drift.DF, drift.DFTotal)
+	}
+	// canonical is the higher-DF constituent's representative (alpha's 5 > beta's 2).
+	if drift.Canonical != "config-drift" {
+		t.Errorf("drift canonical: got %q, want config-drift (highest-df constituent)", drift.Canonical)
+	}
+
+	// Different keys, shared spelling: still ONE row, keyed by the
+	// lexicographically smallest constituent key.
+	i, ok = byKey["degradation-quiet"]
+	if !ok {
+		t.Fatalf("no merged silent-fallback row keyed degradation-quiet; got %+v", body.Embedded.Motifs)
+	}
+	fallback := body.Embedded.Motifs[i]
+	if got := strings.Join(fallback.Members, ","); got != "quiet-degradation,silent-fallback" {
+		t.Errorf("fallback members: got %q, want the sorted union across the shared spelling", got)
+	}
+	if fallback.DF != 7 {
+		t.Errorf("fallback df: got %d, want 7", fallback.DF)
+	}
+	if fallback.Canonical != "silent-fallback" {
+		t.Errorf("fallback canonical: got %q, want silent-fallback (df 4 > 3)", fallback.Canonical)
+	}
+	// The spelling must appear in exactly ONE row — two rows carrying it would
+	// pivot to different lists from names the reader cannot tell apart.
+	rows := 0
+	for _, e := range body.Embedded.Motifs {
+		for _, m := range e.Members {
+			if m == "quiet-degradation" {
+				rows++
+			}
+		}
+	}
+	if rows != 1 {
+		t.Errorf("quiet-degradation appears in %d rows, want exactly 1", rows)
+	}
+
+	// df-desc is the default order: drift 7, fallback 7 (canonical tiebreak
+	// config-drift < silent-fallback), creep-scope 1.
+	if body.Embedded.Motifs[len(body.Embedded.Motifs)-1].ClusterKey != "creep-scope" {
+		t.Errorf("order: got %v, want df-desc with creep-scope last",
+			[]string{body.Embedded.Motifs[0].ClusterKey, body.Embedded.Motifs[1].ClusterKey, body.Embedded.Motifs[2].ClusterKey})
+	}
+
+	if got := getLensFacts(t, r, "/lenses/eng/motifs").Header().Get("Content-Type"); got != hal.ContentType {
+		t.Errorf("content-type: got %q, want %q", got, hal.ContentType)
+	}
+}
+
+// Self links address the LENS, not a mount: a row's self link must be openable
+// as /lenses/{lens}/motifs/{key}.
+func TestLensMotifs_LinksAddressTheLens(t *testing.T) {
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), nil)
+	body := decodeMotifs(t, getLensFacts(t, r, "/lenses/eng/motifs?sort=name"))
+
+	if !strings.HasSuffix(body.Links.Self.Href, "/lenses/eng/motifs?sort=name") {
+		t.Errorf("collection self: got %q", body.Links.Self.Href)
+	}
+	for _, e := range body.Embedded.Motifs {
+		want := "/lenses/eng/motifs/" + e.ClusterKey
+		if !strings.HasSuffix(e.Links.Self.Href, want) {
+			t.Errorf("entry self: got %q, want a href ending %q", e.Links.Self.Href, want)
+		}
+	}
+}
+
+// Health counts are POOLED across mounts and the two ratios are derived ONCE
+// from the pooled totals — never a mean of per-mount ratios.
+func TestLensMotifs_HealthPoolsCountsAndDerivesRatiosOnce(t *testing.T) {
+	stub := splitVocabularyStub()
+	stub.health = map[string]store.MotifVocabularyHealth{
+		"alpha": {Clusters: 10, Recurring: 2, Mints: 8, Links: 4, EpistemicRecurring: 1},
+		"beta":  {Clusters: 10, Recurring: 8, Mints: 2, Links: 16, EpistemicRecurring: 3},
+	}
+	r, _ := lensMotifsServer(t, stub, nil)
+	body := decodeMotifs(t, getLensFacts(t, r, "/lenses/eng/motifs"))
+
+	h := body.Health
+	if h.AuthoredClusters != 20 || h.AuthoredRecurring != 10 || h.AuthoredMints != 10 || h.AuthoredLinks != 20 {
+		t.Fatalf("pooled counts: got %+v", h)
+	}
+	if h.AuthoredEpistemicRecurring != 4 {
+		t.Errorf("authored_epistemic_recurring: got %d, want 4", h.AuthoredEpistemicRecurring)
+	}
+	pooled := store.MotifVocabularyHealth{Clusters: 20, Recurring: 10, Mints: 10, Links: 20, EpistemicRecurring: 4}
+	if h.RecurrenceRate != pooled.RecurrenceRate() {
+		t.Errorf("recurrence_rate: got %v, want %v (the rule applied ONCE to pooled totals)",
+			h.RecurrenceRate, pooled.RecurrenceRate())
+	}
+	// The per-mount ratios are 8/4=2 and 2/16=0.125; their mean (1.0625) is
+	// NOT the pooled answer (10/20=0.5). This is the assertion that fails if
+	// the handler averages ratios instead of pooling counts.
+	if h.MintToLinkRatio != pooled.MintToLinkRatio() {
+		t.Errorf("mint_to_link_ratio: got %v, want %v (pooled, not a mean of ratios)",
+			h.MintToLinkRatio, pooled.MintToLinkRatio())
+	}
+}
+
+// ?path= is SCOPE: it reaches every mount, and it narrows the health block as
+// well as the list — exactly as it does on the repo endpoint.
+func TestLensMotifs_PathScopesEveryMountAndItsHealth(t *testing.T) {
+	stub := splitVocabularyStub()
+	r, _ := lensMotifsServer(t, stub, nil)
+	// A topic the test repos' ontology preset actually has, so the fan-out's
+	// ontology-aware skip does not quietly drop both mounts and turn this into
+	// an assertion about nothing.
+	getLensFacts(t, r, "/lenses/eng/motifs?path=kb/technology/")
+
+	for _, name := range []string{"alpha", "beta"} {
+		if stub.lastPath[name] != "kb/technology/" {
+			t.Errorf("%s clusters path: got %q, want kb/technology/", name, stub.lastPath[name])
+		}
+		if stub.lastHealthPath[name] != "kb/technology/" {
+			t.Errorf("%s health path: got %q, want kb/technology/", name, stub.lastHealthPath[name])
+		}
+	}
+}
+
+// repo=<name> narrows the fan-out; an unknown name is a 422 (the shared lens
+// union-read filter).
+func TestLensMotifs_RepoFilterNarrows(t *testing.T) {
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), nil)
+	body := decodeMotifs(t, getLensFacts(t, r, "/lenses/eng/motifs?repo=beta"))
+	if body.Count != 2 {
+		t.Fatalf("count: got %d, want beta's 2 clusters; %+v", body.Count, body.Embedded.Motifs)
+	}
+	for _, e := range body.Embedded.Motifs {
+		if e.ClusterKey == "creep-scope" {
+			t.Errorf("alpha-only cluster leaked through repo=beta: %+v", e)
+		}
+	}
+}
+
+func TestLensMotifs_UnknownRepoFilterIs422(t *testing.T) {
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), nil)
+	rec := getLensFacts(t, r, "/lenses/eng/motifs?repo=nope")
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A lens never silently shrinks its read set: one mount failing fails the
+// WHOLE request (RFC §9.1), rather than returning the surviving mount's
+// vocabulary as if it were the union's.
+func TestLensMotifs_MountErrorFailsTheWholeRequest(t *testing.T) {
+	stub := splitVocabularyStub()
+	stub.errRepo = "beta"
+	r, _ := lensMotifsServer(t, stub, nil)
+	rec := getLensFacts(t, r, "/lenses/eng/motifs")
+	if rec.Code == http.StatusOK {
+		t.Fatalf("a failing mount must not produce 200; body=%s", rec.Body.String())
+	}
+}
+
+// ?q= narrows the list over member spellings AND definition text, and — unlike
+// ?path= — leaves the health block alone.
+func TestLensMotifs_QNarrowsListAcrossMountsButNotHealth(t *testing.T) {
+	stub := splitVocabularyStub()
+	stub.health = map[string]store.MotifVocabularyHealth{
+		"alpha": {Clusters: 3, Recurring: 1, Mints: 2, Links: 2},
+	}
+	stub.defs = map[string]map[string]store.MotifDefinitionStatus{
+		// The definition lives on the READ mount; a handler that only looks
+		// definitions up on the write repo would miss this match.
+		"beta": {"drift-config": {Definition: "applied state diverges"}},
+	}
+	r, _ := lensMotifsServer(t, stub, nil)
+	body := decodeMotifs(t, getLensFacts(t, r, "/lenses/eng/motifs?q=diverges"))
+
+	if body.Count != 1 || body.Embedded.Motifs[0].ClusterKey != "drift-config" {
+		t.Fatalf("q over definitions: got %d rows %+v", body.Count, body.Embedded.Motifs)
+	}
+	if body.Health.AuthoredClusters != 3 {
+		t.Errorf("health must ignore q: got %d, want 3", body.Health.AuthoredClusters)
+	}
+}
+
+// The definition shown for a merged cluster is the freshest one across mounts:
+// a `current` definition beats a `stale` one wherever it lives.
+func TestLensMotifs_FreshestDefinitionWins(t *testing.T) {
+	stub := splitVocabularyStub()
+	stub.defs = map[string]map[string]store.MotifDefinitionStatus{
+		"alpha": {"drift-config": {Definition: "stale wording", Stale: true}},
+		"beta":  {"drift-config": {Definition: "current wording"}},
+	}
+	r, _ := lensMotifsServer(t, stub, nil)
+	body := decodeMotifs(t, getLensFacts(t, r, "/lenses/eng/motifs?q=wording"))
+	if len(body.Embedded.Motifs) != 1 {
+		t.Fatalf("got %+v", body.Embedded.Motifs)
+	}
+	got := body.Embedded.Motifs[0]
+	if got.Definition != "current wording" || got.DefinitionState != "current" {
+		t.Errorf("definition: got %q/%q, want the current one from the read mount",
+			got.Definition, got.DefinitionState)
+	}
+}
+
+// Paging is by cluster over the MERGED vocabulary, and `count` is the number of
+// merged clusters the query matches — never the number of rows transferred.
+func TestLensMotifs_PagingCountsMatchesNotRows(t *testing.T) {
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), nil)
+	body := decodeMotifs(t, getLensFacts(t, r, "/lenses/eng/motifs?limit=1"))
+	if body.Count != 3 {
+		t.Errorf("count: got %d, want 3 (matches, not the 1 row fetched)", body.Count)
+	}
+	if len(body.Embedded.Motifs) != 1 {
+		t.Errorf("page: got %d rows, want 1", len(body.Embedded.Motifs))
+	}
+	if body.Links.Next == nil || !strings.Contains(body.Links.Next.Href, "offset=1") {
+		t.Errorf("next link: got %+v", body.Links.Next)
+	}
+}
+
+func TestLensMotifs_LimitOverTheCeilingIs400(t *testing.T) {
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), nil)
+	rec := getLensFacts(t, r, "/lenses/eng/motifs?limit=99999")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400 (hard ceiling, never a quiet clamp)", rec.Code)
+	}
+}
+
+// A lens over ONE repo answers with that repo's vocabulary unchanged — same
+// keys, same canonicals, same counts. The merge must be an identity there.
+func TestLensMotifs_LensOfOneIsTheRepoVocabulary(t *testing.T) {
+	stub := &lensMotifsStub{
+		clusters: map[string][]store.MotifCluster{"alpha": threeClusters()},
+		health:   map[string]store.MotifVocabularyHealth{"alpha": {Clusters: 3, Recurring: 1, Mints: 2, Links: 5}},
+	}
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{motifs: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"solo","write":"alpha","reads":[]}`)
+
+	body := decodeMotifs(t, getLensFacts(t, r, "/lenses/solo/motifs"))
+	want := threeClusters()
+	if body.Count != len(want) {
+		t.Fatalf("count: got %d, want %d", body.Count, len(want))
+	}
+	// Keyed, not indexed: the union emits the store's own order (df-desc,
+	// canonical-asc), and threeClusters is a hand-written fixture that is not
+	// in it. What "identity" means here is that every cluster survives with its
+	// key, its representative and its counts untouched.
+	got := map[string]struct {
+		canonical string
+		df        int
+	}{}
+	for _, e := range body.Embedded.Motifs {
+		got[e.ClusterKey] = struct {
+			canonical string
+			df        int
+		}{e.Canonical, e.DF}
+	}
+	for _, c := range want {
+		if g, ok := got[c.ClusterKey]; !ok || g.canonical != c.CanonicalID || g.df != c.DF {
+			t.Errorf("cluster %q: got %+v, want canonical=%q df=%d", c.ClusterKey, g, c.CanonicalID, c.DF)
+		}
+	}
+	// df-desc: the 5 comes before the two 2s.
+	if body.Embedded.Motifs[0].ClusterKey != "drift-config" {
+		t.Errorf("order: got %q first, want the df-5 cluster", body.Embedded.Motifs[0].ClusterKey)
+	}
+	if body.Health.AuthoredClusters != 3 || body.Health.AuthoredLinks != 5 {
+		t.Errorf("health: got %+v, want the single mount's own numbers", body.Health)
+	}
+}
+
+// ─── cluster detail ──────────────────────────────────────────────────────────
+
+// lensCarriersStub is a per-repo factsCollectionProvider for the carrier
+// preview, recording the SearchOptions each mount was asked for.
+type lensCarriersStub struct {
+	byRepo      map[string][]store.RecentFactEntry
+	totalByRepo map[string]int
+	lastOpts    map[string]store.SearchOptions
+}
+
+func (s *lensCarriersStub) RecentFacts(
+	_ context.Context, ri *repos.RepoInstance, _ string, opts store.SearchOptions,
+) ([]store.RecentFactEntry, int, error) {
+	if s.lastOpts == nil {
+		s.lastOpts = map[string]store.SearchOptions{}
+	}
+	s.lastOpts[ri.Name()] = opts
+	e := s.byRepo[ri.Name()]
+	total := len(e)
+	if n, ok := s.totalByRepo[ri.Name()]; ok {
+		total = n
+	}
+	if opts.Limit > 0 && len(e) > opts.Limit {
+		e = e[:opts.Limit]
+	}
+	return e, total, nil
+}
+
+func TestLensMotifCluster_ResolvesByMergedKeyConstituentKeyAndSpelling(t *testing.T) {
+	carriers := &lensCarriersStub{byRepo: map[string][]store.RecentFactEntry{}}
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), carriers)
+
+	// The merged key, the OTHER mount's constituent key, and a member spelling
+	// all address the same merged cluster.
+	for _, key := range []string{"degradation-quiet", "fallback-silent", "silent-fallback", "quiet-degradation"} {
+		body := decodeMotifDetail(t, getLensFacts(t, r, "/lenses/eng/motifs/"+key))
+		if body.ClusterKey != "degradation-quiet" {
+			t.Errorf("%q resolved to %q, want the merged key degradation-quiet", key, body.ClusterKey)
+		}
+		if got := strings.Join(body.Members, ","); got != "quiet-degradation,silent-fallback" {
+			t.Errorf("%q members: got %q", key, got)
+		}
+		if !strings.HasSuffix(body.Links.Self.Href, "/lenses/eng/motifs/degradation-quiet") {
+			t.Errorf("%q self link: got %q, want the merged key", key, body.Links.Self.Href)
+		}
+	}
+}
+
+func TestLensMotifCluster_UnknownIs404(t *testing.T) {
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), &lensCarriersStub{})
+	rec := getLensFacts(t, r, "/lenses/eng/motifs/nothing-like-this")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// The pivot link is the lens's own /facts filtered by the MERGED member list —
+// so every mount expands the union against its own alias table, and the preview
+// and the full listing cannot disagree.
+func TestLensMotifCluster_PivotLinkCarriesTheMergedMembers(t *testing.T) {
+	carriers := &lensCarriersStub{}
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), carriers)
+	body := decodeMotifDetail(t, getLensFacts(t, r, "/lenses/eng/motifs/degradation-quiet"))
+
+	href := body.Links.Facts.Href
+	if !strings.Contains(href, "/lenses/eng/facts?") {
+		t.Fatalf("facts link must point at the lens: got %q", href)
+	}
+	if !strings.Contains(href, "motifs=quiet-degradation%2Csilent-fallback") ||
+		!strings.Contains(href, "motif_match=exact") {
+		t.Errorf("facts link: got %q, want the merged members at the exact tier", href)
+	}
+	// Every mount was asked with the same union filter.
+	for _, name := range []string{"alpha", "beta"} {
+		opts := carriers.lastOpts[name]
+		if strings.Join(opts.Motifs, ",") != "quiet-degradation,silent-fallback" {
+			t.Errorf("%s carrier query motifs: got %v, want the merged union", name, opts.Motifs)
+		}
+		if opts.MotifMatch != store.MotifMatchExact {
+			t.Errorf("%s carrier query tier: got %q, want exact", name, opts.MotifMatch)
+		}
+	}
+}
+
+// TestLensMotifCluster_CarriersCarryQualifiedPaths is the lens-motif twin of
+// TestLensStats_HighlightsCarryQualifiedPaths: every path-bearing row a lens
+// read emits must carry the canonical wire path — bare for the write mount,
+// kb://<id12>/… for a read mount — or opening it 404s against the write repo.
+func TestLensMotifCluster_CarriersCarryQualifiedPaths(t *testing.T) {
+	carriers := &lensCarriersStub{byRepo: map[string][]store.RecentFactEntry{
+		"alpha": {{Path: "kb/from-write.md", Title: "write", Type: "observation", CommittedAt: 200}},
+		"beta":  {{Path: "kb/from-read.md", Title: "read", Type: "observation", CommittedAt: 100}},
+	}}
+	r, m := lensMotifsServer(t, splitVocabularyStub(), carriers)
+	body := decodeMotifDetail(t, getLensFacts(t, r, "/lenses/eng/motifs/drift-config"))
+
+	byTitle := map[string]string{}
+	for _, c := range body.Carriers {
+		byTitle[c.Title] = c.Path
+	}
+	if got := byTitle["write"]; got != "kb/from-write.md" {
+		t.Errorf("write mount carrier: got %q, want the bare path", got)
+	}
+	want := federate.QualifyPath(federate.ID12(m.Get("beta").ID()), "kb/from-read.md")
+	if got := byTitle["read"]; got != want {
+		t.Errorf("read mount carrier: got %q, want %q", got, want)
+	}
+	// Recency order across mounts, newest first.
+	if len(body.Carriers) != 2 || body.Carriers[0].Title != "write" {
+		t.Errorf("carriers: got %+v, want newest-first across mounts", body.Carriers)
+	}
+}
+
+// Qualification happens AFTER the dedupe: a re-rooted fork mounted beside its
+// upstream shares fact UUIDs, so the same repo-relative path arrives from two
+// mounts and the WRITE mount's copy must win exactly once.
+func TestLensMotifCluster_CarrierDedupeKeepsTheWriteCopy(t *testing.T) {
+	carriers := &lensCarriersStub{byRepo: map[string][]store.RecentFactEntry{
+		"alpha": {{Path: "kb/dup.md", Title: "from write", Type: "observation", CommittedAt: 100}},
+		"beta":  {{Path: "kb/dup.md", Title: "from read", Type: "observation", CommittedAt: 300}},
+	}}
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), carriers)
+	body := decodeMotifDetail(t, getLensFacts(t, r, "/lenses/eng/motifs/drift-config"))
+
+	if len(body.Carriers) != 1 {
+		t.Fatalf("carriers: got %d rows, want 1 deduped; %+v", len(body.Carriers), body.Carriers)
+	}
+	if body.Carriers[0].Title != "from write" || body.Carriers[0].Path != "kb/dup.md" {
+		t.Errorf("carrier: got %+v, want the write mount's bare-path copy", body.Carriers[0])
+	}
+	if body.CarrierCount != 1 {
+		t.Errorf("carrier_count: got %d, want 1 — the union holds one fact", body.CarrierCount)
+	}
+}
+
+// carrier_count counts MATCHES, never fetched rows: bounding the preview must
+// never bound the count (kb/invariants/web/collections/count-vs-transfer).
+func TestLensMotifCluster_CarrierCountIsNotBoundedByThePreview(t *testing.T) {
+	carriers := &lensCarriersStub{
+		byRepo: map[string][]store.RecentFactEntry{
+			"alpha": {{Path: "kb/a.md", Title: "a", CommittedAt: 200}},
+			"beta":  {{Path: "kb/b.md", Title: "b", CommittedAt: 100}},
+		},
+		// Both mounts hold far more carriers than the preview fetched.
+		totalByRepo: map[string]int{"alpha": 40, "beta": 9},
+	}
+	r, _ := lensMotifsServer(t, splitVocabularyStub(), carriers)
+	body := decodeMotifDetail(t, getLensFacts(t, r, "/lenses/eng/motifs/drift-config?limit=1"))
+
+	if len(body.Carriers) > 1 {
+		t.Errorf("preview: got %d rows, want at most the requested 1", len(body.Carriers))
+	}
+	if body.CarrierCount != 49 {
+		t.Errorf("carrier_count: got %d, want 49 (the summed per-mount match counts)", body.CarrierCount)
+	}
+}
+
+// Alias rows merge across mounts, write mount first — the audit trail for a
+// spelling comes from the mount that actually recorded a decision about it.
+func TestLensMotifCluster_AliasesMergeWriteFirst(t *testing.T) {
+	stub := splitVocabularyStub()
+	stub.aliases = map[string]map[string]store.AliasRow{
+		"alpha": {
+			"config-drift": {ClusterKey: "drift-config", CanonicalID: "config-drift", Method: "mechanical"},
+		},
+		"beta": {
+			"configuration-drifts": {ClusterKey: "drift-config", CanonicalID: "configuration-drifts", Method: "judge", Rationale: "same mechanism"},
+		},
+	}
+	r, _ := lensMotifsServer(t, stub, &lensCarriersStub{})
+	body := decodeMotifDetail(t, getLensFacts(t, r, "/lenses/eng/motifs/drift-config"))
+
+	byMotif := map[string]struct{ method, rationale string }{}
+	for _, a := range body.Aliases {
+		byMotif[a.Motif] = struct{ method, rationale string }{a.Method, a.Rationale}
+	}
+	if len(body.Aliases) != 2 {
+		t.Fatalf("aliases: got %+v, want one row per merged member", body.Aliases)
+	}
+	if byMotif["config-drift"].method != "mechanical" {
+		t.Errorf("write-mount alias row lost its method: %+v", byMotif["config-drift"])
+	}
+	if byMotif["configuration-drifts"].method != "judge" ||
+		byMotif["configuration-drifts"].rationale != "same mechanism" {
+		t.Errorf("read-mount alias row lost its audit trail: %+v", byMotif["configuration-drifts"])
+	}
+}
+
+func TestLensMotifCluster_MountErrorFailsTheWholeRequest(t *testing.T) {
+	stub := splitVocabularyStub()
+	stub.errRepo = "beta"
+	r, _ := lensMotifsServer(t, stub, &lensCarriersStub{})
+	rec := getLensFacts(t, r, "/lenses/eng/motifs/drift-config")
+	if rec.Code == http.StatusOK {
+		t.Fatalf("a failing mount must not produce 200; body=%s", rec.Body.String())
+	}
+}
+
+// The detail is addressed by IDENTITY, so it is branch-wide on every mount: no
+// path scope reaches the fan-out, exactly as the repo detail passes "".
+func TestLensMotifCluster_IsBranchWideOnEveryMount(t *testing.T) {
+	stub := splitVocabularyStub()
+	r, _ := lensMotifsServer(t, stub, &lensCarriersStub{})
+	getLensFacts(t, r, "/lenses/eng/motifs/drift-config?path=kb/technology/")
+	for _, name := range []string{"alpha", "beta"} {
+		if stub.lastPath[name] != "" {
+			t.Errorf("%s: got path %q, want branch-wide (\"\")", name, stub.lastPath[name])
+		}
+	}
+}

--- a/internal/web/handlers_lenses_motifs_test.go
+++ b/internal/web/handlers_lenses_motifs_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -603,6 +605,265 @@ func TestLensMotifCluster_IsBranchWideOnEveryMount(t *testing.T) {
 	for _, name := range []string{"alpha", "beta"} {
 		if stub.lastPath[name] != "" {
 			t.Errorf("%s: got path %q, want branch-wide (\"\")", name, stub.lastPath[name])
+		}
+	}
+}
+
+// ─── the pivot the vocabulary promises ───────────────────────────────────────
+
+// lensPivotFactsStub models the ONE thing that matters about the store's exact
+// tier: a term matches a fact only if the fact literally carries a spelling in
+// the term list.
+//
+// That is a faithful model of store.expandMotifQuery at the exact tier. It
+// resolves a term through THIS branch's alias table — `canonicalOf[term]`, or
+// the term itself when the branch has never seen it — and then matches the
+// spellings whose canonical equals that. On a mount that spells the shape
+// differently, a term it has never seen resolves to itself, no member's
+// canonical equals it, and the mount contributes nothing.
+type lensPivotFactsStub struct {
+	byRepo   map[string][]store.RecentFactEntry
+	lastOpts map[string]store.SearchOptions
+}
+
+func (s *lensPivotFactsStub) carriers(ri *repos.RepoInstance, opts store.SearchOptions) ([]store.RecentFactEntry, int) {
+	if s.lastOpts == nil {
+		s.lastOpts = map[string]store.SearchOptions{}
+	}
+	s.lastOpts[ri.Name()] = opts
+	want := map[string]bool{}
+	for _, m := range opts.Motifs {
+		want[m] = true
+	}
+	var out []store.RecentFactEntry
+	for _, e := range s.byRepo[ri.Name()] {
+		for _, m := range e.Motifs {
+			if want[m] {
+				out = append(out, e)
+				break
+			}
+		}
+	}
+	return out, len(out)
+}
+
+func (s *lensPivotFactsStub) RecentFacts(
+	_ context.Context, ri *repos.RepoInstance, _ string, opts store.SearchOptions,
+) ([]store.RecentFactEntry, int, error) {
+	out, n := s.carriers(ri, opts)
+	return out, n, nil
+}
+
+func (s *lensPivotFactsStub) Search(
+	_ context.Context, ri *repos.RepoInstance, _ store.Embedder, _ string, opts store.SearchOptions,
+) ([]store.SearchResult, error) {
+	out, _ := s.carriers(ri, opts)
+	res := make([]store.SearchResult, 0, len(out))
+	for _, e := range out {
+		var sr store.SearchResult
+		sr.Path, sr.Title, sr.Motifs = e.Path, e.Title, e.Motifs
+		res = append(res, sr)
+	}
+	return res, nil
+}
+
+// The carriers of the merged `drift-config` cluster, split across mounts by
+// SPELLING: alpha's five carry `config-drift` (the elected canonical), beta's
+// two carry `configuration-drifts` and nothing else. splitVocabularyStub says
+// df 5 + 2, so the merged row promises 7.
+func driftCarriersByMount() *lensPivotFactsStub {
+	alpha := make([]store.RecentFactEntry, 0, 5)
+	for i := range 5 {
+		alpha = append(alpha, store.RecentFactEntry{
+			Path: "kb/a" + strconv.Itoa(i) + ".md", Title: "alpha " + strconv.Itoa(i),
+			Motifs: []string{"config-drift"}, CommittedAt: int64(200 + i),
+		})
+	}
+	return &lensPivotFactsStub{byRepo: map[string][]store.RecentFactEntry{
+		"alpha": alpha,
+		"beta": {
+			{Path: "kb/b0.md", Title: "beta 0", Motifs: []string{"configuration-drifts"}, CommittedAt: 100},
+			{Path: "kb/b1.md", Title: "beta 1", Motifs: []string{"configuration-drifts"}, CommittedAt: 101},
+		},
+	}}
+}
+
+// THE REGRESSION. A pivot minted from the merged vocabulary sends ONE name —
+// the elected canonical — and the store's exact tier is per-branch canonical
+// equality, so beta (which spells the shape `configuration-drifts`) used to
+// contribute zero. The row said df 7 and the list under it held 5.
+//
+// The count and the list are the same query or the surface is lying, so the
+// assertion is exactly that: the pivot's total equals the df beside the name.
+func TestLensFacts_PivotOnAMergedCanonicalReachesEveryMount(t *testing.T) {
+	motifs := splitVocabularyStub()
+	carriers := driftCarriersByMount()
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{motifs: motifs, factsCollection: carriers, search: carriers}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	// The df the vocabulary row promises.
+	vocab := decodeMotifs(t, getLensFacts(t, r, "/lenses/eng/motifs"))
+	wantDF := 0
+	var canonical string
+	for _, e := range vocab.Embedded.Motifs {
+		if e.ClusterKey == "drift-config" {
+			wantDF, canonical = e.DF, e.Canonical
+		}
+	}
+	if wantDF != 7 || canonical != "config-drift" {
+		t.Fatalf("fixture: got df=%d canonical=%q, want 7/config-drift", wantDF, canonical)
+	}
+
+	// The list that name pivots to.
+	body := decodeLensFacts(t, getLensFacts(t, r,
+		"/lenses/eng/facts?motifs="+canonical+"&motif_match=exact"))
+	if body.Total != wantDF {
+		t.Errorf("pivot total: got %d, want %d — the df the row beside it promised", body.Total, wantDF)
+	}
+	if len(body.Facts) != wantDF {
+		t.Errorf("pivot rows: got %d, want %d", len(body.Facts), wantDF)
+	}
+	// Specifically: the mount that spells it differently is IN the answer.
+	fromBeta := 0
+	for _, f := range body.Facts {
+		if f.Source.Repo == "beta" {
+			fromBeta++
+		}
+	}
+	if fromBeta != 2 {
+		t.Errorf("beta contributed %d rows, want 2 — it carries the cluster under another spelling", fromBeta)
+	}
+	// Every mount was asked about the WHOLE shape, not about one mount's name.
+	for _, name := range []string{"alpha", "beta"} {
+		got := strings.Join(motifSorted(carriers.lastOpts[name].Motifs), ",")
+		if got != "config-drift,configuration-drifts" {
+			t.Errorf("%s was asked for %q, want the merged member list", name, got)
+		}
+	}
+}
+
+// motifSorted copies and sorts, so an assertion on the widened set does not
+// depend on the union's iteration order.
+func motifSorted(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+// /search takes the same widening — the pivot's ≈ segment and the filter chip
+// both reach it, and a relevance query that dropped a mount would be the same
+// defect with a different envelope.
+func TestLensSearch_PivotOnAMergedCanonicalReachesEveryMount(t *testing.T) {
+	carriers := driftCarriersByMount()
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		motifs: splitVocabularyStub(), factsCollection: carriers, search: carriers}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/search?q=drift&motifs=config-drift&motif_match=exact")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := strings.Join(motifSorted(carriers.lastOpts["beta"].Motifs), ","); got != "config-drift,configuration-drifts" {
+		t.Errorf("beta was asked for %q, want the merged member list", got)
+	}
+}
+
+// The widening runs over the FULL read set, never the narrowed one. A term
+// minted from the whole vocabulary has to keep naming the same shape when the
+// list under it is narrowed — resolving it through a one-mount union would
+// re-run the exact bug, since that mount is the one spelling it differently.
+func TestLensFacts_PivotWideningIgnoresRepoNarrowing(t *testing.T) {
+	carriers := driftCarriersByMount()
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		motifs: splitVocabularyStub(), factsCollection: carriers, search: carriers}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensFacts(t, getLensFacts(t, r,
+		"/lenses/eng/facts?motifs=config-drift&motif_match=exact&repo=beta"))
+	if body.Total != 2 {
+		t.Errorf("narrowed pivot: got %d, want beta's 2 — the term still names the merged shape", body.Total)
+	}
+}
+
+// A term in no cluster is left exactly as the caller sent it: its own
+// singleton, which is what the store does with it too.
+func TestLensFacts_UnknownMotifTermIsPassedThroughUnchanged(t *testing.T) {
+	carriers := driftCarriersByMount()
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		motifs: splitVocabularyStub(), factsCollection: carriers, search: carriers}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	getLensFacts(t, r, "/lenses/eng/facts?motifs=nothing-like-this")
+	for _, name := range []string{"alpha", "beta"} {
+		if got := strings.Join(carriers.lastOpts[name].Motifs, ","); got != "nothing-like-this" {
+			t.Errorf("%s was asked for %q, want the term unchanged", name, got)
+		}
+	}
+}
+
+// A lens over ONE repo must send exactly what a repo request sends: the
+// widening is an identity there, because every member of a cluster already
+// resolves to that cluster's canonical inside the one branch.
+func TestLensFacts_WideningIsAnIdentityForALensOfOne(t *testing.T) {
+	carriers := driftCarriersByMount()
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		motifs: &lensMotifsStub{clusters: map[string][]store.MotifCluster{
+			"alpha": {{ClusterKey: "drift-config", CanonicalID: "config-drift", Members: []string{"config-drift"}, DF: 5, DFTotal: 5}},
+		}},
+		factsCollection: carriers, search: carriers}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"solo","write":"alpha","reads":[]}`)
+
+	body := decodeLensFacts(t, getLensFacts(t, r, "/lenses/solo/facts?motifs=config-drift&motif_match=exact"))
+	if body.Total != 5 {
+		t.Errorf("lens of one: got %d, want alpha's 5", body.Total)
+	}
+	if got := strings.Join(carriers.lastOpts["alpha"].Motifs, ","); got != "config-drift" {
+		t.Errorf("lens of one sent %q, want the bare term", got)
+	}
+}
+
+// A cluster key is a mechanical function of a spelling, so two corpora can
+// reach the SAME key with different membership. Here beta files the spelling
+// `configuration-drifts` under the key `drift-config` too — but as a cluster of
+// its own, with a rationale that has nothing to do with the merged one. That
+// row must not be attributed to a spelling this mount files elsewhere.
+//
+// The guard has to read the per-mount key set, not the union's: the union holds
+// every mount's keys, so checking it would accept exactly this row.
+func TestLensMotifCluster_AliasAttributionIsPerMount(t *testing.T) {
+	stub := &lensMotifsStub{
+		clusters: map[string][]store.MotifCluster{
+			// Only alpha contributes the merged cluster.
+			"alpha": {{ClusterKey: "drift-config", CanonicalID: "config-drift",
+				Members: []string{"config-drift", "configuration-drifts"}, DF: 5, DFTotal: 5}},
+			// beta has a DIFFERENT cluster; it never contributed drift-config.
+			"beta": {{ClusterKey: "creep-scope", CanonicalID: "scope-creep",
+				Members: []string{"scope-creep"}, DF: 2, DFTotal: 2}},
+		},
+		aliases: map[string]map[string]store.AliasRow{
+			// beta's row for the spelling claims a key beta did not contribute
+			// to this merge. Reading the union's key set would take it.
+			"beta": {"configuration-drifts": {
+				ClusterKey: "drift-config", CanonicalID: "something-else",
+				Method: "judge", Rationale: "beta's own unrelated merge"}},
+		},
+	}
+	r, _ := lensMotifsServer(t, stub, &lensCarriersStub{})
+	body := decodeMotifDetail(t, getLensFacts(t, r, "/lenses/eng/motifs/drift-config"))
+
+	for _, a := range body.Aliases {
+		if a.Motif == "configuration-drifts" && a.Rationale != "" {
+			t.Errorf("took a non-contributing mount's audit trail: %+v", a)
 		}
 	}
 }

--- a/internal/web/handlers_lenses_motifs_test.go
+++ b/internal/web/handlers_lenses_motifs_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"sort"
@@ -25,6 +26,9 @@ type lensMotifsStub struct {
 	health   map[string]store.MotifVocabularyHealth
 	aliases  map[string]map[string]store.AliasRow
 	errRepo  string
+	// errWith overrides what errRepo fails with, so a test can drive the
+	// sentinel-specific error responses rather than only the generic 500.
+	errWith error
 
 	lastPath       map[string]string
 	lastHealthPath map[string]string
@@ -37,6 +41,9 @@ func (s *lensMotifsStub) Clusters(_ context.Context, ri *repos.RepoInstance, _, 
 	}
 	s.lastPath[ri.Name()] = pathPrefix
 	if s.errRepo != "" && ri.Name() == s.errRepo {
+		if s.errWith != nil {
+			return nil, s.errWith
+		}
 		return nil, errors.New("db on fire")
 	}
 	return s.clusters[ri.Name()], nil
@@ -809,9 +816,20 @@ func TestLensFacts_UnknownMotifTermIsPassedThroughUnchanged(t *testing.T) {
 	}
 }
 
-// A lens over ONE repo must send exactly what a repo request sends: the
-// widening is an identity there, because every member of a cluster already
-// resolves to that cluster's canonical inside the one branch.
+// A lens over ONE repo must send exactly what a repo request sends.
+//
+// NOT because the widening would be an identity there — it would not. Within
+// one branch ClustersUnder groups mechanically-equal spellings into one cluster
+// while the store's exact tier resolves a bare term through PER-SPELLING
+// canonicals, so a widened single-mount term would reach a cluster sibling the
+// same repo read directly does not. The skip is what keeps a lens of one
+// answering exactly like the repo it wraps.
+//
+// This stub's cluster has one member, so it is identity by construction and
+// cannot see that divergence: it checks the WIRING (nothing widened, bare term
+// forwarded). The semantic pin is the MCP twin,
+// TestQueryFederation_MotifWideningIsSkippedForOneMount, which runs against
+// real stores with two mechanically-equal spellings in one repo.
 func TestLensFacts_WideningIsAnIdentityForALensOfOne(t *testing.T) {
 	carriers := driftCarriersByMount()
 	m, _ := newTestLensManager(t, "alpha", "beta")
@@ -865,5 +883,66 @@ func TestLensMotifCluster_AliasAttributionIsPerMount(t *testing.T) {
 		if a.Motif == "configuration-drifts" && a.Rationale != "" {
 			t.Errorf("took a non-contributing mount's audit trail: %+v", a)
 		}
+	}
+}
+
+// The widening reads every mount, so a mount pinned to a deleted branch fails
+// there — and the 404 it produces has to NAME that branch. writeStoreError
+// renders store.ErrBranchNotFound as `no branch named "<branch>"`, so a
+// fan-out that dropped the branch on its way out would print the message with
+// the one word it exists to carry missing.
+func TestLensFacts_MotifWideningNamesTheFailingMountsBranch(t *testing.T) {
+	motifs := splitVocabularyStub()
+	motifs.errRepo = "beta"
+	motifs.errWith = store.ErrBranchNotFound
+	carriers := driftCarriersByMount()
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		motifs: motifs, factsCollection: carriers, search: carriers}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/facts?motifs=config-drift&motif_match=exact")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	// Decoded, not substring-matched: the detail carries the branch in quotes
+	// and the body is JSON, so a literal-quote Contains check compares against
+	// the wrong escaping and passes or fails for the wrong reason.
+	var problem struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &problem); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	wantBranch := m.Get("beta").AgentBranch()
+	if want := `no branch named "` + wantBranch + `"`; problem.Detail != want {
+		t.Errorf("detail: got %q, want %q — the failing mount's branch, not an empty one",
+			problem.Detail, want)
+	}
+}
+
+// A mount failing the widening fails the WHOLE request, exactly as a mount
+// failing the vocabulary read does — the term is resolved against the lens, and
+// a lens does not answer from a shrunken read set (RFC §9.1). This is the same
+// rule as everywhere else; it is asserted here because the widening is the one
+// place it reaches a mount the caller did not ask about.
+func TestLensFacts_MotifWideningFailsTheWholeRequest(t *testing.T) {
+	motifs := splitVocabularyStub()
+	motifs.errRepo = "beta"
+	carriers := driftCarriersByMount()
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		motifs: motifs, factsCollection: carriers, search: carriers}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	// ...and it does so even when the caller narrowed beta AWAY: the term's
+	// meaning is lens-wide, so beta is still read to resolve it. That coupling
+	// is deliberate and documented; this pins that it is real rather than
+	// accidental, so a later change cannot quietly drop it as a bug.
+	rec := getLensFacts(t, r, "/lenses/eng/facts?motifs=config-drift&repo=alpha")
+	if rec.Code == http.StatusOK {
+		t.Fatalf("a mount excluded by repo= still resolves the term, so its failure must not produce 200; body=%s", rec.Body.String())
 	}
 }

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -99,7 +99,7 @@ type lensFactsResponse struct {
 // federate.ReadTargetsFor, fetch each mount's RecentFacts at its pinned branch,
 // dedupe by repo-relative path (the write mount's copy wins), merge by
 // committed_at across mounts, and qualify read-mount paths (kb://<id12>/…).
-func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
+func handleHALLensFacts(provider factsCollectionProvider, motifsP motifsProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		b := repos.BindingFromContext(r.Context())
 		qp := r.URL.Query()
@@ -153,15 +153,24 @@ func handleHALLensFacts(provider factsCollectionProvider) http.HandlerFunc {
 			}
 		}
 
-		// Ontology-aware fan-out target selection — the same seam MCP queryRecent
-		// uses. A kb://-qualified path restricts to a single mount (with the
-		// filter made repo-relative); an unqualified path applies per mount,
-		// skipping mounts whose ontology lacks the topic.
 		motifs, motifMatch, ok := motifParams(w, r)
 		if !ok {
 			return
 		}
 
+		// Widen each term to its MERGED cluster before the fan-out. The store's
+		// tiers resolve a term through ONE branch's alias table, so a mount that
+		// spells the shape differently would contribute nothing to a filter the
+		// lens's own vocabulary counted — see expandLensMotifs.
+		motifs, ok = expandLensMotifs(w, r, b, motifsP, motifs)
+		if !ok {
+			return
+		}
+
+		// Ontology-aware fan-out target selection — the same seam MCP queryRecent
+		// uses. A kb://-qualified path restricts to a single mount (with the
+		// filter made repo-relative); an unqualified path applies per mount,
+		// skipping mounts whose ontology lacks the topic.
 		targets, err := federate.ReadTargetsFor(b, path)
 		if err != nil {
 			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
@@ -675,7 +684,7 @@ type lensSearchResponse struct {
 // the facts collection dedupes. A shadowed copy is dropped even when it ranks
 // higher in the fused order than the winner. Read-mount paths are qualified
 // (kb://<id12>/…); each row carries its source {repo,id,branch}.
-func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.HandlerFunc {
+func handleHALLensSearch(provider searchProvider, emb store.Embedder, motifsP motifsProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		b := repos.BindingFromContext(r.Context())
 		qp := r.URL.Query()
@@ -706,14 +715,23 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder) http.Handl
 			return
 		}
 
-		// Ontology-aware fan-out target selection — the same seam MCP queryFirstCall
-		// uses. A kb://-qualified path restricts to one mount (filter made
-		// repo-relative); an unqualified path applies per mount.
 		motifs, motifMatch, ok := motifParams(w, r)
 		if !ok {
 			return
 		}
 
+		// Widen each term to its MERGED cluster before the fan-out. The store's
+		// tiers resolve a term through ONE branch's alias table, so a mount that
+		// spells the shape differently would contribute nothing to a filter the
+		// lens's own vocabulary counted — see expandLensMotifs.
+		motifs, ok = expandLensMotifs(w, r, b, motifsP, motifs)
+		if !ok {
+			return
+		}
+
+		// Ontology-aware fan-out target selection — the same seam MCP queryFirstCall
+		// uses. A kb://-qualified path restricts to one mount (filter made
+		// repo-relative); an unqualified path applies per mount.
 		targets, err := federate.ReadTargetsFor(b, qp.Get("path"))
 		if err != nil {
 			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -1705,10 +1705,9 @@ func (s *motifResolvingLensStub) Search(
 
 // divergentVocabularies builds the asymmetry the semantics turn on: mount alpha
 // judge-merged "config-drift" and "configuration-drifts"; mount beta never did.
-// A query for "config-drift" must therefore pull alpha's aliased fact and NOT
-// beta's identically-spelled one, while still pulling beta's exact carrier —
-// so "beta answered only exactly" is distinguishable from "beta was never
-// asked".
+// Each mount's own resolution is modelled faithfully — beta still answers only
+// for the exact spelling — so what the LENS does with that asymmetry is
+// visible rather than assumed.
 func divergentVocabularies() *motifResolvingLensStub {
 	return &motifResolvingLensStub{
 		facts: map[string][]store.RecentFactEntry{
@@ -1727,15 +1726,48 @@ func divergentVocabularies() *motifResolvingLensStub {
 	}
 }
 
-func TestLensFacts_MotifResolutionIsPerMountNotShared(t *testing.T) {
+// divergentVocabulariesUnion is the motif VOCABULARY behind the same asymmetry:
+// alpha's judge merge produced one cluster holding both spellings; beta filed
+// its lone spelling as a singleton. The two share the spelling
+// `configuration-drifts`, so the lens union merges them into one shape.
+//
+// Supplying this is what makes the tests below test anything. Without a motifs
+// provider the union is empty, every term falls through unwidened, and the
+// assertions pass by describing a code path that never ran.
+func divergentVocabulariesUnion() *lensMotifsStub {
+	return &lensMotifsStub{clusters: map[string][]store.MotifCluster{
+		"alpha": {{ClusterKey: "config-drift", CanonicalID: "config-drift",
+			Members: []string{"config-drift", "configuration-drifts"}, DF: 1, DFTotal: 1}},
+		"beta": {{ClusterKey: "configuration-drifts", CanonicalID: "configuration-drifts",
+			Members: []string{"configuration-drifts"}, DF: 1, DFTotal: 1}},
+	}}
+}
+
+// A JUDGE MERGE ON ANY MOUNT BINDS THE WHOLE LENS, FOR READS.
+//
+// This test used to assert the opposite — that beta's identically-spelled fact
+// must NOT answer, because beta never merged the spellings. That was the
+// pre-lens rule, fossilized: it is what "resolution is per-mount" means when
+// there is no lens-wide vocabulary to resolve against. There is one now, and it
+// says these two spellings are one shape, so every mount answers for it.
+//
+// That follows from what a lens IS rather than from a preference. A lens
+// answers exactly like a single repo (kb/decisions/lens/no-federation-metadata-in-responses),
+// and inside a single repo one judge merge binds every fact in it. Keeping the
+// old rule would mean a lens whose answer depends on which mount a reader's
+// vocabulary happened to come from — which is the shape the merged vocabulary
+// exists to remove.
+//
+// READ-ONLY, and the companion below pins it: nothing is written back to beta.
+func TestLensFacts_AMergeOnAnyMountBindsTheWholeLens(t *testing.T) {
 	m, _ := newTestLensManager(t, "alpha", "beta")
 	stub := divergentVocabularies()
-	s := &Server{Manager: m, providers: storeProviders{factsCollection: stub}}
+	s := &Server{Manager: m, providers: storeProviders{
+		factsCollection: stub, motifs: divergentVocabulariesUnion()}}
 	r := s.NewAPIRouter()
 	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
 
-	rec := getLensFacts(t, r, "/lenses/eng/facts?motifs=config-drift")
-	body := decodeLensFacts(t, rec)
+	body := decodeLensFacts(t, getLensFacts(t, r, "/lenses/eng/facts?motifs=config-drift"))
 
 	titles := map[string]bool{}
 	for _, f := range body.Facts {
@@ -1745,21 +1777,51 @@ func TestLensFacts_MotifResolutionIsPerMountNotShared(t *testing.T) {
 	if !titles["Alpha aliased"] {
 		t.Errorf("the merging mount's aliased fact is missing: %v", titles)
 	}
-	// beta did not, so its identically-spelled fact must NOT — this is the
-	// assertion that fails if resolution were shared or write-repo-only.
-	if titles["Beta aliased"] {
-		t.Errorf("the non-merging mount answered for an aliased spelling: %v", titles)
+	// beta never merged them — and answers anyway, because the LENS did. This
+	// is the assertion that inverted.
+	if !titles["Beta aliased"] {
+		t.Errorf("the non-merging mount did not answer for the merged shape: %v", titles)
 	}
-	// ...but beta WAS queried and did contribute its exact carrier.
+	// ...and beta's exact carrier is still there, so "beta answered for the
+	// whole shape" stays distinguishable from "beta answered for nothing".
 	if !titles["Beta exact"] {
 		t.Errorf("the non-merging mount contributed nothing at all: %v", titles)
 	}
 }
 
-func TestLensSearch_MotifResolutionIsPerMountNotShared(t *testing.T) {
+// The merge binds READS through the lens; it rewrites nothing. Beta's own
+// vocabulary is untouched, so beta read directly still resolves only its exact
+// spelling — the per-mount rule the test above used to assert is still the rule
+// for a mount read on its own.
+func TestLensFacts_TheMergeBindsReadsAndRewritesNothing(t *testing.T) {
 	m, _ := newTestLensManager(t, "alpha", "beta")
 	stub := divergentVocabularies()
-	s := &Server{Manager: m, providers: storeProviders{search: stub}}
+	s := &Server{Manager: m, providers: storeProviders{
+		factsCollection: stub, motifs: divergentVocabulariesUnion()}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	getLensFacts(t, r, "/lenses/eng/facts?motifs=config-drift")
+
+	// The lens widened the TERM. It did not touch beta's alias table, and beta
+	// resolved the widened term with its own vocabulary exactly as before —
+	// which is why "Beta aliased" came back: the term now names its spelling,
+	// not because beta learned a merge.
+	if len(stub.aliases["beta"]) != 0 {
+		t.Errorf("the read mount's alias table was written to: %v", stub.aliases["beta"])
+	}
+	got := stub.lastOpts["beta"].Motifs
+	if len(got) != 2 {
+		t.Errorf("beta was asked for %v, want both spellings of the merged shape", got)
+	}
+}
+
+// The /search twin of the inversion above — the same rule, the other envelope.
+func TestLensSearch_AMergeOnAnyMountBindsTheWholeLens(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	stub := divergentVocabularies()
+	s := &Server{Manager: m, providers: storeProviders{
+		search: stub, motifs: divergentVocabulariesUnion()}}
 	r := s.NewAPIRouter()
 	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
 
@@ -1782,8 +1844,8 @@ func TestLensSearch_MotifResolutionIsPerMountNotShared(t *testing.T) {
 	if !titles["Alpha aliased"] {
 		t.Errorf("the merging mount's aliased fact is missing: %v", titles)
 	}
-	if titles["Beta aliased"] {
-		t.Errorf("the non-merging mount answered for an aliased spelling: %v", titles)
+	if !titles["Beta aliased"] {
+		t.Errorf("the non-merging mount did not answer for the merged shape: %v", titles)
 	}
 	if !titles["Beta exact"] {
 		t.Errorf("the non-merging mount contributed nothing at all: %v", titles)

--- a/internal/web/handlers_motifs.go
+++ b/internal/web/handlers_motifs.go
@@ -178,6 +178,191 @@ func definitionState(st store.MotifDefinitionStatus, ok bool) string {
 	}
 }
 
+// motifCollectionParams is the parsed query of a motif vocabulary collection.
+//
+// Parsed ONCE, in motifCollectionQuery, because the repo and lens surfaces must
+// take the same knobs with the same bounds and the same refusals. Two
+// hand-written copies would agree until one of them was edited — the split
+// this codebase closes by construction rather than by discipline.
+type motifCollectionParams struct {
+	// Sort is "df" (default) or "name"; anything else is a 400.
+	sort string
+	// Q narrows the LIST and the count. A way of reading one page: it never
+	// touches the health block.
+	q string
+	// Path is SCOPE, not a filter over the page: it says which corpus this
+	// vocabulary is of, exactly as it does on /stats — so it narrows the
+	// health block too. The caller applies it (per repo, or per mount).
+	path          string
+	limit, offset int
+}
+
+// motifCollectionQuery parses and validates the vocabulary collection's query.
+// On any refusal it writes the problem response and returns ok=false; the
+// caller must return immediately without writing again.
+func motifCollectionQuery(w http.ResponseWriter, r *http.Request) (motifCollectionParams, bool) {
+	qp := r.URL.Query()
+	p := motifCollectionParams{
+		sort:   qp.Get("sort"),
+		q:      qp.Get("q"),
+		path:   qp.Get("path"),
+		limit:  motifsDefaultLimit,
+		offset: 0,
+	}
+	if p.sort == "" {
+		p.sort = "df"
+	}
+	if p.sort != "df" && p.sort != "name" {
+		hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
+			`invalid sort value (accepted: "df", "name")`, r.URL.Path)
+		return p, false
+	}
+	if v := qp.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		// A HARD CEILING, not a clamp, matching limitParam: a client that
+		// asked for 500 and silently received 200 rows has no way to tell
+		// that from "there were only 200". Split into limitParam's three
+		// messages so the refusal says WHICH bound was missed and what it
+		// is, rather than making the caller guess.
+		switch {
+		case err != nil:
+			badParam(w, r, "invalid limit value")
+			return p, false
+		case n < 1:
+			badParam(w, r, "limit must be at least 1")
+			return p, false
+		case n > motifsMaxLimit:
+			badParam(w, r, "limit must not exceed "+strconv.Itoa(motifsMaxLimit))
+			return p, false
+		}
+		p.limit = n
+	}
+	if v := qp.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		switch {
+		case err != nil:
+			badParam(w, r, "invalid offset value")
+			return p, false
+		case n < 0:
+			badParam(w, r, "offset must not be negative")
+			return p, false
+		}
+		p.offset = n
+	}
+	return p, true
+}
+
+// motifClusterKeys is the bulk-Definitions argument for a cluster list.
+func motifClusterKeys(clusters []store.MotifCluster) []string {
+	keys := make([]string, len(clusters))
+	for i, c := range clusters {
+		keys[i] = c.ClusterKey
+	}
+	return keys
+}
+
+// renderMotifCollection narrows, orders, pages and writes the vocabulary
+// collection — the whole wire body below the point where a repo and a lens
+// stop differing.
+//
+// base is the surface's own /motifs URL, and it is the ONLY thing that differs:
+// a lens answers exactly like a single repo (no federation metadata, same
+// envelope, same links shape), so everything from the ?q= narrowing down is one
+// implementation rather than two kept in step. `defs` carries presence as
+// meaning: a key absent from it has no definition at all.
+func renderMotifCollection(
+	w http.ResponseWriter, r *http.Request, base string,
+	clusters []store.MotifCluster, defs map[string]store.MotifDefinitionStatus,
+	health store.MotifVocabularyHealth, p motifCollectionParams,
+) {
+	if q := strings.ToLower(strings.TrimSpace(p.q)); q != "" {
+		// A NEW slice, never clusters[:0]: filtering in place rewrites the
+		// backing array the provider handed over, so a provider that
+		// returns a cached or shared slice would be silently corrupted by
+		// a read request.
+		kept := make([]store.MotifCluster, 0, len(clusters))
+		for _, c := range clusters {
+			if motifClusterMatches(c, defs[c.ClusterKey].Definition, q) {
+				kept = append(kept, c)
+			}
+		}
+		clusters = kept
+	}
+
+	// Clusters arrives df-desc / canonical-asc from the store (and from the
+	// lens union, which re-sorts by the same rule); only the name sort
+	// re-orders.
+	if p.sort == "name" {
+		// Same reasoning as the narrowing above: sort a copy, never the
+		// provider's own slice.
+		sorted := make([]store.MotifCluster, len(clusters))
+		copy(sorted, clusters)
+		clusters = sorted
+		sort.Slice(clusters, func(i, j int) bool {
+			return clusters[i].CanonicalID < clusters[j].CanonicalID
+		})
+	}
+
+	total := len(clusters)
+	// Page bounds by REMAINDER, never by the sum offset+limit. An offset
+	// near MaxInt clears the `n < 0` parse guard above and then wraps the
+	// sum NEGATIVE, which passes every `< total` test written as a sum and
+	// reaches the slice expression as a negative bound — a bounds panic on
+	// an unauthenticated GET. `limit < total-offset` asks the same question
+	// with operands that cannot overflow (offset is capped at total first).
+	start := min(p.offset, total)
+	end := total
+	if p.limit < total-start {
+		end = start + p.limit
+	}
+
+	links := hal.LinkMap{"self": {Href: selfWithQuery(base, r)}}
+	if end < total {
+		nextQ := r.URL.Query()
+		nextQ.Set("offset", strconv.Itoa(end))
+		links["next"] = hal.Link{Href: base + "?" + nextQ.Encode()}
+	}
+	if p.offset > 0 {
+		prevQ := r.URL.Query()
+		prevQ.Set("offset", strconv.Itoa(max(p.offset-p.limit, 0)))
+		links["prev"] = hal.Link{Href: base + "?" + prevQ.Encode()}
+	}
+
+	page := clusters[start:end]
+	items := make([]motifEntry, 0, len(page))
+	for _, c := range page {
+		st, ok := defs[c.ClusterKey]
+		items = append(items, motifEntry{
+			ClusterKey:      c.ClusterKey,
+			Canonical:       c.CanonicalID,
+			Members:         c.Members,
+			DF:              c.DF,
+			DFTotal:         c.DFTotal,
+			Definition:      st.Definition,
+			DefinitionState: definitionState(st, ok),
+			Links:           hal.LinkMap{"self": {Href: base + "/" + c.ClusterKey}},
+		})
+	}
+
+	hal.WriteHAL(w, http.StatusOK, motifsView{
+		// Count is the post-narrowing total over EVERY origin; the health
+		// block beside it is authored-only and unnarrowed. See
+		// motifHealthView for why its fields carry the population prefix.
+		Count: total,
+		Health: motifHealthView{
+			AuthoredClusters:           health.Clusters,
+			AuthoredRecurring:          health.Recurring,
+			AuthoredMints:              health.Mints,
+			AuthoredLinks:              health.Links,
+			AuthoredEpistemicRecurring: health.EpistemicRecurring,
+			RecurrenceRate:             health.RecurrenceRate(),
+			MintToLinkRatio:            health.MintToLinkRatio(),
+		},
+		Links:    links,
+		Embedded: map[string][]motifEntry{"motifs": items},
+	})
+}
+
 // handleHALMotifs serves GET /repos/{repo}/branches/{branch}/motifs — the
 // per-repo motif vocabulary, one entry per cluster, df-desc by default.
 func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc {
@@ -186,64 +371,18 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 		ri := repos.RepoFromContext(r.Context())
 		branch := BranchFromContext(r.Context())
 		a := hal.Anchor{Branch: branch}
-		qp := r.URL.Query()
 
-		sortBy := qp.Get("sort")
-		if sortBy == "" {
-			sortBy = "df"
-		}
-		if sortBy != "df" && sortBy != "name" {
-			hal.WriteProblem(w, http.StatusBadRequest, "Invalid parameter",
-				`invalid sort value (accepted: "df", "name")`, r.URL.Path)
+		p, ok := motifCollectionQuery(w, r)
+		if !ok {
 			return
 		}
-		limit := motifsDefaultLimit
-		if v := qp.Get("limit"); v != "" {
-			n, err := strconv.Atoi(v)
-			// A HARD CEILING, not a clamp, matching limitParam: a client that
-			// asked for 500 and silently received 200 rows has no way to tell
-			// that from "there were only 200". Split into limitParam's three
-			// messages so the refusal says WHICH bound was missed and what it
-			// is, rather than making the caller guess.
-			switch {
-			case err != nil:
-				badParam(w, r, "invalid limit value")
-				return
-			case n < 1:
-				badParam(w, r, "limit must be at least 1")
-				return
-			case n > motifsMaxLimit:
-				badParam(w, r, "limit must not exceed "+strconv.Itoa(motifsMaxLimit))
-				return
-			}
-			limit = n
-		}
-		offset := 0
-		if v := qp.Get("offset"); v != "" {
-			n, err := strconv.Atoi(v)
-			switch {
-			case err != nil:
-				badParam(w, r, "invalid offset value")
-				return
-			case n < 0:
-				badParam(w, r, "offset must not be negative")
-				return
-			}
-			offset = n
-		}
 
-		// ?path= is SCOPE, not a filter over the page: it says which corpus
-		// this vocabulary is of, exactly as it does on /stats — so it narrows
-		// the health block too, while ?q= (a way of reading the page) narrows
-		// only the list and the count.
-		pathPrefix := qp.Get("path")
-
-		clusters, err := provider.Clusters(r.Context(), ri, branch, pathPrefix)
+		clusters, err := provider.Clusters(r.Context(), ri, branch, p.path)
 		if err != nil {
 			writeStoreError(w, r, err, "Failed to load motif vocabulary", branch)
 			return
 		}
-		health, err := provider.VocabularyHealth(r.Context(), ri, branch, pathPrefix)
+		health, err := provider.VocabularyHealth(r.Context(), ri, branch, p.path)
 		if err != nil {
 			writeStoreError(w, r, err, "Failed to load motif vocabulary", branch)
 			return
@@ -251,102 +390,13 @@ func handleHALMotifs(b hal.URLBuilder, provider motifsProvider) http.HandlerFunc
 
 		// Definitions for every cluster in one bulk read. Fetched before
 		// narrowing because ?q= matches definition text too.
-		keys := make([]string, len(clusters))
-		for i, c := range clusters {
-			keys[i] = c.ClusterKey
-		}
-		defs, err := provider.Definitions(r.Context(), ri, branch, keys)
+		defs, err := provider.Definitions(r.Context(), ri, branch, motifClusterKeys(clusters))
 		if err != nil {
 			writeStoreError(w, r, err, "Failed to load motif vocabulary", branch)
 			return
 		}
 
-		if q := strings.ToLower(strings.TrimSpace(qp.Get("q"))); q != "" {
-			// A NEW slice, never clusters[:0]: filtering in place rewrites the
-			// backing array the provider handed over, so a provider that
-			// returns a cached or shared slice would be silently corrupted by
-			// a read request.
-			kept := make([]store.MotifCluster, 0, len(clusters))
-			for _, c := range clusters {
-				if motifClusterMatches(c, defs[c.ClusterKey].Definition, q) {
-					kept = append(kept, c)
-				}
-			}
-			clusters = kept
-		}
-
-		// Clusters arrives df-desc / canonical-asc from the store; only the
-		// name sort re-orders.
-		if sortBy == "name" {
-			// Same reasoning as the narrowing above: sort a copy, never the
-			// provider's own slice.
-			sorted := make([]store.MotifCluster, len(clusters))
-			copy(sorted, clusters)
-			clusters = sorted
-			sort.Slice(clusters, func(i, j int) bool {
-				return clusters[i].CanonicalID < clusters[j].CanonicalID
-			})
-		}
-
-		total := len(clusters)
-		// Page bounds by REMAINDER, never by the sum offset+limit. An offset
-		// near MaxInt clears the `n < 0` parse guard above and then wraps the
-		// sum NEGATIVE, which passes every `< total` test written as a sum and
-		// reaches the slice expression as a negative bound — a bounds panic on
-		// an unauthenticated GET. `limit < total-offset` asks the same question
-		// with operands that cannot overflow (offset is capped at total first).
-		start := min(offset, total)
-		end := total
-		if limit < total-start {
-			end = start + limit
-		}
-
-		motifsBase := b.Branch(repoName, a) + "/motifs"
-		links := hal.LinkMap{"self": {Href: selfWithQuery(motifsBase, r)}}
-		if end < total {
-			nextQ := r.URL.Query()
-			nextQ.Set("offset", strconv.Itoa(end))
-			links["next"] = hal.Link{Href: motifsBase + "?" + nextQ.Encode()}
-		}
-		if offset > 0 {
-			prevQ := r.URL.Query()
-			prevQ.Set("offset", strconv.Itoa(max(offset-limit, 0)))
-			links["prev"] = hal.Link{Href: motifsBase + "?" + prevQ.Encode()}
-		}
-
-		page := clusters[start:end]
-		items := make([]motifEntry, 0, len(page))
-		for _, c := range page {
-			st, ok := defs[c.ClusterKey]
-			items = append(items, motifEntry{
-				ClusterKey:      c.ClusterKey,
-				Canonical:       c.CanonicalID,
-				Members:         c.Members,
-				DF:              c.DF,
-				DFTotal:         c.DFTotal,
-				Definition:      st.Definition,
-				DefinitionState: definitionState(st, ok),
-				Links:           hal.LinkMap{"self": {Href: motifsBase + "/" + c.ClusterKey}},
-			})
-		}
-
-		hal.WriteHAL(w, http.StatusOK, motifsView{
-			// Count is the post-narrowing total over EVERY origin; the health
-			// block beside it is authored-only and unnarrowed. See
-			// motifHealthView for why its fields carry the population prefix.
-			Count: total,
-			Health: motifHealthView{
-				AuthoredClusters:           health.Clusters,
-				AuthoredRecurring:          health.Recurring,
-				AuthoredMints:              health.Mints,
-				AuthoredLinks:              health.Links,
-				AuthoredEpistemicRecurring: health.EpistemicRecurring,
-				RecurrenceRate:             health.RecurrenceRate(),
-				MintToLinkRatio:            health.MintToLinkRatio(),
-			},
-			Links:    links,
-			Embedded: map[string][]motifEntry{"motifs": items},
-		})
+		renderMotifCollection(w, r, b.Branch(repoName, a)+"/motifs", clusters, defs, health, p)
 	}
 }
 
@@ -368,6 +418,31 @@ const (
 	motifCarriersDefaultLimit = 20
 	motifCarriersMaxLimit     = 100
 )
+
+// motifCarrierLimit parses the cluster detail's carrier preview bound, shared
+// by the repo and lens details so the two cannot drift on the ceiling or on
+// what they say when it is missed. On a refusal it writes the problem response
+// and returns ok=false; the caller must return without writing again.
+func motifCarrierLimit(w http.ResponseWriter, r *http.Request) (int, bool) {
+	v := r.URL.Query().Get("limit")
+	if v == "" {
+		return motifCarriersDefaultLimit, true
+	}
+	n, err := strconv.Atoi(v)
+	// Hard ceiling, same reasoning and same messages as the collection's limit.
+	switch {
+	case err != nil:
+		badParam(w, r, "invalid limit value")
+		return 0, false
+	case n < 1:
+		badParam(w, r, "limit must be at least 1")
+		return 0, false
+	case n > motifCarriersMaxLimit:
+		badParam(w, r, "limit must not exceed "+strconv.Itoa(motifCarriersMaxLimit))
+		return 0, false
+	}
+	return n, true
+}
 
 // motifCarrierItem is one carrier fact in the detail preview, recency-ordered
 // like the /facts pivot it previews.
@@ -417,23 +492,9 @@ func handleHALMotifCluster(b hal.URLBuilder, provider motifsProvider, facts fact
 		a := hal.Anchor{Branch: branch}
 		rawKey := chi.URLParam(r, "key")
 
-		carrierLimit := motifCarriersDefaultLimit
-		if v := r.URL.Query().Get("limit"); v != "" {
-			n, err := strconv.Atoi(v)
-			// Hard ceiling, same reasoning and same messages as the
-			// collection's limit.
-			switch {
-			case err != nil:
-				badParam(w, r, "invalid limit value")
-				return
-			case n < 1:
-				badParam(w, r, "limit must be at least 1")
-				return
-			case n > motifCarriersMaxLimit:
-				badParam(w, r, "limit must not exceed "+strconv.Itoa(motifCarriersMaxLimit))
-				return
-			}
-			carrierLimit = n
+		carrierLimit, ok := motifCarrierLimit(w, r)
+		if !ok {
+			return
 		}
 
 		// Branch-wide, with no path scope: a cluster is being addressed by

--- a/internal/web/handlers_motifs_test.go
+++ b/internal/web/handlers_motifs_test.go
@@ -62,6 +62,7 @@ type motifsCollectionBody struct {
 		AuthoredMints     int     `json:"authored_mints"`
 		AuthoredLinks     int     `json:"authored_links"`
 		RecurrenceRate    float64 `json:"recurrence_rate"`
+		MintToLinkRatio   float64 `json:"mint_to_link_ratio"`
 
 		AuthoredEpistemicRecurring int `json:"authored_epistemic_recurring"`
 	} `json:"health"`

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -239,9 +239,9 @@ func (s *Server) NewAPIRouter() chi.Router {
 
 		r.Group(func(r chi.Router) {
 			r.Use(LensMiddleware(s.Manager))
-			r.Get("/facts", handleHALLensFacts(p.factsCollection))
+			r.Get("/facts", handleHALLensFacts(p.factsCollection, p.motifs))
 			r.Get("/facts/*", handleHALLensFact(b, p.factReader, p.factSub))
-			r.Get("/search", handleHALLensSearch(p.search, s.Embedder))
+			r.Get("/search", handleHALLensSearch(p.search, s.Embedder, p.motifs))
 			r.Get("/completions", handleHALLensCompletions(p.completions))
 			r.Get("/motifs", handleHALLensMotifs(b, p.motifs))
 			r.Get("/motifs/{key}", handleHALLensMotifCluster(b, p.motifs, p.factsCollection))

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -243,6 +243,8 @@ func (s *Server) NewAPIRouter() chi.Router {
 			r.Get("/facts/*", handleHALLensFact(b, p.factReader, p.factSub))
 			r.Get("/search", handleHALLensSearch(p.search, s.Embedder))
 			r.Get("/completions", handleHALLensCompletions(p.completions))
+			r.Get("/motifs", handleHALLensMotifs(b, p.motifs))
+			r.Get("/motifs/{key}", handleHALLensMotifCluster(b, p.motifs, p.factsCollection))
 			r.Get("/stats", handleHALLensStats(p.stats, p.activity))
 			r.Get("/topics", handleHALLensTopics(p.topicLister, s.OntologyRoot))
 			r.Get("/topics/*", handleHALLensTopics(p.topicLister, s.OntologyRoot))

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -1872,6 +1872,115 @@ paths:
               schema: { $ref: "#/components/schemas/Problem" }
         "500": { $ref: "#/components/responses/Problem" }
 
+  /lenses/{lens}/motifs:
+    parameters:
+      - $ref: "#/components/parameters/Lens"
+    get:
+      tags: [lenses, stats, search]
+      summary: Merged motif vocabulary across the lens's mounts
+      description: |
+        The lens-wide motif vocabulary: every mount's clusters merged into one
+        list, in the same envelope the per-repo vocabulary uses. A lens answers
+        exactly like a single repo — there is no coverage or skipped-mount
+        metadata, here or anywhere else.
+
+        Clusters merge when they share a `cluster_key` OR any member spelling.
+        The key is mechanical (a normalized, sorted token form of the
+        spelling), so it names the same shape in every repo; a judge merge is
+        per-branch, so one mount can file a spelling under a key another mount
+        has not adopted, and merging on the key alone would put that one
+        spelling in two rows. The merged `cluster_key` is the smallest of the
+        constituent keys — stable under df change, which is what definitions
+        and this endpoint's own URLs hang off.
+
+        `df` and `df_total` are per-mount SUMS. Mounts are distinct repos but
+        not necessarily disjoint: a re-rooted fork mounted beside its upstream
+        shares fact UUIDs, so such a fact is counted once per mount — the same
+        accepted over-count `/lenses/{lens}/stats` makes on its histograms, and
+        for the same reason (an aggregate carries no per-fact paths to dedupe
+        on). `carriers` on the detail DO carry paths and dedupe exactly.
+
+        `health` counts are pooled across mounts and the two ratios are derived
+        from the pooled totals once — never averaged across mounts.
+
+        Motif clusters do not appear in `/lenses/{lens}/stats`; this endpoint is
+        the vocabulary surface.
+      operationId: listLensMotifs
+      parameters:
+        - name: path
+          in: query
+          description: |
+            Path prefix SCOPE, applied to every mount — the vocabulary of one
+            subtree rather than of the lens. It narrows `health` as well as the
+            list, exactly as it does on the per-repo endpoint. From
+            `kb/<topic>/…` onward, mounts whose ontology lacks the topic are
+            skipped rather than queried.
+          schema: { type: string }
+        - $ref: "#/components/parameters/LensRepoNarrow"
+        - { name: q,      in: query, description: "Case-insensitive substring narrow over member spellings AND definition text, across the merged vocabulary. `count` reflects the narrowed total.", schema: { type: string } }
+        - { name: sort,   in: query, description: "`df` (document frequency desc, ties by canonical asc) or `name` (canonical asc). Any other value is a 400.", schema: { type: string, enum: [df, name], default: df } }
+        - { name: limit,  in: query, description: "1–200; out-of-range or non-integer is 400. The maximum is a hard ceiling, not a clamp.", schema: { type: integer, default: 50, minimum: 1, maximum: 200 } }
+        - { name: offset, in: query, description: "Non-negative; negative or non-integer is 400.", schema: { type: integer, default: 0, minimum: 0 } }
+      responses:
+        "200":
+          description: Merged motif vocabulary page with a pooled health summary
+          content:
+            application/hal+json:
+              schema: { $ref: "#/components/schemas/MotifsCollection" }
+        "400": { $ref: "#/components/responses/Problem" }
+        "404": { $ref: "#/components/responses/Problem" }
+        "422":
+          description: "`repo=` names a mount that is not in this lens"
+          content:
+            application/problem+json:
+              schema: { $ref: "#/components/schemas/Problem" }
+        "500": { $ref: "#/components/responses/Problem" }
+
+  /lenses/{lens}/motifs/{key}:
+    parameters:
+      - $ref: "#/components/parameters/Lens"
+      - name: key
+        in: path
+        required: true
+        description: |
+          The merged `cluster_key`, ANY mount's own `cluster_key`, or any member
+          spelling — all three name the same merged cluster, and a reader
+          arriving from a repo-scoped link holds the second kind. The response
+          and its `self` link always carry the merged `cluster_key`. A key or
+          spelling in no cluster is a 404.
+        schema: { type: string }
+    get:
+      tags: [lenses, stats, search]
+      summary: Merged motif cluster detail through a lens
+      description: |
+        One merged cluster, with a carrier preview drawn from every mount.
+
+        Branch-wide on every mount, and `repo=` is not accepted: a cluster is
+        addressed by IDENTITY here, and its identity is a property of the lens
+        rather than of where the reader was standing.
+
+        `carriers` is a PREVIEW of the same query `_links.facts` performs —
+        `/lenses/{lens}/facts?motifs=<merged members>&motif_match=exact`, so
+        every mount expands the union against its own alias table and the two
+        cannot disagree. Carrier `path` is the canonical wire form (bare for
+        the write mount, `kb://<id12>/…` for a read mount), qualified after the
+        write-mount-wins dedupe. `carrier_count` counts MATCHES, never the rows
+        transferred: exact when no mount was truncated, otherwise the summed
+        per-mount total (an upper bound, off by the cross-mount path
+        collisions) — the same trade `/lenses/{lens}/facts` makes on `total`.
+      operationId: getLensMotifCluster
+      parameters:
+        - { name: limit, in: query, description: "Carrier preview size, per mount and for the merged list. 1–100; out-of-range or non-integer is 400. The maximum is a hard ceiling, not a clamp.", schema: { type: integer, default: 20, minimum: 1, maximum: 100 } }
+      responses:
+        "200":
+          description: Merged motif cluster
+          content:
+            application/hal+json:
+              schema: { $ref: "#/components/schemas/MotifClusterDetail" }
+        "400": { $ref: "#/components/responses/Problem" }
+        "404": { $ref: "#/components/responses/Problem" }
+        "500": { $ref: "#/components/responses/Problem" }
+
   /lenses/{lens}/topics:
     parameters:
       - $ref: "#/components/parameters/Lens"

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -1683,6 +1683,17 @@ paths:
 
         Any mount error fails the whole request — a lens never silently shrinks
         its read set.
+
+        MOTIF FILTERS ARE WIDENED TO THE LENS'S MERGED CLUSTERS before the
+        fan-out. A motif term resolves through ONE branch's alias table, and a
+        cluster's representative spelling is elected per branch, so a term sent
+        as-is would return nothing from a mount that carries the same shape
+        under a different spelling — a pivot whose count came from the merged
+        vocabulary would then list fewer facts than the count promised. Each
+        term is therefore replaced by every spelling in its merged cluster,
+        resolved over the FULL read set: `?path=` and `?repo=` narrow the LIST,
+        never what the term means. A term in no cluster is passed through
+        unchanged.
       operationId: listLensFacts
       parameters:
         - { name: limit,          in: query, description: "1–500; out-of-range or non-integer is 400.", schema: { type: integer, default: 50, minimum: 1, maximum: 500 } }
@@ -1780,6 +1791,17 @@ paths:
         by repo-relative path with the write mount's copy winning, even when a
         shadowed copy ranks higher. Read-mount paths are qualified as
         `kb://<id12>/…`.
+
+        MOTIF FILTERS ARE WIDENED TO THE LENS'S MERGED CLUSTERS before the
+        fan-out. A motif term resolves through ONE branch's alias table, and a
+        cluster's representative spelling is elected per branch, so a term sent
+        as-is would return nothing from a mount that carries the same shape
+        under a different spelling — a pivot whose count came from the merged
+        vocabulary would then list fewer facts than the count promised. Each
+        term is therefore replaced by every spelling in its merged cluster,
+        resolved over the FULL read set: `?path=` and `?repo=` narrow the LIST,
+        never what the term means. A term in no cluster is passed through
+        unchanged.
       operationId: searchLens
       parameters:
         - { name: q,              in: query, schema: { type: string } }
@@ -1901,7 +1923,13 @@ paths:
         on). `carriers` on the detail DO carry paths and dedupe exactly.
 
         `health` counts are pooled across mounts and the two ratios are derived
-        from the pooled totals once — never averaged across mounts.
+        from the pooled totals once — never averaged across mounts. They are
+        SUMS, and so carry the same over-count as `df`: a cluster present on two
+        mounts contributes to both mounts' `authored_clusters`, while `count`
+        above counts the merged cluster once. The two are already different
+        populations in the per-repo response — `health` is authored-only,
+        `count` spans every origin — and in a lens they differ by the overlap
+        as well, so do not read `count`/`authored_clusters` as a fraction.
 
         Motif clusters do not appear in `/lenses/{lens}/stats`; this endpoint is
         the vocabulary surface.
@@ -1958,6 +1986,13 @@ paths:
         Branch-wide on every mount, and `repo=` is not accepted: a cluster is
         addressed by IDENTITY here, and its identity is a property of the lens
         rather than of where the reader was standing.
+
+        A consequence worth stating: when the COLLECTION was narrowed with
+        `repo=`, a row's `self` link still resolves here against the FULL read
+        set, so the cluster it opens can carry a larger `df` and more `members`
+        than the narrowed row promised. It never 404s — a narrowed component's
+        smallest key is always in the full union's key set — and the merged key
+        the row carries is the key this endpoint answers to.
 
         `carriers` is a PREVIEW of the same query `_links.facts` performs —
         `/lenses/{lens}/facts?motifs=<merged members>&motif_match=exact`, so

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -1694,6 +1694,24 @@ paths:
         resolved over the FULL read set: `?path=` and `?repo=` narrow the LIST,
         never what the term means. A term in no cluster is passed through
         unchanged.
+
+        WHAT THAT MEANS FOR JUDGE MERGES: a judge merge on ANY mount changes
+        what a motif term returns for the WHOLE lens. Read through a lens the
+        mounts share one vocabulary, exactly as one repo's folders share one —
+        which is what "a lens answers like a single repo" comes to when the
+        question is about motifs. It is READ-ONLY: no mount's alias table,
+        canonical election or verdict history is touched, and the same repo read
+        directly still answers with its own vocabulary alone. A lens over a
+        single mount is likewise left alone, so it answers exactly as that repo
+        does.
+
+        Two consequences worth planning for. Because the term's meaning is
+        lens-wide, a mount EXCLUDED by `repo=` is still read to resolve it, so
+        that mount failing fails the request — a coupling a narrowed query did
+        not have before. And over two or more mounts a term can reach spellings
+        that a single unrebuilt repo's exact tier would not, because the union
+        groups mechanically-equal spellings the per-branch canonicals keep
+        apart; that is the shared vocabulary, not a leak in the tier.
       operationId: listLensFacts
       parameters:
         - { name: limit,          in: query, description: "1–500; out-of-range or non-integer is 400.", schema: { type: integer, default: 50, minimum: 1, maximum: 500 } }
@@ -1802,6 +1820,24 @@ paths:
         resolved over the FULL read set: `?path=` and `?repo=` narrow the LIST,
         never what the term means. A term in no cluster is passed through
         unchanged.
+
+        WHAT THAT MEANS FOR JUDGE MERGES: a judge merge on ANY mount changes
+        what a motif term returns for the WHOLE lens. Read through a lens the
+        mounts share one vocabulary, exactly as one repo's folders share one —
+        which is what "a lens answers like a single repo" comes to when the
+        question is about motifs. It is READ-ONLY: no mount's alias table,
+        canonical election or verdict history is touched, and the same repo read
+        directly still answers with its own vocabulary alone. A lens over a
+        single mount is likewise left alone, so it answers exactly as that repo
+        does.
+
+        Two consequences worth planning for. Because the term's meaning is
+        lens-wide, a mount EXCLUDED by `repo=` is still read to resolve it, so
+        that mount failing fails the request — a coupling a narrowed query did
+        not have before. And over two or more mounts a term can reach spellings
+        that a single unrebuilt repo's exact tier would not, because the union
+        groups mechanically-equal spellings the per-branch canonicals keep
+        apart; that is the shared vocabulary, not a leak in the tier.
       operationId: searchLens
       parameters:
         - { name: q,              in: query, schema: { type: string } }

--- a/web/src/FilterBar.motif.test.tsx
+++ b/web/src/FilterBar.motif.test.tsx
@@ -14,7 +14,7 @@ import { init } from './state';
 import type { AppState } from './state';
 
 vi.mock('./api', () => ({
-  api: { motifs: vi.fn(), completions: vi.fn(async () => ({ values: [] })), lensCompletions: vi.fn(async () => ({ values: [] })) },
+  api: { motifs: vi.fn(), lensMotifs: vi.fn(), completions: vi.fn(async () => ({ values: [] })), lensCompletions: vi.fn(async () => ({ values: [] })) },
   parseFilterQuery: (raw: string) => ({ chips: [], text: raw, warnings: [] }),
 }));
 
@@ -110,12 +110,33 @@ describe('the motif category in the picker', () => {
     api.motifs = real;
   });
 
-  it('is absent in a lens, where no single vocabulary exists', () => {
+  // The row used to be absent in a lens because cross-mount cluster identity
+  // did not exist and offering the write repo's names would have handed the
+  // reader a vocabulary the union does not have. /lenses/{lens}/motifs IS that
+  // identity, so the row is offered — and it must read the LENS, because the
+  // old objection is still exactly right about the alternative.
+  it('offers Motif in a lens, reading the merged vocabulary', async () => {
+    (api.lensMotifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 3, health: {}, motifs: RANKED.map((canonical, i) => ({
+        cluster_key: `k${i}`, canonical, members: [canonical], df: 26 - i * 9,
+      })),
+    });
     openPicker(repoState({ context: { kind: 'lens', name: 'dev' } }));
-    // Nothing to list: cross-mount cluster identity does not exist, and
-    // offering the write repo's names would hand the reader a vocabulary the
-    // union does not have. The same reasoning keeps `repo` out of this rail.
+    fireEvent.click(screen.getByTestId('picker-cat-motif'));
+    await waitFor(() => expect(api.lensMotifs).toHaveBeenCalledWith('dev',
+      expect.objectContaining({ sort: 'df' })));
+    expect(api.motifs).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId('picker-value').map(e => e.getAttribute('data-value')))
+      .toEqual(RANKED);
+  });
+
+  it('is absent in a lens with no lens vocabulary endpoint', () => {
+    const real = api.lensMotifs;
+    // @ts-expect-error — modelling the vendored client, which has no such call
+    api.lensMotifs = undefined;
+    openPicker(repoState({ context: { kind: 'lens', name: 'dev' } }));
     expect(screen.queryByTestId('picker-cat-motif')).toBeNull();
     expect(screen.getByTestId('picker-cat-domain')).toBeTruthy();
+    api.lensMotifs = real;
   });
 });

--- a/web/src/FilterBar.tsx
+++ b/web/src/FilterBar.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useRef, useState } from 'react';
 import type { Dispatch } from 'react';
 import type { AppState, Action, FilterChip } from './state';
 import { isLive, isLensContext, selectTrail } from './state';
+import { canReadMotifs, motifEndpointOf, readMotifs } from './motifEndpoint';
 import { api, parseFilterQuery } from './api';
 import { chipColors, chipStyle, originGlyphs, typeStyles, MOTIF_GLYPH } from './utils';
 import { TrailBreadcrumb } from './TrailBreadcrumb';
@@ -111,12 +112,13 @@ const PREFIX_RE = /(?:^|\s)(domain|entity|type|kind|origin|motif|path):(\S*)$/;
 export const FilterBar = memo(function FilterBar({ state, dispatch, onJumpTrail, embedded = false }: Props) {
   const isLens   = isLensContext(state);
   const lensName = state.context.kind === 'lens' ? state.context.name : '';
-  // Motif is offered only where its vocabulary can be read: not in a lens (no
-  // cross-mount identity) and not in a build with no such endpoint — the
-  // vendored /explore bundle swaps this client for a static one. A rail row
-  // that opened onto a permanent error is worse than a rail without it.
-  const CATEGORIES = (isLens || typeof api.motifs !== 'function')
-    ? LENS_CATEGORIES : FACT_CATEGORIES;
+  // Motif is offered wherever its vocabulary can be read. That now includes a
+  // lens — /lenses/{lens}/motifs merges every mount's clusters into one
+  // vocabulary — and excludes only a build with no such endpoint: the vendored
+  // /explore bundle swaps this client for a static one. A rail row that opened
+  // onto a permanent error is worse than a rail without it.
+  const motifEndpoint = motifEndpointOf(state);
+  const CATEGORIES = canReadMotifs(motifEndpoint) ? FACT_CATEGORIES : LENS_CATEGORIES;
 
   const [inputValue, setInputValue]               = useState('');
   const [suggestions, setSuggestions]             = useState<string[]>([]);
@@ -147,7 +149,7 @@ export const FilterBar = memo(function FilterBar({ state, dispatch, onJumpTrail,
     // completions endpoint returns bare strings and could do none of that. The
     // cost is a heavier payload, which is why it takes a page at a time.
     if (category === 'motif') {
-      return api.motifs(state.repo, state.branch, { q: prefix || undefined, sort: 'df', limit: 60 })
+      return readMotifs(motifEndpoint, { q: prefix || undefined, sort: 'df', limit: 60 })
         .then(r => ({ values: r.motifs.map(m => m.canonical) }));
     }
     return isLens

--- a/web/src/Library.tsx
+++ b/web/src/Library.tsx
@@ -10,6 +10,7 @@ import { typeStyles, defaultTypeStyle, relativeTimeEpoch, repoHue, displayLensPa
 import { TypeIcon, FolderIcon } from './icons';
 import { LibraryHeader } from './LibraryHeader';
 import { useMotifClusters } from './useMotifClusters';
+import { motifEndpointOf } from './motifEndpoint';
 import { factSubject, subjectSummary } from './motifSubject';
 import type { NavRequest } from './useNavigationManager';
 
@@ -397,7 +398,10 @@ export function Library({ state, dispatch, navigate, narrow = false }: Props) {
   // across the ontology and there is no folder to be in. Two chips is a union
   // of two shapes and has no single name, so it keeps the ordinary header.
   const pivotMotif = (motifs.length === 1 && !state.freeText) ? motifs[0] : null;
-  const pivotResolved = useMotifClusters(state.repo, state.branch, pivotMotif ? [pivotMotif] : undefined);
+  // Resolved against the corpus the list is OF: in a lens, the lens. The
+  // heading this feeds sits over a lens-wide union, so a write-repo-only
+  // cluster would name and count a different set than the rows beneath it.
+  const pivotResolved = useMotifClusters(motifEndpointOf(state), pivotMotif ? [pivotMotif] : undefined);
   const pivotCluster = pivotResolved[0]?.cluster;
 
   useAsync((stale) => {

--- a/web/src/MotifsBlock.test.tsx
+++ b/web/src/MotifsBlock.test.tsx
@@ -115,6 +115,50 @@ describe('MotifsBlock', () => {
       'knomit-kb', 'agent/test', expect.objectContaining({ q: 'silent' })));
   });
 
+  // The denominator of "N of M" is the UNNARROWED COUNT, never a health figure.
+  // The two are different populations — health is counted over authored facts
+  // only while the list spans every origin, and in a lens health is a per-mount
+  // sum while the list counts each merged cluster once — so "12 of 73" could
+  // compare merged clusters against per-mount cluster instances. The fixture
+  // above happens to give both the same number, which is why this one pulls
+  // them apart: only the count answers the question the phrase asks.
+  it('takes the "of M" from the unnarrowed count, not from the health block', async () => {
+    (api.motifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 40, health: { ...HEALTH, authored_clusters: 73 }, motifs: [...REUSED, ...ONCE],
+    });
+    draw();
+    await waitFor(() => expect(screen.getByTestId('motifs-count').textContent).toBe('40'));
+
+    fireEvent.click(screen.getByTestId('motifs-more'));
+    (api.motifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 3, health: { ...HEALTH, authored_clusters: 73 }, motifs: REUSED.slice(0, 3),
+    });
+    fireEvent.change(await screen.findByTestId('motifs-search'), { target: { value: 'signal' } });
+    await waitFor(() => expect(screen.getByTestId('motifs-count').textContent).toBe('3 of 40'));
+  });
+
+  // A folder click mid-search moves the scope: a denominator counted over the
+  // previous folder must not sit over the new folder's rows, exactly as the
+  // health strip must not. Better a bare count than a wrong fraction.
+  it('drops the "of M" counted over another folder', async () => {
+    (api.motifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 40, health: HEALTH, motifs: [...REUSED, ...ONCE],
+    });
+    const { rerender } = render(
+      <MotifsBlock endpoint={REPO} path="kb/decisions" onPick={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('motifs-count').textContent).toBe('40'));
+
+    fireEvent.click(screen.getByTestId('motifs-more'));
+    (api.motifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 3, health: HEALTH, motifs: REUSED.slice(0, 3),
+    });
+    fireEvent.change(await screen.findByTestId('motifs-search'), { target: { value: 'signal' } });
+    await waitFor(() => expect(screen.getByTestId('motifs-count').textContent).toBe('3 of 40'));
+
+    rerender(<MotifsBlock endpoint={REPO} path="kb/gotchas" onPick={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('motifs-count').textContent).toBe('3'));
+  });
+
   it('narrows the block count but NEVER the health figures', async () => {
     resolve();
     draw();

--- a/web/src/MotifsBlock.test.tsx
+++ b/web/src/MotifsBlock.test.tsx
@@ -3,7 +3,11 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MotifsBlock } from './MotifsBlock';
 import { api } from './api';
 
-vi.mock('./api', () => ({ api: { motifs: vi.fn() } }));
+vi.mock('./api', () => ({ api: { motifs: vi.fn(), lensMotifs: vi.fn() } }));
+
+// The endpoint the block reads from. A repo branch for most of the file; the
+// lens block below asserts the same behaviour against /lenses/{lens}/motifs.
+const REPO = { kind: 'repo', repo: 'knomit-kb', branch: 'agent/test' } as const;
 
 const entry = (canonical: string, df: number, definition?: string) => ({
   cluster_key: `key-${canonical}`, canonical, members: [canonical], df, definition,
@@ -34,7 +38,7 @@ const resolve = (over: Partial<{ count: number; motifs: typeof REUSED }> = {}) =
   });
 
 const draw = (onPick = vi.fn(), path = '') => {
-  render(<MotifsBlock repo="knomit-kb" branch="agent/test" path={path} onPick={onPick} />);
+  render(<MotifsBlock endpoint={REPO} path={path} onPick={onPick} />);
   return onPick;
 };
 
@@ -257,10 +261,10 @@ describe('MotifsBlock', () => {
   it('re-asks when the reader moves to another folder', async () => {
     resolve();
     const { rerender } = render(
-      <MotifsBlock repo="knomit-kb" branch="agent/test" path="kb/decisions" onPick={vi.fn()} />);
+      <MotifsBlock endpoint={REPO} path="kb/decisions" onPick={vi.fn()} />);
     await waitFor(() => expect(api.motifs).toHaveBeenLastCalledWith(
       'knomit-kb', 'agent/test', expect.objectContaining({ path: 'kb/decisions' })));
-    rerender(<MotifsBlock repo="knomit-kb" branch="agent/test" path="kb/gotchas" onPick={vi.fn()} />);
+    rerender(<MotifsBlock endpoint={REPO} path="kb/gotchas" onPick={vi.fn()} />);
     await waitFor(() => expect(api.motifs).toHaveBeenLastCalledWith(
       'knomit-kb', 'agent/test', expect.objectContaining({ path: 'kb/gotchas' })));
   });
@@ -272,7 +276,7 @@ describe('MotifsBlock', () => {
   it('drops health counted over another folder rather than pairing it with the new list', async () => {
     resolve();
     const { rerender } = render(
-      <MotifsBlock repo="knomit-kb" branch="agent/test" path="kb/decisions" onPick={vi.fn()} />);
+      <MotifsBlock endpoint={REPO} path="kb/decisions" onPick={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('motifs-health')).toBeTruthy());
 
     fireEvent.click(screen.getByTestId('motifs-more'));
@@ -280,7 +284,7 @@ describe('MotifsBlock', () => {
     await waitFor(() => expect(api.motifs).toHaveBeenLastCalledWith(
       'knomit-kb', 'agent/test', expect.objectContaining({ q: 'signal' })));
 
-    rerender(<MotifsBlock repo="knomit-kb" branch="agent/test" path="kb/gotchas" onPick={vi.fn()} />);
+    rerender(<MotifsBlock endpoint={REPO} path="kb/gotchas" onPick={vi.fn()} />);
     await waitFor(() => expect(api.motifs).toHaveBeenLastCalledWith(
       'knomit-kb', 'agent/test', expect.objectContaining({ path: 'kb/gotchas', q: 'signal' })));
     await waitFor(() => expect(screen.queryByTestId('motifs-health')).toBeNull());
@@ -372,6 +376,48 @@ describe('MotifsBlock', () => {
   });
 });
 
+// The v1 block was repo-only: there was no single vocabulary across a lens to
+// show, so it was absent there. /lenses/{lens}/motifs merges every mount's
+// clusters into one, and the block reads it through the same props — the point
+// of these three is that NOTHING about the block itself is lens-aware.
+describe('in a lens', () => {
+  const LENS = { kind: 'lens', lens: 'eng' } as const;
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the lens vocabulary and never the write repo', async () => {
+    (api.lensMotifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 73, health: HEALTH, motifs: [...REUSED, ...ONCE],
+    });
+    render(<MotifsBlock endpoint={LENS} path="kb/decisions" onPick={vi.fn()} />);
+    await waitFor(() => expect(api.lensMotifs).toHaveBeenLastCalledWith(
+      'eng', expect.objectContaining({ path: 'kb/decisions' })));
+    // Not a fallback to one mount: a write-repo vocabulary shown in a lens
+    // would be one mount's names presented as the union's.
+    expect(api.motifs).not.toHaveBeenCalled();
+    expect(await screen.findByText('failure-presents-as-success')).toBeTruthy();
+  });
+
+  it('pivots on a pick exactly as it does in a repo', async () => {
+    (api.lensMotifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 73, health: HEALTH, motifs: [...REUSED, ...ONCE],
+    });
+    const onPick = vi.fn();
+    render(<MotifsBlock endpoint={LENS} path="" onPick={onPick} />);
+    fireEvent.click(await screen.findByText('failure-presents-as-success'));
+    expect(onPick).toHaveBeenCalledWith('failure-presents-as-success');
+  });
+
+  it('absents itself where the lens vocabulary cannot be read', () => {
+    const real = api.lensMotifs;
+    // @ts-expect-error — modelling the vendored client, which has no such call
+    api.lensMotifs = undefined;
+    const { container } = render(<MotifsBlock endpoint={LENS} path="" onPick={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+    api.lensMotifs = real;
+  });
+});
+
 describe('where there is no vocabulary endpoint', () => {
   it('absents itself rather than reporting a fault', () => {
     // The public /explore build vendors these components against a static
@@ -381,7 +427,7 @@ describe('where there is no vocabulary endpoint', () => {
     const real = api.motifs;
     // @ts-expect-error — modelling the vendored client, which has no such call
     api.motifs = undefined;
-    const { container } = render(<MotifsBlock repo="r" branch="b" path="" onPick={vi.fn()} />);
+    const { container } = render(<MotifsBlock endpoint={{ kind: 'repo', repo: 'r', branch: 'b' }} path="" onPick={vi.fn()} />);
     expect(container.firstChild).toBeNull();
     api.motifs = real;
   });

--- a/web/src/MotifsBlock.tsx
+++ b/web/src/MotifsBlock.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { api } from './api';
 import type { MotifEntry, MotifHealth } from './api';
+import type { MotifEndpoint } from './motifEndpoint';
+import { canReadMotifs, motifEndpointKey, readMotifs } from './motifEndpoint';
 import { useAsync } from './hooks';
 import { MOTIF_GLYPH } from './utils';
 
@@ -9,11 +10,15 @@ import { MOTIF_GLYPH } from './utils';
  *
  * NOT A NAVIGATION ENTRY. A nav entry captures a WAY OF LOOKING at the corpus,
  * and this is not one — it is a list of names, and the way of looking it leads
- * to is the pivot, which already exists. It is also per-repository: there is no
- * single vocabulary across a lens, so an entry would have to go dark whenever
- * one was open, and an entry live for two of the four things above it is a
- * feature with a switch on it. A block simply absent from a panel is a far
- * smaller absence than a hole in the navigation.
+ * to is the pivot, which already exists. A block simply absent from a panel is
+ * a far smaller absence than a hole in the navigation, and this block is
+ * absent in builds with no vocabulary endpoint to ask.
+ *
+ * It renders in a lens as readily as in a repo. The v1 exclusion — "there is
+ * no single vocabulary across a lens" — was true of the SERVER at the time and
+ * is not true now: /lenses/{lens}/motifs merges every mount's clusters into
+ * one list in this same envelope, so the block reads a lens's vocabulary
+ * through `endpoint` without knowing which kind it holds.
  *
  * It borrows the three facet columns' mechanics — ranked rows, a share bar, an
  * overflow row that opens the whole thing full-width with a search and a way
@@ -34,9 +39,10 @@ import { MOTIF_GLYPH } from './utils';
  * to load must never render as a vocabulary with nothing in it — "no names"
  * would claim this corpus has no shared motifs at all.
  */
-export function MotifsBlock({ repo, branch, path, onPick }: {
-  repo: string;
-  branch: string;
+export function MotifsBlock({ endpoint, path, onPick }: {
+  /** Which surface to read from — a repo branch or a lens. The two answer with
+   *  the same shape, so nothing below this prop branches on it. */
+  endpoint: MotifEndpoint;
   /** The ontology path the panel is describing. SCOPE, not a filter: the block
    *  lists the vocabulary of the folder the reader is standing in, exactly as
    *  the facet columns beside it list that folder's domains and entities. A
@@ -61,46 +67,49 @@ export function MotifsBlock({ repo, branch, path, onPick }: {
   // more` to look for something, and the sibling facet browser does the same.
   useEffect(() => { if (browsing) searchRef.current?.focus(); }, [browsing]);
 
+  const endpointKey = motifEndpointKey(endpoint);
+  const readable = canReadMotifs(endpoint);
+
   useAsync((stale) => {
-    if (!repo || !branch) return;
+    if (!readable) return;
     setStatus('loading');
-    // try/catch around the CALL, not just the promise: a client that throws
-    // synchronously would otherwise take the whole summary panel down with it,
-    // and this block is a fourth thing on a dashboard whose other three have
-    // nothing to do with motifs. A vocabulary that cannot be read is this
-    // block's problem to report, not the panel's problem to crash on.
-    let pending: ReturnType<typeof api.motifs>;
+    // try/catch around the CALL and the subscription, not just the promise's
+    // rejection: a client that throws synchronously — or hands back something
+    // that is not a promise at all — would otherwise take the whole summary
+    // panel down with it, and this block is a fourth thing on a dashboard
+    // whose other three have nothing to do with motifs. A vocabulary that
+    // cannot be read is this block's problem to report, not the panel's
+    // problem to crash on.
     try {
-      pending = api.motifs(repo, branch, { q: q || undefined, path: path || undefined, sort, limit: 200 });
+      readMotifs(endpoint, { q: q || undefined, path: path || undefined, sort, limit: 200 })
+        .then(r => {
+          if (stale()) return;
+          setEntries(r.motifs);
+          setCount(r.count);
+          // The health block is NOT narrowed by the search — it describes the
+          // vocabulary, not the list under it — so a narrowing query must not
+          // overwrite it with a figure counted over the matches. The PATH is a
+          // different thing and does reach it: the server counts health over the
+          // same subtree it counted the list over, so the strip and the rows are
+          // always about one population. Which is why the held figures are KEYED
+          // by scope: a folder click mid-search refetches the list but leaves
+          // the query set, and a bare `if (!q)` would hold the old folder's
+          // figures over the new folder's rows — the exact two-populations row
+          // the pairing rule forbids. Better no strip than that strip; clearing
+          // the search refills it.
+          const scope = `${endpointKey}\n${path}`;
+          if (!q) { setHealth(r.health); healthFor.current = scope; }
+          else if (healthFor.current !== scope) setHealth(null);
+          setStatus('ok');
+        })
+        .catch(() => { if (!stale()) setStatus('error'); });
     } catch {
       setStatus('error');
-      return;
     }
-    pending
-      .then(r => {
-        if (stale()) return;
-        setEntries(r.motifs);
-        setCount(r.count);
-        // The health block is NOT narrowed by the search — it describes the
-        // vocabulary, not the list under it — so a narrowing query must not
-        // overwrite it with a figure counted over the matches. The PATH is a
-        // different thing and does reach it: the server counts health over the
-        // same subtree it counted the list over, so the strip and the rows are
-        // always about one population. Which is why the held figures are KEYED
-        // by scope: a folder click mid-search refetches the list but leaves
-        // the query set, and a bare `if (!q)` would hold the old folder's
-        // figures over the new folder's rows — the exact two-populations row
-        // the pairing rule forbids. Better no strip than that strip; clearing
-        // the search refills it.
-        const scope = `${repo}\n${branch}\n${path}`;
-        if (!q) { setHealth(r.health); healthFor.current = scope; }
-        else if (healthFor.current !== scope) setHealth(null);
-        setStatus('ok');
-      })
-      .catch(() => { if (!stale()) setStatus('error'); });
-  }, [repo, branch, path, q, sort, reloads]);
+    // `endpointKey`, not `endpoint`: the object is rebuilt on every render of
+    // the panel, and depending on it would re-issue the request each time.
+  }, [endpointKey, path, q, sort, reloads]);
 
-  if (!repo) return null;
   // ABSENT, not broken, where there is no vocabulary endpoint to ask.
   //
   // The public /explore build vendors these components and swaps api.ts for a
@@ -110,7 +119,10 @@ export function MotifsBlock({ repo, branch, path, onPick }: {
   // exactly as intended — so the block simply is not there, and the panel has
   // three columns instead of three columns and a block. The pivot still works,
   // because a pivot is a filter.
-  if (typeof api.motifs !== 'function') return null;
+  //
+  // The same absence covers an endpoint that is not addressable yet: App picks
+  // a repo from /repos on mount, so the first render has no repo to ask about.
+  if (!readable) return null;
 
   // Names used once are half the vocabulary and none of the reading: a name
   // minted once says something about authoring hygiene and nothing about the

--- a/web/src/MotifsBlock.tsx
+++ b/web/src/MotifsBlock.tsx
@@ -54,6 +54,16 @@ export function MotifsBlock({ endpoint, path, onPick }: {
   const [entries, setEntries] = useState<MotifEntry[]>([]);
   const [health, setHealth] = useState<MotifHealth | null>(null);
   const [count, setCount] = useState(0);
+  /** The count with NO search applied — the denominator of "N of M".
+   *
+   *  It used to be health.authored_clusters, which is a different population
+   *  from the rows twice over: health is counted over AUTHORED facts while the
+   *  list spans every origin, and in a lens health is a per-mount SUM while the
+   *  list counts each merged cluster once. "12 of 73" then compared a number of
+   *  merged clusters against a number of per-mount cluster instances. The
+   *  unnarrowed count is the same query as the rows with the search taken off,
+   *  which is exactly what the phrase claims. */
+  const [total, setTotal] = useState<number | null>(null);
   const [status, setStatus] = useState<'loading' | 'ok' | 'error'>('loading');
   const [browsing, setBrowsing] = useState(false);
   const [q, setQ] = useState('');
@@ -98,8 +108,12 @@ export function MotifsBlock({ endpoint, path, onPick }: {
           // the pairing rule forbids. Better no strip than that strip; clearing
           // the search refills it.
           const scope = `${endpointKey}\n${path}`;
-          if (!q) { setHealth(r.health); healthFor.current = scope; }
-          else if (healthFor.current !== scope) setHealth(null);
+          // `total` is held under the SAME scope rule as health, and for the
+          // same reason: a folder click mid-search refetches the list but
+          // leaves the query set, so a denominator counted over the previous
+          // folder would sit over the new folder's rows. Better no "of M".
+          if (!q) { setHealth(r.health); setTotal(r.count); healthFor.current = scope; }
+          else if (healthFor.current !== scope) { setHealth(null); setTotal(null); }
           setStatus('ok');
         })
         .catch(() => { if (!stale()) setStatus('error'); });
@@ -183,9 +197,14 @@ export function MotifsBlock({ endpoint, path, onPick }: {
           Motifs
         </span>
         {/* The block count IS narrowed by the search; the health figures beside
-            it are not. They sit close together, so each says which it is. */}
+            it are not. They sit close together, so each says which it is — and
+            the "of M" is the unnarrowed COUNT, never a health figure, so both
+            halves of the fraction describe the same population. With no
+            denominator held for THIS scope the fraction is dropped rather than
+            defaulted to the numerator — "3 of 3" would claim the search matched
+            everything. */}
         <span data-testid="motifs-count" style={{ fontSize: 10, color: '#5f6a7c', fontFamily: 'var(--k-font-mono)' }}>
-          {status === 'ok' ? (q ? `${count} of ${health?.authored_clusters ?? count}` : count) : ''}
+          {status !== 'ok' ? '' : q && total !== null ? `${count} of ${total}` : count}
         </span>
         {health && (
           <span data-testid="motifs-health" style={{

--- a/web/src/RightPanel.lensstats.test.tsx
+++ b/web/src/RightPanel.lensstats.test.tsx
@@ -15,6 +15,9 @@ vi.mock('./api', () => ({
     fact: vi.fn(),
     getLensFact: vi.fn(),
     getLensStats: vi.fn(),
+    // Resolved by default: the summary renders the motif block, and a mock
+    // handing back a non-promise would blank the panel these tests are about.
+    lensMotifs: vi.fn().mockResolvedValue({ count: 0, health: {}, motifs: [] }),
     getAgentBranch: vi.fn().mockResolvedValue('agent/main'),
     stats: vi.fn().mockResolvedValue(null),
     activity: vi.fn().mockResolvedValue(null),
@@ -208,5 +211,36 @@ describe('RightPanel — the summary honours the mount selection', () => {
     render(<RightPanel state={withSources([])} dispatch={vi.fn()} />);
     await screen.findByTestId('lens-stats-empty');
     expect(api.getLensStats).not.toHaveBeenCalled();
+  });
+});
+
+// The lens summary carries the merged motif vocabulary in the same slot the
+// repo summary gives it. It used to be absent here because there was no single
+// vocabulary across a lens to show.
+describe('RightPanel — the lens summary motif block', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('reads the lens vocabulary, never the write repo’s', async () => {
+    (api.getLensStats as ReturnType<typeof vi.fn>).mockResolvedValue(unionStats);
+    (api.lensMotifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 1, health: { authored_clusters: 1 },
+      motifs: [{ cluster_key: 'as-failure-present-success', canonical: 'failure-presents-as-success', members: ['failure-presents-as-success'], df: 26, df_total: 26 }],
+    });
+    render(<RightPanel state={lensSummaryState()} dispatch={vi.fn()} />);
+    await screen.findByTestId('motifs-block');
+    await waitFor(() => expect(api.lensMotifs).toHaveBeenCalledWith('eng', expect.anything()));
+    expect(screen.getByText('failure-presents-as-success')).toBeTruthy();
+  });
+
+  it('dispatches the pivot on a pick, as the repo summary does', async () => {
+    const dispatch = vi.fn();
+    (api.getLensStats as ReturnType<typeof vi.fn>).mockResolvedValue(unionStats);
+    (api.lensMotifs as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 1, health: { authored_clusters: 1 },
+      motifs: [{ cluster_key: 'as-failure-present-success', canonical: 'failure-presents-as-success', members: ['failure-presents-as-success'], df: 26, df_total: 26 }],
+    });
+    render(<RightPanel state={lensSummaryState()} dispatch={dispatch} />);
+    fireEvent.click(await screen.findByText('failure-presents-as-success'));
+    expect(dispatch).toHaveBeenCalledWith({ type: 'PIVOT_MOTIF', motif: 'failure-presents-as-success' });
   });
 });

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -1015,11 +1015,10 @@ export const RightPanel = memo(function RightPanel({ state, dispatch, navigate, 
                 )}
               </div>
               <FacetPanel domains={stats.domains} entities={stats.entities} types={stats.types} dispatch={dispatch} />
-              {/* Repo context only. There is no single vocabulary across a
-                  lens — cross-mount cluster identity does not exist — so the
-                  block is ABSENT there rather than showing one mount's names as
-                  if they were the union's. The pivot still works in a lens;
-                  browsing the vocabulary is what cannot. */}
+              {/* The repo's vocabulary. The lens summary above renders the
+                  same block against its own merged vocabulary — cross-mount
+                  cluster identity is what /lenses/{lens}/motifs defines — so
+                  this is one block in two contexts, not a repo-only feature. */}
               <MotifsBlock endpoint={motifEndpoint} path={path}
                 onPick={motif => dispatch({ type: 'PIVOT_MOTIF', motif })} />
               <HighlightsPanel

--- a/web/src/RightPanel.tsx
+++ b/web/src/RightPanel.tsx
@@ -19,6 +19,8 @@ import { FacetPanel } from './FacetPanel';
 import { MotifCell } from './MotifCell';
 import { MotifOverflowCell, orderMotifs, OVERFLOW } from './MotifRow';
 import { useMotifClusters } from './useMotifClusters';
+import { motifEndpointOf } from './motifEndpoint';
+import type { MotifEndpoint } from './motifEndpoint';
 import { MotifPanel } from './MotifPanel';
 import { MotifsBlock } from './MotifsBlock';
 import type { OrderedMotifs } from './MotifRow';
@@ -457,12 +459,19 @@ function StatFigure({ label, value, color = '#e8edf3' }: {
 // sums, total-weighted confidence, max last_commit — computed server-side by
 // GET /lenses/{lens}/stats) over the merged histograms, then one compact row
 // per mount.
-function LensStatsView({ stats, dispatch, axis, onAxisChange, navigate }: {
+function LensStatsView({ stats, dispatch, axis, onAxisChange, navigate, motifEndpoint, path }: {
   stats: LensStats;
   dispatch: Dispatch<Action>;
   axis: RankAxis;
   onAxisChange: (a: RankAxis) => void;
   navigate?: (req: NavRequest) => void;
+  /** Passed in rather than derived here: RightPanel already holds the app
+   *  state this comes from, and one derivation keeps the summary block and the
+   *  fact header reading the same vocabulary. */
+  motifEndpoint: MotifEndpoint;
+  /** The ontology path the panel is describing — SCOPE for the motif block,
+   *  exactly as it is for the repo summary's. */
+  path: string;
 }) {
   const domainCount = Object.keys(stats.domains).length;
   const entityCount = Object.keys(stats.entities).length;
@@ -488,6 +497,13 @@ function LensStatsView({ stats, dispatch, axis, onAxisChange, navigate }: {
         )}
       </div>
       <FacetPanel domains={stats.domains} entities={stats.entities} types={stats.types} dispatch={dispatch} />
+      {/* The lens's own merged vocabulary, in the same slot the repo summary
+          gives it. It used to be absent here because there was no single
+          vocabulary across a lens to show; /lenses/{lens}/motifs is that
+          vocabulary, so the block is a block in both contexts now rather than
+          a feature with a switch on it. */}
+      <MotifsBlock endpoint={motifEndpoint} path={path}
+        onPick={motif => dispatch({ type: 'PIVOT_MOTIF', motif })} />
       <HighlightsPanel
         highlights={stats.highlights}
         axis={axis}
@@ -592,11 +608,15 @@ export const RightPanel = memo(function RightPanel({ state, dispatch, navigate, 
   // fact and cost nothing; each count is a request, so the row draws the names
   // at once and fills the counts in — see useMotifClusters.
   //
-  // The anchor is the fact's own history anchor, the same one the edges use, so
-  // a lens fact resolves against the mount it actually lives in rather than the
-  // write repo.
-  const motifAnchor = factHistoryAnchor(state);
-  const resolvedMotifs = useMotifClusters(motifAnchor.repo, motifAnchor.branch, fact?.motifs);
+  // Resolved against the corpus the reader is BROWSING, not the mount the fact
+  // happens to live on: in a lens that is the whole lens. The count sits beside
+  // a pivot, and the pivot lists the lens — a mount-scoped count under a
+  // lens-scoped pivot would promise one number and deliver another. (Edges and
+  // history still anchor on the fact's own mount, via factHistoryAnchor: those
+  // are questions about the fact's history, which is a property of where it
+  // lives.)
+  const motifEndpoint = motifEndpointOf(state);
+  const resolvedMotifs = useMotifClusters(motifEndpoint, fact?.motifs);
   const orderedMotifs = useMemo(() => orderMotifs(resolvedMotifs), [resolvedMotifs]);
   const motifPanelId = 'motif-panel';
 
@@ -963,7 +983,8 @@ export const RightPanel = memo(function RightPanel({ state, dispatch, navigate, 
               ? <div data-testid="lens-stats-error" style={{ color: '#f88' }}>Couldn’t load lens stats — a mount failed to respond.</div>
               : lensStats
                 ? <LensStatsView stats={lensStats} dispatch={dispatch} axis={axis ?? lensStats.default_axis}
-                    onAxisChange={setAxis} navigate={navigate} />
+                    onAxisChange={setAxis} navigate={navigate}
+                    motifEndpoint={motifEndpoint} path={path} />
                 : <div style={{ color: '#666' }}>Loading lens stats…</div>}
           </div>
         </div>
@@ -999,7 +1020,7 @@ export const RightPanel = memo(function RightPanel({ state, dispatch, navigate, 
                   block is ABSENT there rather than showing one mount's names as
                   if they were the union's. The pivot still works in a lens;
                   browsing the vocabulary is what cannot. */}
-              <MotifsBlock repo={state.repo} branch={state.branch} path={path}
+              <MotifsBlock endpoint={motifEndpoint} path={path}
                 onPick={motif => dispatch({ type: 'PIVOT_MOTIF', motif })} />
               <HighlightsPanel
                 highlights={stats.highlights}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1027,6 +1027,51 @@ const EMPTY_MOTIF_HEALTH: MotifHealth = {
   recurrence_rate: 0, mint_to_link_ratio: 0,
 };
 
+/** The vocabulary query. `repos` is lens-only (repeated `repo=`, narrowing the
+ *  fan-out); the repo endpoint has no mounts to narrow and ignores it. */
+export interface MotifsQuery {
+  q?: string; path?: string; sort?: 'df' | 'name';
+  limit?: number; offset?: number; repos?: string[];
+}
+
+export interface MotifsPage { count: number; health: MotifHealth; motifs: MotifEntry[] }
+
+/** The vocabulary reads, written ONCE against a base URL.
+ *
+ *  A lens's motif vocabulary is the SAME resource as a repo's — same query,
+ *  same envelope, same defaults — over a bigger corpus, and the server keeps
+ *  it that way deliberately (one shared renderer behind both handlers). Two
+ *  clients kept in step would be two chances to drift on the shape the server
+ *  went out of its way to make single; the base URL is the only difference,
+ *  so it is the only parameter. */
+function fetchMotifs(base: string, opts?: MotifsQuery): Promise<MotifsPage> {
+  const p = new URLSearchParams();
+  if (opts?.q) p.set('q', opts.q);
+  // `path` is SCOPE, not a filter over the page — it says which corpus the
+  // vocabulary is of, exactly as it does on /stats, and it narrows the health
+  // block along with the list. `q` is a way of reading one page and does not.
+  if (opts?.path) p.set('path', opts.path);
+  if (opts?.sort) p.set('sort', opts.sort);
+  if (opts?.limit !== undefined) p.set('limit', String(Math.min(opts.limit, MOTIFS_MAX_LIMIT)));
+  if (opts?.offset) p.set('offset', String(opts.offset));
+  for (const repo of opts?.repos ?? []) p.append('repo', repo);
+  const qs = p.toString();
+  return fetchJSON<any>(`${base}/motifs${qs ? `?${qs}` : ''}`).then(data => ({
+    count: data.count ?? 0,
+    health: data.health ?? EMPTY_MOTIF_HEALTH,
+    motifs: data._embedded?.motifs ?? [],
+  }));
+}
+
+function fetchMotifCluster(base: string, key: string): Promise<MotifCluster> {
+  return fetchJSON<any>(`${base}/motifs/${encodeURIComponent(key)}`).then(data => ({
+    ...data,
+    members: data.members ?? [],
+    carriers: data.carriers ?? [],
+    aliases: data.aliases ?? [],
+  }));
+}
+
 // listLensFacts GETs /api/v1/lenses/{lens}/facts — the recency-ordered, deduped
 // union of the lens's write repo + read mounts. Flat envelope ({facts,total});
 // each row carries a canonical `path` and its `source` mount. `repos` maps to
@@ -1237,25 +1282,14 @@ export const api = {
    *  `path` scopes the whole answer to one subtree: a cluster no fact there
    *  carries is absent, `df` counts the carriers under it, and `health` is
    *  counted over the same facts. */
-  motifs: (repo: string, branch: string,
-    opts?: { q?: string; path?: string; sort?: 'df' | 'name'; limit?: number; offset?: number }
-  ): Promise<{ count: number; health: MotifHealth; motifs: MotifEntry[] }> => {
-    const p = new URLSearchParams();
-    if (opts?.q) p.set('q', opts.q);
-    // `path` is SCOPE, not a filter over the page — it says which corpus the
-    // vocabulary is of, exactly as it does on /stats, and it narrows the health
-    // block along with the list. `q` is a way of reading one page and does not.
-    if (opts?.path) p.set('path', opts.path);
-    if (opts?.sort) p.set('sort', opts.sort);
-    if (opts?.limit !== undefined) p.set('limit', String(Math.min(opts.limit, MOTIFS_MAX_LIMIT)));
-    if (opts?.offset) p.set('offset', String(opts.offset));
-    const qs = p.toString();
-    return fetchJSON<any>(`${branchBase(repo, branch)}/motifs${qs ? `?${qs}` : ''}`).then(data => ({
-      count: data.count ?? 0,
-      health: data.health ?? EMPTY_MOTIF_HEALTH,
-      motifs: data._embedded?.motifs ?? [],
-    }));
-  },
+  motifs: (repo: string, branch: string, opts?: MotifsQuery): Promise<MotifsPage> =>
+    fetchMotifs(branchBase(repo, branch), opts),
+
+  /** The lens-wide motif vocabulary: every mount's clusters merged into one
+   *  list, in the repo endpoint's own envelope. `repos` narrows the fan-out to
+   *  the named mounts, like every other lens union read. */
+  lensMotifs: (lens: string, opts?: MotifsQuery): Promise<MotifsPage> =>
+    fetchMotifs(lensBase(lens), opts),
 
   /** One cluster. `key` accepts the cluster_key or any member spelling, and is
    *  encoded because neither is guaranteed URL-safe. Carriers and aliases
@@ -1263,12 +1297,15 @@ export const api = {
    *  empty `carriers` with a non-zero `carrier_count` is a real state (a preview
    *  the server chose not to send), not a contradiction to paper over. */
   motifCluster: (repo: string, branch: string, key: string): Promise<MotifCluster> =>
-    fetchJSON<any>(`${branchBase(repo, branch)}/motifs/${encodeURIComponent(key)}`).then(data => ({
-      ...data,
-      members: data.members ?? [],
-      carriers: data.carriers ?? [],
-      aliases: data.aliases ?? [],
-    })),
+    fetchMotifCluster(branchBase(repo, branch), key),
+
+  /** One MERGED cluster through a lens. `key` additionally accepts any single
+   *  mount's own cluster_key, because a merged cluster's key is the smallest of
+   *  its constituents' and a reader can hold either. Carrier paths come back in
+   *  the canonical lens form (bare for the write mount, kb://<id12>/… for a
+   *  read mount), so they are openable through the lens as they arrive. */
+  lensMotifCluster: (lens: string, key: string): Promise<MotifCluster> =>
+    fetchMotifCluster(lensBase(lens), key),
 
   listLensFacts,
   lensSearch,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1027,11 +1027,16 @@ const EMPTY_MOTIF_HEALTH: MotifHealth = {
   recurrence_rate: 0, mint_to_link_ratio: 0,
 };
 
-/** The vocabulary query. `repos` is lens-only (repeated `repo=`, narrowing the
- *  fan-out); the repo endpoint has no mounts to narrow and ignores it. */
+/** The vocabulary query.
+ *
+ *  No `repos`: the lens collection accepts a repeated `repo=` narrow, but
+ *  nothing in this client sends one, and a field no caller sets is a field
+ *  whose behaviour nobody has checked — it would also be silently dropped
+ *  against the repo endpoint, which has no mounts to narrow. Add it back with
+ *  the caller that needs it. */
 export interface MotifsQuery {
   q?: string; path?: string; sort?: 'df' | 'name';
-  limit?: number; offset?: number; repos?: string[];
+  limit?: number; offset?: number;
 }
 
 export interface MotifsPage { count: number; health: MotifHealth; motifs: MotifEntry[] }
@@ -1054,7 +1059,6 @@ function fetchMotifs(base: string, opts?: MotifsQuery): Promise<MotifsPage> {
   if (opts?.sort) p.set('sort', opts.sort);
   if (opts?.limit !== undefined) p.set('limit', String(Math.min(opts.limit, MOTIFS_MAX_LIMIT)));
   if (opts?.offset) p.set('offset', String(opts.offset));
-  for (const repo of opts?.repos ?? []) p.append('repo', repo);
   const qs = p.toString();
   return fetchJSON<any>(`${base}/motifs${qs ? `?${qs}` : ''}`).then(data => ({
     count: data.count ?? 0,
@@ -1286,8 +1290,7 @@ export const api = {
     fetchMotifs(branchBase(repo, branch), opts),
 
   /** The lens-wide motif vocabulary: every mount's clusters merged into one
-   *  list, in the repo endpoint's own envelope. `repos` narrows the fan-out to
-   *  the named mounts, like every other lens union read. */
+   *  list, in the repo endpoint's own envelope. */
   lensMotifs: (lens: string, opts?: MotifsQuery): Promise<MotifsPage> =>
     fetchMotifs(lensBase(lens), opts),
 

--- a/web/src/motifEndpoint.ts
+++ b/web/src/motifEndpoint.ts
@@ -1,0 +1,83 @@
+import { api } from './api';
+import type { MotifsQuery, MotifsPage, MotifCluster } from './api';
+import type { AppState } from './state';
+import { isLensContext } from './state';
+
+/**
+ * Which REST surface a motif vocabulary read goes to.
+ *
+ * NOT called a "scope": `path` is already the scope in every motif surface —
+ * "which corpus this vocabulary is of" — and reusing the word for the
+ * repo/lens axis would put two different questions under one name. This names
+ * the only thing that actually differs between the two reads: the endpoint.
+ *
+ * The two answer with the SAME shape. A lens's vocabulary is every mount's
+ * clusters merged into one list, in the repo endpoint's own envelope, with the
+ * same query and the same defaults — the server keeps it that way through one
+ * shared renderer behind both handlers. So everything above this file works in
+ * both contexts without branching, and the branch lives here, once.
+ */
+export type MotifEndpoint =
+  | { kind: 'repo'; repo: string; branch: string }
+  | { kind: 'lens'; lens: string };
+
+/** The endpoint the app's current context reads its vocabulary from. */
+export function motifEndpointOf(s: AppState): MotifEndpoint {
+  if (isLensContext(s) && s.context.kind === 'lens') {
+    return { kind: 'lens', lens: s.context.name };
+  }
+  return { kind: 'repo', repo: s.repo, branch: s.branch };
+}
+
+/**
+ * Whether the endpoint is ADDRESSABLE yet.
+ *
+ * App picks a repo from /api/v1/repos on mount, so the first render has no
+ * repo, and a request then is a certain 404 that would render as a failure of
+ * the motifs themselves rather than of the timing. Waiting is the honest state.
+ */
+export function motifEndpointReady(e: MotifEndpoint): boolean {
+  return e.kind === 'lens' ? !!e.lens : !!e.repo && !!e.branch;
+}
+
+/**
+ * Whether the VOCABULARY COLLECTION can be read here.
+ *
+ * Addressable, and the client actually has the method: the vendored /explore
+ * build swaps api.ts for a static bundle, and a control that opened onto a
+ * permanent error is worse than no control.
+ *
+ * Kept apart from canReadMotifCluster below because the two are different
+ * questions with different answers — a bundle can carry one read and not the
+ * other — and collapsing them would make one surface's absence silently
+ * govern the other's.
+ */
+export function canReadMotifs(e: MotifEndpoint): boolean {
+  return motifEndpointReady(e) &&
+    (e.kind === 'lens' ? typeof api.lensMotifs === 'function' : typeof api.motifs === 'function');
+}
+
+/** Whether ONE cluster can be read here. See canReadMotifs. */
+export function canReadMotifCluster(e: MotifEndpoint): boolean {
+  return motifEndpointReady(e) &&
+    (e.kind === 'lens' ? typeof api.lensMotifCluster === 'function' : typeof api.motifCluster === 'function');
+}
+
+/** The vocabulary collection, from whichever surface `e` names. */
+export function readMotifs(e: MotifEndpoint, opts?: MotifsQuery): Promise<MotifsPage> {
+  return e.kind === 'lens'
+    ? api.lensMotifs(e.lens, opts)
+    : api.motifs(e.repo, e.branch, opts);
+}
+
+/** One cluster, by cluster_key or by any member spelling. */
+export function readMotifCluster(e: MotifEndpoint, key: string): Promise<MotifCluster> {
+  return e.kind === 'lens'
+    ? api.lensMotifCluster(e.lens, key)
+    : api.motifCluster(e.repo, e.branch, key);
+}
+
+/** A stable string identity for an endpoint, for effect dependency arrays. */
+export function motifEndpointKey(e: MotifEndpoint): string {
+  return e.kind === 'lens' ? `lens\0${e.lens}` : `repo\0${e.repo}\0${e.branch}`;
+}

--- a/web/src/useMotifClusters.test.ts
+++ b/web/src/useMotifClusters.test.ts
@@ -13,7 +13,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useMotifClusters } from './useMotifClusters';
 import { api } from './api';
 
-vi.mock('./api', () => ({ api: { motifCluster: vi.fn() } }));
+vi.mock('./api', () => ({ api: { motifCluster: vi.fn(), lensMotifCluster: vi.fn() } }));
+
+// The endpoint the hook reads from. A repo branch here; the lens twin below
+// asserts the same hook against /lenses/{lens}/motifs/{key}.
+const REPO = { kind: 'repo', repo: 'r', branch: 'b' } as const;
 
 const cluster = (canonical: string, carrier_count: number) => ({
   cluster_key: `key-${canonical}`, canonical, members: [canonical],
@@ -28,7 +32,7 @@ describe('useMotifClusters', () => {
   it('reports every name as loading before any response lands', () => {
     (api.motifCluster as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
     const { result } = renderHook(() =>
-      useMotifClusters('r', 'b', ['failure-presents-as-success', 'absence-encodes-value']));
+      useMotifClusters(REPO, ['failure-presents-as-success', 'absence-encodes-value']));
     // The names are already known, so the caller can draw them immediately —
     // the whole reason the count is allowed to arrive late.
     expect(result.current.map(m => m.motif))
@@ -40,7 +44,7 @@ describe('useMotifClusters', () => {
     (api.motifCluster as ReturnType<typeof vi.fn>).mockImplementation(async (_r, _b, key: string) =>
       cluster(key, key === 'failure-presents-as-success' ? 26 : 7));
     const { result } = renderHook(() =>
-      useMotifClusters('r', 'b', ['failure-presents-as-success', 'absence-encodes-value']));
+      useMotifClusters(REPO, ['failure-presents-as-success', 'absence-encodes-value']));
     await waitFor(() => expect(result.current.every(m => m.status === 'ok')).toBe(true));
     // Distinct counts, matched by name: a hook that resolved both entries from
     // one response would pass with equal fixtures and fail here.
@@ -51,7 +55,7 @@ describe('useMotifClusters', () => {
 
   it('marks a failed fetch as an error, never as a zero', async () => {
     (api.motifCluster as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('502'));
-    const { result } = renderHook(() => useMotifClusters('r', 'b', ['handle-outlives-target']));
+    const { result } = renderHook(() => useMotifClusters(REPO, ['handle-outlives-target']));
     await waitFor(() => expect(result.current[0].status).toBe('error'));
     // The name survives the failure — it came from the fact, not the request —
     // and there is no count at all, rather than a zero standing in for one.
@@ -64,7 +68,7 @@ describe('useMotifClusters', () => {
       if (key === 'bad-one') throw new Error('boom');
       return cluster(key, 9);
     });
-    const { result } = renderHook(() => useMotifClusters('r', 'b', ['bad-one', 'good-one']));
+    const { result } = renderHook(() => useMotifClusters(REPO, ['bad-one', 'good-one']));
     await waitFor(() => expect(result.current.every(m => m.status !== 'loading')).toBe(true));
     expect(result.current[0].status).toBe('error');
     expect(result.current[1].status).toBe('ok');
@@ -74,7 +78,7 @@ describe('useMotifClusters', () => {
   it('asks once per motif, and not again on re-render', async () => {
     (api.motifCluster as ReturnType<typeof vi.fn>).mockImplementation(async (_r, _b, k: string) => cluster(k, 3));
     const motifs = ['a', 'b'];
-    const { result, rerender } = renderHook(() => useMotifClusters('r', 'b', motifs));
+    const { result, rerender } = renderHook(() => useMotifClusters(REPO, motifs));
     await waitFor(() => expect(result.current.every(m => m.status === 'ok')).toBe(true));
     rerender();
     rerender();
@@ -87,7 +91,7 @@ describe('useMotifClusters', () => {
     (api.motifCluster as ReturnType<typeof vi.fn>).mockImplementation(async (_r, _b, k: string) =>
       cluster(k, k === 'first' ? 11 : 22));
     let motifs = ['first'];
-    const { result, rerender } = renderHook(() => useMotifClusters('r', 'b', motifs));
+    const { result, rerender } = renderHook(() => useMotifClusters(REPO, motifs));
     await waitFor(() => expect(result.current[0].status).toBe('ok'));
 
     motifs = ['second'];
@@ -99,16 +103,53 @@ describe('useMotifClusters', () => {
   });
 
   it('asks for nothing when the fact carries no motifs', () => {
-    const { result } = renderHook(() => useMotifClusters('r', 'b', undefined));
+    const { result } = renderHook(() => useMotifClusters(REPO, undefined));
     expect(result.current).toEqual([]);
     expect(api.motifCluster).not.toHaveBeenCalled();
   });
 
-  it('does not fetch before a repo and branch are known', () => {
-    const { result } = renderHook(() => useMotifClusters('', '', ['a']));
+  it('does not fetch before there is an endpoint to ask', () => {
+    const { result } = renderHook(() =>
+      useMotifClusters({ kind: 'repo', repo: '', branch: '' }, ['a']));
     // A request against an empty repo is a guaranteed 404 that would render as
     // a failed count on a fact whose motifs are perfectly fine.
     expect(api.motifCluster).not.toHaveBeenCalled();
     expect(result.current[0].status).toBe('loading');
+  });
+
+  // In a lens the count must come from the LENS, not from whichever mount the
+  // fact lives on: the count sits beside a pivot and the pivot lists the lens.
+  // The repo endpoint must not be touched at all — a fallback that silently
+  // asked the write repo would answer with a smaller, plausible number.
+  it('resolves through the lens endpoint in a lens context', async () => {
+    (api.lensMotifCluster as ReturnType<typeof vi.fn>)
+      .mockImplementation(async (_lens: string, key: string) => cluster(key, 26));
+    const { result } = renderHook(() =>
+      useMotifClusters({ kind: 'lens', lens: 'eng' }, ['failure-presents-as-success']));
+    await waitFor(() => expect(result.current[0].status).toBe('ok'));
+    expect(api.lensMotifCluster).toHaveBeenCalledWith('eng', 'failure-presents-as-success');
+    expect(api.motifCluster).not.toHaveBeenCalled();
+    expect(result.current[0].cluster?.carrier_count).toBe(26);
+  });
+
+  it('does not fetch before a lens name is known', () => {
+    renderHook(() => useMotifClusters({ kind: 'lens', lens: '' }, ['a']));
+    expect(api.lensMotifCluster).not.toHaveBeenCalled();
+  });
+
+  // Switching context re-resolves: the same names against a different corpus
+  // are different counts, and holding the previous ones would attribute one
+  // corpus's numbers to another.
+  it('refetches when the endpoint changes under the same names', async () => {
+    (api.motifCluster as ReturnType<typeof vi.fn>)
+      .mockImplementation(async (_r: string, _b: string, k: string) => cluster(k, 3));
+    (api.lensMotifCluster as ReturnType<typeof vi.fn>)
+      .mockImplementation(async (_l: string, k: string) => cluster(k, 9));
+    let endpoint: Parameters<typeof useMotifClusters>[0] = REPO;
+    const { result, rerender } = renderHook(() => useMotifClusters(endpoint, ['shared-name']));
+    await waitFor(() => expect(result.current[0].cluster?.carrier_count).toBe(3));
+    endpoint = { kind: 'lens', lens: 'eng' };
+    rerender();
+    await waitFor(() => expect(result.current[0].cluster?.carrier_count).toBe(9));
   });
 });

--- a/web/src/useMotifClusters.ts
+++ b/web/src/useMotifClusters.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { api } from './api';
 import type { MotifCluster } from './api';
+import type { MotifEndpoint } from './motifEndpoint';
+import { canReadMotifCluster, motifEndpointKey, readMotifCluster } from './motifEndpoint';
 import { useAsync } from './hooks';
 
 /** One motif on a fact, and how far its resolution has got.
@@ -40,25 +41,32 @@ const NONE: ResolvedMotif[] = [];
  * different fact re-fetches. `stale()` guards the write-back: opening a second
  * fact while the first fact's requests are in flight must not paint the first
  * fact's counts beside the second fact's names.
+ *
+ * The counts are of whatever corpus `endpoint` names, which in a lens is the
+ * WHOLE lens rather than the mount the fact happens to live on. That is the
+ * number the reader can act on: the count sits beside a pivot, and the pivot
+ * lists the lens. A mount-scoped count under a lens-scoped pivot would promise
+ * one number and deliver another.
  */
 export function useMotifClusters(
-  repo: string, branch: string, motifs: string[] | undefined,
+  endpoint: MotifEndpoint, motifs: string[] | undefined,
 ): ResolvedMotif[] {
   const names = motifs ?? NONE.map(String);
   const key = names.join('\0');
+  const endpointKey = motifEndpointKey(endpoint);
   const [resolved, setResolved] = useState<Record<string, ResolvedMotif>>({});
 
   useAsync((stale) => {
     if (names.length === 0) return;
-    // No repo yet (App picks one from /api/v1/repos on mount) means any request
-    // is a certain 404, which would render as a failed count on a fact whose
-    // motifs are perfectly fine. Waiting is the honest state; the entries below
-    // stay 'loading' until there is somewhere to ask.
-    if (!repo || !branch) return;
+    // Nowhere to ask yet (App picks a repo from /api/v1/repos on mount) means
+    // any request is a certain 404, which would render as a failed count on a
+    // fact whose motifs are perfectly fine. Waiting is the honest state; the
+    // entries below stay 'loading' until there is somewhere to ask.
+    if (!canReadMotifCluster(endpoint)) return;
 
     setResolved({});
     for (const motif of names) {
-      api.motifCluster(repo, branch, motif)
+      readMotifCluster(endpoint, motif)
         .then(cluster => {
           if (stale()) return;
           setResolved(prev => ({ ...prev, [motif]: { motif, status: 'ok', cluster } }));
@@ -68,10 +76,10 @@ export function useMotifClusters(
           setResolved(prev => ({ ...prev, [motif]: { motif, status: 'error', error: String(err) } }));
         });
     }
-    // `key`, not `motifs`: the array identity changes on every render of the
-    // fact view, and depending on it would re-issue every request each time.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key, repo, branch]);
+    // `key` and `endpointKey`, not `motifs` and `endpoint`: both of those are
+    // rebuilt on every render of the fact view, and depending on them would
+    // re-issue every request each time.
+  }, [key, endpointKey]);
 
   if (names.length === 0) return NONE;
   // Built from the NAMES, in the fact's own order — so an unanswered motif is a


### PR DESCRIPTION
Motif filtering for lenses, working the way it does for repos.

## What was missing

The list endpoints already parsed `motifs=` / `motif_match=`. What did not exist was the **vocabulary** behind them: there was no cross-mount cluster identity, so the vocabulary block, the `motif:` filter category and the pivot's cluster resolution were all dark whenever a lens was open.

## What this adds

- `GET /lenses/{lens}/motifs` and `/lenses/{lens}/motifs/{key}` — every mount's motif clusters merged into one vocabulary, in the per-repo endpoint's own envelope.
- The union itself lives in `internal/federate`, because **two** surfaces answer motif queries against a lens: the REST lens reads and the MCP `knomit_query` fan-out.
- The web client picks its surface through one `MotifEndpoint` value derived from app state, so `MotifsBlock`, `useMotifClusters`, the filter picker and the pivot heading each gained a lens without gaining a lens code path.

## How clusters merge

A `cluster_key` is a mechanical function of a spelling (canonicalize → tokenize → sort → join), so the same key names the same shape in every repo. That is not sufficient: a judge merge is **per-branch**, so one mount can file `quiet-degradation` under `fallback-silent` while another still keys it `degradation-quiet`. Merging on the key alone puts one spelling in two rows that answer different queries.

So clusters union transitively on **shared key OR shared member spelling**. The merged key is the smallest constituent one — stable under df change, which is the property definitions and URLs need.

## The semantic change to know about

**A judge merge on any mount changes what a motif term returns for the whole lens.** Read through a lens the mounts share one vocabulary, exactly as one repo's folders share one. It is **read-only**: no mount's alias table, canonical election or verdict history is touched, and the same repo read directly still answers with its own vocabulary alone. A lens over a single mount is left alone entirely, so it answers exactly as that repo does.

Two tests asserted the opposite rule and stayed green only because their fixture had no motif index, so the widening never ran. They now assert the new rule, with a companion pinning the read-only half.

## Review rounds

Three rounds, each finding something real:

1. **The pivot silently dropped mounts its own count included.** The store's exact tier is per-branch canonical equality, so a row reading `df 7` listed 5. Fixed at the endpoint (`federate.ExpandMotifTerms`) rather than in the callers, so a chip minted anywhere is correct because the endpoint resolves it.
2. **MCP was never widened**, leaving the same defect live on the most-used motif path. That is what moved the union into `federate` — one definition both fan-outs reach.
3. Smaller: the `N of M` denominator was a different population from its rows; alias attribution read the union's key set where it needed the per-mount one; the widening's error dropped the branch name from `no branch named "<branch>"`.

Every regression test here was sabotage-verified — the mutant that should kill each one does.

## Accepted trade-offs, stated

- `df` / `df_total` and the pooled health counts are per-mount sums, carrying the same fork over-count the lens `/stats` histograms accept. Documented in the OpenAPI spec.
- Because a term's meaning is lens-wide, a mount excluded by `repo=` is still read to resolve it — so that mount failing fails the request. Deliberate under RFC §9.1, and pinned by a test so it is not later tidied away as a bug.
- Over two or more mounts a term can reach spellings a single unrebuilt repo's exact tier would not. That is the shared vocabulary, not a leak in the tier.

## Verification

`go test ./...`, `tsc --noEmit`, `vitest` (1362 tests), `eslint` at one warning below baseline.
