### PR TITLE
perf(lens): make opening a lens fast — stats and search stop multiplying by mount count

### DIFF
--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -1,7 +1,10 @@
 package mcp
 
 import (
+	"context"
 	"errors"
+
+	"github.com/rs/zerolog/log"
 
 	"knomit/internal/repos"
 	"knomit/internal/store"
@@ -52,4 +55,36 @@ func storeIndices(ri *repos.RepoInstance) (mcpStore, func(), error) {
 		branches:    svc.Branches(),
 		motifs:      svc.Motifs(),
 	}, release, nil
+}
+
+// fanoutQueryVec embeds a federated query's text ONCE, for every mount in the
+// fan-out to share, and is the reason a lens query is not N inferences of the
+// same string.
+//
+// Without it the cost is real and it is the whole request: store.Search embeds
+// whenever SearchOptions.QueryVec is empty (internal/store/search_query.go), so
+// an N-mount fan-out ran the identical ~81 ms ONNX inference N times. It is a
+// fixed per-mount cost, independent of corpus size — the same query against an
+// EMPTY mount also cost 81 ms, while that mount answered a text-less filter in
+// 0.4 ms. A single-repo binding never showed it: there is only one mount to pay
+// for.
+//
+// The hoist cannot change a result. repos.Manager installs ONE embedder on
+// every repo instance, so the N vectors were already identical by construction
+// — this computes one of them instead of N.
+//
+// A nil vector is the DEGRADED path, not an error: with no embedder, no text,
+// or a failed inference, each mount falls back to exactly what it does today
+// (its own embedder, else keyword-only search). Never fail a query because it
+// could not be embedded.
+func fanoutQueryVec(ctx context.Context, emb store.Embedder, text string) []float32 {
+	if text == "" || emb == nil {
+		return nil
+	}
+	vec, err := emb.EmbedQuery(ctx, text)
+	if err != nil {
+		log.Warn().Err(err).Msg("federated query: embed query failed")
+		return nil
+	}
+	return vec
 }

--- a/internal/mcp/query.go
+++ b/internal/mcp/query.go
@@ -171,7 +171,17 @@ type pagedRowState struct {
 
 // QueryHandler returns the handler function for knomit_query.
 // The repo is resolved from the request context at call time via RepoMiddleware.
-func QueryHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+//
+// If an embedder is supplied it is used to embed a text query ONCE for the
+// whole fan-out (see fanoutQueryVec); without one, each mount falls back to
+// embedding the query itself, which is what this handler did before. Variadic
+// for the same reason LearnHandler is: the embedder is optional, and callers
+// that have none (tests, embeddings-disabled builds) pass nothing.
+func QueryHandler(embedders ...store.BatchEmbedder) func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+	var emb store.Embedder
+	if len(embedders) > 0 && embedders[0] != nil {
+		emb = embedders[0]
+	}
 	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
@@ -208,9 +218,9 @@ func QueryHandler() func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToo
 		}
 
 		if sort == sortRecent {
-			return queryRecent(ctx, b, sWrite, req, pageSize, maxResults, includeBody)
+			return queryRecent(ctx, b, sWrite, emb, req, pageSize, maxResults, includeBody)
 		}
-		return queryFirstCall(ctx, b, sWrite, req, pageSize, maxResults, includeBody)
+		return queryFirstCall(ctx, b, sWrite, emb, req, pageSize, maxResults, includeBody)
 	}
 }
 
