### PR TITLE
Remember what a word's singular is

### DIFF
--- a/internal/textnorm/stem_memo_bench_test.go
+++ b/internal/textnorm/stem_memo_bench_test.go
@@ -1,0 +1,77 @@
+package textnorm
+
+import "testing"
+
+// The measurement behind Stem's memo. Run:
+//
+//	go test ./internal/textnorm/ -run XXX -bench 'Stem|Tokens' -benchtime 2000x
+//
+// On an Apple M4 (2026-09-01), rounded to the precision that reproduces —
+// the warm figures are tens of nanoseconds and move run to run, so read the
+// ORDER, never the digit, and do not treat a differing last digit as a
+// regression:
+//
+//	BenchmarkStemCold      ~25 µs/op    ~480 B/op   13 allocs/op
+//	BenchmarkStem         tens of ns      0 B/op    0 allocs/op
+//	BenchmarkTokensCold    ~45 µs/op   ~1450 B/op   35 allocs/op
+//	BenchmarkTokens      hundreds of ns  128 B/op    2 allocs/op
+//
+// Three orders of magnitude on Stem is the result; the allocation counts are
+// the part worth pinning exactly, and the hit path's zero is the one a change
+// here must not move.
+//
+// Cold is what EVERY call cost before the memo, not a rare first-call price:
+// nothing cached the pluralizer's answer, so the knomit_motif_key SQL callback
+// paid it per token per motif per row on every request. End to end that was a
+// five-mount lens vocabulary at ~133ms; with the memo it is ~9ms.
+//
+// The cold benchmarks clear the memo per iteration OUTSIDE the timer, so they
+// measure go-pluralize and not map churn. One of Cold's allocations is the
+// strings.Clone that keeps an entry from pinning its caller's buffer; it lands
+// on the miss, and the hit path stays at zero allocations.
+
+var benchToken = "vulnerabilities"
+
+var benchCanonical = Canonicalize("failure-presents-as-success")
+
+var stemSink string
+
+var tokensSink []string
+
+func BenchmarkStem(b *testing.B) {
+	stemSink = Stem(benchToken) // warm
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		stemSink = Stem(benchToken)
+	}
+}
+
+func BenchmarkStemCold(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		resetStemMemo()
+		b.StartTimer()
+		stemSink = Stem(benchToken)
+	}
+}
+
+func BenchmarkTokens(b *testing.B) {
+	tokensSink = Tokens(benchCanonical) // warm
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		tokensSink = Tokens(benchCanonical)
+	}
+}
+
+func BenchmarkTokensCold(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		b.StopTimer()
+		resetStemMemo()
+		b.StartTimer()
+		tokensSink = Tokens(benchCanonical)
+	}
+}

--- a/internal/textnorm/stem_memo_test.go
+++ b/internal/textnorm/stem_memo_test.go
@@ -1,0 +1,211 @@
+package textnorm
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"unicode"
+	"unsafe"
+
+	"github.com/gertd/go-pluralize"
+	"github.com/stretchr/testify/require"
+)
+
+// resetStemMemo empties the memo so a test starts from a known state. Tests
+// that read the memo must not race with a neighbour populating it, so they run
+// serially — none of them calls t.Parallel().
+func resetStemMemo() {
+	stemMemo.Range(func(k, _ any) bool {
+		stemMemo.Delete(k)
+		return true
+	})
+}
+
+func stemMemoEntries() map[string]string {
+	out := map[string]string{}
+	stemMemo.Range(func(k, v any) bool {
+		out[k.(string)] = v.(string)
+		return true
+	})
+	return out
+}
+
+// unmemoizedStem is Stem's definition with the memo removed — the reference
+// the memoized implementation must match byte for byte. Written out rather
+// than reached for, so that editing Stem's GUARDS without editing this one
+// makes the transparency test fail loudly instead of comparing a function to
+// itself.
+func unmemoizedStem(t string) string {
+	if len(t) <= 3 || strings.HasSuffix(t, "ics") {
+		return t
+	}
+	return pluralize.NewClient().Singular(t)
+}
+
+// motifCorpus is real motif spellings from a knomit corpus — the population
+// that actually reaches Stem through groupingKey, hyphenated and multi-token,
+// with the plurals ("reads", "shifts", "meanings", "ids", "handlers",
+// "cases", "lifetimes", "referents") that make singularization observable.
+var motifCorpus = []string{
+	"intervention-perturbs-measurement", "fix-inherits-its-origin",
+	"duplicate-reads-as-corroboration", "name-implies-absent-capability",
+	"artifact-mistaken-for-signal", "inherited-context-silently-dropped",
+	"remediation-inherits-observation-scope", "implicit-retyping-on-parse",
+	"allowlist-avoids-naming-forbidden", "limit-applied-before-filter",
+	"failure-presents-as-success", "fixture-cannot-discriminate",
+	"proxy-inverts-predicate", "layout-shifts-under-cursor",
+	"same-word-two-meanings", "silent-no-op",
+	"several-ids-different-lifetimes", "one-name-many-referents",
+	"cost-in-wrong-currency", "reentrant-use-exhausts-pool",
+	"continuity-mistaken-for-identity", "transient-state-becomes-permanent",
+	"partial-capture-wrong-restore", "silent-overwrite-on-collision",
+	"derived-not-assumed", "separate-axis-not-enum",
+	"signal-cannot-distinguish-cases", "idempotent-absorption",
+	"marked-done-blocks-retry", "two-handlers-one-event",
+	"shared-path-prevents-divergence", "per-call-full-rescan",
+	"exclusion-by-deletion", "aggregation-erases-provenance",
+	"edge-trigger-starves-level", "test-mode-hides-condition",
+	"single-writer-per-partition", "sentinel-vs-explicit-default",
+	"removal-manufactures-dead-code", "mechanical-key-underdetermines-identity",
+	// The irregulars a naive stemmer breaks, and the guarded shapes.
+	"analyses-of-indices", "matrices-and-theses", "vulnerabilities-in-metrics",
+	"aws-tls-llm", "robotics-and-ethics",
+}
+
+// THE MEMO IS SEMANTICALLY TRANSPARENT: for every spelling the corpus can
+// produce, the memoized pipeline answers exactly what the unmemoized one does.
+//
+// This is the test that matters. Tokens feeds store.groupingKey, the motif-term
+// query tiers and the motif subject-word strip, so a memo that answered
+// differently for even one token would silently re-key clusters — a spelling
+// would join, or stop joining, a different cluster. Comparing whole
+// Tokens(Canonicalize(...)) output, not just Stem, is what covers that: the
+// memo sits under Tokens and a per-token divergence shows up in the slice.
+func TestStemMemoIsSemanticallyTransparent(t *testing.T) {
+	resetStemMemo()
+
+	for _, m := range motifCorpus {
+		canonical := Canonicalize(m)
+
+		var want []string
+		seen := map[string]bool{}
+		for _, f := range strings.FieldsFunc(canonical, func(r rune) bool {
+			return r == '/' || unicode.IsSpace(r)
+		}) {
+			st := unmemoizedStem(f)
+			if seen[st] {
+				continue
+			}
+			seen[st] = true
+			want = append(want, st)
+		}
+
+		// Twice: the cold call populates the memo, the warm call reads it, and
+		// both must equal the reference.
+		require.Equalf(t, want, Tokens(canonical), "cold pipeline for %q", m)
+		require.Equalf(t, want, Tokens(canonical), "warm pipeline for %q", m)
+	}
+}
+
+// The memo is keyed on the INPUT token and holds the singular form. Keying it
+// on the output instead would still return the right answer on every call —
+// the first one computes it and stemming is idempotent — so the only thing
+// that catches it is asserting which key carries which value.
+func TestStemMemoKeysTheInputAndHoldsTheSingular(t *testing.T) {
+	resetStemMemo()
+
+	require.Equal(t, "vulnerability", Stem("vulnerabilities"))
+
+	require.Equal(t, map[string]string{"vulnerabilities": "vulnerability"}, stemMemoEntries(),
+		"one entry, keyed on the token that was asked about")
+}
+
+// The two guards return before the pluralizer runs, so there is nothing to
+// memoize: caching them would spend a map entry to avoid a length check.
+func TestStemMemoSkipsTheGuardedTokens(t *testing.T) {
+	resetStemMemo()
+
+	require.Equal(t, "aws", Stem("aws"))         // len <= 3
+	require.Equal(t, "metrics", Stem("metrics")) // -ics
+
+	require.Empty(t, stemMemoEntries())
+}
+
+// A stored entry must retain ONLY its own bytes — BOTH HALVES OF IT.
+//
+// Tokens hands Stem a strings.FieldsFunc substring, which shares the
+// canonicalized input's backing array, so an entry stored as-is pins that whole
+// string — and request-supplied ?domain= and ?motifs= values do reach here, so
+// the pinned buffer can be as long as a caller cares to make it. Comparing the
+// data pointers is the only assertion that sees this: the strings are EQUAL
+// either way, and an equality test passes on the aliasing version.
+//
+// The two halves need DIFFERENT probe tokens, and that is the whole reason this
+// test has two parts. A word Singular rewrites gets a fresh allocation for the
+// value whatever the code does, so it can only ever prove the key; the value is
+// only pinnable when Singular hands its argument straight back. Checking the
+// value with a rewritten word looks like coverage and is not: it leaves
+// `Singular(t)` in place of `Singular(key)` — half the leak, restored — passing.
+func TestStemMemoEntryDoesNotPinItsInput(t *testing.T) {
+	resetStemMemo()
+
+	// One long canonical string; both probes are windows onto it.
+	long := Canonicalize("vulnerabilities-" + strings.Repeat("padding-", 200) + "tail")
+	tokens := strings.FieldsFunc(long, func(r rune) bool { return r == '/' || unicode.IsSpace(r) })
+	require.Equal(t, "vulnerabilities", tokens[0], "probe 1 must be a substring of the long string")
+	require.Equal(t, "padding", tokens[1], "probe 2 must be a substring of the long string")
+
+	// KEY. "vulnerabilities" is rewritten by Singular, so this half is about the
+	// key alone.
+	require.Equal(t, "vulnerability", Stem(tokens[0]))
+	keyStored, ok := stemMemoKeyFor("vulnerabilities")
+	require.True(t, ok)
+	require.NotSame(t, unsafe.StringData(tokens[0]), unsafe.StringData(keyStored),
+		"the memo key must be its own allocation, not a window onto the caller's buffer")
+
+	// VALUE. "padding" is >3 chars, not -ics, and already singular, so Singular
+	// returns its argument unchanged — which is the only case in which the value
+	// can alias, and therefore the only case that can catch singularizing the
+	// original instead of the clone.
+	require.Equal(t, "padding", Stem(tokens[1]))
+	v, loaded := stemMemo.Load("padding")
+	require.True(t, loaded)
+	require.NotSame(t, unsafe.StringData(tokens[1]), unsafe.StringData(v.(string)),
+		"the memo value must be its own allocation too, even when Singular is a no-op")
+}
+
+// stemMemoKeyFor returns the string the memo actually STORED as the key for
+// name — not name itself, which is the point: the two are equal and may or may
+// not be the same allocation.
+func stemMemoKeyFor(name string) (string, bool) {
+	var found string
+	var ok bool
+	stemMemo.Range(func(k, _ any) bool {
+		if k.(string) == name {
+			found, ok = k.(string), true
+			return false
+		}
+		return true
+	})
+	return found, ok
+}
+
+// Stem is called from a SQLite callback on pooled connections, so concurrent
+// callers hit the memo at once. Run under -race.
+func TestStemMemoIsSafeUnderConcurrency(t *testing.T) {
+	resetStemMemo()
+
+	toks := []string{"vulnerabilities", "analyses", "indices", "fallbacks", "clusters"}
+	var wg sync.WaitGroup
+	for i := range 64 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			tok := toks[i%len(toks)]
+			require.Equal(t, unmemoizedStem(tok), Stem(tok))
+		}(i)
+	}
+	wg.Wait()
+
+	require.Len(t, stemMemoEntries(), len(toks))
+}