@@ -243,7 +253,7 @@ func mountLabel(rt repos.ReadTarget) string {
 // ordered candidate set from RecentFacts (already filtered + committed_at
 // DESC), snapshots it into a session, and serves the first page through the
 // shared resume path so body hydration and pagination match relevance mode.
-func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcpgo.CallToolRequest, pageSize, maxResults int, includeBody bool) (*mcpgo.CallToolResult, error) {
+func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, emb store.Embedder, req mcpgo.CallToolRequest, pageSize, maxResults int, includeBody bool) (*mcpgo.CallToolResult, error) {
 	q, err := parseQueryFilters(req)
 	if err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
@@ -260,6 +270,10 @@ func queryRecent(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcp
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
 	q.Limit = maxResults // per-mount snapshot depth (RFC §7.1: no overscan factor)
+	// Embed the query ONCE for the whole fan-out rather than once per mount —
+	// see fanoutQueryVec. Nil (no embedder, no text, failed inference) leaves
+	// every mount on the path it took before: its own embedder, else keywords.
+	q.QueryVec = fanoutQueryVec(ctx, emb, q.Text)
 
 	// Fan out in parallel; any mount error fails the whole query — a lens must
 	// never silently shrink its read set (RFC §9.1).
@@ -450,7 +464,7 @@ func hasAnyFilter(q store.SearchOptions) bool {
 // parallel, fuses the per-mount ranked lists with reciprocal rank fusion,
 // returns the first page, and (only when the fused set exceeds one page)
 // snapshots the remainder into the write repo's session DB with WIRE paths.
-func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req mcpgo.CallToolRequest, pageSize, maxResults int, includeBody bool) (*mcpgo.CallToolResult, error) {
+func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, emb store.Embedder, req mcpgo.CallToolRequest, pageSize, maxResults int, includeBody bool) (*mcpgo.CallToolResult, error) {
 	q, err := parseQueryFilters(req)
 	if err != nil {
 		return mcpgo.NewToolResultError(err.Error()), nil
@@ -472,6 +486,10 @@ func queryFirstCall(ctx context.Context, b *repos.Binding, sWrite mcpStore, req 
 		return mcpgo.NewToolResultError(err.Error()), nil
 	}
 	q.Limit = maxResults // per-mount snapshot depth (RFC §7.1: no overscan factor)
+	// Embed the query ONCE for the whole fan-out rather than once per mount —
+	// see fanoutQueryVec. Nil (no embedder, no text, failed inference) leaves
+	// every mount on the path it took before: its own embedder, else keywords.
+	q.QueryVec = fanoutQueryVec(ctx, emb, q.Text)
 
 	// Fan out in parallel; any mount error fails the whole query — a lens must
 	// never silently shrink its read set (RFC §9.1).

--- a/internal/mcp/query_embed_hoist_test.go
+++ b/internal/mcp/query_embed_hoist_test.go
@@ -80,21 +80,31 @@ func countingFedRepo(t *testing.T, emb countingFedEmbedder) (*repos.RepoInstance
 }
 
 // A federated text query embeds the query ONCE for the whole fan-out, not once
-// per mount.
+// per mount — on BOTH knomit_query fan-outs.
 //
 // Both sides of this test run the same query over the same 3-mount binding; the
 // only difference is whether QueryHandler was given the embedder to hoist with.
 // Without it, each mount embeds for itself inside store.Search — 3 inferences of
 // the identical string. That is the shape that made the REST twin 88% embedding
 // on a 5-mount lens, and it is a fixed per-mount cost, not a corpus-size one.
+//
+// sort=recent is covered because it is NOT a filter-only path: RecentFacts
+// delegates to recentFactsSearch whenever there is a text query
+// (internal/store/search_query.go), so the recency browse embeds exactly like
+// the relevance one. It hoists in queryRecent, a second call site that a
+// regression could revert on its own — and one nothing else here would notice,
+// since re-embedding is invisible to every assertion except this count.
 func TestQueryFederation_EmbedsQueryOncePerFanout(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
+		sort   string
 		hoists bool
 		want   int64
 	}{
-		{"hoisted", true, 1},
-		{"per-mount (pre-fix shape)", false, 3},
+		{"relevance/hoisted", sortRelevance, true, 1},
+		{"relevance/per-mount (pre-fix shape)", sortRelevance, false, 3},
+		{"recent/hoisted", sortRecent, true, 1},
+		{"recent/per-mount (pre-fix shape)", sortRecent, false, 3},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var meter atomic.Int64
@@ -119,7 +129,7 @@ func TestQueryFederation_EmbedsQueryOncePerFanout(t *testing.T) {
 				handler = QueryHandler(emb)
 			}
 			var req mcpgo.CallToolRequest
-			req.Params.Arguments = map[string]any{"text": "alpha"}
+			req.Params.Arguments = map[string]any{"text": "alpha", "sort": tc.sort}
 			result, err := handler(repos.WithBinding(context.Background(), b), req)
 			require.NoError(t, err)
 			require.NotNil(t, result)
@@ -133,27 +143,31 @@ func TestQueryFederation_EmbedsQueryOncePerFanout(t *testing.T) {
 }
 
 // A text-LESS query must not reach an embedder at all — the hoist adds no
-// inference to a pure filter browse.
+// inference to a pure filter browse, on either fan-out.
 func TestQueryFederation_FilterOnlyQueryNeverEmbeds(t *testing.T) {
-	var meter atomic.Int64
-	emb := countingFedEmbedder{queries: &meter}
-	repoA, ctxA := countingFedRepo(t, emb)
-	repoB, _ := countingFedRepo(t, emb)
-	seedFedFact(t, ctxA, "seed-a", "mission/store", "alpha fact", "store", nil)
+	for _, sort := range []string{sortRelevance, sortRecent} {
+		t.Run(sort, func(t *testing.T) {
+			var meter atomic.Int64
+			emb := countingFedEmbedder{queries: &meter}
+			repoA, ctxA := countingFedRepo(t, emb)
+			repoB, _ := countingFedRepo(t, emb)
+			seedFedFact(t, ctxA, "seed-a", "mission/store", "alpha fact", "store", nil)
 
-	b := repos.NewBindingForTest(repoA,
-		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
-		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
-	)
-	meter.Store(0)
+			b := repos.NewBindingForTest(repoA,
+				repos.ReadTarget{RI: repoA, Branch: "agent/test"},
+				repos.ReadTarget{RI: repoB, Branch: "agent/test"},
+			)
+			meter.Store(0)
 
-	var req mcpgo.CallToolRequest
-	req.Params.Arguments = map[string]any{"domain": []any{"store"}}
-	result, err := QueryHandler(emb)(repos.WithBinding(context.Background(), b), req)
-	require.NoError(t, err)
-	require.Falsef(t, result.IsError, "query failed: %s", resultText(t, result))
+			var req mcpgo.CallToolRequest
+			req.Params.Arguments = map[string]any{"domain": []any{"store"}, "sort": sort}
+			result, err := QueryHandler(emb)(repos.WithBinding(context.Background(), b), req)
+			require.NoError(t, err)
+			require.Falsef(t, result.IsError, "query failed: %s", resultText(t, result))
 
-	if got := meter.Load(); got != 0 {
-		t.Errorf("EmbedQuery called %d times for a filter-only query, want 0", got)
+			if got := meter.Load(); got != 0 {
+				t.Errorf("EmbedQuery called %d times for a filter-only query, want 0", got)
+			}
+		})
 	}
 }

--- a/internal/mcp/query_embed_hoist_test.go
+++ b/internal/mcp/query_embed_hoist_test.go
@@ -1,0 +1,159 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"knomit/internal/embeddings/params"
+	"knomit/internal/fact"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// countingFedEmbedder answers every query with the same fixed vector and counts
+// the inferences. The vector's VALUE is irrelevant here; the COUNT is the whole
+// point, and a constant vector is what makes the hoisted and per-mount runs
+// comparable at all.
+type countingFedEmbedder struct{ queries *atomic.Int64 }
+
+func (e countingFedEmbedder) vec() []float32 {
+	out := make([]float32, 768)
+	out[0] = 1
+	return out
+}
+
+func (e countingFedEmbedder) EmbedQuery(context.Context, string) ([]float32, error) {
+	e.queries.Add(1)
+	return e.vec(), nil
+}
+
+func (e countingFedEmbedder) EmbedDocument(context.Context, string, string) ([]float32, error) {
+	return e.vec(), nil
+}
+
+func (e countingFedEmbedder) EmbedDocuments(_ context.Context, titles, _ []string) ([][]float32, error) {
+	out := make([][]float32, len(titles))
+	for i := range titles {
+		out[i] = e.vec()
+	}
+	return out, nil
+}
+
+func (e countingFedEmbedder) EmbedShortStrings(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = e.vec()
+	}
+	return out, nil
+}
+
+func (countingFedEmbedder) Dim() int                      { return 768 }
+func (countingFedEmbedder) ID() string                    { return "counting-fed" }
+func (countingFedEmbedder) Thresholds() params.Thresholds { return params.Defaults() }
+
+// countingFedRepo builds a repo wired to the SHARED counting embedder, so a
+// per-mount embed inside the store is counted by the same meter as the
+// handler's hoisted one — which is what lets one assertion distinguish them.
+func countingFedRepo(t *testing.T, emb countingFedEmbedder) (*repos.RepoInstance, context.Context) {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := store.Open(filepath.Join(dir, "k.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = svc.Close() })
+	svc.SetEmbedder(emb)
+	require.NoError(t, svc.InitRepo(map[string]string{}, "agent/test"))
+	ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+		Name:         "test",
+		UID:          nextTestRepoUID(),
+		AgentBranch:  "agent/test",
+		Svc:          svc,
+		Ontology:     fact.CodeOntology(),
+		OntologyRoot: "kb",
+		Embedder:     emb,
+	})
+	return ri, repos.WithRepoInstance(context.Background(), ri)
+}
+
+// A federated text query embeds the query ONCE for the whole fan-out, not once
+// per mount.
+//
+// Both sides of this test run the same query over the same 3-mount binding; the
+// only difference is whether QueryHandler was given the embedder to hoist with.
+// Without it, each mount embeds for itself inside store.Search — 3 inferences of
+// the identical string. That is the shape that made the REST twin 88% embedding
+// on a 5-mount lens, and it is a fixed per-mount cost, not a corpus-size one.
+func TestQueryFederation_EmbedsQueryOncePerFanout(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		hoists bool
+		want   int64
+	}{
+		{"hoisted", true, 1},
+		{"per-mount (pre-fix shape)", false, 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var meter atomic.Int64
+			emb := countingFedEmbedder{queries: &meter}
+			repoA, ctxA := countingFedRepo(t, emb)
+			repoB, _ := countingFedRepo(t, emb)
+			repoC, _ := countingFedRepo(t, emb)
+			seedFedFact(t, ctxA, "seed-a", "mission/store", "alpha fact", "store", nil)
+
+			b := repos.NewBindingForTest(repoA,
+				repos.ReadTarget{RI: repoA, Branch: "agent/test"},
+				repos.ReadTarget{RI: repoB, Branch: "agent/test"},
+				repos.ReadTarget{RI: repoC, Branch: "agent/test"},
+			)
+
+			// Seeding embeds documents, not queries, but reset anyway so the
+			// number below can only have come from the query path.
+			meter.Store(0)
+
+			handler := QueryHandler()
+			if tc.hoists {
+				handler = QueryHandler(emb)
+			}
+			var req mcpgo.CallToolRequest
+			req.Params.Arguments = map[string]any{"text": "alpha"}
+			result, err := handler(repos.WithBinding(context.Background(), b), req)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Falsef(t, result.IsError, "query failed: %s", resultText(t, result))
+
+			if got := meter.Load(); got != tc.want {
+				t.Errorf("EmbedQuery called %d times across 3 mounts, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// A text-LESS query must not reach an embedder at all — the hoist adds no
+// inference to a pure filter browse.
+func TestQueryFederation_FilterOnlyQueryNeverEmbeds(t *testing.T) {
+	var meter atomic.Int64
+	emb := countingFedEmbedder{queries: &meter}
+	repoA, ctxA := countingFedRepo(t, emb)
+	repoB, _ := countingFedRepo(t, emb)
+	seedFedFact(t, ctxA, "seed-a", "mission/store", "alpha fact", "store", nil)
+
+	b := repos.NewBindingForTest(repoA,
+		repos.ReadTarget{RI: repoA, Branch: "agent/test"},
+		repos.ReadTarget{RI: repoB, Branch: "agent/test"},
+	)
+	meter.Store(0)
+
+	var req mcpgo.CallToolRequest
+	req.Params.Arguments = map[string]any{"domain": []any{"store"}}
+	result, err := QueryHandler(emb)(repos.WithBinding(context.Background(), b), req)
+	require.NoError(t, err)
+	require.Falsef(t, result.IsError, "query failed: %s", resultText(t, result))
+
+	if got := meter.Load(); got != 0 {
+		t.Errorf("EmbedQuery called %d times for a filter-only query, want 0", got)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -98,7 +98,7 @@ type toolReg struct {
 func toolRegistrations(embedders ...store.BatchEmbedder) []toolReg {
 	return []toolReg{
 		{learnTool(), LearnHandler(embedders...), true},
-		{queryTool(), QueryHandler(), false},
+		{queryTool(), QueryHandler(embedders...), false},
 		{explainTool(), ExplainHandler(), false},
 		{updateTool(), UpdateHandler(), true},
 		{retractTool(), RetractHandler(), true},

--- a/internal/store/highlights_test.go
+++ b/internal/store/highlights_test.go
@@ -485,6 +485,15 @@ func TestHighlights_NarrowCallUsesTheAxisItIsGiven(t *testing.T) {
 	viaStats, err := svc.FactQuery().Stats(ctx, branch, "", other)
 	require.NoError(t, err)
 
+	// The premise, made explicit: the two axes must actually order this fixture
+	// differently. If they agreed, "answered for the axis it was given" and
+	// "silently re-derived the default" would produce the same rows and the
+	// assertion below would hold for a call that ignored its argument entirely.
+	require.NotEqual(t, full.Highlights, viaStats.Highlights,
+		"fixture no longer distinguishes axis %q from the default %q — this test "+
+			"cannot fail as written, so it must be reseeded rather than trusted",
+		other, full.DefaultAxis)
+
 	require.Equal(t, viaStats.Highlights, pinned,
 		"the narrow call answered for some axis other than the one it was given")
 }

--- a/internal/store/highlights_test.go
+++ b/internal/store/highlights_test.go
@@ -427,3 +427,64 @@ func TestHighlights_AnEmptyScopeIsNotAFallback(t *testing.T) {
 	require.Empty(t, res.Highlights)
 	require.False(t, res.HighlightsFallback)
 }
+
+// FactQuery.Highlights must return exactly what Stats would have returned for
+// the same axis — rows AND fallback flag. It exists so the lens union's axis
+// correction can re-cut one mount's top-N without recomputing the aggregates it
+// already holds; the moment the two disagree, that correction starts producing
+// a top-N the union could never have got from Stats, and nothing else would
+// notice.
+//
+// Swept across every axis and both scopes of the fixture (the root, where real
+// highlights exist, and the pure-observation subtree, where the fallback
+// fires), because "agrees with Stats" is a claim about the whole surface, not
+// about one lucky axis.
+func TestHighlights_NarrowCallAgreesWithStats(t *testing.T) {
+	const branch = "main"
+	svc := seedHighlightFixture(t, branch)
+	ctx := context.Background()
+
+	for _, scope := range []string{"", "kb/o", "kb/nothing-here"} {
+		for _, axis := range []string{AxisImpact, AxisConfidence, AxisRecent} {
+			t.Run(scope+"/"+axis, func(t *testing.T) {
+				full, err := svc.FactQuery().Stats(ctx, branch, scope, axis)
+				require.NoError(t, err)
+
+				narrowRows, narrowFallback, err := svc.FactQuery().Highlights(ctx, branch, scope, axis)
+				require.NoError(t, err)
+
+				require.Equal(t, full.Highlights, narrowRows,
+					"narrow Highlights diverged from the rows Stats returned for the same axis")
+				require.Equal(t, full.HighlightsFallback, narrowFallback,
+					"narrow Highlights diverged from Stats on whether the fallback fired")
+			})
+		}
+	}
+}
+
+// Unlike Stats, the narrow call does NOT substitute the branch's own default
+// for an unresolved axis: the lens union asks for it precisely to pin a mount
+// to an axis that mount did not choose, so silently re-deriving one would undo
+// the correction it was built for. Normalising is the caller's job.
+func TestHighlights_NarrowCallUsesTheAxisItIsGiven(t *testing.T) {
+	const branch = "main"
+	svc := seedHighlightFixture(t, branch)
+	ctx := context.Background()
+
+	// The fixture's own recommendation, and an axis deliberately different from
+	// it — the narrow call must answer for the axis passed, not for the default.
+	full, err := svc.FactQuery().Stats(ctx, branch, "", "")
+	require.NoError(t, err)
+	other := AxisRecent
+	if full.DefaultAxis == AxisRecent {
+		other = AxisConfidence
+	}
+
+	pinned, _, err := svc.FactQuery().Highlights(ctx, branch, "", other)
+	require.NoError(t, err)
+	viaStats, err := svc.FactQuery().Stats(ctx, branch, "", other)
+	require.NoError(t, err)
+
+	require.Equal(t, viaStats.Highlights, pinned,
+		"the narrow call answered for some axis other than the one it was given")
+}

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -234,6 +234,35 @@ type StatsResult struct {
 	ObservationEdges   int  `json:"-"`
 }
 
+// Highlights returns just the top-N highlight rows a Stats call would have
+// returned, under an EXPLICIT axis, without computing any of the aggregates
+// around them.
+//
+// It exists for the lens union's axis correction. That handler resolves a
+// POOLED default axis across mounts, and when the pooled verdict differs from
+// what a mount chose for itself, that mount's top-N was cut by the wrong axis
+// for the union and has to be re-fetched. Re-fetching it through Stats meant
+// recomputing the count, both json_each histograms, the type counts and the
+// separation counters — every one of them already in hand and about to be
+// thrown away. On the 5-mount `all` lens that second pass cost 37.0 ms of an
+// 84 ms request; the highlights inside it were 10.6 ms.
+//
+// It shares fq.highlights with Stats rather than reimplementing the query, so
+// the corrected rows cannot drift from the ones Stats would have produced —
+// including the second return value, the per-scope fallback flag whose meaning
+// the union handler depends on (see the comment on fq.highlights).
+//
+// axis is used as given. Unlike Stats it does not fall back to this branch's
+// own DefaultAxis, because the whole point of the call is to pin a mount to an
+// axis it did not choose; NormalizeAxis is the caller's to apply.
+func (fq *factQuery) Highlights(ctx context.Context, branch, pathPrefix, axis string) ([]Highlight, bool, error) {
+	branchID, err := fq.rh.branchID(ctx, branch)
+	if err != nil {
+		return nil, false, fmt.Errorf("highlights: %w", err)
+	}
+	return fq.highlights(ctx, branchID, pathPrefix, axis)
+}
+
 // Stats returns aggregate statistics over all indexed facts on a branch,
 // optionally filtered to those whose path starts with pathPrefix. axis
 // selects the Highlights ranking (see NormalizeAxis); it does not affect

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -47,6 +47,10 @@ type FactQuery interface {
 	GetByPath(ctx context.Context, branch, path string) (*FactWithBody, error)
 	LastCommitForPath(ctx context.Context, branch, path string) (string, bool)
 	Stats(ctx context.Context, branch, pathPrefix, axis string) (StatsResult, error)
+	// Highlights returns only the highlight rows Stats would have returned,
+	// under an explicit axis. For callers that need to re-cut a top-N by a
+	// different axis and already hold every aggregate Stats computes.
+	Highlights(ctx context.Context, branch, pathPrefix, axis string) ([]Highlight, bool, error)
 	Completions(ctx context.Context, branch, category, prefix string, limit int) ([]string, error)
 	RecentFacts(ctx context.Context, branch string, opts SearchOptions) ([]RecentFactEntry, int, error)
 	FactsIter(ctx context.Context, branch string) (*FactsIter, error)

--- a/internal/synthesize/mock_search_index_test.go
+++ b/internal/synthesize/mock_search_index_test.go
@@ -176,6 +176,22 @@ func (mr *MockSearchIndexMockRecorder) GetByPath(ctx, branch, path any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByPath", reflect.TypeOf((*MockSearchIndex)(nil).GetByPath), ctx, branch, path)
 }
 
+// Highlights mocks base method.
+func (m *MockSearchIndex) Highlights(ctx context.Context, branch, pathPrefix, axis string) ([]store.Highlight, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Highlights", ctx, branch, pathPrefix, axis)
+	ret0, _ := ret[0].([]store.Highlight)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Highlights indicates an expected call of Highlights.
+func (mr *MockSearchIndexMockRecorder) Highlights(ctx, branch, pathPrefix, axis any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Highlights", reflect.TypeOf((*MockSearchIndex)(nil).Highlights), ctx, branch, pathPrefix, axis)
+}
+
 // IncomingAtCommit mocks base method.
 func (m *MockSearchIndex) IncomingAtCommit(ctx context.Context, branch, path, commitHash string) ([]store.RefSummary, error) {
 	m.ctrl.T.Helper()

--- a/internal/web/handlers_lenses_embed_hoist_test.go
+++ b/internal/web/handlers_lenses_embed_hoist_test.go
@@ -1,0 +1,192 @@
+package web
+
+import (
+	"context"
+	"reflect"
+	"sync/atomic"
+	"testing"
+
+	"knomit/internal/embeddings/params"
+	"knomit/internal/store"
+)
+
+// countingEmbedder answers every query with the same fixed vector and counts
+// the inferences. The vector's VALUE is irrelevant to these tests; the COUNT is
+// the whole point, and a fixed vector is what makes "hoisted" and "per-mount"
+// results comparable at all.
+type countingEmbedder struct {
+	queries atomic.Int64
+	vec     []float32
+}
+
+func (e *countingEmbedder) EmbedQuery(_ context.Context, _ string) ([]float32, error) {
+	e.queries.Add(1)
+	return e.vec, nil
+}
+
+func (e *countingEmbedder) EmbedDocument(context.Context, string, string) ([]float32, error) {
+	return e.vec, nil
+}
+
+func (e *countingEmbedder) EmbedDocuments(_ context.Context, titles, _ []string) ([][]float32, error) {
+	out := make([][]float32, len(titles))
+	for i := range out {
+		out[i] = e.vec
+	}
+	return out, nil
+}
+
+func (e *countingEmbedder) EmbedShortStrings(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = e.vec
+	}
+	return out, nil
+}
+
+func (e *countingEmbedder) Dim() int                      { return len(e.vec) }
+func (e *countingEmbedder) ID() string                    { return "counting-stub" }
+func (e *countingEmbedder) Thresholds() params.Thresholds { return params.Defaults() }
+
+func newCountingEmbedder() *countingEmbedder {
+	return &countingEmbedder{vec: []float32{0.25, -0.5, 0.75}}
+}
+
+// A lens text search embeds the query ONCE no matter how many mounts it fans
+// out to. This is the regression that made /lenses/{lens}/search 88% embedding
+// on a 5-mount lens: the per-mount searchProvider embeds whenever QueryVec is
+// empty, so the handler paid the same ~81 ms inference once per mount.
+//
+// The count is asserted against the MOUNT COUNT, not a literal 1, so the test
+// still fails the day someone re-introduces a per-mount embed on a lens of a
+// different size.
+func TestLensSearch_EmbedsQueryOncePerRequest_NotPerMount(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta", "gamma")
+	stub := &lensSearchStub{byRepo: map[string][]store.SearchResult{
+		"alpha": {sr("kb/a/1.md", "Write fact", 9)},
+		"beta":  {sr("kb/b/2.md", "Read fact", 8)},
+		"gamma": {sr("kb/g/3.md", "Other fact", 7)},
+	}}
+	emb := newCountingEmbedder()
+	s := &Server{Manager: m, Embedder: emb, providers: storeProviders{search: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"},{"repo":"gamma"}]}`)
+
+	body := decodeLensSearch(t, getLensFacts(t, r, "/lenses/eng/search?q=x"))
+
+	const mounts = 3
+	if len(stub.lastOpts) != mounts {
+		t.Fatalf("fan-out reached %d mounts, want %d — the count below is only "+
+			"meaningful against the full fan-out", len(stub.lastOpts), mounts)
+	}
+	if got := emb.queries.Load(); got != 1 {
+		t.Errorf("EmbedQuery called %d times across %d mounts, want 1", got, mounts)
+	}
+	if len(body.Results) != mounts {
+		t.Errorf("results: got %d, want %d", len(body.Results), mounts)
+	}
+}
+
+// Every mount is handed the SAME vector — the one the handler embedded. This is
+// what makes the hoist result-preserving rather than merely faster: if a future
+// change made the vector mount-dependent (per-mount embedder, per-mount query
+// rewriting), the mounts would no longer be ranking against a common query and
+// RRF would be fusing incomparable lists.
+func TestLensSearch_EveryMountGetsTheSameQueryVector(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta", "gamma")
+	stub := &lensSearchStub{}
+	emb := newCountingEmbedder()
+	s := &Server{Manager: m, Embedder: emb, providers: storeProviders{search: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"},{"repo":"gamma"}]}`)
+
+	getLensFacts(t, r, "/lenses/eng/search?q=x")
+
+	for _, repo := range []string{"alpha", "beta", "gamma"} {
+		opts, ok := stub.lastOpts[repo]
+		if !ok {
+			t.Fatalf("mount %q never reached", repo)
+		}
+		if !float32SliceEqual(opts.QueryVec, emb.vec) {
+			t.Errorf("mount %q got QueryVec %v, want the hoisted %v", repo, opts.QueryVec, emb.vec)
+		}
+	}
+}
+
+// The results a hoisted embed produces are the ones per-mount embedding
+// produced. Driven by passing the SAME stub the same rows and comparing the
+// wire bodies: the hoist is a pure move of where the vector is computed, so the
+// fused order, the dedupe and the totals must all be untouched.
+func TestLensSearch_HoistedEmbedMatchesPerMountEmbed(t *testing.T) {
+	rows := map[string][]store.SearchResult{
+		"alpha": {sr("kb/a/1.md", "A one", 3), sr("kb/shared.md", "Shadowed", 99)},
+		"beta":  {sr("kb/shared.md", "Winner-shadowed copy", 50), sr("kb/b/2.md", "B two", 1)},
+	}
+
+	// ONE manager for both runs. Two managers would mint two sets of repos with
+	// different root commits, and the id12 in every qualified path and source
+	// would differ for reasons that have nothing to do with embedding.
+	m, _ := newTestLensManager(t, "alpha", "beta")
+
+	// Without a server embedder the handler cannot hoist and every mount is left
+	// to embed for itself — the pre-hoist shape. With one, the vector is computed
+	// once, up front. The wire body must not be able to tell the difference.
+	perMount := &Server{Manager: m, providers: storeProviders{search: &lensSearchStub{byRepo: rows}}}
+	r := perMount.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+	withoutHoist := decodeLensSearch(t, getLensFacts(t, r, "/lenses/eng/search?q=x"))
+
+	hoisted := &Server{Manager: m, Embedder: newCountingEmbedder(),
+		providers: storeProviders{search: &lensSearchStub{byRepo: rows}}}
+	withHoist := decodeLensSearch(t,
+		getLensFacts(t, hoisted.NewAPIRouter(), "/lenses/eng/search?q=x"))
+
+	if withHoist.Total != withoutHoist.Total {
+		t.Errorf("total: hoisted %d, per-mount %d", withHoist.Total, withoutHoist.Total)
+	}
+	if !reflect.DeepEqual(withHoist.Results, withoutHoist.Results) {
+		t.Errorf("result rows differ:\n hoisted   %+v\n per-mount %+v",
+			withHoist.Results, withoutHoist.Results)
+	}
+}
+
+// /lenses/{lens}/facts?q= is the SAME fan-out with the same defect — the
+// Library search box, and the one that measured worst (474 ms on 5 mounts). A
+// text-LESS browse must not reach an embedder at all.
+func TestLensFacts_EmbedsQueryOncePerRequest_AndNotAtAllWithoutText(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  int64
+	}{
+		{"with text", "/lenses/eng/facts?q=x", 1},
+		{"no text", "/lenses/eng/facts", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestLensManager(t, "alpha", "beta", "gamma")
+			stub := &lensFactsStub{}
+			emb := newCountingEmbedder()
+			s := &Server{Manager: m, Embedder: emb, providers: storeProviders{factsCollection: stub}}
+			r := s.NewAPIRouter()
+			createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"},{"repo":"gamma"}]}`)
+
+			getLensFacts(t, r, tc.query)
+
+			if got := emb.queries.Load(); got != tc.want {
+				t.Errorf("EmbedQuery called %d times across 3 mounts, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func float32SliceEqual(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/web/handlers_lenses_embed_hoist_test.go
+++ b/internal/web/handlers_lenses_embed_hoist_test.go
@@ -116,10 +116,23 @@ func TestLensSearch_EveryMountGetsTheSameQueryVector(t *testing.T) {
 	}
 }
 
-// The results a hoisted embed produces are the ones per-mount embedding
-// produced. Driven by passing the SAME stub the same rows and comparing the
-// wire bodies: the hoist is a pure move of where the vector is computed, so the
-// fused order, the dedupe and the totals must all be untouched.
+// Hoisting the embed does not perturb the fusion, the dedupe or the totals.
+//
+// Be precise about what this can and cannot show. lensSearchStub answers from
+// canned rows and ignores the embedder entirely, so both arms retrieve the same
+// rows by construction — this is NOT evidence that a hoisted vector retrieves
+// what N per-mount vectors would have. It pins the surrounding machinery: that
+// setting base.QueryVec, and the extra code path that comes with it, leaves the
+// RRF order, the write-mount dedupe and `total` exactly as they were.
+//
+// The other half of the claim lives elsewhere, deliberately:
+//   - that every mount receives the SAME vector — the test below.
+//   - that the same embedder and string produce it, so the N vectors were
+//     already identical — repos.Manager installs one Embedder on every repo
+//     instance (internal/repos/swapstore.go, builder.go).
+//   - that real retrieval is unchanged end to end — 14 lens reads captured from
+//     the pre- and post-change binaries against the same corpus, byte-for-byte
+//     identical (see the branch's measurement writeup).
 func TestLensSearch_HoistedEmbedMatchesPerMountEmbed(t *testing.T) {
 	rows := map[string][]store.SearchResult{
 		"alpha": {sr("kb/a/1.md", "A one", 3), sr("kb/shared.md", "Shadowed", 99)},

--- a/internal/web/handlers_lenses_embed_hoist_test.go
+++ b/internal/web/handlers_lenses_embed_hoist_test.go
@@ -2,9 +2,12 @@ package web
 
 import (
 	"context"
+	"net/http"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"knomit/internal/embeddings/params"
 	"knomit/internal/store"
@@ -189,4 +192,70 @@ func float32SliceEqual(a, b []float32) bool {
 		}
 	}
 	return true
+}
+
+// ── concurrent search fan-out: fusion order and §9.1 ────────────────────────
+
+// A mount's INDEX is its identity to FuseRRF and WriteFirstWinners: rank fusion
+// orders by per-mount rank, and the dedupe resolves a shared path in favour of
+// the write mount and then binding order. Both read the per-mount lists as an
+// indexed slice, so a concurrent fan-out that collected results as they arrived
+// would silently re-map every row's mount — changing the fused order AND which
+// copy of a duplicated path wins.
+//
+// The write mount is made the SLOWEST so it finishes last, and it shares a path
+// with a read mount that finishes first. Correct behaviour: the write mount
+// still wins that path, and the fused order is unchanged.
+func TestLensSearch_FusionIsBindingOrderNotCompletionOrder(t *testing.T) {
+	stub := &lensSearchStub{
+		byRepo: map[string][]store.SearchResult{
+			"alpha": {sr("kb/shared.md", "write copy", 1), sr("kb/a.md", "alpha only", 2)},
+			"beta":  {sr("kb/shared.md", "read copy", 99), sr("kb/b.md", "beta only", 98)},
+		},
+		// alpha (the write mount, index 0) finishes last.
+		delayByRepo: map[string]time.Duration{"alpha": 50 * time.Millisecond},
+	}
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{search: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	body := decodeLensSearch(t, getLensFacts(t, r, "/lenses/eng/search?q=x"))
+
+	if len(body.Results) != 3 {
+		t.Fatalf("results: got %d, want 3 (one shared path deduped); body=%+v",
+			len(body.Results), body.Results)
+	}
+	for _, row := range body.Results {
+		if row.Path == "kb/shared.md" && row.Title != "write copy" {
+			t.Errorf("shared path resolved to %q, want the write mount's copy — the dedupe "+
+				"read a mount index that completion order had reshuffled", row.Title)
+		}
+	}
+	// The read mount's copy must not ALSO be present under a qualified path.
+	for _, row := range body.Results {
+		if strings.HasSuffix(row.Path, "/kb/shared.md") {
+			t.Errorf("shadowed copy survived as %q — both copies were emitted", row.Path)
+		}
+	}
+}
+
+// §9.1 under concurrency on the search fan-out: one failing mount fails the
+// whole request, even when the healthy mounts are still in flight.
+func TestLensSearch_MountErrorFailsWholeRequestUnderConcurrency(t *testing.T) {
+	stub := &lensSearchStub{
+		byRepo:      map[string][]store.SearchResult{"alpha": {sr("kb/a.md", "alpha", 1)}},
+		errRepo:     "beta",
+		delayByRepo: map[string]time.Duration{"alpha": 40 * time.Millisecond},
+	}
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{search: stub}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	rec := getLensFacts(t, r, "/lenses/eng/search?q=x")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500 — a lens must never silently shrink its read "+
+			"set (RFC §9.1); body=%s", rec.Code, rec.Body.String())
+	}
 }

--- a/internal/web/handlers_lenses_motifs_test.go
+++ b/internal/web/handlers_lenses_motifs_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"knomit/internal/federate"
@@ -629,15 +630,22 @@ func TestLensMotifCluster_IsBranchWideOnEveryMount(t *testing.T) {
 // differently, a term it has never seen resolves to itself, no member's
 // canonical equals it, and the mount contributes nothing.
 type lensPivotFactsStub struct {
-	byRepo   map[string][]store.RecentFactEntry
+	byRepo map[string][]store.RecentFactEntry
+	// mu guards lastOpts. The lens SEARCH fan-out calls this stub once per
+	// mount concurrently, so the recording is shared across goroutines — the
+	// production providers are stateless and need no lock. (The facts fan-out
+	// this stub also serves is still serial; the lock is harmless there.)
+	mu       sync.Mutex
 	lastOpts map[string]store.SearchOptions
 }
 
 func (s *lensPivotFactsStub) carriers(ri *repos.RepoInstance, opts store.SearchOptions) ([]store.RecentFactEntry, int) {
+	s.mu.Lock()
 	if s.lastOpts == nil {
 		s.lastOpts = map[string]store.SearchOptions{}
 	}
 	s.lastOpts[ri.Name()] = opts
+	s.mu.Unlock()
 	want := map[string]bool{}
 	for _, m := range opts.Motifs {
 		want[m] = true

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -818,16 +818,26 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder, motifsP mo
 		// error fails the whole request — a lens must never silently shrink its read
 		// set (RFC §9.1). The embedder (possibly nil when embeddings are disabled)
 		// is forwarded exactly as the repo /search handler forwards it.
+		//
+		// Fanned out CONCURRENTLY: mounts are independent databases with nothing
+		// to serialise on, so a lens's search cost is the slowest mount rather
+		// than the sum of all of them. Each goroutine writes only lists[i], and
+		// the fusion below reads that slice in mount order — a mount's index IS
+		// its identity to FuseRRF and WriteFirstWinners, so results must never be
+		// appended from inside a goroutine.
 		lists := make([][]store.SearchResult, len(targets))
-		for i, t := range targets {
+		if f := fanOutMounts(targets, func(i int, t federate.Target) (string, error) {
 			q := base
 			q.Path = t.Path
 			res, err := provider.Search(r.Context(), t.RT.RI, emb, t.RT.Branch, q)
 			if err != nil {
-				writeStoreError(w, r, err, "Search failed", t.RT.Branch)
-				return
+				return "Search failed", err
 			}
 			lists[i] = res
+			return "", nil
+		}); f != nil {
+			writeStoreError(w, r, f.Err, f.Title, targets[f.Mount].RT.Branch)
+			return
 		}
 
 		// Fuse the per-mount ranked lists by reciprocal rank fusion — the SAME

--- a/internal/web/handlers_lenses_read.go
+++ b/internal/web/handlers_lenses_read.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
 
 	knomitfact "knomit/internal/fact"
 	"knomit/internal/federate"
@@ -93,13 +95,47 @@ type lensFactsResponse struct {
 	Total int            `json:"total"`
 }
 
+// lensQueryVec embeds a lens fan-out's query text ONCE, for every mount to
+// share, and is the reason a lens text read is not N inferences of the same
+// string.
+//
+// Without it the cost is real and it is the whole request: the per-mount
+// searchProvider embeds whenever SearchOptions.QueryVec is empty
+// (handlers_search_hal.go), so a 5-mount lens ran the identical ~81 ms ONNX
+// inference five times — 88% of a 464 ms /lenses/{lens}/search, and the same
+// again on /lenses/{lens}/facts?q=. The repo-scoped twins never showed it
+// because they only ever have one mount to pay for. It is a fixed per-mount
+// cost, independent of corpus size: the same query against an EMPTY mount also
+// cost 81 ms, while the same mount answered a text-less filter in 0.4 ms.
+//
+// The hoist cannot change a result. Every mount is handed the SAME server-wide
+// embedder (repos.Manager installs one Embedder on every repo instance), so
+// the N vectors were already identical by construction — this computes one of
+// them instead of N.
+//
+// A nil vector is the caller's DEGRADED path, not an error: with no embedder,
+// no text, or a failed inference, each mount falls back to exactly what it
+// does today (its own embedder, else keyword-only search). Never fail a read
+// because a query could not be embedded.
+func lensQueryVec(ctx context.Context, emb store.Embedder, text string) []float32 {
+	if text == "" || emb == nil {
+		return nil
+	}
+	vec, err := emb.EmbedQuery(ctx, text)
+	if err != nil {
+		log.Warn().Err(err).Msg("lens search: embed query failed")
+		return nil
+	}
+	return vec
+}
+
 // handleHALLensFacts serves GET /lenses/{lens}/facts — the recency-ordered
 // union of a lens's write repo + N read mounts. It is the REST twin of the MCP
 // queryRecent fan-out (internal/mcp/query.go): select targets via
 // federate.ReadTargetsFor, fetch each mount's RecentFacts at its pinned branch,
 // dedupe by repo-relative path (the write mount's copy wins), merge by
 // committed_at across mounts, and qualify read-mount paths (kb://<id12>/…).
-func handleHALLensFacts(provider factsCollectionProvider, motifsP motifsProvider) http.HandlerFunc {
+func handleHALLensFacts(provider factsCollectionProvider, motifsP motifsProvider, emb store.Embedder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		b := repos.BindingFromContext(r.Context())
 		qp := r.URL.Query()
@@ -193,6 +229,10 @@ func handleHALLensFacts(provider factsCollectionProvider, motifsP motifsProvider
 		// wrong order), diverging from both the repo and MCP twins.
 		base := store.SearchOptions{
 			Text: text,
+			// Embedded ONCE for the whole fan-out, not once per mount — see
+			// lensQueryVec. A text-less browse leaves this nil and never
+			// reaches an embedder at all.
+			QueryVec: lensQueryVec(r.Context(), emb, text),
 			// `entity` (singular) is the canonical name advertised by the HAL
 			// template and matches the data-model column; `entities` (plural) is a
 			// back-compat alias. Merge both, exactly as the repo facts collection
@@ -769,6 +809,9 @@ func handleHALLensSearch(provider searchProvider, emb store.Embedder, motifsP mo
 			MinConfidence: minConfidence,
 			MinSimilarity: minSimilarity,
 			Limit:         maxLensSearchCandidates,
+			// Embedded ONCE for the whole fan-out, not once per mount — see
+			// lensQueryVec.
+			QueryVec: lensQueryVec(r.Context(), emb, qp.Get("q")),
 		}
 
 		// Fan out to every selected mount at its Binding-resolved branch. Any mount

--- a/internal/web/handlers_lenses_read_test.go
+++ b/internal/web/handlers_lenses_read_test.go
@@ -3,13 +3,16 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	knomitfact "knomit/internal/fact"
 	"knomit/internal/federate"
@@ -481,7 +484,19 @@ func TestLensFacts_EmptyMounts(t *testing.T) {
 // whole fan-out. It records the last SearchOptions and whether a non-nil
 // embedder was forwarded, per repo.
 type lensSearchStub struct {
-	byRepo   map[string][]store.SearchResult
+	byRepo map[string][]store.SearchResult
+	// delayByRepo staggers per-mount latency. Under a concurrent fan-out this
+	// decides completion order — which the fused response must NOT depend on,
+	// because a mount's INDEX is its identity to FuseRRF and WriteFirstWinners.
+	delayByRepo map[string]time.Duration
+	// errRepo makes that one mount fail.
+	errRepo string
+	// mu guards the recording maps. The lens fan-out calls this provider ONCE
+	// PER MOUNT CONCURRENTLY, so a stub that records what it saw is shared
+	// mutable state across goroutines — the production provider is stateless and
+	// needs no such thing. Without the lock the recording, not the code under
+	// test, is the race.
+	mu       sync.Mutex
 	lastOpts map[string]store.SearchOptions
 	embSeen  map[string]bool
 }
@@ -490,6 +505,7 @@ func (s *lensSearchStub) Search(
 	_ context.Context,
 	ri *repos.RepoInstance, emb store.Embedder, _ string, opts store.SearchOptions,
 ) ([]store.SearchResult, error) {
+	s.mu.Lock()
 	if s.lastOpts == nil {
 		s.lastOpts = map[string]store.SearchOptions{}
 	}
@@ -498,6 +514,13 @@ func (s *lensSearchStub) Search(
 	}
 	s.lastOpts[ri.Name()] = opts
 	s.embSeen[ri.Name()] = emb != nil
+	s.mu.Unlock()
+	if d := s.delayByRepo[ri.Name()]; d > 0 {
+		time.Sleep(d)
+	}
+	if s.errRepo != "" && ri.Name() == s.errRepo {
+		return nil, errors.New("db on fire: " + ri.Name())
+	}
 	return s.byRepo[ri.Name()], nil
 }
 
@@ -1637,7 +1660,9 @@ type motifResolvingLensStub struct {
 	// aliases[repo][term] is the set of spellings that mount resolves term to.
 	// A mount that judge-merged two spellings lists both; a mount that never
 	// did resolves a term to itself, which is the store's own degradation.
-	aliases  map[string]map[string][]string
+	aliases map[string]map[string][]string
+	// mu guards lastOpts — the search fan-out is concurrent per mount.
+	mu       sync.Mutex
 	lastOpts map[string]store.SearchOptions
 }
 
@@ -1658,10 +1683,14 @@ func (s *motifResolvingLensStub) resolve(repo string, terms []string) map[string
 }
 
 func (s *motifResolvingLensStub) carriers(repo string, opts store.SearchOptions) []store.RecentFactEntry {
+	// Recorded under the lock: the lens search fan-out calls this stub once per
+	// mount concurrently (see lensSearchStub's note).
+	s.mu.Lock()
 	if s.lastOpts == nil {
 		s.lastOpts = map[string]store.SearchOptions{}
 	}
 	s.lastOpts[repo] = opts
+	s.mu.Unlock()
 	corpus := s.facts[repo]
 	if len(opts.Motifs) == 0 {
 		return corpus

--- a/internal/web/handlers_lenses_stats.go
+++ b/internal/web/handlers_lenses_stats.go
@@ -143,17 +143,37 @@ func handleHALLensStats(statsP statsProvider, actP activityProvider) http.Handle
 		fallback := make([]bool, len(targets))
 		var topFacts, topEdges, obsFacts, obsEdges int // pooled AxisFromSeparation inputs
 		var confWeight float64                         // Σ(avg_i · total_i); divided by Σ(total_i) below
-		for i, t := range targets {
+
+		// FETCH in parallel, REDUCE in order. Mounts are independent databases
+		// with nothing to serialise on, and this fan-out was the lens's whole
+		// cost — the sum of its mounts rather than the slowest of them.
+		//
+		// The split matters as much as the parallelism. Every goroutine writes
+		// only its own slot; nothing accumulates into resp from inside one. The
+		// reduction below runs on the request goroutine in mount order, so
+		// resp.Repos keeps binding order and the response stays a function of
+		// the request, not of which mount happened to finish first.
+		sts := make([]store.StatsResult, len(targets))
+		acts := make([]store.ActivityResult, len(targets))
+		if f := fanOutMounts(targets, func(i int, t federate.Target) (string, error) {
 			st, err := statsP.Stats(r.Context(), t.RT.RI, t.RT.Branch, t.Path, axis)
 			if err != nil {
-				writeStoreError(w, r, err, "Failed to load stats", t.RT.Branch)
-				return
+				return "Failed to load stats", err
 			}
 			act, err := actP.Activity(r.Context(), t.RT.RI, t.RT.Branch, t.Path)
 			if err != nil {
-				writeStoreError(w, r, err, "Failed to load activity", t.RT.Branch)
-				return
+				return "Failed to load activity", err
 			}
+			sts[i], acts[i] = st, act
+			return "", nil
+		}); f != nil {
+			// Any mount error fails the whole request (RFC §9.1).
+			writeStoreError(w, r, f.Err, f.Title, targets[f.Mount].RT.Branch)
+			return
+		}
+
+		for i, t := range targets {
+			st, act := sts[i], acts[i]
 			// Mirror handleHALStats: JSON must carry {} for empty maps, never
 			// null — an empty StatsResult has nil Domains/Entities.
 			domains := st.Domains
@@ -259,14 +279,16 @@ func handleHALLensStats(statsP statsProvider, actP activityProvider) http.Handle
 		// so the corrected rows and the fallback flag are the ones Stats would
 		// have returned for the same axis.
 		if store.NormalizeAxis(axis, "") == "" && mountsDisagreeWithResolved {
-			for i, t := range targets {
+			if f := fanOutMounts(targets, func(i int, t federate.Target) (string, error) {
 				hs, fb, err := statsP.Highlights(r.Context(), t.RT.RI, t.RT.Branch, t.Path, rankAxis)
 				if err != nil {
-					writeStoreError(w, r, err, "Failed to load stats", t.RT.Branch)
-					return
+					return "Failed to load stats", err
 				}
-				highlights[i] = hs
-				fallback[i] = fb
+				highlights[i], fallback[i] = hs, fb
+				return "", nil
+			}); f != nil {
+				writeStoreError(w, r, f.Err, f.Title, targets[f.Mount].RT.Branch)
+				return
 			}
 		}
 

--- a/internal/web/handlers_lenses_stats.go
+++ b/internal/web/handlers_lenses_stats.go
@@ -245,15 +245,28 @@ func handleHALLensStats(statsP statsProvider, actP activityProvider) http.Handle
 				break
 			}
 		}
+		//
+		// It re-fetches the HIGHLIGHTS ONLY, not the whole StatsResult. Every
+		// other field this handler reads from a mount — the count, the average
+		// confidence, both histograms, the type counts, the separation
+		// counters — is axis-INDEPENDENT and already summed from the pass
+		// above; re-running Stats recomputed all of it to use none of it. On
+		// the 5-mount `all` lens that was 37.0 ms of an 84 ms request, against
+		// 10.6 ms for the highlights it actually wanted.
+		//
+		// This is not a second, parallel definition of a highlight: the narrow
+		// store call shares fq.highlights with Stats (one query, two callers),
+		// so the corrected rows and the fallback flag are the ones Stats would
+		// have returned for the same axis.
 		if store.NormalizeAxis(axis, "") == "" && mountsDisagreeWithResolved {
 			for i, t := range targets {
-				st, err := statsP.Stats(r.Context(), t.RT.RI, t.RT.Branch, t.Path, rankAxis)
+				hs, fb, err := statsP.Highlights(r.Context(), t.RT.RI, t.RT.Branch, t.Path, rankAxis)
 				if err != nil {
 					writeStoreError(w, r, err, "Failed to load stats", t.RT.Branch)
 					return
 				}
-				highlights[i] = st.Highlights
-				fallback[i] = st.HighlightsFallback
+				highlights[i] = hs
+				fallback[i] = fb
 			}
 		}
 

--- a/internal/web/handlers_lenses_stats_test.go
+++ b/internal/web/handlers_lenses_stats_test.go
@@ -32,6 +32,11 @@ type lensStatsStub struct {
 	errRepo    string
 	lastPath   map[string]string
 	lastAxis   map[string]string
+	// statsCalls / highlightCalls count the two fan-out passes separately, so a
+	// test can assert that the axis correction re-fetches HIGHLIGHTS rather
+	// than re-running the whole aggregate.
+	statsCalls     int
+	highlightCalls int
 }
 
 func (s *lensStatsStub) Stats(_ context.Context, ri *repos.RepoInstance, _ string, pathPrefix, axis string) (store.StatsResult, error) {
@@ -42,6 +47,7 @@ func (s *lensStatsStub) Stats(_ context.Context, ri *repos.RepoInstance, _ strin
 		s.lastAxis = map[string]string{}
 	}
 	name := ri.Name()
+	s.statsCalls++
 	s.lastPath[name] = pathPrefix
 	s.lastAxis[name] = axis
 	if s.errRepo != "" && name == s.errRepo {
@@ -53,6 +59,21 @@ func (s *lensStatsStub) Stats(_ context.Context, ri *repos.RepoInstance, _ strin
 		}
 	}
 	return s.byRepo[name], nil
+}
+
+// Highlights answers the axis-correction pass from the SAME fixtures Stats
+// answers from, deliberately: the production narrow call shares fq.highlights
+// with Stats, and a stub that served the two paths from different data would
+// hide a divergence rather than pin its absence. Every existing axis-correction
+// assertion therefore keeps its exact meaning.
+func (s *lensStatsStub) Highlights(ctx context.Context, ri *repos.RepoInstance, branch, pathPrefix, axis string) ([]store.Highlight, bool, error) {
+	res, err := s.Stats(ctx, ri, branch, pathPrefix, axis)
+	s.statsCalls-- // the delegation above is bookkeeping, not a second aggregate fetch
+	s.highlightCalls++
+	if err != nil {
+		return nil, false, err
+	}
+	return res.Highlights, res.HighlightsFallback, nil
 }
 
 // lensActivityStub is the per-repo activityProvider twin of lensStatsStub.
@@ -866,5 +887,72 @@ func TestLensStats_AnEmptyMountDoesNotCountAsARealHighlightList(t *testing.T) {
 	body := decodeLensStats(t, getLensFacts(t, r, "/lenses/eng/stats?axis=confidence"))
 	if len(body.Highlights) != 1 {
 		t.Fatalf("highlights: got %d, want the read mount's own; %+v", len(body.Highlights), body.Highlights)
+	}
+}
+
+// The axis correction re-fetches HIGHLIGHTS, not the whole StatsResult.
+//
+// Everything else the union reads from a mount — total, avg_confidence, both
+// histograms, type counts, separation counters — is axis-independent and
+// already in hand after the first pass. Re-running Stats recomputed all of it
+// to use none of it: 37.0 ms of an 84 ms request on the 5-mount `all` lens,
+// against 10.6 ms for the highlights it wanted. Two counters, because "it got
+// faster" is not something a unit test can see, but "it stopped asking for the
+// aggregates twice" is.
+func TestLensStats_AxisCorrectionRefetchesOnlyHighlights(t *testing.T) {
+	// alpha defaults to impact, beta to confidence: the mounts disagree, which
+	// is what arms the corrective pass at all.
+	byRepo := map[string]store.StatsResult{
+		"alpha": {Total: 1, DefaultAxis: "impact", TopLayerFacts: 1, TopLayerEdges: 1,
+			Highlights: []store.Highlight{{Path: "kb/a.md", Type: "synthesis", Impact: 9}}},
+		"beta": {Total: 1, DefaultAxis: "confidence",
+			Highlights: []store.Highlight{{Path: "kb/b.md", Type: "synthesis", Confidence: 0.9}}},
+	}
+	stub := &lensStatsStub{byRepo: byRepo}
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		stats:    stub,
+		activity: &lensActivityStub{byRepo: map[string]store.ActivityResult{}},
+	}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	getLensFacts(t, r, "/lenses/eng/stats")
+
+	const mounts = 2
+	if stub.highlightCalls != mounts {
+		t.Errorf("Highlights called %d times, want %d — the corrective pass did not run, "+
+			"so this test is no longer measuring what it claims", stub.highlightCalls, mounts)
+	}
+	if stub.statsCalls != mounts {
+		t.Errorf("Stats called %d times, want %d (one pass); a second full fan-out is the "+
+			"regression this test exists to catch", stub.statsCalls, mounts)
+	}
+}
+
+// With every mount already agreeing with the pooled verdict there is nothing to
+// correct, and the narrow call must not fire at all — the fast path stays one
+// fan-out, exactly as before.
+func TestLensStats_AgreeingMountsSkipTheHighlightsRefetch(t *testing.T) {
+	byRepo := map[string]store.StatsResult{
+		"alpha": {Total: 1, DefaultAxis: "impact", TopLayerFacts: 1, TopLayerEdges: 1,
+			Highlights: []store.Highlight{{Path: "kb/a.md", Type: "synthesis", Impact: 9}}},
+		"beta": {Total: 1, DefaultAxis: "impact", TopLayerFacts: 1, TopLayerEdges: 1,
+			Highlights: []store.Highlight{{Path: "kb/b.md", Type: "synthesis", Impact: 5}}},
+	}
+	stub := &lensStatsStub{byRepo: byRepo}
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	s := &Server{Manager: m, providers: storeProviders{
+		stats:    stub,
+		activity: &lensActivityStub{byRepo: map[string]store.ActivityResult{}},
+	}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"}]}`)
+
+	getLensFacts(t, r, "/lenses/eng/stats")
+
+	if stub.highlightCalls != 0 {
+		t.Errorf("Highlights called %d times, want 0 — nothing disagreed with the pooled axis",
+			stub.highlightCalls)
 	}
 }

--- a/internal/web/handlers_lenses_stats_test.go
+++ b/internal/web/handlers_lenses_stats_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"knomit/internal/federate"
 	"knomit/internal/repos"
@@ -30,8 +32,21 @@ type lensStatsStub struct {
 	byRepo     map[string]store.StatsResult
 	byRepoAxis map[string]map[string]store.StatsResult
 	errRepo    string
-	lastPath   map[string]string
-	lastAxis   map[string]string
+	// errRepos makes SEVERAL mounts fail at once, so a test can pin WHICH
+	// failure a concurrent fan-out reports.
+	errRepos map[string]bool
+	// delayByRepo staggers per-mount latency. Under a concurrent fan-out this
+	// is what decides completion order, which is exactly what the response must
+	// NOT depend on.
+	delayByRepo map[string]time.Duration
+	// mu guards every recording field below. Both stats fan-out passes call
+	// this provider ONCE PER MOUNT CONCURRENTLY, so the bookkeeping a test
+	// asserts on is shared across goroutines — the production provider is
+	// stateless and needs no lock. Without this, the recording would be the
+	// race, not the code under test.
+	mu       sync.Mutex
+	lastPath map[string]string
+	lastAxis map[string]string
 	// statsCalls / highlightCalls count the two fan-out passes separately, so a
 	// test can assert that the axis correction re-fetches HIGHLIGHTS rather
 	// than re-running the whole aggregate.
@@ -40,18 +55,23 @@ type lensStatsStub struct {
 }
 
 func (s *lensStatsStub) Stats(_ context.Context, ri *repos.RepoInstance, _ string, pathPrefix, axis string) (store.StatsResult, error) {
+	name := ri.Name()
+	s.mu.Lock()
 	if s.lastPath == nil {
 		s.lastPath = map[string]string{}
 	}
 	if s.lastAxis == nil {
 		s.lastAxis = map[string]string{}
 	}
-	name := ri.Name()
 	s.statsCalls++
 	s.lastPath[name] = pathPrefix
 	s.lastAxis[name] = axis
-	if s.errRepo != "" && name == s.errRepo {
-		return store.StatsResult{}, errors.New("db on fire")
+	s.mu.Unlock()
+	if d := s.delayByRepo[name]; d > 0 {
+		time.Sleep(d)
+	}
+	if (s.errRepo != "" && name == s.errRepo) || s.errRepos[name] {
+		return store.StatsResult{}, errors.New("db on fire: " + name)
 	}
 	if perAxis, ok := s.byRepoAxis[name]; ok {
 		if res, ok := perAxis[axis]; ok {
@@ -68,8 +88,10 @@ func (s *lensStatsStub) Stats(_ context.Context, ri *repos.RepoInstance, _ strin
 // assertion therefore keeps its exact meaning.
 func (s *lensStatsStub) Highlights(ctx context.Context, ri *repos.RepoInstance, branch, pathPrefix, axis string) ([]store.Highlight, bool, error) {
 	res, err := s.Stats(ctx, ri, branch, pathPrefix, axis)
+	s.mu.Lock()
 	s.statsCalls-- // the delegation above is bookkeeping, not a second aggregate fetch
 	s.highlightCalls++
+	s.mu.Unlock()
 	if err != nil {
 		return nil, false, err
 	}
@@ -78,16 +100,20 @@ func (s *lensStatsStub) Highlights(ctx context.Context, ri *repos.RepoInstance, 
 
 // lensActivityStub is the per-repo activityProvider twin of lensStatsStub.
 type lensActivityStub struct {
-	byRepo   map[string]store.ActivityResult
-	errRepo  string
+	byRepo  map[string]store.ActivityResult
+	errRepo string
+	// mu guards lastPath — same concurrent fan-out as lensStatsStub.
+	mu       sync.Mutex
 	lastPath map[string]string
 }
 
 func (s *lensActivityStub) Activity(_ context.Context, ri *repos.RepoInstance, _ string, path string) (store.ActivityResult, error) {
+	s.mu.Lock()
 	if s.lastPath == nil {
 		s.lastPath = map[string]string{}
 	}
 	s.lastPath[ri.Name()] = path
+	s.mu.Unlock()
 	if s.errRepo != "" && ri.Name() == s.errRepo {
 		return store.ActivityResult{}, errors.New("git on fire")
 	}
@@ -954,5 +980,137 @@ func TestLensStats_AgreeingMountsSkipTheHighlightsRefetch(t *testing.T) {
 	if stub.highlightCalls != 0 {
 		t.Errorf("Highlights called %d times, want 0 — nothing disagreed with the pooled axis",
 			stub.highlightCalls)
+	}
+}
+
+// ── concurrent fan-out: §9.1 and determinism ────────────────────────────────
+
+// The response must be a function of the REQUEST, not of which mount finished
+// first. The slowest mount is deliberately the FIRST in binding order, so a
+// handler that assembled results as they arrived — appending from inside a
+// goroutine — would emit the repos rows inverted, and the qualified paths and
+// per-mount attribution with them.
+func TestLensStats_ResponseOrderIsBindingOrderNotCompletionOrder(t *testing.T) {
+	byRepo := map[string]store.StatsResult{
+		"alpha": {Total: 1, DefaultAxis: "impact", TopLayerFacts: 1, TopLayerEdges: 1,
+			Highlights: []store.Highlight{{Path: "kb/a.md", Title: "from alpha", Type: "synthesis", Impact: 5}}},
+		"beta": {Total: 2, DefaultAxis: "impact", TopLayerFacts: 1, TopLayerEdges: 1,
+			Highlights: []store.Highlight{{Path: "kb/b.md", Title: "from beta", Type: "synthesis", Impact: 9}}},
+		"gamma": {Total: 3, DefaultAxis: "impact", TopLayerFacts: 1, TopLayerEdges: 1,
+			Highlights: []store.Highlight{{Path: "kb/g.md", Title: "from gamma", Type: "synthesis", Impact: 1}}},
+	}
+	// Completion order is forced to the exact reverse of binding order.
+	stub := &lensStatsStub{byRepo: byRepo, delayByRepo: map[string]time.Duration{
+		"alpha": 60 * time.Millisecond,
+		"beta":  30 * time.Millisecond,
+	}}
+	m, _ := newTestLensManager(t, "alpha", "beta", "gamma")
+	s := &Server{Manager: m, providers: storeProviders{
+		stats:    stub,
+		activity: &lensActivityStub{byRepo: map[string]store.ActivityResult{}},
+	}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"},{"repo":"gamma"}]}`)
+
+	body := decodeLensStats(t, getLensFacts(t, r, "/lenses/eng/stats"))
+
+	want := []string{"alpha", "beta", "gamma"}
+	got := make([]string, 0, len(body.Repos))
+	for _, row := range body.Repos {
+		got = append(got, row.Name)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("repos: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("repos order: got %v, want %v (binding order; the slowest mount is first, "+
+				"so this is completion order leaking into the response)", got, want)
+		}
+	}
+	// Highlights are ranked by the axis, never by arrival: beta (impact 9) tops
+	// the list despite finishing second.
+	if len(body.Highlights) != 3 || body.Highlights[0].Title != "from beta" {
+		t.Errorf("highlights: got %+v, want beta's row first (impact 9); note read-mount "+
+			"paths are kb://-qualified, so compare on title", body.Highlights)
+	}
+	// The sums are order-independent, but assert them anyway: a reduction that
+	// dropped a slow mount's contribution would still order correctly.
+	if body.Total != 6 {
+		t.Errorf("total: got %d, want 6 — a mount's result was lost", body.Total)
+	}
+}
+
+// §9.1 survives concurrency: one failing mount still fails the whole request,
+// wherever it sits in the fan-out and however fast it fails relative to the
+// others. The failing mount here finishes FIRST while two healthy mounts are
+// still running, so an implementation that returned early on the first error
+// would race the goroutines still writing their slots.
+func TestLensStats_MountErrorFailsWholeRequestUnderConcurrency(t *testing.T) {
+	for _, failing := range []string{"alpha", "beta", "gamma"} {
+		t.Run("failing="+failing, func(t *testing.T) {
+			stub := &lensStatsStub{
+				byRepo:  map[string]store.StatsResult{},
+				errRepo: failing,
+				delayByRepo: map[string]time.Duration{
+					"alpha": 40 * time.Millisecond,
+					"beta":  40 * time.Millisecond,
+					"gamma": 40 * time.Millisecond,
+				},
+			}
+			// The failing mount answers immediately; the others are still in flight.
+			delete(stub.delayByRepo, failing)
+
+			m, _ := newTestLensManager(t, "alpha", "beta", "gamma")
+			s := &Server{Manager: m, providers: storeProviders{
+				stats:    stub,
+				activity: &lensActivityStub{byRepo: map[string]store.ActivityResult{}},
+			}}
+			r := s.NewAPIRouter()
+			createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"},{"repo":"gamma"}]}`)
+
+			rec := getLensFacts(t, r, "/lenses/eng/stats")
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status: got %d, want 500 — a lens must never silently shrink its "+
+					"read set (RFC §9.1); body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// When SEVERAL mounts fail, the reported error is deterministic: the
+// LOWEST-INDEXED failing mount, which is the one a serial loop would have hit
+// first. Otherwise the message a caller sees — and a lens error names the
+// offending mount — would be decided by goroutine scheduling, and the same
+// request would answer differently between runs.
+//
+// gamma is made to fail FAST and beta SLOWLY, so "first to fail" and "first in
+// binding order" disagree; the assertion is that binding order wins.
+func TestLensStats_ConcurrentFailuresReportTheLowestIndexedMount(t *testing.T) {
+	stub := &lensStatsStub{
+		byRepo:      map[string]store.StatsResult{},
+		errRepos:    map[string]bool{"beta": true, "gamma": true},
+		delayByRepo: map[string]time.Duration{"beta": 50 * time.Millisecond},
+	}
+	m, _ := newTestLensManager(t, "alpha", "beta", "gamma")
+	s := &Server{Manager: m, providers: storeProviders{
+		stats:    stub,
+		activity: &lensActivityStub{byRepo: map[string]store.ActivityResult{}},
+	}}
+	r := s.NewAPIRouter()
+	createLens(t, m, r, `{"name":"eng","write":"alpha","reads":[{"repo":"beta"},{"repo":"gamma"}]}`)
+
+	// Repeated, because a scheduling-dependent answer is exactly the failure
+	// mode and one run could get lucky.
+	for i := 0; i < 10; i++ {
+		rec := getLensFacts(t, r, "/lenses/eng/stats")
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("run %d status: got %d, want 500", i, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "db on fire: beta") {
+			t.Fatalf("run %d: got %s\nwant the error of beta (mount 1), the lowest-indexed "+
+				"failing mount — gamma fails sooner, so this is completion order deciding "+
+				"which error the caller sees", i, rec.Body.String())
+		}
 	}
 }

--- a/internal/web/handlers_stats.go
+++ b/internal/web/handlers_stats.go
@@ -12,8 +12,15 @@ import (
 )
 
 // statsProvider is the narrow interface the stats handler depends on.
+//
+// Highlights is the lens union's axis-correction path: only that handler needs
+// to re-cut one mount's top-N by an axis the mount did not pick, and it needs
+// to do it without paying for the aggregates it already holds. It sits here
+// rather than in its own interface because it is the same store surface and
+// the same fake in tests.
 type statsProvider interface {
 	Stats(ctx context.Context, ri *repos.RepoInstance, branch, pathPrefix, axis string) (store.StatsResult, error)
+	Highlights(ctx context.Context, ri *repos.RepoInstance, branch, pathPrefix, axis string) ([]store.Highlight, bool, error)
 }
 
 // defaultStatsProvider is the production statsProvider.
@@ -31,6 +38,21 @@ func (defaultStatsProvider) Stats(ctx context.Context, ri *repos.RepoInstance, b
 		result, err = svc.FactQuery().Stats(ctx, branch, pathPrefix, axis)
 	})
 	return result, err
+}
+
+func (defaultStatsProvider) Highlights(ctx context.Context, ri *repos.RepoInstance, branch, pathPrefix, axis string) ([]store.Highlight, bool, error) {
+	var (
+		out      []store.Highlight
+		fallback bool
+		err      error
+	)
+	ri.WithRead(func(svc *store.Service) {
+		if svc == nil {
+			return
+		}
+		out, fallback, err = svc.FactQuery().Highlights(ctx, branch, pathPrefix, axis)
+	})
+	return out, fallback, err
 }
 
 // statsView is the HAL response body for the stats endpoint.

--- a/internal/web/handlers_stats_test.go
+++ b/internal/web/handlers_stats_test.go
@@ -28,6 +28,15 @@ func (s *stubStatsProvider) Stats(_ context.Context, _ *repos.RepoInstance, _, p
 	return s.result, s.err
 }
 
+// The repo-scoped /stats handler never calls Highlights — only the lens union's
+// axis correction does. Served from the same fixture so the two paths cannot
+// disagree if a future handler starts using it.
+func (s *stubStatsProvider) Highlights(_ context.Context, _ *repos.RepoInstance, _, pathPrefix, axis string) ([]store.Highlight, bool, error) {
+	s.pathPrefix = pathPrefix
+	s.axis = axis
+	return s.result.Highlights, s.result.HighlightsFallback, s.err
+}
+
 func TestHandleHALStats_ReturnsHAL(t *testing.T) {
 	provider := &stubStatsProvider{
 		result: store.StatsResult{

--- a/internal/web/lens_fanout.go
+++ b/internal/web/lens_fanout.go
@@ -1,0 +1,79 @@
+package web
+
+import (
+	"fmt"
+	"sync"
+
+	"knomit/internal/federate"
+)
+
+// mountFailure is one mount's failed fan-out leg: which mount, the error, and
+// the problem title the handler would have reported had the loop been serial.
+type mountFailure struct {
+	Mount int
+	Title string
+	Err   error
+}
+
+// fanOutMounts runs fn against every mount CONCURRENTLY and returns the failure
+// of the LOWEST-INDEXED mount that failed, or nil when all succeeded.
+//
+// Why concurrently: a lens read's cost was the SUM of its mounts, and mounts are
+// independent SQLite databases with nothing to serialise on — RepoInstance
+// acquisition is an RWMutex read lock plus a WaitGroup, never exclusive. Serial
+// was simply the shape the single-mount original had. internal/mcp/query.go's
+// fan-outs have always been parallel; this is the same pattern, kept
+// deliberately identical rather than re-invented.
+//
+// Why lowest-indexed and not first-to-fail: RFC §9.1 says any mount error fails
+// the whole request — a lens must never silently shrink its read set — and that
+// was already true serially. What parallelism could quietly change is WHICH
+// error a caller sees when two mounts fail, and the wording of a lens error
+// names the offending mount's branch. Racing goroutines would make that a
+// coin-flip between runs. Taking the lowest index yields exactly the error the
+// serial loop would have hit first, so the response is a function of the request
+// and not of scheduling.
+//
+// fn MUST confine its writes to its own index. Every caller collects into
+// slices pre-sized to len(targets) and reduces them afterwards, in index order,
+// on the request goroutine — never appending from inside a goroutine, which
+// would make the response order depend on which mount finished first.
+//
+// fn returns the problem TITLE alongside its error because one leg can fail in
+// more than one way (stats fetches both aggregates and activity) and the titles
+// differ; carrying it here keeps the reported title the one the serial code
+// reported for that same failure.
+func fanOutMounts(targets []federate.Target, fn func(i int, t federate.Target) (string, error)) *mountFailure {
+	failures := make([]*mountFailure, len(targets))
+	var wg sync.WaitGroup
+	for i, t := range targets {
+		wg.Add(1)
+		go func(i int, t federate.Target) {
+			defer wg.Done()
+			// A panic here must become this mount's error, not the process's
+			// death. net/http recovers panics on the REQUEST goroutine only, so
+			// an unrecovered panic in one of these bare per-mount goroutines
+			// takes the whole server down rather than the one connection —
+			// exactly the widening internal/mcp/query.go's recoverFanout exists
+			// to prevent, and a real one: an archive/shutdown race can leave a
+			// mount's svc nil. Routed into the mount's slot, it flows out
+			// through the ordinary §9.1 path.
+			defer func() {
+				if p := recover(); p != nil {
+					failures[i] = &mountFailure{Mount: i, Title: "Mount failed",
+						Err: fmt.Errorf("mount %s@%s panicked: %v", t.RT.RI.Name(), t.RT.Branch, p)}
+				}
+			}()
+			if title, err := fn(i, t); err != nil {
+				failures[i] = &mountFailure{Mount: i, Title: title, Err: err}
+			}
+		}(i, t)
+	}
+	wg.Wait()
+	for _, f := range failures {
+		if f != nil {
+			return f
+		}
+	}
+	return nil
+}

--- a/internal/web/lens_fanout.go
+++ b/internal/web/lens_fanout.go
@@ -47,8 +47,22 @@ func fanOutMounts(targets []federate.Target, fn func(i int, t federate.Target) (
 	failures := make([]*mountFailure, len(targets))
 	var wg sync.WaitGroup
 	for i, t := range targets {
+		// The mount's label is built HERE, before the goroutine, and without
+		// dereferencing anything that might be absent.
+		//
+		// It is the recover handler's message, and a recover handler that can
+		// itself panic is worse than none: the second panic escapes the
+		// goroutine and kills the process — precisely what the recover exists
+		// to prevent. RepoInstance.Name() reads a field, so it panics on a nil
+		// instance, and a nil RepoInstance is the same archive/shutdown-race
+		// family that motivates the recover in the first place. Naming the
+		// mount must never be the thing that fails.
+		label := "mount " + t.RT.Branch
+		if t.RT.RI != nil {
+			label = "mount " + t.RT.RI.Name() + "@" + t.RT.Branch
+		}
 		wg.Add(1)
-		go func(i int, t federate.Target) {
+		go func(i int, t federate.Target, label string) {
 			defer wg.Done()
 			// A panic here must become this mount's error, not the process's
 			// death. net/http recovers panics on the REQUEST goroutine only, so
@@ -61,13 +75,13 @@ func fanOutMounts(targets []federate.Target, fn func(i int, t federate.Target) (
 			defer func() {
 				if p := recover(); p != nil {
 					failures[i] = &mountFailure{Mount: i, Title: "Mount failed",
-						Err: fmt.Errorf("mount %s@%s panicked: %v", t.RT.RI.Name(), t.RT.Branch, p)}
+						Err: fmt.Errorf("%s panicked: %v", label, p)}
 				}
 			}()
 			if title, err := fn(i, t); err != nil {
 				failures[i] = &mountFailure{Mount: i, Title: title, Err: err}
 			}
-		}(i, t)
+		}(i, t, label)
 	}
 	wg.Wait()
 	for _, f := range failures {

--- a/internal/web/lens_fanout_bench_test.go
+++ b/internal/web/lens_fanout_bench_test.go
@@ -1,0 +1,98 @@
+package web
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"knomit/internal/fact"
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+	"knomit/internal/store"
+)
+
+// benchSink keeps benchMountWork's result live. Without an escaping store the
+// function is pure and its result unused, and the compiler is free to delete
+// the loop in one arm of the comparison but not the other — which produces a
+// confident, meaningless speed-up.
+var benchSink atomic.Uint64
+
+// benchMountWork is a deterministic, CPU-bound stand-in for one mount's store
+// work. Real per-mount cost is SQLite doing aggregates or a KNN scan; what
+// matters to the fan-out is only that it is CPU-bound and independent, so a
+// pure computation makes the scaling property measurable without a database.
+func benchMountWork() {
+	var acc uint64
+	for i := uint64(0); i < 400_000; i++ {
+		acc = acc*1664525 + 1013904223 + i
+	}
+	benchSink.Add(acc)
+}
+
+// benchTargets builds n fan-out targets backed by real (empty) store
+// instances. Real ones rather than zero values because fanOutMounts names the
+// mount when a leg panics, and a benchmark that would crash on the diagnostic
+// path is not a safe thing to leave lying around.
+func benchTargets(b *testing.B, n int) []federate.Target {
+	b.Helper()
+	dir := b.TempDir()
+	out := make([]federate.Target, 0, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("m%02d", i)
+		svc, err := store.Open(filepath.Join(dir, name+".db"))
+		if err != nil {
+			b.Fatalf("open %s: %v", name, err)
+		}
+		b.Cleanup(func() { _ = svc.Close() })
+		if err := svc.InitRepo(map[string]string{}, "agent/bench"); err != nil {
+			b.Fatalf("init %s: %v", name, err)
+		}
+		ri := repos.NewTestInstanceWithDeps(repos.TestInstanceConfig{
+			Name:         name,
+			UID:          name,
+			AgentBranch:  "agent/bench",
+			Svc:          svc,
+			Ontology:     fact.CodeOntology(),
+			OntologyRoot: "kb",
+		})
+		out = append(out, federate.Target{RT: repos.ReadTarget{RI: ri, Branch: "agent/bench"}})
+	}
+	return out
+}
+
+// BenchmarkFanOutMounts measures what the serial loop cost and what the
+// concurrent one costs, at the mount counts that matter: today's lens (5) and
+// the tens-of-mounts scale this work exists for.
+//
+// This is the Go-level counterpart to the end-to-end lab numbers in the commit
+// messages. The lab measures a real corpus but through curl, which carries
+// process-spawn noise and cannot separate connection-pool contention from CPU
+// saturation. This measures only the fan-out's own shape: identical independent
+// per-mount work, serial against concurrent. Serial is expected to be linear in
+// mount count and concurrent to flatten until it saturates the machine's cores
+// — the whole reason a 40-mount lens is viable at all.
+func BenchmarkFanOutMounts(b *testing.B) {
+	for _, mounts := range []int{1, 5, 20, 40} {
+		targets := benchTargets(b, mounts)
+
+		b.Run(fmt.Sprintf("serial/mounts=%d", mounts), func(b *testing.B) {
+			for b.Loop() {
+				for range targets {
+					benchMountWork()
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("concurrent/mounts=%d", mounts), func(b *testing.B) {
+			for b.Loop() {
+				if f := fanOutMounts(targets, func(int, federate.Target) (string, error) {
+					benchMountWork()
+					return "", nil
+				}); f != nil {
+					b.Fatalf("unexpected failure: %v", f.Err)
+				}
+			}
+		})
+	}
+}

--- a/internal/web/lens_fanout_test.go
+++ b/internal/web/lens_fanout_test.go
@@ -1,0 +1,114 @@
+package web
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"knomit/internal/federate"
+	"knomit/internal/repos"
+)
+
+// A panicking mount becomes that mount's error, not the process's death — even
+// when the mount has NO RepoInstance to name.
+//
+// The nil instance is the point. RepoInstance.Name() reads a field, so it
+// panics on a nil receiver, and the recover handler used to build its message
+// from exactly that call: a mount that panicked BECAUSE its instance was gone
+// would panic the handler too, and the second panic escapes the goroutine and
+// takes the server down. That is the archive/shutdown-race family the recover
+// was written for, so the recover failing on it defeats the whole mechanism.
+//
+// A nil RepoInstance cannot be produced through the HTTP surface, which is why
+// this constructs one directly rather than through a router: the hazard is real
+// but only reachable from inside.
+func TestFanOutMounts_PanicWithNoRepoInstanceDoesNotEscape(t *testing.T) {
+	targets := []federate.Target{
+		{RT: repos.ReadTarget{RI: nil, Branch: "agent/gone"}},
+	}
+
+	f := fanOutMounts(targets, func(int, federate.Target) (string, error) {
+		panic("mount store vanished")
+	})
+
+	if f == nil {
+		t.Fatal("a panicking mount produced no failure — §9.1 says it must fail the request")
+	}
+	if f.Mount != 0 {
+		t.Errorf("mount: got %d, want 0", f.Mount)
+	}
+	if !strings.Contains(f.Err.Error(), "mount store vanished") {
+		t.Errorf("error %q does not carry the panic value", f.Err)
+	}
+	// The mount is still identified by whatever identity survived.
+	if !strings.Contains(f.Err.Error(), "agent/gone") {
+		t.Errorf("error %q does not name the mount", f.Err)
+	}
+}
+
+// The ordinary case: a mount with an instance is named by repo and branch.
+func TestFanOutMounts_PanicNamesTheMount(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha")
+	targets := []federate.Target{
+		{RT: repos.ReadTarget{RI: m.Get("alpha"), Branch: "machine/test"}},
+	}
+
+	f := fanOutMounts(targets, func(int, federate.Target) (string, error) {
+		panic("boom")
+	})
+
+	if f == nil {
+		t.Fatal("a panicking mount produced no failure")
+	}
+	if !strings.Contains(f.Err.Error(), "alpha@machine/test") {
+		t.Errorf("error %q does not name repo@branch", f.Err)
+	}
+}
+
+// All mounts succeeding reports no failure — the helper's own happy path,
+// asserted so the tests above cannot pass by always returning something.
+func TestFanOutMounts_AllSucceedingReportsNoFailure(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	targets := []federate.Target{
+		{RT: repos.ReadTarget{RI: m.Get("alpha"), Branch: "machine/test"}},
+		{RT: repos.ReadTarget{RI: m.Get("beta"), Branch: "machine/test"}},
+	}
+
+	seen := make([]int, len(targets))
+	if f := fanOutMounts(targets, func(i int, _ federate.Target) (string, error) {
+		seen[i] = i + 1
+		return "", nil
+	}); f != nil {
+		t.Fatalf("unexpected failure: %v", f.Err)
+	}
+	for i, v := range seen {
+		if v != i+1 {
+			t.Errorf("mount %d never ran (seen=%v)", i, seen)
+		}
+	}
+}
+
+// A panic in ONE mount does not suppress a lower-indexed mount's ordinary
+// error: the two failure kinds share one slot array and one ordering rule.
+func TestFanOutMounts_PanicDoesNotOutrankALowerIndexedError(t *testing.T) {
+	m, _ := newTestLensManager(t, "alpha", "beta")
+	targets := []federate.Target{
+		{RT: repos.ReadTarget{RI: m.Get("alpha"), Branch: "machine/test"}},
+		{RT: repos.ReadTarget{RI: m.Get("beta"), Branch: "machine/test"}},
+	}
+
+	f := fanOutMounts(targets, func(i int, _ federate.Target) (string, error) {
+		if i == 0 {
+			return "Failed", errors.New("alpha said no")
+		}
+		panic("beta exploded")
+	})
+
+	if f == nil {
+		t.Fatal("no failure reported")
+	}
+	if f.Mount != 0 || !strings.Contains(f.Err.Error(), "alpha said no") {
+		t.Errorf("got mount %d / %v, want mount 0's error — binding order decides, "+
+			"not the kind of failure or which arrived first", f.Mount, f.Err)
+	}
+}

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -239,7 +239,7 @@ func (s *Server) NewAPIRouter() chi.Router {
 
 		r.Group(func(r chi.Router) {
 			r.Use(LensMiddleware(s.Manager))
-			r.Get("/facts", handleHALLensFacts(p.factsCollection, p.motifs))
+			r.Get("/facts", handleHALLensFacts(p.factsCollection, p.motifs, s.Embedder))
 			r.Get("/facts/*", handleHALLensFact(b, p.factReader, p.factSub))
 			r.Get("/search", handleHALLensSearch(p.search, s.Embedder, p.motifs))
 			r.Get("/completions", handleHALLensCompletions(p.completions))


### PR DESCRIPTION
Opening a lens was slow because three independent things each multiplied by the mount count. On the 5-mount `all` lens, search dropped **483 ms → 121 ms** and stats **88 ms → 52 ms**, with **no change to a single byte on the wire**.

## What was actually wrong

Measured first, in a lab (rsync copy of a real `~/.knomit`, own binary, own port, `lsof`-verified port ownership on every run), before any fix was written. Two of the three causes were not what we expected going in.

**1. The same query string was embedded once per mount.** Instrumented, a 464 ms `/lenses/all/search?q=cache` spent 406.8 ms — **88%** — in five `EmbedQuery` calls of 81.1/81.3/81.4/81.4/81.6 ms. The tell is that it is a fixed per-mount cost with no relation to corpus size: the same query against an **empty** mount (0 facts) also cost 82.7 ms, while that same mount answered a text-less filter in 0.42 ms.

`SearchOptions.QueryVec` has always existed for exactly this, and the repo-scoped `/search` handler has always set it. Only the federated twins diverged — they grew a loop the single-mount original did not have. Four call sites had it: web lens search, web lens `facts?q=` (the Library search box, and the worst-hit at 494 ms), and MCP's `queryFirstCall` *and* `queryRecent`.

**2. `/lenses/{lens}/stats` fanned out twice and threw away most of the second pass.** The second fan-out is there for a real reason — `store.Stats` cuts each mount's top-N by that mount's *own* default axis, so when the caller names no axis and the mounts disagree, every mount's highlights were cut by a different ruler than the union ranks by. Pinning them to the resolved pooled axis and re-fetching is correct and stays. What it re-fetched was not: it called the whole of `Stats` again and read only `Highlights`/`HighlightsFallback` out of it.

```
pass 1  per-mount Stats + Activity   43.2 ms
pass 2  the same Stats again         37.0 ms   ← 44% of an 84 ms request
        of which highlights          10.6 ms   ← all it wanted
```

This is not a rare edge case. Mounts disagreeing is the normal state — core and agentic-engineering default to `impact`, knomit-kb, knomit-io-kb and test to `confidence` — and the UI sends no axis. Every lens open paid it.

**3. Both web lens fan-outs were serial loops**, so a lens read cost the *sum* of its mounts. Nothing required that: mounts are independent SQLite databases, and `RepoInstance.Acquire` is an RWMutex **read** lock plus a WaitGroup — never exclusive. `internal/mcp/query.go`'s twins have always been parallel; this reuses that pattern rather than re-inventing it.

**Not** the cause, despite being the leading hypothesis going in: `CommitLogActivity` — the `COUNT(DISTINCT commit_hash)` with wall-clock cutoffs — is 0.35–3.5 ms per mount, **6.9 ms total, 8% of the request**.

## Numbers

Base and final binaries run back-to-back against the same home, same machine state. curl n=9, p50.

| endpoint | before | after | |
|---|---|---|---|
| `GET /lenses/all/search?q=cache` | 483.4 ms | 121.1 ms | 4.0× |
| `GET /lenses/all/facts?q=cache` | 493.5 ms | 147.3 ms | 3.4× |
| `GET /lenses/all/stats` | 87.6 ms | 52.4 ms | 1.7× |
| `GET /lenses/all/stats?axis=impact` | 48.7 ms | 42.3 ms | — |
| `GET /lenses/all/facts` (no text) | 5.5 ms | 5.3 ms | — |

`?axis=impact` is the **control**: it skips the corrective pass entirely, so it must *not* move. The ~3.5 ms it wobbles by is the noise floor the other numbers have to clear.

Per commit, on the endpoint each one targets:

| | base | + embed hoist | + highlights-only | + parallel |
|---|---|---|---|---|
| `search?q=cache` | 465 ms | 134 ms | 148 ms | 121 ms |
| `stats` | 84 ms | 86 ms | 67 ms | 52 ms |

### The slope is the point

`repo=`-narrowed fan-outs, 1..5 mounts:

| mounts | search before | search after | stats before | stats after |
|---|---|---|---|---|
| 1 | 113 ms | 119 ms | 27 ms | 29 ms |
| 2 | 209 ms | 120 ms | 69 ms | 43 ms |
| 3 | 303 ms | 121 ms | 81 ms | 48 ms |
| 4 | 387 ms | 121 ms | 84 ms | 50 ms |
| 5 | 470 ms | 123 ms | 85 ms | 52 ms |

Search went from **+~89 ms per mount to +~1 ms per mount** — flat. At the target scale of lenses up to ~40 mounts, that is **~3.6 s → ~110 ms**. The first two commits made the constant small; this one stops it multiplying.

`BenchmarkFanOutMounts` measures the fan-out's own shape without curl or SQLite in the way (M4, 10 cores, `-benchtime 200x`):

| mounts | 1 | 5 | 20 | 40 |
|---|---|---|---|---|
| serial | 0.51 ms | 2.25 ms | 9.02 ms | 18.07 ms |
| concurrent | 0.46 ms | 0.59 ms | 1.23 ms | 2.41 ms |

At one mount the two agree, as they must. Give it a large `-benchtime`: at 20–50 iterations warm-up noise is the size of that one-mount difference and reads as a speed-up that is not there.

## Semantics

14 lens reads — every axis, repo-narrowed, path-scoped, searches with limits and similarity floors, text and text-less facts browses, a filter-only search — captured from the pre- and post-change binaries against the same home. **14 of 14 byte-for-byte identical**, with no normalisation: the wall-clock activity counters did not tick between captures, so nothing had to be excused.

**Two stated limits of that evidence**, because "14 of 14" reads stronger than it is:

1. **A single capture cannot falsify nondeterminism.** Concurrency's failure mode is an answer that varies between runs, and one capture per binary samples that once. The evidence for determinism is not the captures — it is the forced-delay tests, which invert completion order relative to binding order (slowest mount first; the write mount slowest *and* sharing a path with a read mount that finishes first) and pin the result anyway.
2. **The 5-mount lab home does not exercise the fork-shared-UUID dedupe path.** `WriteFirstWinners` exists for a re-rooted fork mounted beside its upstream — distinct root-commit IDs sharing server-generated fact UUIDs — which this corpus has no instance of. That path is covered by unit tests, not by these captures.

Invariants held throughout: RFC §9.1 (any mount error fails the whole request), `count-vs-transfer` (`total` counts matches, never fetched rows), qualified highlight paths (`lensWirePath` after the dedupe, untouched), no federation metadata added, no new constants, and **no caching of any kind** — every fix is algorithmic.

## Concurrency, specifically

Fetch in parallel, **reduce in order**. Every goroutine writes only its own slot; the reduction runs afterwards on the request goroutine, walking targets in binding order. Nothing appends from inside a goroutine — a mount's *index* is its identity to `FuseRRF` and `WriteFirstWinners`, so collecting results as they arrive would re-map every row's mount, changing both the fused order and which copy of a cross-mount duplicate wins.

§9.1 is preserved and made **deterministic**: when several mounts fail, the reported error is the **lowest-indexed** one — what the serial loop would have hit first. Racing goroutines would otherwise make the message a coin-flip, and a lens error names the offending mount's branch. Pinned with a fast-failing high-index mount racing a slow-failing low-index one, asserted over ten runs.

A panic in a per-mount goroutine becomes that mount's error rather than the process's death: `net/http` recovers panics on the *request* goroutine only.

## Review provenance

A reviewer pass mutation-verified the concurrency tests (append-from-goroutine, first-error-to-arrive, and full-`Stats` reverts all die on the right assertions), confirmed the hoisted `QueryVec` is safe as a shared read-only slice, and verified all four production providers are stateless. Five items came back and are folded in.

One was a **live crash**, not a style note. `fanOutMounts` built its recover message from `t.RT.RI.Name()`, which reads a field and so panics on a nil `RepoInstance` — the same archive/shutdown race the recover exists to survive. The handler failed on precisely the input it was written for, and the second panic escapes the goroutine and kills the process. Verified by reverting the one line under the new test: it prints `panic: mount store vanished [recovered] / panic: runtime error: invalid memory address or nil pointer dereference` and takes the test binary with it.

The others tightened evidence rather than code: the `sort=recent` MCP hoist was unpinned (and its pre-fix arm confirms it genuinely re-embedded per mount); one test's doc comment claimed more than the test showed; one was vacuous if its fixture's two axes ever ordered alike.

## Deliberately not done

- **`/lenses/{lens}/facts` keeps its serial fan-out.** Its loop re-fans at doubling depth against a merge horizon, and folding that in would have put the one intricate case in the commit a reviewer most needs to read plainly. It got the embed hoist (494 → 147 ms) but not the parallelism; 5.3 ms at 5 mounts.
- **`/lenses/{lens}/topics` keeps its serial fan-out — measured, not assumed.** 0.43–0.60 ms at 5 mounts across the root listing, mid-tree nodes, and a leaf-bearing node where the per-leaf `GetByPath` fires; slope ~0.02 ms per mount, ~1 ms extrapolated to 40. Its second store loop is also **not a per-mount fan-out at all**: it is one `GetByPath` per *winning leaf*, so that cost tracks leaf count, not mount count, and parallelising the mount loop would not touch it.
- **The remaining stats slope is unattributed.** 8 concurrent `/lenses/all/stats` take 717 ms against 105 ms for one, and 4 concurrent reads of the *same* repo (89 ms) do worse than 4 across *different* repos (55 ms) — pointing at the per-repo SQLite pool (`SetMaxOpenConns(4)`) plus CPU. The curl harness that produced those carries ~15–20 ms of process-spawn noise and cannot separate the two. Wants a benchmark over real stores.

One correction worth recording: an earlier writeup attributed the parallel-request cost to "per-mount read locks". That is wrong — `Acquire` is an `RLock`, so concurrent readers cannot serialise on it, which is also why parallelising was safe to do at all.

## Verification

- `go test ./...` green.
- `go test -race` green on `internal/web`, `internal/mcp`, `internal/store`.
- `web/` untouched, so its tsc/vitest/eslint baseline is unaffected.
- Rebased onto `dev` after #182/#184 merged; both conflicts were additive handler signatures. Widening runs before the fan-out, the `QueryVec` hoist stays, the parallel fan-out wraps the same §9.1 semantics. Lab numbers re-verified on the rebased tree (search 120.3 ms, stats 52.4 ms, motifs 8.4 ms).