--- a/internal/textnorm/textnorm.go
+++ b/internal/textnorm/textnorm.go
@@ -17,6 +17,7 @@ package textnorm
 
 import (
 	"strings"
+	"sync"
 	"unicode"
 
 	"github.com/gertd/go-pluralize"
@@ -82,11 +83,59 @@ func Canonicalize(s string) string {
 //
 // Both guards are symmetric (applied identically at index and query time), so
 // they never break matching; they only avoid mangling internal keys.
+//
+// MEMOIZED, and that is a performance fix rather than a design choice about
+// meaning: go-pluralize's Singular runs a table of backtracking regexes and
+// costs ~25µs per token, which is three to four orders of magnitude more than
+// everything else on this path. That price used to be paid per token per motif
+// per ROW, inside the knomit_motif_key SQL callback, on every request — the
+// motif vocabulary of a single repo took ~40ms, and a five-mount lens paid it
+// five times. Memoizing takes Stem to tens of nanoseconds — three orders of
+// magnitude, and 0 allocations on the hit — and the lens vocabulary from
+// ~133ms to ~9ms. See BenchmarkStem, which records the orders rather than the
+// digits, because the warm figure moves run to run.
+//
+// It needs NO invalidation, ever. Stem is a pure function of its argument, so
+// the memo is not derived corpus state that can go stale — it is the same
+// answer, remembered. That is why it lives here on the primitive rather than
+// as a per-branch cache in a consumer: one seam, and every caller — groupingKey,
+// domain matching, the motif-term tiers in store.expandMotifQuery, the motif
+// subject-word strip — gets it. Free-text search is NOT one of them: opts.Text
+// goes to the embedder, and never through this package.
+//
+// Unbounded, deliberately, and matching store.branchCache's posture. What
+// bounds it is worth stating exactly, because it is NOT only the corpus: the
+// keys are single tokens from a corpus's own vocabulary PLUS whatever
+// domain and motif filter tokens callers have asked about — ?domain= and
+// ?motifs= reach here through store.canonicalizeDomain and the motif tiers, so
+// a request can mint an entry. There is still no size to pick that would not
+// be a guess about how big a corpus is, but see the Clone below for what that
+// admission costs.
+var stemMemo sync.Map // token → singular form
+
 func Stem(t string) string {
 	if len(t) <= 3 || strings.HasSuffix(t, "ics") {
 		return t
 	}
-	return pluralizer.Singular(t)
+	if s, ok := stemMemo.Load(t); ok {
+		return s.(string)
+	}
+	// CLONED BEFORE IT IS STORED, and that is about retention, not correctness.
+	// Tokens hands us a strings.FieldsFunc substring, which shares the
+	// canonicalized input's backing array — so storing it as-is would pin the
+	// WHOLE canonical string for the entry's life, and Singular returning its
+	// argument unchanged (the common case) would pin it through the value too.
+	// One token off a long ?domain= would hold that whole filter value forever.
+	// Cloning first, and singularizing the clone, means an entry retains its
+	// own bytes and nothing else. It costs one allocation on a MISS; the hit
+	// path above never reaches here.
+	//
+	// Racing callers may both compute this; Singular is pure, so they compute
+	// the same string and the second Store is a no-op in everything but timing.
+	key := strings.Clone(t)
+	s := pluralizer.Singular(key)
+	stemMemo.Store(key, s)
+	return s
 }
 
 // Tokens returns the stemmed, de-duplicated token set of a canonical string,


### PR DESCRIPTION
Stacked on #182 — base is `feat/lens-motif-filtering`, and it retargets to `dev` when that merges. One commit, 3 files, all in `internal/textnorm`.

## What was actually slow

The brief was "the lens motif feature is slow, and the suspect is the per-request union rebuild fanned out over every mount". Measured, that is not where the time went. The fan-out is honest: a lens costs **exactly the sum of its mounts**, with no superlinearity and no server-side N+1. The per-mount unit cost was the whole problem — a **single repo's** `/motifs` took ~40ms.

A stack profile under load, then an instrumented build counting calls, found this:

```
knomit_motif_key (SQL callback)
  → store.groupingKey
    → textnorm.Tokens
      → textnorm.Stem
        → go-pluralize Singular    ← backtracking regexes, ~25µs per token
```

`ClustersUnder` computes the cluster key **in SQL**, for every row whose motif has no stored alias. Nothing cached the pluralizer's answer, so that ~25µs was paid per token, per motif, **per row**, on every request. One `GET /lenses/all/motifs` over five mounts:

| mount | ClustersUnder | groupingKey calls | groupingKey ms | share |
|---|---|---|---|---|
| knomit-kb | 25.2 ms | 576 | 24.1 | 96% |
| core | 30.0 ms | 732 | 28.6 | 95% |
| knomit-io-kb | 2.4 ms | 68 | 2.2 | 90% |
| agentic-engineering | 26.4 ms | 640 | 25.1 | 95% |
| test | 0.1 ms | 0 | 0.0 | — |

**It only bites where the alias table does not cover the branch.** The `COALESCE` in `motifClusterKeyExpr` short-circuits on a stored `cluster_key`, so a fully rebuilt branch never calls `knomit_motif_key` at all. A branch with zero coverage — a freshly created agent branch, which a repo takeover makes — pays for every row; a partially covered one pays for the rest. Neither is exotic: `ClustersUnder`'s own comment says any corpus with facts written since the last rebuild is in this state.

| `knomit-kb` `/motifs` | zero alias coverage | partial coverage |
|---|---|---|
| before | 39.3 ms | 9.5 ms |
| after | 2.9 ms | 2.4 ms |

## The fix

Memoize `textnorm.Stem`.

`Stem` is a **pure function of its argument**, so remembering its answer needs no invalidation at all — it is the same answer, not derived corpus state that can go stale. That is why the memo lives on the primitive rather than as a per-branch cache in a consumer: one seam, and `groupingKey`, domain matching, the motif-term query tiers and the motif subject-word strip all get it. Free-text search is *not* among them — `opts.Text` goes to the embedder and never through `textnorm`.

Unbounded, matching `store.branchCache`'s posture. What bounds it is worth stating exactly, because it is **not only the corpus**: the keys are corpus vocabulary *plus whatever domain and motif filter tokens callers have asked about* — `?domain=` and `?motifs=` reach `Stem` through `canonicalizeDomain` and the motif tiers, so a request can mint an entry. Any size to evict at would still be a guess about how big a corpus is.

Because request strings do get in, an entry must not retain more than itself. `Tokens` hands `Stem` a `strings.FieldsFunc` substring sharing the canonicalized input's backing array, so **the key is cloned before it is stored, and the clone is what gets singularized** — `Singular` returns its argument unchanged for an already-singular word, which would otherwise pin the caller's buffer through the value too. One token off a long `?domain=` would hold that whole value forever. The clone costs one allocation on a miss; the hit path stays at 0 allocations.

## Before / after

Lens `all`, 5 real mounts, `curl` n=15. Both binaries against the same home, one at a time, port ownership checked on every run.

| endpoint | before | after | |
|---|---|---|---|
| `GET /lenses/all/motifs` | 126.8 ms | 8.6 ms | 14.7× |
| `GET /lenses/all/motifs/{key}` | 105.5 ms | 8.3 ms | 12.7× |
| `GET /lenses/all/facts?motifs=` (widening) | 106.2 ms | 8.3 ms | 12.8× |
| `GET /lenses/all/facts` (no motif filter) | 3.8 ms | 3.8 ms | — |
| `GET /lenses/all/stats` | 85.9 ms | 85.2 ms | — |

Committed benchmark, `go test ./internal/textnorm/ -run XXX -bench 'Stem|Tokens'`. **Recorded as orders, not digits** — the warm figure moves run to run, and an earlier draft of this comment recorded that noise as a result:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| `BenchmarkStemCold` | ~25 µs | ~480 | 13 |
| `BenchmarkStem` | tens of ns | 0 | 0 |
| `BenchmarkTokensCold` | ~45 µs | ~1450 | 35 |
| `BenchmarkTokens` | hundreds of ns | 128 | 2 |

The allocation counts are the part worth pinning exactly; the hit path's zero is the one a future change must not move.

**Cold path.** The memo is per process, so a restart pays it once — but boot-time index work already warms most of it. First three requests on a freshly booted server: **22.5 / 13.2 / 12.3 ms**, settling at 8.6 ms. Even the coldest request is 5.6× faster than the pre-fix steady state.

## Semantics: unchanged, and checked two ways

**Test.** `TestStemMemoIsSemanticallyTransparent` runs 45 real motif spellings through `Tokens(Canonicalize(·))` against a written-out unmemoized reference, on the cold call and the warm one. `Tokens` feeds `groupingKey`, so a memo that answered differently for even one token would silently re-key clusters — a spelling would join, or stop joining, a different cluster.

**End to end.** 17 responses captured from both binaries against the same home — the lens motif collection (both pages), a cluster detail, a motif-filtered facts read, an unfiltered facts read, a lens search, lens stats, and each of the five mounts' `/motifs` on two branches. **16 of 17 byte-for-byte identical.** The 17th, `/lenses/all/stats`, differs in one field — `changes_7d` 438 vs 439, a time-window counter, and the captures were minutes apart. No motif surface differs at all.

### The pin test needs two probes, and that is the point

Retention is asserted on `unsafe.StringData`, not on equality: the strings are equal whether or not the entry aliases its caller's buffer, so an equality assertion passes on the leaking version.

It takes **two different probe tokens**, one per half:

- **key** — `"vulnerabilities"`, a word `Singular` rewrites.
- **value** — `"padding"`, a word `Singular` leaves alone.

A rewritten word can only ever prove the key, because the value is a fresh allocation whatever the code does. Checking the value with a rewritten word *looks* like coverage and is not.

## Review provenance

Reviewed adversarially, and the review found real gaps rather than nits:

- Three prose findings, all verified against the code before being accepted: the design-rationale sentence claimed the keys were corpus vocabulary only, when `?domain=` and `?motifs=` demonstrably reach `Stem`; "search tokenization" overclaimed, since `q.Text` never touches `textnorm`; and "a few dozen bytes per entry" understated retention, which produced the `strings.Clone`.
- One coverage finding: the first pin test asserted on the key only, and its probe token made the value side structurally unreachable. The reviewer proved it with a mutant — clone the key but singularize the *original*, restoring half the leak — that left the suite green. That mutant now fails.

Every guard here is sabotage-verified. Five mutants, each killed by a named test: a memo hit returning the raw token, a memo keyed on the output, a dropped `-ics` guard, a dropped `Clone`, and singularizing the original instead of the clone.

## Verification

`go test ./...` exit 0 · `go vet` clean · `go test ./internal/textnorm/ -race` green · `tsc --noEmit` clean · vitest 96 files / 1362 tests passed · eslint unchanged at baseline — this branch touches **zero** files under `web/`.

## Out of scope, flagged not fixed

Two costs the motif work does not own and this PR does not touch, both measured in the same lab:

- `GET /lenses/all/search` — 470 ms (lab), 97 ms on a live server. The embedding/RRF path.
- `GET /lenses/all/stats` — ~86 ms (lab), 83 ms live.

After this fix, `/lenses/all/stats` is the only large term left in a lens-open request set (156 ms → 112 ms wall for the six requests the summary panel fires). Whether to pursue either is a scope call for the maintainer.

`useMotifClusters` still fires one cluster-detail request per motif on an opened fact. At 8.3 ms per detail rather than 105 ms it is no longer the user-visible problem; batching it is a separate judgement call, deliberately deferred.
